### PR TITLE
WIP: Native pre processor (no boundaries)

### DIFF
--- a/include/NeoFOAM/mesh/cellDefinitions.hpp
+++ b/include/NeoFOAM/mesh/cellDefinitions.hpp
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2023 NeoFOAM authors
+#pragma once
+
+#include <array>
+#include <vector>
+#include <string>
+
+#include "cellTypes.h"
+#include "NeoFOAM/blas/primitives/label.hpp"
+
+namespace NeoFOAM {
+
+inline const std::array<std::string, totalCellTypes> cellNames = {
+    "edge",
+    "quad",
+    "tri",
+    "hexah",
+    "tetra",
+    "prism",
+    "pyram",
+};
+
+
+// cell to edges
+using CellEdgeTable std::vector<std::array<localIdx, 2> >;
+inline const CellEdgeTable EdgeEdge = {{0, 1}};
+inline const CellEdgeTable QuadEdge = {{0, 1}, {1, 2}, {2, 3}, {3, 0}};
+inline const CellEdgeTable TriEdge = {{0, 1}, {1, 2}, {2, 0}};     
+inline const CellEdgeTable HexahEdge = {{0, 4}, {0, 1}, {1, 5}, {4, 5}, {1, 3}, {3, 7}, {5, 7}, {2, 3}, {2, 6}, {6, 7}, {0, 2}, {4, 6}};
+inline const CellEdgeTable PrismEdge = {{0, 1}, {1, 2}, {2, 0}, {3, 4}, {4, 5}, {5, 3}, {0, 3}, {1, 4}, {2, 5}};
+inline const CellEdgeTable TetraEdge = {{0, 1}, {1, 2}, {2, 0}, {0, 3}, {1, 3}, {2, 3}};
+inline const CellEdgeTable PyramEdge = {{0, 1}, {1, 3}, {3, 2}, {0, 2}, {0, 4}, {1, 4}, {3, 4}, {2, 4}};
+
+struct CellLocalEdgeHelper
+{
+    [[no_discard]] static const CellEdgeTable& operator[](const cellTypes cellType) const {
+        switch (cellType) {
+            case cellTypes::edge:
+                return EdgeEdge;
+            case cellTypes::quad:
+                return QuadEdge;
+            case cellTypes::tri:
+                return TriEdge;
+            case cellTypes::hexah:
+                return HexahEdge;
+            case cellTypes::prism:
+                return PrismEdge;
+            case cellTypes::tetra:
+                return TetraEdge;
+            case cellTypes::pyram:
+                return PyramEdge;
+            default:
+                throw std::runtime_error("Invalid cell type");
+        }
+    }
+};
+const inline CellLocalEdge = CellLocalEdgeHelper();
+
+// cell to faces
+using CellFaceTable std::vector<std::vector<localIdx> >;
+inline const CellFaceTable EdgeFace = {};
+inline const CellFaceTable QuadFace = {};
+inline const CellFaceTable TriFace = {};
+inline const CellFaceTable HexahFace = {{0, 1, 5, 4}, {1, 3, 7, 5}, {3, 2, 6, 7}, {2, 0, 4, 6}, {1, 0, 2, 3}, {4, 5, 7, 6}};
+inline const CellFaceTable PrismFace = {{0, 1, 4, 3}, {1, 2, 5, 4}, {2, 0, 3, 5}, {0, 2, 1}, {3, 4, 5}};
+inline const CellFaceTable TetraFace = {{1, 0, 2}, {0, 1, 3}, {1, 2, 3}, {2, 0, 3}};
+inline const CellFaceTable PyramFace = {{0, 2, 3, 1}, {0, 1, 4}, {1, 3, 4}, {3, 2, 4}, {2, 0, 4}};
+
+template<bool 2d_edge_as_face>
+struct CellLocalFaceHelper
+{
+    [[no_discard]] static const CellFaceTable& operator[](const cellTypes cellType) const {
+        switch (cellType) {
+            case cellTypes::edge:
+                return 2d_edge_as_face ? EdgeEdge : EdgeFace;
+            case cellTypes::quad:
+                return 2d_edge_as_face ? QuadEdge : QuadFace;
+            case cellTypes::tri:
+                return 2d_edge_as_face ? TriEdge : TriFace;
+            case cellTypes::hexah:
+                return HexahFace;
+            case cellTypes::prism:
+                return PrismFace;
+            case cellTypes::tetra:
+                return TetraFace;
+            case cellTypes::pyram:
+                return PyramFace;
+            default:
+                throw std::runtime_error("Invalid cell type");
+        }
+    }
+};
+const inline CellLocalFace = CellLocalFaceHelper<false>();
+const inline CellLocalEdgeasFace = CellLocalFaceHelper<true>();
+
+// local to global
+template<typename label_t>
+struct FaceGlobal{
+
+    LocalToGlobal() = delete; // no default construction that would break shit.
+    LocalToGlobal(const std::span<label_t>& global, const std::vector<label_t>& local_face) : global_(global), local_face_(local_face) {};
+
+    std::size_t size() {return local_face_.size()}; // number of vertices on the face
+
+    [[no_discard]] static const label_t& operator[](const label_t i_local) const  // given a local vertex index returns the global vertex index
+    { 
+        return global_[local_face_[i_local]];
+    }
+
+    private:
+    const std::span<label_t>& global_;
+    const std::vector<label_t>& local_face_; 
+};
+
+template<typename label_t, bool 2d_edge_as_face>
+struct LocalToGlobalFaceHelper
+{   
+    LocalToGlobal() = delete; // no default construction that would break shit.
+    LocalToGlobal(const std::span<label_t>& global, const cellTypes type) : global_(global), type_(type) {};
+
+    std::size_t size(){helper[type_].size()}; // total number of faces
+
+    [[no_discard]] static const FaceGlobalHelper<>& operator[](const label_t i_face) const { // returns a global face helper.
+        return {global_, helper[type_][i_face]};
+    }
+
+    private:
+    const CellLocalFaceHelper<2d_edge_as_face> helper;
+    const std::span<label_t>& global_;
+    const cellTypes& type_;
+};
+template<typename label_t>
+using CellGlobalFace = LocalToGlobalFaceHelper<label_t, cell_t, false>();
+template<typename label_t>
+using CellGlobalEdgeasFace = LocalToGlobalEdgeasFaceHelper<label_t, cell_t, true>();
+
+} // namespace 

--- a/include/NeoFOAM/mesh/cellTypes.h
+++ b/include/NeoFOAM/mesh/cellTypes.h
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2023 NeoFOAM authors
+#pragma once
+
+namespace NeoFOAM
+{
+
+enum class cellTypes : std::uint8_t{
+    edge,
+    quad,
+    tri,
+    hexah,
+    prism,
+    tetra,
+    pyram,
+    total
+};
+
+inline const consteval std::size_t totalCellTypes = static_cast<std::size_t>(cellTypes::total);
+
+} // namespace NeoFOAM

--- a/include/NeoFOAM/mesh/cellUtilities.h
+++ b/include/NeoFOAM/mesh/cellUtilities.h
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2023 NeoFOAM authors
+#pragma once
+
+#include "NeoFOAM/blas/primative/label.hpp"
+
+#include "cellDefinitions.hpp"
+
+namespace NeoFOAM
+{      
+    template<typename label_t>
+    [[no_discard]] inline bool isVertexFaceVertex(const FaceGlobal<label_t> face, const label_t& vertex)
+    {
+        for(auto local_vertex = 0; local_vertex < face.size(); ++local_vertex) if(face[local_vertex] == vertex) return true;
+        return false;
+    }
+
+    template<typename label_t>
+    [[no_discard]] inline bool isFaceCellFace(const CellGlobalFace<label_t>& cell_global_faces, const FaceGlobal<label_t>& face) {
+
+        for(auto i_face = 0; i_face < cell_global_faces.size(); ++i_face) {
+            if(cell_global_faces[i_face].size() != face.size()) continue;
+           
+            bool all_vertex_on_face = true;
+            for(auto i_face_vertex = 0; i_face_vertex < face.size() : ++i_face_vertex) {
+                if(!isVertexFaceVertex(cell_global_faces[i_face], face[i_face_vertex])) {
+                    all_vertex_on_face = false;
+                    break;
+                }
+            }
+            if(all_vertex_on_face) return true;
+        }
+        return false;
+    }    
+
+    template<typename label_t>
+    [[no_discard]] inline bool CellShareFace(const CellGlobalFace<label_t>& cell0_global_faces, const CellGlobalFace<label_t>& cell1_global_faces)
+    {   
+        for(auto i_face = 0; i_face < cell1_global_faces.size(); ++i_face)
+            if(isFaceCellFace(cell0_global_faces, cell1_global_faces[i_face]])) return true;
+        return false;
+    }
+
+}

--- a/include/NeoFOAM/mesh/unstructuredMesh/unstructuredMesh.hpp
+++ b/include/NeoFOAM/mesh/unstructuredMesh/unstructuredMesh.hpp
@@ -5,35 +5,86 @@
 #include <array>
 #include <vector>
 
+#include "NeoFOAM/blas/adjacency.hpp"
 #include "NeoFOAM/blas/fields.hpp"
+
+#include "../cellDefinitions.hpp"
+#include "../cellUtities.hpp"
 
 namespace NeoFOAM
 {
 
 class Stencil<int8_t>; // 0 is dynamic
 
-    struct unstructuredMesh
-    {
+struct unstructuredMesh
+{
 
-        unstructuredMesh(NeoFOAM::vectorField Sf, NeoFOAM::labelField owner, NeoFOAM::labelField neighbour, NeoFOAM::scalarField V, int32_t nCells, int32_t nInternalFaces)
-            : Sf_(Sf)
-            , owner_(owner)
-            , neighbour_(neighbour)
-            , V_(V)
-            , nCells_(nCells)
-            , nInternalFaces_(nInternalFaces){
+    unstructuredMesh(NeoFOAM::vectorField Sf, NeoFOAM::labelField owner, NeoFOAM::labelField neighbour, NeoFOAM::scalarField V, int32_t nCells, int32_t nInternalFaces)
+        : Sf_(Sf)
+        , owner_(owner)
+        , neighbour_(neighbour)
+        , V_(V)
+        , nCells_(nCells)
+        , nInternalFaces_(nInternalFaces){
 
-            };
+        };
 
-        vectorField Sf_; // area vector
+    vectorField Sf_; // area vector
 
-        labelField owner_;     // owner cell
-        labelField neighbour_; // neighbour cell
+    labelField owner_;     // owner cell
+    labelField neighbour_; // neighbour cell
 
-        scalarField V_; // cell volume
+    scalarField V_; // cell volume
 
-        int32_t nCells_; // number of cells
-        int32_t nInternalFaces_; // number of internal faces
-    };
+    int32_t nCells_; // number of cells
+    int32_t nInternalFaces_; // number of internal faces
+
+    kokkos::View<NeoFOAM::cellType*> cellTypes_; // cell types
+
+    localAdjacency<false> face_cell_;
+
+    localAdjacency<false> cell_vertex_;
+    localAdjacency<false> cellFace_boundary_;
+    
+    localAdjacency<true> cellCell;
+    localAdjacency<false> cellFace; 
+};
+
+void createUnstructuredConnectivity(const localAdjacency<false>& cell_vertex, const kokkos::View<NeoFOAM::cellType*>& cell_type) {
+    
+    // first invert the cell_vertex_ adjacency - reduces n^2 cell-cell connectivity construction to local (nlogn or something like it).
+    localAdjacency<false> vertex_cell = createVertexCellAdjacency(cell_vertex);
+
+    // create cell cell connectivity
+    createFaceCellAdjacency(vertex_cell, const kokkos::View<NeoFOAM::cellType*>& cell_type);
+    
+}
+
+localAdjacency<false> createVertexCellAdjacency(const localAdjacency<false>& cell_vertex){
+    return cell_vertex.transpose(); // need to make this still
+
+}
+
+// very inefficient algorithm, but it works. - we will search for cell - cell connection multiple times, even after we know there is no connection.
+localAdjacency<true> createFaceCellAdjacency(const localAdjacency<false>& vertex_cell, const localAdjacency<false>& cell_vertex, 
+                                             const kokkos::View<NeoFOAM::cellType*>& celltype) {
+    localAdjacency<true> cellCell;
+    cell_cell.resize(cell_type.size());
+
+    for(auto i_vertex = 0; i_vertex < vertex_cell.size(); ++i_vertex){
+        for(auto i_cell = 1; i_cell < vertex_cell[i_vertex].size(); ++i_cell){
+            
+            const auto& cell0 = vertex_cell(i_vertex)(i_cell - 1);
+            const auto& cell1 = vertex_cell(i_vertex)(i_cell);
+            if(cellCell.contains({cell0, cell1})) continue; // we already know this cell-cell connection exists.
+            CellGlobalFace cell0(cell_vertex(cell0), celltype(cell0));
+            CellGlobalFace cell1(cell_vertex(cell1), celltype(cell1));
+            if(CellShareFace(cell0, cell1)) cellCell.insert(cell0, cell1);
+        }
+    }
+
+
+    return cellCell;
+}
 
 } // namespace NeoFOAM

--- a/src/test/test_cellUtilities.cpp
+++ b/src/test/test_cellUtilities.cpp
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MPL-2.0
+// SPDX-FileCopyrightText: 2023 NeoFOAM authors
+
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+
+#include "NeoFOAM/blas/adjacency.hpp"
+
+TEST(cellUtities, isVertexFaceVertex) {
+    EXPECT_TRUE(false);
+}
+
+TEST(cellUtities, isFaceCellFace) {
+    EXPECT_TRUE(false);
+}
+
+TEST(cellUtities, CellShareFace) {
+    EXPECT_TRUE(false);
+}


### PR DESCRIPTION
_This branch should only be merged after the adjacency branch is merged (I have pulled that branch's history into this one)_

This is basically to set up some of the most basic and core parts of mesh data structures and pre-processing so that we can read/create and use it in the Gauss green gradient tests ASAP. Therefore boundaries are neglected presently, cell-centred only, not all connectivity and geometric data will be constructed, and algorithms will not be optimised for speed performance - most likely there will be n^2 operations floating around and no parallelizations have used.

I used the [gambit nuetral](https://web.stanford.edu/class/me469b/handouts/gambit_write.pdf) format to represent cell-vertex adjacency. I checked for some other formats (esp vtk due to conversations with @HenningScheufler), but ultimately I could either not find the 'face and edge' local connectivity information for the various cell types and/or the faces were not defined in a positively oriented manner when considering accending face index ordering (vtk) - perhaps with the tables done correctly this is not an issue. What is need is a format/library to use with similar tables to the above link. 

Ultimately this is all up for debate I am pretty open to any format/library, we can consider this a 'first baseline'. This can be changed easily for connectivity pre-processing since the process involves lookups to determine connections and these are abstracted away from the user. Geometry may be a little bit harder -> but at this early stage, will be easy to change. Finally, I am not 100% on how openFoam orders cells so this may all be a moot point, and we reimplement the same format here? 

The approach to unstructured mesh pre-processing (from my experience) should be broken into the following steps:
1. Read/create points/point cloud, cell-vertex, and cell-type data (primitive mesh) - later boundary data as well.
2. Connectivity setup, create all connectivity structures required by the mesh.
3. Geometry setup, compute volumes, face areas, normals etc.

Still to be completed
- [ ] testing
- [x] basic cell definitions
- [ ] minimum cell utilities (searches etc).
- [ ] cellCell adjacency
- [ ] faceCell adjacency
- [ ] cellFace adjacency
- [ ] face area + normal
- [ ] cell volume

The above will give the ability to compute non-boundary cell's gradients both through face looping and by cell looping.
