### PR TITLE
Enforce a consistent naming scheme

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,15 @@
+---
+Checks: "-*,readability-identifier-naming"
+CheckOptions:
+  - { key: readability-identifier-naming.ClassCase, value: CamelCase }
+  - { key: readability-identifier-naming.StructCase, value: CamelCase }
+  - { key: readability-identifier-naming.EnumCase, value: CamelCase }
+  - { key: readability-identifier-naming.UnionCase, value: CamelCase }
+  - { key: readability-identifier-naming.FunctionCase, value: camelBack }
+  - { key: readability-identifier-naming.VariableCase, value: camelBack }
+  - { key: readability-identifier-naming.ParameterCase, value: camelBack }
+FormatStyle: file
+WarningsAsErrors: ''
+HeaderFilterRegex: '.*/include/NeoFOAM/.*'
+InheritParentConfig: true
+User: user

--- a/.github/workflows/clang-tidy-check.yml
+++ b/.github/workflows/clang-tidy-check.yml
@@ -1,0 +1,59 @@
+name: Check clang-tidy
+run-name: Check clang-tidy
+
+on: push
+jobs:
+  clang-tidy-check:
+    name: Clang-tidy Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Add clang repo
+      run: |
+        sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main'
+        wget https://apt.llvm.org/llvm-snapshot.gpg.key
+        sudo apt-key add llvm-snapshot.gpg.key
+
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install \
+           ninja-build \
+           clang-16 \
+           clang-tidy-16 \
+           libomp-16-dev
+
+    - name: Create Compilation Database
+      run: |
+        cmake -S . -B build -G Ninja \
+              -DCMAKE_CXX_COMPILER=clang++-16 \
+              -DKokkos_ENABLE_SERIAL=ON \
+              -DKokkos_ENABLE_OPENMP=ON \
+              -DNEOFOAM_DEVEL_TOOLS=OFF \
+              -DNEOFOAM_BUILD_TESTS=ON \
+              -DNEOFOAM_BUILD_BENCHMARKS=ON \
+              -DNEOFOAM_BUILD_APPS=ON \
+              -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+    - name: Run clang-tidy
+      run: |
+        # Create list of .cpp files belonging to this repository
+        git ls-files | grep -E "\.(cpp)" > pattern
+        # Create list of .cpp files that are in this repository and part of the
+        # compilation database
+        # also filters out " at the begin and end of the filename
+        jq ".[] | .file" build/compile_commands.json \
+          | sed 's/^"\(.*\)"$/\1/' \
+          | grep -F -f pattern - > files
+        # run clang-tidy on all specified files
+        clang-tidy-16 --fix --extra-arg=-w -p build $(cat files)
+
+    - name: Check for fixes
+      run: |
+        if [[ $(git ls-files -m | wc -l) -eq 0 ]]; then
+          exit 0
+        fi
+        echo "There are fixes available from clang-tidy."
+        echo "Please use your local clang-tidy or apply the following patch:"
+        git diff -p
+        exit 1

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -31,7 +31,7 @@ Files: CMakePresets.json
 Copyright: 2023 NeoFOAM authors
 License: Unlicense
 
-Files: .clang-format
+Files: .clang-format .clang-tidy
 Copyright: 2023 NeoFOAM authors
 License: Unlicense
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Version 0.1.0 (unreleased)
+- Use clang-tidy check to enforce consistent naming scheme [#46](https://github.com/exasim-project/NeoFOAM/pull/46)
 - Added equality operators for executors [#45](https://github.com/exasim-project/NeoFOAM/pull/45)
 - Added pre-commit hooks, see [PR #38](https://github.com/exasim-project/NeoFOAM/pull/38)
 - Added CPM package manager [PR #37](https://github.com/exasim-project/NeoFOAM/pull/37)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,11 @@ if(NOT CMAKE_BUILD_TYPE)
       CACHE STRING "Choose the type of build." FORCE)
 endif()
 
+if(NOT DEFINED CMAKE_EXPORT_COMPILE_COMMANDS)
+  message(STATUS "Enabling generation of compilation database.")
+  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+endif()
+
 include(cmake/CxxThirdParty.cmake)
 include(cmake/PreventInSourceBuilds.cmake)
 include(cmake/StandardProjectSettings.cmake)


### PR DESCRIPTION
This PR adds a clang-tidy check to enforce a consistent naming scheme. Currently the scheme is defined as

- anything type related: CamelCase
- anything variable related: snake_case

Other ideas are up to discussion. The clang-tidy check can be adjusted quite a lot, for example different case for const varibles, global variables, abstract classes, etc. The full list can be found here: https://clang.llvm.org/extra/clang-tidy/checks/readability/identifier-naming.html#cmdoption-arg-AbstractClassCase

Right now this check is not enforced. It needs either IDE support (e.g. CLion has this out-of-the-box), or manual invocation. To run it manually do

```
clang-tidy -p /dir/containing/compile_commands.json FILE [FILES ...]
```

It requires to have the `compile_commands.json` available, which can be generated by CMake, by configuring it with `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`. IMO we should just always set this option, there is no downside to it.

I will also try to make it part of our git hooks.