### PR TITLE
compile class discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Version 0.1.0 (unreleased)
+- add compile time derived class discovery [#80](https://github.com/exasim-project/NeoFOAM/pull/80)
 - Basic introduction macros for console printouts to screen (Debug, Info, and Error), as well as assert checking and throwing [#63](https://github.com/exasim-project/NeoFOAM/pull/63)
 - Added boundaryField and domainField [#54](https://github.com/exasim-project/NeoFOAM/pull/54)
 - Basic implementation of an unstructuredMesh [#53](https://github.com/exasim-project/NeoFOAM/pull/53)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Version 0.1.0 (unreleased)
-- add compile time derived class discovery [#80](https://github.com/exasim-project/NeoFOAM/pull/80)
+- Add compile time derived class discovery [#80](https://github.com/exasim-project/NeoFOAM/pull/80)
 - Basic introduction macros for console printouts to screen (Debug, Info, and Error), as well as assert checking and throwing [#63](https://github.com/exasim-project/NeoFOAM/pull/63)
 - Added boundaryField and domainField [#54](https://github.com/exasim-project/NeoFOAM/pull/54)
 - Basic implementation of an unstructuredMesh [#53](https://github.com/exasim-project/NeoFOAM/pull/53)

--- a/doc/basics/index.rst
+++ b/doc/basics/index.rst
@@ -12,4 +12,5 @@ Basics
     containers.rst
     unstructuredMesh.rst
     dictionary.rst
+    registerclass.rst
     macros.rst

--- a/doc/basics/registerclass.rst
+++ b/doc/basics/registerclass.rst
@@ -86,7 +86,7 @@ We derive the base class from the ``TestBaseClassManager`` and define the interf
 
     };
 
-The derived classes will be registered using the ``registerClass`` function. The derived classes will implement the interface functions ``testString`` and ``testValue``. The ``create`` function will be used to instantiate the derived classes based on the name provided in the ``name`` function.
+The derived classes is registered using the ``registerClass`` function. The derived classes implements the interface functions ``testString`` and ``testValue``. The ``create`` function is used to instantiate the derived classes based on the name provided in the ``name`` function.
 
 .. code-block:: cpp
 

--- a/doc/basics/registerclass.rst
+++ b/doc/basics/registerclass.rst
@@ -26,7 +26,7 @@ Usage
 
 The following example shows how to use the ``RegisterClass`` and ``RegisterClassManager`` to automatically register derived classes. (details see ``test_RegisterClass.cpp``).
 
-To implement our design, we must first define a createFunction. This function will return a ``std::unique_ptr`` to a base class, taking an argument list that specifies the class interface. Following this, we'll establish a ``RegisterClassManager``. This manager will handle the registration and storage of all classes that have been registered.
+To implement this design, we must first define a createFunction. This function has to return a ``std::unique_ptr`` to its base class and taking an argument list  specified by the class interface. Furthemore, the ``RegisterClassManager`` handles the registration and storage of all classes that have been registered.
 
 .. code-block:: cpp
 

--- a/doc/basics/registerclass.rst
+++ b/doc/basics/registerclass.rst
@@ -122,7 +122,7 @@ The derived classes will be registered using the ``registerClass`` function. The
     };
 
 
-After the classes have been defined, we can use the ``create`` function to instantiate the derived classes based on the name provided.
+After the classes have been defined,  the ``create`` function can be used to instantiate the derived classes based on the name provided.
 
 .. code-block:: cpp
 

--- a/doc/basics/registerclass.rst
+++ b/doc/basics/registerclass.rst
@@ -1,0 +1,130 @@
+.. _basics_registerclass:
+
+Derived class discovery at compile time
+=======================================
+
+The ``RegisterClass`` class is a template class that allows to register derived class into a map to the can be instaniated from the base class similar to the OpenFOAM runtime mechanism. The classes at registered at compile time via static member initialization. Additional explanation can be found in the following links: `Ref1 <https://stackoverflow.com/questions/52354538/derived-class-discovery-at-compile-time>`_ `Ref2 <https://stackoverflow.com/questions/10332725/how-to-automatically-register-a-class-on-creation>`_ .
+
+This approach allows to create a plugin architecture where now derived class can be loaded at runtime and simplifies the runtime selection of a specific class. Now the derived classes can be created based on the name provided:
+
+.. code-block:: cpp
+
+    std::unique_ptr<baseClass> derivedClass =
+        baseClass::create("Name of derivedClass", "Additional arguments",...);
+
+
+.. doxygenclass:: NeoFOAM::RegisterClass
+   :members:
+
+The ``RegisterClassManager`` class is a template class that manages the registration of the derived classes and stores the map of the registered classes. The map associates a function with a string that is used to create the derived class.
+
+.. doxygenclass:: NeoFOAM::RegisterClassManager
+   :members:
+
+Usage
+^^^^^
+
+The following example shows how to use the ``RegisterClass`` and ``RegisterClassManager`` to automatically register derived classes. (details see ``test_RegsiterClass.cpp``).
+
+To implement our design, we must first define a createFunction. This function will return a ``std::unique_ptr`` to a base class, taking an argument list that specifies the class interface. Following this, we'll establish a ``RegisterClassManager``. This manager will handle the registration and storage of all classes that have been registered.
+
+.. code-block:: cpp
+
+    // forward declaration so we can use it to define the create function and the class manager
+    class TestBaseClass;
+
+    // define the create function use to instantiate the derived classes
+    using createFunc = std::function<std::unique_ptr<TestBaseClass>(std::string, double)>;
+
+    // define the class manager to register the classes
+    using TestBaseClassManager = NeoFOAM::RegisterClassManager<TestBaseClass, createFunc>;
+
+We derive the base class from the ``TestBaseClassManager`` and define the interface that the derived classes must implement. We also define a template alias ``TestBaseClassReg`` that will be used to register the derived classes. The ``create`` function will be used to instantiate the derived classes based on the name provided. The ``registerClass`` function will be used to register the derived classes. The derived classes will implement the interface functions ``testString`` and ``testValue``.
+
+.. code-block:: cpp
+
+    // interface that needs to be implemented by the derived classes
+    class TestBaseClass : public TestBaseClassManager
+    {
+    public:
+
+
+        template<typename derivedClass>
+        using TestBaseClassReg = NeoFOAM::RegisterClass<derivedClass, TestBaseClass, createFunc>;
+
+        // create function to instantiate the derived classes
+        static std::unique_ptr<TestBaseClass>
+        create(const std::string& name, std::string testString, double testValue)
+        {
+            try
+            {
+                auto func = classMap.at(name);
+                return func(testString, testValue);
+            }
+            catch (const std::out_of_range& e)
+            {
+                std::cerr << "Error: " << e.what() << std::endl;
+                return nullptr;
+            }
+        }
+
+
+        template<typename derivedClass>
+        bool registerClass()
+        {
+            return TestBaseClassReg<derivedClass>::reg;
+        }
+
+        virtual ~TestBaseClass() = default;
+
+        // interface that needs to be implemented by the derived classes
+        virtual std::string testString() = 0;
+
+        virtual double testValue() = 0;
+
+        // ...
+
+    };
+
+The derived classes will be registered using the ``registerClass`` function. The derived classes will implement the interface functions ``testString`` and ``testValue``. The ``create`` function will be used to instantiate the derived classes based on the name provided in the ``name`` function.
+
+.. code-block:: cpp
+
+    class TestDerivedClass : public TestBaseClass
+    {
+
+    public:
+
+        // the constructor is used to register the class
+        TestDerivedClass(std::string name, double test)
+            : TestBaseClass(), testString_(name), testValue_(test)
+        {
+            registerClass<TestDerivedClass>(); // register the class
+        }
+
+        // must be implemented by the derived classes to register the class
+        static std::unique_ptr<TestBaseClass> create(std::string name, double test)
+        {
+            return std::make_unique<TestDerivedClass>(name, test);
+        }
+
+        // must be implemented by the derived classes to register the class
+        static std::string name() { return "TestDerivedClass"; }
+
+        virtual std::string testString() override { return testString_; };
+
+        virtual double testValue() override { return testValue_; };
+
+    private:
+
+        std::string testString_;
+        double testValue_;
+    };
+
+
+After the classes have been defined, we can use the ``create`` function to instantiate the derived classes based on the name provided.
+
+.. code-block:: cpp
+
+    std::unique_ptr<TestBaseClass> testDerived =
+        TestBaseClass::create("TestDerivedClass", "FirstDerived", 1.0);

--- a/doc/basics/registerclass.rst
+++ b/doc/basics/registerclass.rst
@@ -1,9 +1,9 @@
-.. _basics_registerclass:
+.. _basics_RegisteredClass:
 
 Derived class discovery at compile time
 =======================================
 
-The ``RegisterClass`` class is a template class that allows to register derived classes into a map. This allows to instaniate derived classes from the base class by its name.  This mechanisem is similar to OpenFOAMs runtime selection mechanism. The classes are registered at compile time via static member initialization. Additional explanation can be found at: `here <https://stackoverflow.com/questions/52354538/derived-class-discovery-at-compile-time>`_ and  `here <https://stackoverflow.com/questions/10332725/how-to-automatically-register-a-class-on-creation>`_ .
+The ``RegisteredClass`` class is a template class that allows to register derived classes into a map. This allows to instaniate derived classes from the base class by its name.  This mechanisem is similar to OpenFOAMs runtime selection mechanism. The classes are registered at compile time via static member initialization. Additional explanation can be found at: `here <https://stackoverflow.com/questions/52354538/derived-class-discovery-at-compile-time>`_ and  `here <https://stackoverflow.com/questions/10332725/how-to-automatically-register-a-class-on-creation>`_ .
 
 This approach allows to create a plugin architecture where now a derived class can be loaded at runtime. Additionally, it simplifies the runtime selection of a specific class. The derived classes can be created by providing its  name, as shown below:
 
@@ -13,20 +13,20 @@ This approach allows to create a plugin architecture where now a derived class c
         baseClass::create("Name of derivedClass", "Additional arguments",...);
 
 
-.. doxygenclass:: NeoFOAM::RegisterClass
+.. doxygenclass:: NeoFOAM::RegisteredClass
    :members:
 
-The ``RegisterClassManager`` class is a template class that manages the registration of the derived classes and stores the map of the registered classes. The map associates a function with a string that is used to create the derived class.
+The ``BaseClassRegistry`` class is a template class that manages the registration of the derived classes and stores the map of the registered classes. The map associates a function with a string that is used to create the derived class.
 
-.. doxygenclass:: NeoFOAM::RegisterClassManager
+.. doxygenclass:: NeoFOAM::BaseClassRegistry
    :members:
 
 Usage
 ^^^^^
 
-The following example shows how to use the ``RegisterClass`` and ``RegisterClassManager`` to automatically register derived classes. (details see ``test_RegisterClass.cpp``).
+The following example shows how to use the ``RegisteredClass`` and ``BaseClassRegistry`` to automatically register derived classes. (details see ``test_RegisterClass.cpp``).
 
-To implement this design, we must first define a createFunction. This function has to return a ``std::unique_ptr`` to its base class and taking an argument list  specified by the class interface. Furthemore, the ``RegisterClassManager`` handles the registration and storage of all classes that have been registered.
+To implement this design, we must first define a createFunction. This function has to return a ``std::unique_ptr`` to its base class and taking an argument list  specified by the class interface. Furthemore, the ``BaseClassRegistry`` handles the registration and storage of all classes that have been registered.
 
 .. code-block:: cpp
 
@@ -37,9 +37,9 @@ To implement this design, we must first define a createFunction. This function h
     using createFunc = std::function<std::unique_ptr<TestBaseClass>(std::string, double)>;
 
     // define the class manager to register the classes
-    using TestBaseClassManager = NeoFOAM::RegisterClassManager<TestBaseClass, createFunc>;
+    using TestBaseClassManager = NeoFOAM::BaseClassRegistry<TestBaseClass, createFunc>;
 
-We derive the base class from the ``TestBaseClassManager`` and define the interface that the derived classes must implement. We also define a template alias ``TestBaseClassReg`` that will be used to register the derived classes. The ``create`` function will be used to instantiate the derived classes based on the name provided. The ``registerClass`` function will be used to register the derived classes. The derived classes will implement the interface functions ``testString`` and ``testValue``.
+We derive the base class from the ``TestBaseClassManager`` and define the interface that the derived classes must implement. We also define a template alias ``TestBaseClassReg`` that will be used to register the derived classes. The ``create`` function will be used to instantiate the derived classes based on the name provided. The ``RegisteredClass`` function will be used to register the derived classes. The derived classes will implement the interface functions ``testString`` and ``testValue``.
 
 .. code-block:: cpp
 
@@ -50,7 +50,7 @@ We derive the base class from the ``TestBaseClassManager`` and define the interf
 
 
         template<typename derivedClass>
-        using TestBaseClassReg = NeoFOAM::RegisterClass<derivedClass, TestBaseClass, createFunc>;
+        using TestBaseClassReg = NeoFOAM::RegisteredClass<derivedClass, TestBaseClass, createFunc>;
 
         // create function to instantiate the derived classes
         static std::unique_ptr<TestBaseClass>
@@ -86,7 +86,7 @@ We derive the base class from the ``TestBaseClassManager`` and define the interf
 
     };
 
-The derived classes is registered using the ``registerClass`` function. The derived classes implements the interface functions ``testString`` and ``testValue``. The ``create`` function is used to instantiate the derived classes based on the name provided in the ``name`` function.
+The derived classes is registered using the ``RegisteredClass`` function. The derived classes implements the interface functions ``testString`` and ``testValue``. The ``create`` function is used to instantiate the derived classes based on the name provided in the ``name`` function.
 
 .. code-block:: cpp
 

--- a/doc/basics/registerclass.rst
+++ b/doc/basics/registerclass.rst
@@ -24,7 +24,7 @@ The ``RegisterClassManager`` class is a template class that manages the registra
 Usage
 ^^^^^
 
-The following example shows how to use the ``RegisterClass`` and ``RegisterClassManager`` to automatically register derived classes. (details see ``test_RegsiterClass.cpp``).
+The following example shows how to use the ``RegisterClass`` and ``RegisterClassManager`` to automatically register derived classes. (details see ``test_RegisterClass.cpp``).
 
 To implement our design, we must first define a createFunction. This function will return a ``std::unique_ptr`` to a base class, taking an argument list that specifies the class interface. Following this, we'll establish a ``RegisterClassManager``. This manager will handle the registration and storage of all classes that have been registered.
 

--- a/doc/basics/registerclass.rst
+++ b/doc/basics/registerclass.rst
@@ -3,7 +3,7 @@
 Derived class discovery at compile time
 =======================================
 
-The ``RegisterClass`` class is a template class that allows to register derived class into a map to the can be instaniated from the base class similar to the OpenFOAM runtime mechanism. The classes at registered at compile time via static member initialization. Additional explanation can be found in the following links: `Ref1 <https://stackoverflow.com/questions/52354538/derived-class-discovery-at-compile-time>`_ `Ref2 <https://stackoverflow.com/questions/10332725/how-to-automatically-register-a-class-on-creation>`_ .
+The ``RegisterClass`` class is a template class that allows to register derived classes into a map. This allows to instaniate derived classes from the base class by its name.  This mechanisem is similar to OpenFOAMs runtime selection mechanism. The classes are registered at compile time via static member initialization. Additional explanation can be found at: `here <https://stackoverflow.com/questions/52354538/derived-class-discovery-at-compile-time>`_ and  `here <https://stackoverflow.com/questions/10332725/how-to-automatically-register-a-class-on-creation>`_ .
 
 This approach allows to create a plugin architecture where now derived class can be loaded at runtime and simplifies the runtime selection of a specific class. Now the derived classes can be created based on the name provided:
 

--- a/doc/basics/registerclass.rst
+++ b/doc/basics/registerclass.rst
@@ -5,7 +5,7 @@ Derived class discovery at compile time
 
 The ``RegisterClass`` class is a template class that allows to register derived classes into a map. This allows to instaniate derived classes from the base class by its name.  This mechanisem is similar to OpenFOAMs runtime selection mechanism. The classes are registered at compile time via static member initialization. Additional explanation can be found at: `here <https://stackoverflow.com/questions/52354538/derived-class-discovery-at-compile-time>`_ and  `here <https://stackoverflow.com/questions/10332725/how-to-automatically-register-a-class-on-creation>`_ .
 
-This approach allows to create a plugin architecture where now derived class can be loaded at runtime and simplifies the runtime selection of a specific class. Now the derived classes can be created based on the name provided:
+This approach allows to create a plugin architecture where now a derived class can be loaded at runtime. Additionally, it simplifies the runtime selection of a specific class. The derived classes can be created by providing its  name, as shown below:
 
 .. code-block:: cpp
 

--- a/include/NeoFOAM/core/registerClass.hpp
+++ b/include/NeoFOAM/core/registerClass.hpp
@@ -11,13 +11,13 @@ namespace NeoFOAM
 
 
 template<typename baseClass, typename... Args>
-struct registerClassManager
+struct RegisterClassManager
 {
     using createFunction = std::function<std::unique_ptr<baseClass>(Args... args)>;
 
     static bool registerClass(const std::string name, createFunction funcCreate)
     {
-        auto result = s_methods.insert({name, funcCreate});
+        auto result = classMap_.insert({name, funcCreate});
         if (!result.second)
         {
             throw std::runtime_error("Insertion failed: Key already exists.");
@@ -29,7 +29,7 @@ struct registerClassManager
     {
         try
         {
-            auto func = s_methods.at(name);
+            auto func = classMap_.at(name);
             return func(args...);
         }
         catch (const std::out_of_range& e)
@@ -39,24 +39,24 @@ struct registerClassManager
         }
     }
 
-    static inline std::unordered_map<std::string, createFunction> s_methods;
+    static inline std::unordered_map<std::string, createFunction> classMap_;
 
 protected:
 };
 
 
 template<typename derivedClass, typename baseClass, typename... Args>
-struct registerClass
+struct RegisterClass
 {
 
     using createFunction = std::function<std::unique_ptr<baseClass>(Args... args)>;
-    registerClass() { reg; };
+    RegisterClass() { reg; };
 
     static bool reg;
 
     static bool init()
     {
-        registerClassManager<baseClass, Args...>::registerClass(
+        RegisterClassManager<baseClass, Args...>::registerClass(
             derivedClass::name(), derivedClass::create
         );
         return true;
@@ -64,7 +64,7 @@ struct registerClass
 };
 
 template<typename derivedClass, typename baseClass, typename... Args>
-bool NeoFOAM::registerClass<derivedClass, baseClass, Args...>::reg =
-    NeoFOAM::registerClass<derivedClass, baseClass, Args...>::init();
+bool NeoFOAM::RegisterClass<derivedClass, baseClass, Args...>::reg =
+    NeoFOAM::RegisterClass<derivedClass, baseClass, Args...>::init();
 
 } // namespace NeoFOAM

--- a/include/NeoFOAM/core/registerClass.hpp
+++ b/include/NeoFOAM/core/registerClass.hpp
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2024 NeoFOAM authors
+
+#pragma once
+
+#include <functional>
+#include <iostream>
+
+namespace NeoFOAM
+{
+
+
+template<typename baseClass, typename... Args>
+struct registerClassManager
+{
+    using createFunction = std::function<std::unique_ptr<baseClass>(Args... args)>;
+
+    static bool registerClass(const std::string name, createFunction funcCreate)
+    {
+        auto result = s_methods.insert({name, funcCreate});
+        if (!result.second)
+        {
+            throw std::runtime_error("Insertion failed: Key already exists.");
+        }
+        return result.second;
+    }
+
+    // static std::unique_ptr<baseClass> Create()
+    static std::unique_ptr<baseClass> Create(const std::string& name, Args... args)
+    {
+        try
+        {
+            auto func = s_methods.at(name);
+            return func(args...);
+        }
+        catch (const std::out_of_range& e)
+        {
+            std::cerr << "Error: " << e.what() << std::endl;
+            return nullptr;
+        }
+    }
+
+    static inline std::unordered_map<std::string, createFunction> s_methods;
+
+protected:
+};
+
+
+// template <typename baseClass, typename... Args>
+// bool registerClass<baseClass, Args...>::reg = registerClassManager<baseClass, Args...>::init();
+
+// template< typename derivedClass, typename baseClass>
+template<typename derivedClass, typename baseClass, typename... Args>
+struct registerClass
+{
+
+    using createFunction = std::function<std::unique_ptr<baseClass>(Args... args)>;
+    registerClass() { reg; };
+
+    // virtual std::string name() = 0;
+
+    static bool reg;
+    static bool init()
+    {
+        // derivedClass t;
+        // registerClassManager<baseClass, Args..>::registerClass(derivedClass::name(), [](Args...
+        // args) { return std::make_unique<derivedClass>(Args... args); });
+        // decltype(registerClassManager<baseClass, Args...>::Create) funcCreate = [](Args... args)
+        // { return std::make_unique<derivedClass>(args...); };
+        // std::function<std::unique_ptr<baseClass>(Args... args)> funcCreate2 = [](Args... args) {
+        // return std::make_unique<derivedClass>(Args... args); }; registerClassManager<baseClass,
+        // Args...>::createFunction funcCreate;
+        //  = [](Args... args) { return std::make_unique<derivedClass>(Args... args); };
+        registerClassManager<baseClass, Args...>::registerClass(
+            derivedClass::name(), derivedClass::create
+        ); //, [](Args... args) { return std::make_unique<derivedClass>(args...); });
+        // registerClassManager<baseClass>::registerClass(derivedClass::name());
+        return true;
+    }
+};
+
+template<typename derivedClass, typename baseClass, typename... Args>
+bool NeoFOAM::registerClass<derivedClass, baseClass, Args...>::reg =
+    NeoFOAM::registerClass<derivedClass, baseClass, Args...>::init();
+
+} // namespace NeoFOAM

--- a/include/NeoFOAM/core/registerClass.hpp
+++ b/include/NeoFOAM/core/registerClass.hpp
@@ -25,7 +25,6 @@ struct registerClassManager
         return result.second;
     }
 
-    // static std::unique_ptr<baseClass> Create()
     static std::unique_ptr<baseClass> Create(const std::string& name, Args... args)
     {
         try
@@ -46,10 +45,6 @@ protected:
 };
 
 
-// template <typename baseClass, typename... Args>
-// bool registerClass<baseClass, Args...>::reg = registerClassManager<baseClass, Args...>::init();
-
-// template< typename derivedClass, typename baseClass>
 template<typename derivedClass, typename baseClass, typename... Args>
 struct registerClass
 {
@@ -62,19 +57,10 @@ struct registerClass
     static bool reg;
     static bool init()
     {
-        // derivedClass t;
-        // registerClassManager<baseClass, Args..>::registerClass(derivedClass::name(), [](Args...
-        // args) { return std::make_unique<derivedClass>(Args... args); });
-        // decltype(registerClassManager<baseClass, Args...>::Create) funcCreate = [](Args... args)
-        // { return std::make_unique<derivedClass>(args...); };
-        // std::function<std::unique_ptr<baseClass>(Args... args)> funcCreate2 = [](Args... args) {
-        // return std::make_unique<derivedClass>(Args... args); }; registerClassManager<baseClass,
-        // Args...>::createFunction funcCreate;
-        //  = [](Args... args) { return std::make_unique<derivedClass>(Args... args); };
+
         registerClassManager<baseClass, Args...>::registerClass(
             derivedClass::name(), derivedClass::create
-        ); //, [](Args... args) { return std::make_unique<derivedClass>(args...); });
-        // registerClassManager<baseClass>::registerClass(derivedClass::name());
+        );
         return true;
     }
 };

--- a/include/NeoFOAM/core/registerClass.hpp
+++ b/include/NeoFOAM/core/registerClass.hpp
@@ -67,7 +67,7 @@ public:
      *
      * @return The number of registered classes.
      */
-    static size_t size() { return classMap.size(); }
+    static size_t size() const { return classMap.size(); }
 
     /**
      * @brief A container that maps strings to create functions.

--- a/include/NeoFOAM/core/registerClass.hpp
+++ b/include/NeoFOAM/core/registerClass.hpp
@@ -101,7 +101,7 @@ public:
      *
      * reg needs to be called in the constructor to ensure that the class is registered.
      */
-    RegisterClass() { reg; };
+    RegisterClass() { reg; }
 
     /**
      * @brief Static flag indicating if the class has been registered.

--- a/include/NeoFOAM/core/registerClass.hpp
+++ b/include/NeoFOAM/core/registerClass.hpp
@@ -39,7 +39,7 @@ concept StdFunction = is_std_function<T>::value;
  * @tparam CreateFunction The type of the create function.
  */
 template<typename baseClass, StdFunction CreateFunction>
-class RegisterClassManager // needs to be a class otherwise breathe will not document it
+class BaseClassRegistry // needs to be a class otherwise breathe will not document it
 {
 public:
 
@@ -92,16 +92,20 @@ public:
  * @tparam CreateFunction The function pointer type for creating an instance of the derived class.
  */
 template<typename derivedClass, typename baseClass, StdFunction CreateFunction>
-class RegisterClass
+class RegisteredClass
 {
 public:
 
     /**
-     * @brief Constructor for the RegisterClass struct.
+     * @brief Constructor for the RegisteredClass struct.
      *
      * reg needs to be called in the constructor to ensure that the class is registered.
      */
-    RegisterClass() { reg; }
+    RegisteredClass()
+    {
+        bool store = reg; // force the initialization of the static variable
+        // store in bool to avoid warning
+    };
 
     /**
      * @brief Static flag indicating if the class has been registered.
@@ -112,14 +116,14 @@ public:
      * @brief Initializes the registration of the derived class with the base class.
      *
      * This function registers the derived class with the base class by calling the
-     * RegisterClassManager::registerClass() function with the derived class's name and
+     * BaseClassRegistry::registerClass() function with the derived class's name and
      * create function.
      *
      * @return True if the registration is successful, false otherwise.
      */
     static bool init()
     {
-        RegisterClassManager<baseClass, CreateFunction>::registerClass(
+        BaseClassRegistry<baseClass, CreateFunction>::registerClass(
             derivedClass::name(), derivedClass::create
         );
         return true;
@@ -139,7 +143,7 @@ public:
  * @tparam CreateFunction The function pointer type for creating an instance of the derived class.
  */
 template<typename derivedClass, typename baseClass, StdFunction CreateFunction>
-bool NeoFOAM::RegisterClass<derivedClass, baseClass, CreateFunction>::reg =
-    NeoFOAM::RegisterClass<derivedClass, baseClass, CreateFunction>::init();
+bool NeoFOAM::RegisteredClass<derivedClass, baseClass, CreateFunction>::reg =
+    NeoFOAM::RegisteredClass<derivedClass, baseClass, CreateFunction>::init();
 
 } // namespace NeoFOAM

--- a/include/NeoFOAM/core/registerClass.hpp
+++ b/include/NeoFOAM/core/registerClass.hpp
@@ -17,7 +17,7 @@ struct RegisterClassManager
 
     static bool registerClass(const std::string name, createFunction funcCreate)
     {
-        auto result = classMap_.insert({name, funcCreate});
+        auto result = classMap.insert({name, funcCreate});
         if (!result.second)
         {
             throw std::runtime_error("Insertion failed: Key already exists.");
@@ -25,11 +25,11 @@ struct RegisterClassManager
         return result.second;
     }
 
-    static std::unique_ptr<baseClass> Create(const std::string& name, Args... args)
+    static std::unique_ptr<baseClass> create(const std::string& name, Args... args)
     {
         try
         {
-            auto func = classMap_.at(name);
+            auto func = classMap.at(name);
             return func(args...);
         }
         catch (const std::out_of_range& e)
@@ -39,7 +39,7 @@ struct RegisterClassManager
         }
     }
 
-    static inline std::unordered_map<std::string, createFunction> classMap_;
+    static inline std::unordered_map<std::string, createFunction> classMap;
 
 protected:
 };

--- a/include/NeoFOAM/core/registerClass.hpp
+++ b/include/NeoFOAM/core/registerClass.hpp
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2024 NeoFOAM authors
 
+// additional information see:
+// https://stackoverflow.com/questions/52354538/derived-class-discovery-at-compile-time
+// https://stackoverflow.com/questions/10332725/how-to-automatically-register-a-class-on-creation
+
 #pragma once
 
 #include <functional>
@@ -9,15 +13,48 @@
 namespace NeoFOAM
 {
 
-
-template<typename baseClass, typename... Args>
-struct RegisterClassManager
+// Type trait to check if a type is a std::function
+template<typename T>
+struct is_std_function : std::false_type
 {
-    using createFunction = std::function<std::unique_ptr<baseClass>(Args... args)>;
+};
 
-    static bool registerClass(const std::string name, createFunction funcCreate)
+template<typename Ret, typename... Args>
+struct is_std_function<std::function<Ret(Args...)>> : std::true_type
+{
+};
+
+// Concept that uses the type trait
+template<typename T>
+concept StdFunction = is_std_function<T>::value;
+
+/**
+ * @brief Template struct for managing class registration.
+ *
+ * This struct provides a mechanism for registering classes with a given base class and a create
+ * function. It maintains a map of class names to create functions, allowing for dynamic class
+ * instantiation.
+ *
+ * @tparam baseClass The base class type.
+ * @tparam CreateFunction The type of the create function.
+ */
+template<typename baseClass, StdFunction CreateFunction>
+class RegisterClassManager // needs to be a class otherwise breathe will not document it
+{
+public:
+
+    /**
+     * @brief Registers a class with the given name and create function.
+     *
+     * @param name The name of the class.
+     * @param createFunc The create function for the class.
+     * @return true if the class was successfully registered, false if the class name already exists
+     * in the map.
+     * @throws std::runtime_error if the class name already exists in the map.
+     */
+    static bool registerClass(const std::string name, CreateFunction createFunc)
     {
-        auto result = classMap.insert({name, funcCreate});
+        auto result = classMap.insert({name, createFunc});
         if (!result.second)
         {
             throw std::runtime_error("Insertion failed: Key already exists.");
@@ -25,45 +62,84 @@ struct RegisterClassManager
         return result.second;
     }
 
-    static std::unique_ptr<baseClass> create(const std::string& name, Args... args)
-    {
-        try
-        {
-            auto func = classMap.at(name);
-            return func(args...);
-        }
-        catch (const std::out_of_range& e)
-        {
-            std::cerr << "Error: " << e.what() << std::endl;
-            return nullptr;
-        }
-    }
+    /**
+     * @brief Gets the number of registered classes.
+     *
+     * @return The number of registered classes.
+     */
+    static size_t size() { return classMap.size(); }
 
-    static inline std::unordered_map<std::string, createFunction> classMap;
-
+    /**
+     * @brief A container that maps strings to create functions.
+     *
+     * This unordered map is used to store a mapping between strings and create functions.
+     * The keys are strings, and the values are functions that create objects
+     *
+     * @tparam Key The type of the keys in the map (std::string).
+     * @tparam T The type of the values in the map (CreateFunction)
+     */
+    static inline std::unordered_map<std::string, CreateFunction> classMap;
 };
 
 
-template<typename derivedClass, typename baseClass, typename... Args>
-struct RegisterClass
+/**
+ * @brief Template struct for registering a derived class with a base class.
+ *
+ * This struct provides a mechanism for registering a derived class with a base class.
+ *
+ * @tparam derivedClass The derived class to be registered.
+ * @tparam baseClass The base class that the derived class inherits from.
+ * @tparam CreateFunction The function pointer type for creating an instance of the derived class.
+ */
+template<typename derivedClass, typename baseClass, StdFunction CreateFunction>
+class RegisterClass
 {
+public:
 
-    using createFunction = std::function<std::unique_ptr<baseClass>(Args... args)>;
+    /**
+     * @brief Constructor for the RegisterClass struct.
+     *
+     * reg needs to be called in the constructor to ensure that the class is registered.
+     */
     RegisterClass() { reg; };
 
+    /**
+     * @brief Static flag indicating if the class has been registered.
+     */
     static bool reg;
 
+    /**
+     * @brief Initializes the registration of the derived class with the base class.
+     *
+     * This function registers the derived class with the base class by calling the
+     * RegisterClassManager::registerClass() function with the derived class's name and
+     * create function.
+     *
+     * @return True if the registration is successful, false otherwise.
+     */
     static bool init()
     {
-        RegisterClassManager<baseClass, Args...>::registerClass(
+        RegisterClassManager<baseClass, CreateFunction>::registerClass(
             derivedClass::name(), derivedClass::create
         );
         return true;
     }
 };
 
-template<typename derivedClass, typename baseClass, typename... Args>
-bool NeoFOAM::RegisterClass<derivedClass, baseClass, Args...>::reg =
-    NeoFOAM::RegisterClass<derivedClass, baseClass, Args...>::init();
+
+/**
+ * @brief Template specialization for registering a derived class with a base class in NeoFOAM.
+ *
+ * This template class is used to register a derived class with a base class in NeoFOAM.
+ * It provides a static member variable `reg` which is initialized to `true` when the class is
+ * instantiated
+ *
+ * @tparam derivedClass The derived class to be registered.
+ * @tparam baseClass The base class with which the derived class is registered.
+ * @tparam CreateFunction The function pointer type for creating an instance of the derived class.
+ */
+template<typename derivedClass, typename baseClass, StdFunction CreateFunction>
+bool NeoFOAM::RegisterClass<derivedClass, baseClass, CreateFunction>::reg =
+    NeoFOAM::RegisterClass<derivedClass, baseClass, CreateFunction>::init();
 
 } // namespace NeoFOAM

--- a/include/NeoFOAM/core/registerClass.hpp
+++ b/include/NeoFOAM/core/registerClass.hpp
@@ -41,7 +41,6 @@ struct RegisterClassManager
 
     static inline std::unordered_map<std::string, createFunction> classMap;
 
-protected:
 };
 
 

--- a/include/NeoFOAM/core/registerClass.hpp
+++ b/include/NeoFOAM/core/registerClass.hpp
@@ -52,12 +52,10 @@ struct registerClass
     using createFunction = std::function<std::unique_ptr<baseClass>(Args... args)>;
     registerClass() { reg; };
 
-    // virtual std::string name() = 0;
-
     static bool reg;
+
     static bool init()
     {
-
         registerClassManager<baseClass, Args...>::registerClass(
             derivedClass::name(), derivedClass::create
         );

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -14,4 +14,4 @@ target_link_libraries(test_executor PRIVATE Catch2::Catch2 NeoFOAM
 add_test(NAME registerClass_test COMMAND test_registerClass)
 add_executable(test_registerClass "test_RegisterClass.cpp" "../test_main.cpp")
 target_link_libraries(test_registerClass PRIVATE Catch2::Catch2 NeoFOAM
-                                                 Kokkos::kokkos)
+                                                  cpptrace::cpptrace Kokkos::kokkos)

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -10,3 +10,8 @@ add_test(NAME executor_test COMMAND test_executor)
 add_executable(test_executor "test_Executor.cpp" "../test_main.cpp")
 target_link_libraries(test_executor PRIVATE Catch2::Catch2 NeoFOAM
                                             Kokkos::kokkos)
+
+add_test(NAME registerClass_test COMMAND test_registerClass)
+add_executable(test_registerClass "test_RegisterClass.cpp" "../test_main.cpp")
+target_link_libraries(test_registerClass PRIVATE Catch2::Catch2 NeoFOAM
+                                                 Kokkos::kokkos)

--- a/test/core/test_RegisterClass.cpp
+++ b/test/core/test_RegisterClass.cpp
@@ -105,14 +105,14 @@ TEST_CASE("Register Class")
     REQUIRE(TestBaseClass::size() == 2);
 
     std::unique_ptr<TestBaseClass> testDerived =
-        TestBaseClass::regTestBaseClass::Create("TestDerivedClass", "FirstDerived", 1.0);
+        TestBaseClass::regTestBaseClass::create("TestDerivedClass", "FirstDerived", 1.0);
     std::cout << "TestBaseClass testValue: " << testDerived->testValue() << std::endl;
     std::cout << "TestBaseClass testString: " << testDerived->testString() << std::endl;
     REQUIRE(testDerived->testString() == "FirstDerived");
     REQUIRE(testDerived->testValue() == 1.0);
 
     std::unique_ptr<TestBaseClass> testDerived2 =
-        TestBaseClass::regTestBaseClass::Create("TestDerivedClass2", "SecondDerived", 1.0);
+        TestBaseClass::regTestBaseClass::create("TestDerivedClass2", "SecondDerived", 1.0);
 
     std::cout << "TestBaseClass testValue: " << testDerived2->testValue() << std::endl;
     std::cout << "TestBaseClass testString: " << testDerived2->testString() << std::endl;

--- a/test/core/test_RegisterClass.cpp
+++ b/test/core/test_RegisterClass.cpp
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2024 NeoFOAM authors
+
+#define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
+                            // a custom main
+#include <catch2/catch_session.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators_adapters.hpp>
+#include "NeoFOAM/core/registerClass.hpp"
+#include "NeoFOAM/core/dictionary.hpp"
+#include <iostream>
+
+
+class TestBaseClass
+{
+public:
+
+    // entries required runtime discovery
+    using regTestBaseClass = NeoFOAM::registerClassManager<TestBaseClass, std::string, double>;
+
+    template<typename derivedClass>
+    using TestBaseClassReg =
+        NeoFOAM::registerClass<derivedClass, TestBaseClass, std::string, double>;
+
+    template<typename derivedClass>
+    void registerClass()
+    {
+        TestBaseClassReg<derivedClass> reg;
+    }
+
+    static int size() { return regTestBaseClass::s_methods.size(); }
+
+    // standard base class entries
+    virtual ~TestBaseClass() = default;
+
+    virtual std::string testString() = 0;
+
+    virtual double testValue() = 0;
+
+
+private:
+};
+
+
+class TestDerivedClass : public TestBaseClass
+{
+
+public:
+
+    TestDerivedClass(std::string name, double test)
+        : TestBaseClass(), testString_(name), testValue_(test)
+    {
+        registerClass<TestDerivedClass>();
+    }
+
+    static std::unique_ptr<TestBaseClass> create(std::string name, double test)
+    {
+        return std::make_unique<TestDerivedClass>(name, test);
+    }
+
+    static std::string name() { return "TestDerivedClass"; }
+
+    virtual std::string testString() override { return testString_; };
+
+    virtual double testValue() override { return testValue_; };
+
+private:
+
+    std::string testString_;
+    double testValue_;
+};
+
+class TestDerivedClass2 : public TestBaseClass
+{
+
+public:
+
+    TestDerivedClass2(std::string name, double test)
+        : TestBaseClass(), testString_(name), testValue_(test)
+    {
+        registerClass<TestDerivedClass2>();
+    }
+
+    static std::unique_ptr<TestBaseClass> create(std::string name, double test)
+    {
+        return std::make_unique<TestDerivedClass2>(name, test);
+    }
+
+    static std::string name() { return "TestDerivedClass2"; }
+
+    virtual std::string testString() override { return testString_; };
+
+    virtual double testValue() override { return testValue_ * 2; };
+
+private:
+
+    std::string testString_;
+    double testValue_;
+};
+
+
+TEST_CASE("Register Class")
+{
+    std::cout << "Number of registered classes: " << TestBaseClass::size() << std::endl;
+    REQUIRE(TestBaseClass::size() == 2);
+
+    std::unique_ptr<TestBaseClass> testDerived =
+        TestBaseClass::regTestBaseClass::Create("TestDerivedClass", "FirstDerived", 1.0);
+    std::cout << "TestBaseClass testValue: " << testDerived->testValue() << std::endl;
+    std::cout << "TestBaseClass testString: " << testDerived->testString() << std::endl;
+    REQUIRE(testDerived->testString() == "FirstDerived");
+    REQUIRE(testDerived->testValue() == 1.0);
+
+    std::unique_ptr<TestBaseClass> testDerived2 =
+        TestBaseClass::regTestBaseClass::Create("TestDerivedClass2", "SecondDerived", 1.0);
+
+    std::cout << "TestBaseClass testValue: " << testDerived2->testValue() << std::endl;
+    std::cout << "TestBaseClass testString: " << testDerived2->testString() << std::endl;
+    REQUIRE(testDerived2->testString() == "SecondDerived");
+    REQUIRE(testDerived2->testValue() == 2.0);
+}

--- a/test/core/test_RegisterClass.cpp
+++ b/test/core/test_RegisterClass.cpp
@@ -17,7 +17,7 @@ class TestBaseClass;
 using createFunc = std::function<std::unique_ptr<TestBaseClass>(std::string, double)>;
 
 // define the class manager to register the classes
-using TestBaseClassManager = NeoFOAM::RegisterClassManager<TestBaseClass, createFunc>;
+using TestBaseClassManager = NeoFOAM::BaseClassRegistry<TestBaseClass, createFunc>;
 
 
 class TestBaseClass : public TestBaseClassManager
@@ -26,7 +26,7 @@ public:
 
 
     template<typename derivedClass>
-    using TestBaseClassReg = NeoFOAM::RegisterClass<derivedClass, TestBaseClass, createFunc>;
+    using TestBaseClassReg = NeoFOAM::RegisteredClass<derivedClass, TestBaseClass, createFunc>;
 
     static std::unique_ptr<TestBaseClass>
     create(const std::string& name, std::string testString, double testValue)

--- a/test/core/test_RegisterClass.cpp
+++ b/test/core/test_RegisterClass.cpp
@@ -117,5 +117,7 @@ TEST_CASE("Register Class")
     std::cout << "TestBaseClass testValue: " << testDerived2->testValue() << std::endl;
     std::cout << "TestBaseClass testString: " << testDerived2->testString() << std::endl;
     REQUIRE(testDerived2->testString() == "SecondDerived");
-    REQUIRE(testDerived2->testValue() == 2.0);
+    REQUIRE(
+        testDerived2->testValue() == 2.0
+    ); // multiplied by 2 (see implementation of TestDerivedClass2)
 }

--- a/test/core/test_RegisterClass.cpp
+++ b/test/core/test_RegisterClass.cpp
@@ -38,7 +38,6 @@ public:
     virtual double testValue() = 0;
 
 
-private:
 };
 
 

--- a/test/core/test_RegisterClass.cpp
+++ b/test/core/test_RegisterClass.cpp
@@ -10,36 +10,52 @@
 #include "NeoFOAM/core/dictionary.hpp"
 #include <iostream>
 
+// forward declaration so we can use it to define the create function and the class manager
+class TestBaseClass;
 
-class TestBaseClass
+// define the create function use to instantiate the derived classes
+using createFunc = std::function<std::unique_ptr<TestBaseClass>(std::string, double)>;
+
+// define the class manager to register the classes
+using TestBaseClassManager = NeoFOAM::RegisterClassManager<TestBaseClass, createFunc>;
+
+
+class TestBaseClass : public TestBaseClassManager
 {
 public:
 
-    // entries required runtime discovery
-    using regTestBaseClass = NeoFOAM::RegisterClassManager<TestBaseClass, std::string, double>;
 
     template<typename derivedClass>
-    using TestBaseClassReg =
-        NeoFOAM::RegisterClass<derivedClass, TestBaseClass, std::string, double>;
+    using TestBaseClassReg = NeoFOAM::RegisterClass<derivedClass, TestBaseClass, createFunc>;
 
-    template<typename derivedClass>
-    void registerClass()
+    static std::unique_ptr<TestBaseClass>
+    create(const std::string& name, std::string testString, double testValue)
     {
-        TestBaseClassReg<derivedClass> reg;
+        try
+        {
+            auto func = classMap.at(name);
+            return func(testString, testValue);
+        }
+        catch (const std::out_of_range& e)
+        {
+            std::cerr << "Error: " << e.what() << std::endl;
+            return nullptr;
+        }
     }
 
-    static int size() { return regTestBaseClass::classMap.size(); }
 
-    // standard base class entries
+    template<typename derivedClass>
+    bool registerClass()
+    {
+        return TestBaseClassReg<derivedClass>::reg;
+    }
+
     virtual ~TestBaseClass() = default;
 
     virtual std::string testString() = 0;
 
     virtual double testValue() = 0;
-
-
 };
-
 
 class TestDerivedClass : public TestBaseClass
 {
@@ -104,17 +120,20 @@ TEST_CASE("Register Class")
     REQUIRE(TestBaseClass::size() == 2);
 
     std::unique_ptr<TestBaseClass> testDerived =
-        TestBaseClass::regTestBaseClass::create("TestDerivedClass", "FirstDerived", 1.0);
+        TestBaseClass::create("TestDerivedClass", "FirstDerived", 1.0);
+
     std::cout << "TestBaseClass testValue: " << testDerived->testValue() << std::endl;
     std::cout << "TestBaseClass testString: " << testDerived->testString() << std::endl;
+
     REQUIRE(testDerived->testString() == "FirstDerived");
     REQUIRE(testDerived->testValue() == 1.0);
 
     std::unique_ptr<TestBaseClass> testDerived2 =
-        TestBaseClass::regTestBaseClass::create("TestDerivedClass2", "SecondDerived", 1.0);
+        TestBaseClass::create("TestDerivedClass2", "SecondDerived", 1.0);
 
     std::cout << "TestBaseClass testValue: " << testDerived2->testValue() << std::endl;
     std::cout << "TestBaseClass testString: " << testDerived2->testString() << std::endl;
+
     REQUIRE(testDerived2->testString() == "SecondDerived");
     REQUIRE(
         testDerived2->testValue() == 2.0

--- a/test/core/test_RegisterClass.cpp
+++ b/test/core/test_RegisterClass.cpp
@@ -28,7 +28,7 @@ public:
         TestBaseClassReg<derivedClass> reg;
     }
 
-    static int size() { return regTestBaseClass::classMap_.size(); }
+    static int size() { return regTestBaseClass::classMap.size(); }
 
     // standard base class entries
     virtual ~TestBaseClass() = default;

--- a/test/core/test_RegisterClass.cpp
+++ b/test/core/test_RegisterClass.cpp
@@ -16,11 +16,11 @@ class TestBaseClass
 public:
 
     // entries required runtime discovery
-    using regTestBaseClass = NeoFOAM::registerClassManager<TestBaseClass, std::string, double>;
+    using regTestBaseClass = NeoFOAM::RegisterClassManager<TestBaseClass, std::string, double>;
 
     template<typename derivedClass>
     using TestBaseClassReg =
-        NeoFOAM::registerClass<derivedClass, TestBaseClass, std::string, double>;
+        NeoFOAM::RegisterClass<derivedClass, TestBaseClass, std::string, double>;
 
     template<typename derivedClass>
     void registerClass()
@@ -28,7 +28,7 @@ public:
         TestBaseClassReg<derivedClass> reg;
     }
 
-    static int size() { return regTestBaseClass::s_methods.size(); }
+    static int size() { return regTestBaseClass::classMap_.size(); }
 
     // standard base class entries
     virtual ~TestBaseClass() = default;


### PR DESCRIPTION
The provided code provides a template for compile class discovery in C++.

All derived class are automatically registered inside:

`static inline std::unordered_map<std::string, createFunction> classMap;`

To sucessfully register the class the derived class needs to defined the following function: static create, static name and call registerClass inside the constructor.

```
    TestDerivedClass(std::string name, double test)
        : TestBaseClass(), testString_(name), testValue_(test)
    {
        registerClass<TestDerivedClass>();
    }

    static std::unique_ptr<TestBaseClass> create(std::string name, double test)
    {
        return std::make_unique<TestDerivedClass>(name, test);
    }

    static std::string name() { return "TestDerivedClass"; }
```

The derived class can now the instantiated by calling the static create function

```
    std::unique_ptr<TestBaseClass> testDerived =
        TestBaseClass::regTestBaseClass::create("TestDerivedClass", "FirstDerived", 1.0);
```

more details see test_RegisterClass:

TODO:

- [x] documentation how to register classes
