### PR TITLE
Simplify boundary condition implementation

### DIFF
--- a/include/NeoFOAM/core/executor/OMPExecutor.hpp
+++ b/include/NeoFOAM/core/executor/OMPExecutor.hpp
@@ -19,7 +19,9 @@ class OMPExecutor
 {
 public:
 
-    using exec = Kokkos::OpenMP;
+    // It is set to the highest available in the hierarchy host-parallel,host-serial
+    // works with OpenMP, Threads
+    using exec = Kokkos::DefaultHostExecutionSpace;
 
     OMPExecutor();
     ~OMPExecutor();

--- a/include/NeoFOAM/finiteVolume/cellCentred/boundary/surface/calculated.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/boundary/surface/calculated.hpp
@@ -35,5 +35,10 @@ public:
     static std::string doc() { return "TBD"; }
 
     static std::string schema() { return "none"; }
+
+    virtual std::unique_ptr<SurfaceBoundaryFactory<ValueType>> clone() const override
+    {
+        return std::make_unique<Calculated>(*this);
+    }
 };
 }

--- a/include/NeoFOAM/finiteVolume/cellCentred/boundary/surface/empty.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/boundary/surface/empty.hpp
@@ -32,6 +32,11 @@ public:
     static std::string doc() { return "Do nothing on the boundary."; }
 
     static std::string schema() { return "none"; }
+
+    virtual std::unique_ptr<SurfaceBoundaryFactory<ValueType>> clone() const override
+    {
+        return std::make_unique<Empty>(*this);
+    }
 };
 
 }

--- a/include/NeoFOAM/finiteVolume/cellCentred/boundary/surface/fixedValue.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/boundary/surface/fixedValue.hpp
@@ -64,6 +64,11 @@ public:
 
     static std::string schema() { return "none"; }
 
+    virtual std::unique_ptr<SurfaceBoundaryFactory<ValueType>> clone() const override
+    {
+        return std::make_unique<FixedValue>(*this);
+    }
+
 private:
 
     const UnstructuredMesh& mesh_;

--- a/include/NeoFOAM/finiteVolume/cellCentred/boundary/surfaceBoundaryFactory.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/boundary/surfaceBoundaryFactory.hpp
@@ -30,6 +30,8 @@ public:
         : BoundaryPatchMixin(mesh, patchID) {};
 
     virtual void correctBoundaryCondition(DomainField<ValueType>& domainField) = 0;
+
+    virtual std::unique_ptr<SurfaceBoundaryFactory> clone() const = 0;
 };
 
 
@@ -52,6 +54,11 @@ public:
           boundaryCorrectionStrategy_(SurfaceBoundaryFactory<ValueType>::create(
               dict.get<std::string>("type"), mesh, dict, patchID
           ))
+    {}
+
+    SurfaceBoundary(const SurfaceBoundary& other)
+        : BoundaryPatchMixin(other),
+          boundaryCorrectionStrategy_(other.boundaryCorrectionStrategy_->clone())
     {}
 
     virtual void correctBoundaryCondition(DomainField<ValueType>& domainField)

--- a/include/NeoFOAM/finiteVolume/cellCentred/boundary/volume/calculated.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/boundary/volume/calculated.hpp
@@ -27,12 +27,17 @@ public:
         : Base(mesh, dict, patchID)
     {}
 
-    virtual void correctBoundaryCondition(DomainField<ValueType>& domainField) override {}
+    virtual void correctBoundaryCondition(DomainField<ValueType>& domainField) final {}
 
     static std::string name() { return "calculated"; }
 
     static std::string doc() { return "TBD"; }
 
     static std::string schema() { return "none"; }
+
+    virtual std::unique_ptr<VolumeBoundaryFactory<ValueType>> clone() const final
+    {
+        return std::make_unique<Calculated>(*this);
+    }
 };
 }

--- a/include/NeoFOAM/finiteVolume/cellCentred/boundary/volume/empty.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/boundary/volume/empty.hpp
@@ -25,13 +25,18 @@ public:
         : Base(mesh, dict, patchID)
     {}
 
-    virtual void correctBoundaryCondition(DomainField<ValueType>& domainField) override {}
+    virtual void correctBoundaryCondition(DomainField<ValueType>& domainField) final {}
 
     static std::string name() { return "empty"; }
 
     static std::string doc() { return "Do nothing on the boundary."; }
 
     static std::string schema() { return "none"; }
+
+    virtual std::unique_ptr<VolumeBoundaryFactory<ValueType>> clone() const final
+    {
+        return std::make_unique<Empty>(*this);
+    }
 };
 
 }

--- a/include/NeoFOAM/finiteVolume/cellCentred/boundary/volume/fixedGradient.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/boundary/volume/fixedGradient.hpp
@@ -58,7 +58,7 @@ public:
           fixedGradient_(dict.get<ValueType>("fixedGradient"))
     {}
 
-    virtual void correctBoundaryCondition(DomainField<ValueType>& domainField) override
+    virtual void correctBoundaryCondition(DomainField<ValueType>& domainField) final
     {
         detail::setGradientValue(
             domainField, mesh_, this->range(), this->patchID(), fixedGradient_
@@ -71,6 +71,10 @@ public:
 
     static std::string schema() { return "none"; }
 
+    virtual std::unique_ptr<VolumeBoundaryFactory<ValueType>> clone() const final
+    {
+        return std::make_unique<FixedGradient>(*this);
+    }
 
 private:
 

--- a/include/NeoFOAM/finiteVolume/cellCentred/boundary/volume/fixedValue.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/boundary/volume/fixedValue.hpp
@@ -59,6 +59,11 @@ public:
 
     static std::string schema() { return "none"; }
 
+    virtual std::unique_ptr<VolumeBoundaryFactory<ValueType>> clone() const final
+    {
+        return std::make_unique<FixedValue>(*this);
+    }
+
 private:
 
     ValueType fixedValue_;

--- a/include/NeoFOAM/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp
@@ -29,6 +29,8 @@ public:
         : BoundaryPatchMixin(mesh, patchID) {};
 
     virtual void correctBoundaryCondition(DomainField<ValueType>& domainField) = 0;
+
+    virtual std::unique_ptr<VolumeBoundaryFactory> clone() const = 0;
 };
 
 
@@ -51,6 +53,11 @@ public:
           boundaryCorrectionStrategy_(VolumeBoundaryFactory<ValueType>::create(
               dict.get<std::string>("type"), mesh, dict, patchID
           ))
+    {}
+
+    VolumeBoundary(const VolumeBoundary& other)
+        : BoundaryPatchMixin(other),
+          boundaryCorrectionStrategy_(other.boundaryCorrectionStrategy_->clone())
     {}
 
     virtual void correctBoundaryCondition(DomainField<ValueType>& domainField)

--- a/include/NeoFOAM/finiteVolume/cellCentred/fields/surfaceField.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/fields/surfaceField.hpp
@@ -30,7 +30,7 @@ public:
     SurfaceField(
         const Executor& exec,
         const UnstructuredMesh& mesh,
-        std::vector<std::unique_ptr<SurfaceBoundary<ValueType>>>&& boundaryConditions
+        const std::vector<SurfaceBoundary<ValueType>>& boundaryConditions
     )
         : GeometricFieldMixin<ValueType>(
             exec,
@@ -42,29 +42,13 @@ public:
                 mesh.nBoundaries()
             )
         ),
-          boundaryConditions_(std::move(boundaryConditions))
+          boundaryConditions_(boundaryConditions)
     {}
 
-    SurfaceField(
-        const Executor& exec,
-        const UnstructuredMesh& mesh,
-        const DomainField<ValueType>& field,
-        std::vector<std::unique_ptr<SurfaceBoundary<ValueType>>>&& boundaryConditions
-    )
-        : GeometricFieldMixin<ValueType>(exec, mesh, field),
-          boundaryConditions_(std::move(boundaryConditions))
-    {}
 
     SurfaceField(const SurfaceField& other)
-        : GeometricFieldMixin<ValueType>(other),
-          boundaryConditions_(other.boundaryConditions_.size())
-    {
-        // for (size_t i = 0; i < other.boundaryConditions_.size(); ++i)
-        // {
-        //     boundaryConditions_[i] =
-        //     std::make_unique<SurfaceBoundary<ValueType>>(*other.boundaryConditions_[i]);
-        // }
-    }
+        : GeometricFieldMixin<ValueType>(other), boundaryConditions_(other.boundaryConditions_)
+    {}
 
     /**
      * @brief Corrects the boundary conditions of the surface field.
@@ -76,13 +60,13 @@ public:
     {
         for (auto& boundaryCondition : boundaryConditions_)
         {
-            boundaryCondition->correctBoundaryCondition(this->field_);
+            boundaryCondition.correctBoundaryCondition(this->field_);
         }
     }
 
 private:
 
-    std::vector<std::unique_ptr<SurfaceBoundary<ValueType>>>
+    std::vector<SurfaceBoundary<ValueType>>
         boundaryConditions_; // The vector of boundary conditions
 };
 

--- a/include/NeoFOAM/finiteVolume/cellCentred/fields/volumeField.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/fields/volumeField.hpp
@@ -30,26 +30,19 @@ public:
     VolumeField(
         const Executor& exec,
         const UnstructuredMesh& mesh,
-        std::vector<std::unique_ptr<VolumeBoundary<ValueType>>>&& boundaryConditions
+        const std::vector<VolumeBoundary<ValueType>>& boundaryConditions
     )
         : GeometricFieldMixin<ValueType>(
             exec,
             mesh,
             DomainField<ValueType>(exec, mesh.nCells(), mesh.nBoundaryFaces(), mesh.nBoundaries())
         ),
-          boundaryConditions_(std::move(boundaryConditions))
+          boundaryConditions_(boundaryConditions)
     {}
 
     VolumeField(const VolumeField& other)
-        : GeometricFieldMixin<ValueType>(other),
-          boundaryConditions_(other.boundaryConditions_.size())
-    {
-        // for (size_t i = 0; i < other.boundaryConditions_.size(); ++i)
-        // {
-        //     boundaryConditions_[i] =
-        //     std::make_unique<SurfaceBoundary<ValueType>>(*other.boundaryConditions_[i]);
-        // }
-    }
+        : GeometricFieldMixin<ValueType>(other), boundaryConditions_(other.boundaryConditions_)
+    {}
 
     /**
      * @brief Corrects the boundary conditions of the surface field.
@@ -61,14 +54,13 @@ public:
     {
         for (auto& boundaryCondition : boundaryConditions_)
         {
-            boundaryCondition->correctBoundaryCondition(this->field_);
+            boundaryCondition.correctBoundaryCondition(this->field_);
         }
     }
 
 private:
 
-    std::vector<std::unique_ptr<VolumeBoundary<ValueType>>>
-        boundaryConditions_; // The vector of boundary conditions
+    std::vector<VolumeBoundary<ValueType>> boundaryConditions_; // The vector of boundary conditions
 };
 
 } // namespace NeoFOAM

--- a/include/NeoFOAM/mesh/stencil/fvccGeometryScheme.hpp
+++ b/include/NeoFOAM/mesh/stencil/fvccGeometryScheme.hpp
@@ -16,16 +16,15 @@ namespace NeoFOAM
 namespace fvcc = finiteVolume::cellCentred;
 
 template<typename ValueType>
-std::vector<std::unique_ptr<fvcc::SurfaceBoundary<ValueType>>>
-createCalculatedBCs(const UnstructuredMesh& mesh)
+std::vector<fvcc::SurfaceBoundary<ValueType>> createCalculatedBCs(const UnstructuredMesh& mesh)
 {
     const auto& bMesh = mesh.boundaryMesh();
-    std::vector<std::unique_ptr<fvcc::SurfaceBoundary<ValueType>>> bcs;
+    std::vector<fvcc::SurfaceBoundary<ValueType>> bcs;
 
     for (int patchID = 0; patchID < mesh.nBoundaries(); patchID++)
     {
         Dictionary patchDict({{"type", std::string("calculated")}});
-        bcs.push_back(std::make_unique<fvcc::SurfaceBoundary<ValueType>>(mesh, patchDict, patchID));
+        bcs.push_back(fvcc::SurfaceBoundary<ValueType>(mesh, patchDict, patchID));
     }
 
     return bcs;

--- a/test/finiteVolume/cellCentred/fields/surfaceField.cpp
+++ b/test/finiteVolume/cellCentred/fields/surfaceField.cpp
@@ -25,17 +25,15 @@ TEST_CASE("surfaceField")
     SECTION("can instantiate SurfaceField with fixedValues on: " + execName)
     {
         NeoFOAM::UnstructuredMesh mesh = NeoFOAM::createSingleCellMesh(exec);
-        std::vector<std::unique_ptr<fvcc::SurfaceBoundary<NeoFOAM::scalar>>> bcs {};
+        std::vector<fvcc::SurfaceBoundary<NeoFOAM::scalar>> bcs {};
         for (size_t patchi : {0, 1, 2, 3})
         {
             NeoFOAM::Dictionary dict;
             dict.insert("type", std::string("fixedValue"));
             dict.insert("fixedValue", 2.0);
-            bcs.push_back(
-                std::make_unique<fvcc::SurfaceBoundary<NeoFOAM::scalar>>(mesh, dict, patchi)
-            );
+            bcs.push_back(fvcc::SurfaceBoundary<NeoFOAM::scalar>(mesh, dict, patchi));
         }
-        fvcc::SurfaceField<NeoFOAM::scalar> sf(exec, mesh, std::move(bcs));
+        fvcc::SurfaceField<NeoFOAM::scalar> sf(exec, mesh, bcs);
         // the internal field is 4 because the mesh has 4 boundaryFaces
         NeoFOAM::fill(sf.internalField(), 1.0);
 

--- a/test/finiteVolume/cellCentred/fields/volumeField.cpp
+++ b/test/finiteVolume/cellCentred/fields/volumeField.cpp
@@ -25,17 +25,15 @@ TEST_CASE("volumeField")
     SECTION("can instantiate volumeField with fixedValues on: " + execName)
     {
         NeoFOAM::UnstructuredMesh mesh = NeoFOAM::createSingleCellMesh(exec);
-        std::vector<std::unique_ptr<fvcc::VolumeBoundary<NeoFOAM::scalar>>> bcs {};
+        std::vector<fvcc::VolumeBoundary<NeoFOAM::scalar>> bcs {};
         for (size_t patchi : {0, 1, 2, 3})
         {
             NeoFOAM::Dictionary dict;
             dict.insert("type", std::string("fixedValue"));
             dict.insert("fixedValue", 2.0);
-            bcs.push_back(
-                std::make_unique<fvcc::VolumeBoundary<NeoFOAM::scalar>>(mesh, dict, patchi)
-            );
+            bcs.push_back(fvcc::VolumeBoundary<NeoFOAM::scalar>(mesh, dict, patchi));
         }
-        fvcc::VolumeField<NeoFOAM::scalar> vf(exec, mesh, std::move(bcs));
+        fvcc::VolumeField<NeoFOAM::scalar> vf(exec, mesh, bcs);
         NeoFOAM::fill(vf.internalField(), 1.0);
         vf.correctBoundaryConditions();
 


### PR DESCRIPTION
- OMP uses Kokkos::DefaultHostExecutionSpace so it also works with Threads
- BC are copyable
- BC are stored in a simple vector instead of a vector of unique ptrs