### PR TITLE
update documentation build workflow

### DIFF
--- a/.github/workflows/build_doc.yaml
+++ b/.github/workflows/build_doc.yaml
@@ -1,5 +1,8 @@
 name: Build documentation
 
+env:
+  PR_NUMBER: ${{ github.event.number }}
+
 on:
  pull_request:
     branches:

--- a/.github/workflows/build_doc.yaml
+++ b/.github/workflows/build_doc.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
     types: [closed, synchronize, opened]
+ push:
+    tags:
+       - v*
 
 jobs:
   build:
@@ -22,13 +25,20 @@ jobs:
         sphinx-build -b html ./doc ./docs_build/
         cd docs_build
         touch .nojekyll
-    - name: Deploy Test Build
+    - name: Deploy PR Build
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         folder: docs_build
-        target-folder: test_build
-    - name: Deploy Build
+        target-folder: Build_PR_${{ env.PR_NUMBER }}
+    - name: Deploy Versioned Build
+      if: ${{ github.ref_type == 'tag'}}
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        folder: docs_build
+        target-folder: ${{ github.ref_name }}
+    - name: Deploy Latest Build
       if: ${{ github.event.pull_request.merged }}
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         folder: docs_build
+        target-folder: latest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 **[Requirements](#requirements)** |
 **[Compilation](#Compilation)** |
-**[Documentation](https://exasim-project.com/NeoFOAM/)** |
+**[Documentation](https://exasim-project.com/NeoFOAM/latest)** |
 # NeoFOAM
 
 > [!IMPORTANT]


### PR DESCRIPTION
This PR updates our workflow for building and deploying documentation. Now three separate versions are being deployed:
- every PR builds a separate version of the documentation gets  deployed into the `Build_PR_${{ env.PR_NUMBER }}` folder, e.g. https://exasim-project.com/NeoFOAM/Build_PR_99/ for this PR.
- if a version tag is pushed the documentation gets deployed to `v?.?.?` folder depending on the tag
- every merge into main updates the `latest` folder.