### PR TITLE
Add a style guide section

### DIFF
--- a/.github/workflows/static_checks.yaml
+++ b/.github/workflows/static_checks.yaml
@@ -110,6 +110,7 @@ jobs:
         echo "Found $NTODOS TODO DONT MERGE notes"
         ! grep -q -r "TODO DONT MERGE" --exclude-dir=.github
   changelog:
+    if: ${{!contains(github.event.pull_request.labels.*.name, 'Skip-Changelog')}}
     name: Changelog check
     runs-on: ubuntu-latest
     steps:

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -6,24 +6,30 @@ Contributions are highly welcomed. Here is some information getting you started.
 NeoFOAM Code Style Guide
 """"""""""""""""""""""""
 
-To simplify coding and code reviews the following code style should be considered.
-Formatting and non-format related code style is enforced via clang-format and clang-tidy.
+To simplify coding and code reviews you should adhere to the following code style. However, most
+of NeoFOAMs code style guide is checked via automated tools.
+For example, formatting and non-format related code style is enforced via clang-format and clang-tidy.
 Corresponding configuration files are `.clang-format <https://exasim-project.com/NeoFOAM/.clang-format>`_
-`.clang-tidy <https://exasim-project.com/NeoFOAM/.clang-tidy>`_
+`.clang-tidy <https://exasim-project.com/NeoFOAM/.clang-tidy>`_.
+Furthermore, adequate licensing of the source code is checked via the reuse linter and typos checks for obvious spelling issues.
+Thus, this style guide doesn't list all stylistic rules explicitly but rather gives advise for ambiguous situations and mentions the rational for some decissions.
 
- * use US spelling
  * Use `camelCase` for functions and members and capitalized `CamelCase` for classes
  * Use descriptive template parameter names.
-   For example prefer `template <class ValueType>` over `template <class T>`
- * Use `[[nodiscard]]` except for getters. To indicate that a function simply
-   returns a value instead of performing expensice computations `[[nodiscard]]` can be omitted.
- * Use `final` except for abstract classes
+   For example prefer `template <class ValueType>` over `template <class T>` if the type can be a float or double.
+ * Use `[[nodiscard]]` except for getters.
+   To indicate that a function simply returns a value instead of performing expensive computations `[[nodiscard]]` can be omitted.
+ * Use `final` except for abstract classes.
+   NeoFOAMs aims at having a rather flat inheritance hierarchy and composition is generally preferred.
+   To avoid unintended inheritance the using `final` is advised.
  * Avoid storing references as data members in classes.
    An exception might be a `const Unstructured& mesh` as it will most likely outlive any other objects.
- * Place inout parameter at the end of function argument lists.
+ * Place in-out parameter at the end of function argument lists.
    E.g. `foo(const Type& in, Type& out)` instead of `foo(Type& out,const Type& in)`.
+ * use US spelling
 
 Folder structurce and file names:
+
  * use `camelCase` for files and folder names
  * the location of implementation and header files should be consistent.
    Ie. a file `src/model/a.cpp` should have a header file in `include/NeoFOAM/model/a.hpp` and corresponding test implementation in `test/model/a.cpp`

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -14,6 +14,7 @@ and `.clang-tidy <https://github.com/exasim-project/NeoFOAM/blob/main/.clang-for
 Furthermore, adequate licensing of the source code is checked via the reuse linter and typos checks for obvious spelling issues.
 Thus, this style guide doesn't list all stylistic rules explicitly but rather gives advise for ambiguous situations and mentions the rational for some decissions.
 
+ * We generally try to comply with the `C++ core guidelines <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines>_`.
  * Use `camelCase` for functions and members and capitalized `CamelCase` for classes
  * Use descriptive template parameter names.
    For example prefer `template <class ValueType>` over `template <class T>` if the type can be a float or double.

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -33,7 +33,25 @@ Folder structurce and file names:
  * use `camelCase` for files and folder names
  * the location of implementation and header files should be consistent.
    Ie. a file `src/model/a.cpp` should have a header file in `include/NeoFOAM/model/a.hpp` and corresponding test implementation in `test/model/a.cpp`
- * File and folder names should not be redundant.
+ * File and folder names should not be redundant. Ie. `finiteVolume/cellCentred/geometryModel/finiteVolumecellCentredgeometryModel.hpp` should be
+   `finiteVolume/cellCentred/geometryModel/model.hpp`.
+
+Collabortion via Pull Requests
+""""""""""""""""""""""""""""""
+
+If you want to contribute a specific feature or fix, please don't hesitate to open a PR. After creating the PR the following process is applied.
+
+ * Request a review by a given person or set the Ready-for-Review label.
+ * At least one (ideally two) approval(s) is required before the PR can be merged.
+ * Make sure that all required pipelines succeed.
+ * If you add a new feature or bug-fix, please add an entry to the `Changelog.md` file.
+   For pure refactor PRs the `Skip-Changelog` label can be set.
+ * If the PR should be merged in a specific order or if you don't have the permission to merge, add the `ready-to-merge` label.
+ * Before merging make sure to rebase your PR on to the latest state of `main`.
+ * Make sure to add yourself to the `Authors.md` file.
+ * To simplify the review process small to medium sized PRs are preferred.
+   If your PR exceeds 1000 lines of code changes consider to break the PR up into smaller PRs which can be merged via `stacked PRs <https://graphite.dev/blog/stacked-prs>`_.
+
 
 
 Building the Documentation

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -25,8 +25,8 @@ Thus, this style guide doesn't list all stylistic rules explicitly but rather gi
  * Avoid storing references as data members in classes.
    An exception might be a `const Unstructured& mesh` as it will most likely outlive any other objects.
  * Private member variables should be postfixed with `_`.
- * Place in-out parameter at the end of function argument lists.
-   E.g. `foo(const Type& in, Type& out)` instead of `foo(Type& out,const Type& in)`.
+ * Order of parameters to functions should be in, in-out, out.
+   E.g. `foo(const Type& in, Type& inOut, Type& out)` instead of `foo(Type& inOut,  Type& out, const Type& in)` or some other variation.
  * use US spelling
 
 Folder structurce and file names:

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -42,8 +42,10 @@ Collabortion via Pull Requests
 If you want to contribute a specific feature or fix, please don't hesitate to open a PR. After creating the PR the following process is applied.
 
  * Request a review by a given person or set the Ready-for-Review label.
- * At least one (ideally two) approval(s) is required before the PR can be merged.
+ * At least one (ideally two) approval(s) is/are required before a PR can be merged.
  * Make sure that all required pipelines succeed.
+ * If you add new features make sure to provide sufficent unit tests.
+   Also at some point before merging you can add the `full-ci` label to include build and tests on GPU hardware.
  * If you add a new feature or bug-fix, please add an entry to the `Changelog.md` file.
    For pure refactor PRs the `Skip-Changelog` label can be set.
  * If the PR should be merged in a specific order or if you don't have the permission to merge, add the `ready-to-merge` label.

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -9,8 +9,8 @@ NeoFOAM Code Style Guide
 To simplify coding and code reviews you should adhere to the following code style. However, most
 of NeoFOAMs code style guide is checked via automated tools.
 For example, formatting and non-format related code style is enforced via clang-format and clang-tidy.
-Corresponding configuration files are `.clang-format <https://exasim-project.com/NeoFOAM/.clang-format>`_
-`.clang-tidy <https://exasim-project.com/NeoFOAM/.clang-tidy>`_.
+Corresponding configuration files are `.clang-format <https://github.com/exasim-project/NeoFOAM/blob/main/.clang-format>`_
+and `.clang-tidy <https://github.com/exasim-project/NeoFOAM/blob/main/.clang-format/.clang-tidy>`_.
 Furthermore, adequate licensing of the source code is checked via the reuse linter and typos checks for obvious spelling issues.
 Thus, this style guide doesn't list all stylistic rules explicitly but rather gives advise for ambiguous situations and mentions the rational for some decissions.
 

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -21,9 +21,10 @@ Thus, this style guide doesn't list all stylistic rules explicitly but rather gi
    To indicate that a function simply returns a value instead of performing expensive computations `[[nodiscard]]` can be omitted.
  * Use `final` except for abstract classes.
    NeoFOAMs aims at having a rather flat inheritance hierarchy and composition is generally preferred.
-   To avoid unintended inheritance the using `final` is advised.
+   To avoid unintended inheritance the using final` is advised.
  * Avoid storing references as data members in classes.
    An exception might be a `const Unstructured& mesh` as it will most likely outlive any other objects.
+ * Private member variables should be postfixed with `_`.
  * Place in-out parameter at the end of function argument lists.
    E.g. `foo(const Type& in, Type& out)` instead of `foo(Type& out,const Type& in)`.
  * use US spelling
@@ -44,7 +45,7 @@ If you want to contribute a specific feature or fix, please don't hesitate to op
  * Request a review by a given person or set the Ready-for-Review label.
  * At least one (ideally two) approval(s) is/are required before a PR can be merged.
  * Make sure that all required pipelines succeed.
- * If you add new features make sure to provide sufficent unit tests.
+ * If you add new features make sure to provide sufficient unit tests.
    Also at some point before merging you can add the `full-ci` label to include build and tests on GPU hardware.
  * If you add a new feature or bug-fix, please add an entry to the `Changelog.md` file.
    For pure refactor PRs the `Skip-Changelog` label can be set.

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -6,12 +6,26 @@ Contributions are highly welcomed. Here is some information getting you started.
 NeoFOAM Code Style Guide
 """"""""""""""""""""""""
 
+To simplify coding and code reviews the following code style should be considered.
+Formatting and non-format related code style is enforced via clang-format and clang-tidy.
+Corresponding configuration files are `.clang-format <https://exasim-project.com/NeoFOAM/.clang-format>`_
+`.clang-tidy <https://exasim-project.com/NeoFOAM/.clang-tidy>`_
 
- * use `camelCase` for functions and members and capitalized `CamelCase` for classes
+ * use US spelling
+ * Use `camelCase` for functions and members and capitalized `CamelCase` for classes
+ * Use descriptive template parameter names.
+   For example prefer `template <class ValueType>` over `template <class T>`
+ * Use `[[nodiscard]]` except for getters. To indicate that a function simply
+   returns a value instead of performing expensice computations `[[nodiscard]]` can be omitted.
+ * Use `final` except for abstract classes
+ * Avoid storing references as data members in classes.
+   An exception might be a `const Unstructured& mesh` as it will most likely outlive any other objects.
+
+Folder structurce and file names:
  * use `camelCase` for files and folder names
- * use `[[nodiscard]]` except for getters
- * use `[[nodiscard]]` except for getters
- * use `final except` for abstract classes
+ * the location of implementation and header files should be consistent.
+   Ie. a file `src/model/a.cpp` should have a header file in `include/NeoFOAM/model/a.hpp` and corresponding test implementation in `test/model/a.cpp`
+ * File and folder names should not be redundant.
 
 
 Building the Documentation

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -20,6 +20,8 @@ Corresponding configuration files are `.clang-format <https://exasim-project.com
  * Use `final` except for abstract classes
  * Avoid storing references as data members in classes.
    An exception might be a `const Unstructured& mesh` as it will most likely outlive any other objects.
+ * Place inout parameter at the end of function argument lists.
+   E.g. `foo(const Type& in, Type& out)` instead of `foo(Type& out,const Type& in)`.
 
 Folder structurce and file names:
  * use `camelCase` for files and folder names

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -3,6 +3,17 @@ Contributing
 
 Contributions are highly welcomed. Here is some information getting you started.
 
+NeoFOAM Code Style Guide
+""""""""""""""""""""""""
+
+
+ * use `camelCase` for functions and members and capitalized `CamelCase` for classes
+ * use `camelCase` for files and folder names
+ * use `[[nodiscard]]` except for getters
+ * use `[[nodiscard]]` except for getters
+ * use `final except` for abstract classes
+
+
 Building the Documentation
 """"""""""""""""""""""""""
 


### PR DESCRIPTION
This PR adds a section to our documentation listing the defaults we agreed on.

Test build: https://exasim-project.com/NeoFOAM/Build_PR_73/contributing.html#neofoam-code-style-guide