### PR TITLE
Fix compiler warnings

### DIFF
--- a/benchmarks/fields/bench_fields.cpp
+++ b/benchmarks/fields/bench_fields.cpp
@@ -99,7 +99,7 @@ TEST_CASE("Vector addition [benchmark]")
     auto sGpuC = gpuC.span();
     BENCHMARK("Field<GPU> addition no allocation")
     {
-        gpuA.apply(KOKKOS_LAMBDA(const int i) { return sGpuB[i] + sGpuC[i]; });
+        gpuA.apply(KOKKOS_LAMBDA(const NeoFOAM::size_t i) { return sGpuB[i] + sGpuC[i]; });
         return Kokkos::fence();
         // return GPUa;
     };
@@ -118,7 +118,7 @@ TEST_CASE("Vector addition [benchmark]")
     auto sompC = ompC.span();
     BENCHMARK("Field<OMP> addition no allocation")
     {
-        ompA.apply(KOKKOS_LAMBDA(const int i) { return sompB[i] + sompC[i]; });
+        ompA.apply(KOKKOS_LAMBDA(const NeoFOAM::size_t i) { return sompB[i] + sompC[i]; });
     };
 }
 }

--- a/doc/basics/containers.rst
+++ b/doc/basics/containers.rst
@@ -38,7 +38,7 @@ To run the for loop on the GPU is a bit more complicated and is based on the Kok
      std::span<double> sB = b.field();
      Kokkos::parallel_for(
           Kokkos::RangePolicy<gpuExec::exec>(0, sB.size()),
-          KOKKOS_LAMBDA(const int i) { sB[i] = 1.0; }
+          KOKKOS_LAMBDA(const NeoFOAM::size_t i) { sB[i] = 1.0; }
      );
 
 Kokkos requires the knowledge of where to run the code and the range of the loop. The range is defined by the size of the data and the executor. The `KOKKOS_LAMBDA` is required to mark the function so it is also compiled for the GPU. This approach however is not very user-friendly and requires the knowledge of the Kokkos library. To simplify the process, the Field class stores the executor and the field independent of the device can be set to 1.0 with the following code.

--- a/doc/finiteVolume/cellCentred/boundaryConditions.rst
+++ b/doc/finiteVolume/cellCentred/boundaryConditions.rst
@@ -52,7 +52,7 @@ The logic is implemented in the kernel classes:
         Kokkos::parallel_for(
             "fvccScalarFixedValueBoundaryField",
             Kokkos::RangePolicy<executor>(start_, end_),
-            KOKKOS_LAMBDA(const int i) {
+            KOKKOS_LAMBDA(const size_t i) {
                 s_value[i] = uniformValue;
                 s_refValue[i] = uniformValue;
             }

--- a/include/NeoFOAM/core/mpi/environment.hpp
+++ b/include/NeoFOAM/core/mpi/environment.hpp
@@ -72,14 +72,14 @@ public:
      *
      * @return The number of ranks.
      */
-    int sizeRank() const { return mpi_size; }
+    size_t sizeRank() const { return static_cast<size_t>(mpi_size); }
 
     /**
      * @brief Returns the rank of the current process.
      *
      * @return The rank of the current process.
      */
-    int rank() const { return mpi_rank; }
+    size_t rank() const { return static_cast<size_t>(mpi_rank); }
 
     /**
      * @brief Returns the communicator.

--- a/include/NeoFOAM/core/mpi/fullDuplexCommBuffer.hpp
+++ b/include/NeoFOAM/core/mpi/fullDuplexCommBuffer.hpp
@@ -70,7 +70,7 @@ public:
      * @return A span of data for the send buffer.
      */
     template<typename valueType>
-    std::span<valueType> getSend(const int rank)
+    std::span<valueType> getSend(const size_t rank)
     {
         return send_.get<valueType>(rank);
     }
@@ -82,7 +82,7 @@ public:
      * @return A span of data for the send buffer.
      */
     template<typename valueType>
-    std::span<const valueType> getSend(const int rank) const
+    std::span<const valueType> getSend(const size_t rank) const
     {
         return send_.get<valueType>(rank);
     }
@@ -94,7 +94,7 @@ public:
      * @return A span of data for the receive buffer.
      */
     template<typename valueType>
-    std::span<valueType> getReceive(const int rank)
+    std::span<valueType> getReceive(const size_t rank)
     {
         return receive_.get<valueType>(rank);
     }
@@ -106,7 +106,7 @@ public:
      * @return A span of data for the receive buffer.
      */
     template<typename valueType>
-    std::span<const valueType> getReceive(const int rank) const
+    std::span<const valueType> getReceive(const size_t rank) const
     {
         return receive_.get<valueType>(rank);
     }

--- a/include/NeoFOAM/core/mpi/halfDuplexCommBuffer.hpp
+++ b/include/NeoFOAM/core/mpi/halfDuplexCommBuffer.hpp
@@ -66,7 +66,7 @@ public:
      * @param mpiEnviron The MPI environment.
      * @param rankCommSize The number of nodes per rank to be communicated with.
      */
-    HalfDuplexCommBuffer(MPIEnvironment mpiEnviron, std::vector<std::size_t> rankCommSize)
+    HalfDuplexCommBuffer(MPIEnvironment mpiEnviron, std::vector<size_t> rankCommSize)
         : mpiEnviron_(mpiEnviron)
     {
         setCommRankSize<char>(rankCommSize);
@@ -93,7 +93,7 @@ public:
      * @param rankCommSize The number of nodes per rank to be communicated with.
      */
     template<typename valueType>
-    void setCommRankSize(std::vector<std::size_t> rankCommSize)
+    void setCommRankSize(std::vector<size_t> rankCommSize)
     {
         NF_DEBUG_ASSERT(
             !isCommInit(), "Communication buffer was initialised by name: " << commName_ << "."
@@ -105,7 +105,7 @@ public:
         typeSize_ = sizeof(valueType);
         rankOffset_.resize(rankCommSize.size() + 1);
         request_.resize(rankCommSize.size(), MPI_REQUEST_NULL);
-        updateDataSize([&](const int rank) { return rankCommSize[rank]; }, sizeof(valueType));
+        updateDataSize([&](const size_t rank) { return rankCommSize[rank]; }, sizeof(valueType));
     }
 
     /**
@@ -167,7 +167,7 @@ public:
      * @return std::span<valueType> A span of the data for the given rank.
      */
     template<typename valueType>
-    std::span<valueType> get(const int rank)
+    std::span<valueType> get(const size_t rank)
     {
         NF_DEBUG_ASSERT(isCommInit(), "Communication buffer is not initialised.");
         NF_DEBUG_ASSERT(typeSize_ == sizeof(valueType), "Data type (size) mismatch.");
@@ -185,7 +185,7 @@ public:
      * @return std::span<const valueType> A span of the data for the given rank.
      */
     template<typename valueType>
-    std::span<const valueType> get(const int rank) const
+    std::span<const valueType> get(const size_t rank) const
     {
         NF_DEBUG_ASSERT(isCommInit(), "Communication buffer is not initialised.");
         NF_DEBUG_ASSERT(typeSize_ == sizeof(valueType), "Data type (size) mismatch.");
@@ -217,7 +217,7 @@ private:
         );
         if (0 == (typeSize_ - sizeof(valueType))) return;
         updateDataSize(
-            [rankOffset = rankOffset_, typeSize = typeSize_](const int rank)
+            [rankOffset = rankOffset_, typeSize = typeSize_](const size_t rank)
             { return (rankOffset[rank + 1] - rankOffset[rank]) / typeSize; },
             sizeof(valueType)
         );
@@ -236,7 +236,7 @@ private:
     void updateDataSize(func rankSize, std::size_t newSize)
     {
         std::size_t dataSize = 0;
-        for (auto rank = 0; rank < mpiEnviron_.sizeRank(); ++rank)
+        for (size_t rank = 0; rank < mpiEnviron_.sizeRank(); ++rank)
         {
             rankOffset_[rank] = dataSize;
             dataSize += rankSize(rank) * newSize;

--- a/include/NeoFOAM/core/mpi/operators.hpp
+++ b/include/NeoFOAM/core/mpi/operators.hpp
@@ -147,7 +147,7 @@ inline void allReduce(Vector& vector, const ReduceOp op, MPI_Comm comm)
     MPI_Allreduce(
         MPI_IN_PLACE,
         reinterpret_cast<void*>(vector.data()),
-        vector.size(),
+        static_cast<mpi_label_t>(vector.size()),
         getType<scalar>(),
         getOp(op),
         comm
@@ -169,14 +169,15 @@ inline void allReduce(Vector& vector, const ReduceOp op, MPI_Comm comm)
 template<typename valueType>
 void isend(
     const valueType* buffer,
-    const int size,
-    int rankReceive,
-    int tag,
+    const mpi_label_t size,
+    mpi_label_t rankReceive,
+    mpi_label_t tag,
     MPI_Comm comm,
     MPI_Request* request
 )
 {
-    int err = MPI_Isend(buffer, size, getType<valueType>(), rankReceive, tag, comm, request);
+    mpi_label_t err =
+        MPI_Isend(buffer, size, getType<valueType>(), rankReceive, tag, comm, request);
     NF_DEBUG_ASSERT(err == MPI_SUCCESS, "MPI_Isend failed.");
 }
 
@@ -194,10 +195,15 @@ void isend(
  */
 template<typename valueType>
 void irecv(
-    valueType* buffer, const int size, int rankSend, int tag, MPI_Comm comm, MPI_Request* request
+    valueType* buffer,
+    const mpi_label_t size,
+    mpi_label_t rankSend,
+    mpi_label_t tag,
+    MPI_Comm comm,
+    MPI_Request* request
 )
 {
-    int err = MPI_Irecv(buffer, size, getType<valueType>(), rankSend, tag, comm, request);
+    mpi_label_t err = MPI_Irecv(buffer, size, getType<valueType>(), rankSend, tag, comm, request);
     NF_DEBUG_ASSERT(err == MPI_SUCCESS, "MPI_Irecv failed.");
 }
 
@@ -210,8 +216,8 @@ void irecv(
  */
 inline bool test(MPI_Request* request)
 {
-    int flag;
-    int err = MPI_Test(request, &flag, MPI_STATUS_IGNORE);
+    mpi_label_t flag;
+    mpi_label_t err = MPI_Test(request, &flag, MPI_STATUS_IGNORE);
     NF_DEBUG_ASSERT(err == MPI_SUCCESS, "MPI_Test failed.");
     return static_cast<bool>(flag);
 }

--- a/include/NeoFOAM/core/parallelAlgorithms.hpp
+++ b/include/NeoFOAM/core/parallelAlgorithms.hpp
@@ -3,22 +3,30 @@
 #pragma once
 
 #include <Kokkos_Core.hpp>
-#include "NeoFOAM/core/executor/executor.hpp"
 #include <type_traits>
+
+#include "NeoFOAM/core/executor/executor.hpp"
 
 namespace NeoFOAM
 {
 
+
+template<typename ValueType>
+class Field;
+
+
 // Concept to check if a callable is compatible with void(const size_t)
 template<typename Kernel>
-concept parallelForKernel = requires(Kernel t, const size_t i) {
+concept parallelForKernel = requires(Kernel t, size_t i) {
     {
         t(i)
     } -> std::same_as<void>;
 };
 
 template<typename Executor, parallelForKernel Kernel>
-void parallelFor(const Executor& exec, std::pair<size_t, size_t> range, Kernel kernel)
+void parallelFor(
+    [[maybe_unused]] const Executor& exec, std::pair<size_t, size_t> range, Kernel kernel
+)
 {
     auto [start, end] = range;
     if constexpr (std::is_same<std::remove_reference_t<Executor>, CPUExecutor>::value)
@@ -48,14 +56,14 @@ void parallelFor(const NeoFOAM::Executor& exec, std::pair<size_t, size_t> range,
 
 // Concept to check if a callable is compatible with ValueType(const size_t)
 template<typename Kernel, typename ValueType>
-concept parallelForFieldKernel = requires(Kernel t, ValueType val, const size_t i) {
+concept parallelForFieldKernel = requires(Kernel t, ValueType val, size_t i) {
     {
         t(i)
     } -> std::same_as<ValueType>;
 };
 
 template<typename Executor, typename ValueType, parallelForFieldKernel<ValueType> Kernel>
-void parallelFor(const Executor& exec, Field<ValueType>& field, Kernel kernel)
+void parallelFor([[maybe_unused]] const Executor& exec, Field<ValueType>& field, Kernel kernel)
 {
     auto span = field.span();
     if constexpr (std::is_same<std::remove_reference_t<Executor>, CPUExecutor>::value)
@@ -84,7 +92,9 @@ void parallelFor(Field<ValueType>& field, Kernel kernel)
 
 
 template<typename Executor, typename Kernel, typename T>
-void parallelReduce(const Executor& exec, std::pair<size_t, size_t> range, Kernel kernel, T& value)
+void parallelReduce(
+    [[maybe_unused]] const Executor& exec, std::pair<size_t, size_t> range, Kernel kernel, T& value
+)
 {
     auto [start, end] = range;
     if constexpr (std::is_same<std::remove_reference_t<Executor>, CPUExecutor>::value)
@@ -113,7 +123,9 @@ void parallelReduce(
 
 
 template<typename Executor, typename ValueType, typename Kernel, typename T>
-void parallelReduce(const Executor& exec, Field<ValueType>& field, Kernel kernel, T& value)
+void parallelReduce(
+    [[maybe_unused]] const Executor& exec, Field<ValueType>& field, Kernel kernel, T& value
+)
 {
     if constexpr (std::is_same<std::remove_reference_t<Executor>, CPUExecutor>::value)
     {

--- a/include/NeoFOAM/core/primitives/label.hpp
+++ b/include/NeoFOAM/core/primitives/label.hpp
@@ -14,4 +14,6 @@ using label = int32_t;
 using localIdx = uint32_t;
 #endif
 using globalIdx = uint64_t;
+using size_t = std::size_t;
+using mpi_label_t = int;
 }

--- a/include/NeoFOAM/core/primitives/vector.hpp
+++ b/include/NeoFOAM/core/primitives/vector.hpp
@@ -55,19 +55,19 @@ public:
      *
      * @return The size of the vector
      */
-    constexpr std::size_t size() const { return 3; }
+    constexpr size_t size() const { return 3; }
 
     KOKKOS_INLINE_FUNCTION
-    scalar& operator[](const int i) { return cmpts_[i]; }
+    scalar& operator[](const size_t i) { return cmpts_[i]; }
 
     KOKKOS_INLINE_FUNCTION
-    scalar operator[](const int i) const { return cmpts_[i]; }
+    scalar operator[](const size_t i) const { return cmpts_[i]; }
 
     KOKKOS_INLINE_FUNCTION
-    scalar& operator()(const int i) { return cmpts_[i]; }
+    scalar& operator()(const size_t i) { return cmpts_[i]; }
 
     KOKKOS_INLINE_FUNCTION
-    scalar operator()(const int i) const { return cmpts_[i]; }
+    scalar operator()(const size_t i) const { return cmpts_[i]; }
 
     KOKKOS_INLINE_FUNCTION
     bool operator==(const Vector& rhs) const

--- a/include/NeoFOAM/core/time.hpp
+++ b/include/NeoFOAM/core/time.hpp
@@ -19,7 +19,7 @@ class ArgList
 
 public:
 
-    ArgList(int argc, char* argv[]) {};
+    ArgList([[maybe_unused]] int argc, [[maybe_unused]] char* argv[]) {};
 
     [[nodiscard]] bool checkRootCase() const { return true; };
 };

--- a/include/NeoFOAM/fields/boundaryFields.hpp
+++ b/include/NeoFOAM/fields/boundaryFields.hpp
@@ -44,7 +44,7 @@ public:
     {}
 
 
-    BoundaryFields(const Executor& exec, int nBoundaryFaces, int nBoundaries)
+    BoundaryFields(const Executor& exec, size_t nBoundaryFaces, size_t nBoundaries)
         : exec_(exec), value_(exec, nBoundaryFaces), refValue_(exec, nBoundaryFaces),
           valueFraction_(exec, nBoundaryFaces), refGrad_(exec, nBoundaryFaces),
           boundaryTypes_(exec, nBoundaries), offset_(exec, nBoundaries + 1),
@@ -105,13 +105,13 @@ public:
      * @brief Get the number of boundaries.
      * @return The number of boundaries.
      */
-    int nBoundaries() const { return nBoundaries_; }
+    size_t nBoundaries() const { return nBoundaries_; }
 
     /**
      * @brief Get the number of boundary faces.
      * @return The number of boundary faces.
      */
-    int nBoundaryFaces() const { return nBoundaryFaces_; }
+    size_t nBoundaryFaces() const { return nBoundaryFaces_; }
 
     const Executor& exec() { return exec_; }
 
@@ -135,8 +135,8 @@ private:
     NeoFOAM::Field<T> refGrad_;            ///< The Field storing the Neumann boundary values.
     NeoFOAM::Field<int> boundaryTypes_;    ///< The Field storing the boundary types.
     NeoFOAM::Field<localIdx> offset_;      ///< The Field storing the offsets of each boundary.
-    int nBoundaries_;                      ///< The number of boundaries.
-    int nBoundaryFaces_;                   ///< The number of boundary faces.
+    size_t nBoundaries_;                   ///< The number of boundaries.
+    size_t nBoundaryFaces_;                ///< The number of boundary faces.
 };
 
 }

--- a/include/NeoFOAM/fields/domainField.hpp
+++ b/include/NeoFOAM/fields/domainField.hpp
@@ -36,7 +36,7 @@ public:
         : exec_(exec), internalField_(exec, 0), boundaryFields_(exec, 0, 0)
     {}
 
-    DomainField(const Executor& exec, int nCells, int nBoundaryFaces, int nBoundaries)
+    DomainField(const Executor& exec, size_t nCells, size_t nBoundaryFaces, size_t nBoundaries)
         : exec_(exec), internalField_(exec, nCells),
           boundaryFields_(exec, nBoundaryFaces, nBoundaries)
     {}

--- a/include/NeoFOAM/fields/field.hpp
+++ b/include/NeoFOAM/fields/field.hpp
@@ -59,7 +59,8 @@ public:
     {
         void* ptr = nullptr;
         std::visit(
-            [this, &ptr, size](const auto& exec) { ptr = exec.alloc(size * sizeof(ValueType)); },
+            [this, &ptr, size](const auto& concreteExec)
+            { ptr = concreteExec.alloc(size * sizeof(ValueType)); },
             exec_
         );
         data_ = static_cast<ValueType*>(ptr);
@@ -76,7 +77,8 @@ public:
         Executor hostExec = CPUExecutor();
         void* ptr = nullptr;
         std::visit(
-            [this, &ptr](const auto& exec) { ptr = exec.alloc(this->size_ * sizeof(ValueType)); },
+            [this, &ptr](const auto& concreteExec)
+            { ptr = concreteExec.alloc(this->size_ * sizeof(ValueType)); },
             exec_
         );
         data_ = static_cast<ValueType*>(ptr);
@@ -157,7 +159,7 @@ public:
      * @returns The value at the index i
      */
     KOKKOS_FUNCTION
-    ValueType& operator[](const int i) { return data_[i]; }
+    ValueType& operator[](const size_t i) { return data_[i]; }
 
     /**
      * @brief Subscript operator
@@ -165,7 +167,7 @@ public:
      * @returns The value at the index i
      */
     KOKKOS_FUNCTION
-    const ValueType& operator[](const int i) const { return data_[i]; }
+    const ValueType& operator[](const size_t i) const { return data_[i]; }
 
     /**
      * @brief Function call operator
@@ -173,7 +175,7 @@ public:
      * @returns The value at the index i
      */
     KOKKOS_FUNCTION
-    ValueType& operator()(const int i) { return data_[i]; }
+    ValueType& operator()(const size_t i) { return data_[i]; }
 
     /**
      * @brief Function call operator
@@ -181,7 +183,7 @@ public:
      * @returns The value at the index i
      */
     KOKKOS_FUNCTION
-    const ValueType& operator()(const int i) const { return data_[i]; }
+    const ValueType& operator()(const size_t i) const { return data_[i]; }
 
     /**
      * @brief Assignment operator, Sets the field values to that of the passed value.
@@ -253,7 +255,7 @@ public:
     {
         Field<ValueType> result(exec_, size_);
         result = *this;
-        scalar_mul(result, rhs);
+        scalarMul(result, rhs);
         return result;
     }
 

--- a/include/NeoFOAM/fields/operations/comparison.hpp
+++ b/include/NeoFOAM/fields/operations/comparison.hpp
@@ -13,7 +13,7 @@ template<typename T>
 bool equal(Field<T>& field, T value)
 {
     auto hostSpan = field.copyToHost().span();
-    for (int i = 0; i < hostSpan.size(); i++)
+    for (size_t i = 0; i < hostSpan.size(); i++)
     {
         if (hostSpan[i] != value)
         {
@@ -34,7 +34,7 @@ bool equal(const Field<T>& field, const Field<T>& field2)
         return false;
     }
 
-    for (int i = 0; i < hostSpan.size(); i++)
+    for (size_t i = 0; i < hostSpan.size(); i++)
     {
         if (hostSpan[i] != hostSpan2[i])
         {
@@ -55,7 +55,7 @@ bool equal(const Field<T>& field, std::span<T> span2)
         return false;
     }
 
-    for (int i = 0; i < hostSpan.size(); i++)
+    for (size_t i = 0; i < hostSpan.size(); i++)
     {
         if (hostSpan[i] != span2[i])
         {

--- a/include/NeoFOAM/fields/operations/operationsMacros.hpp
+++ b/include/NeoFOAM/fields/operations/operationsMacros.hpp
@@ -3,95 +3,90 @@
 #pragma once
 
 #include <Kokkos_Core.hpp>
+#include "NeoFOAM/core/primitives/label.hpp"
 #include "NeoFOAM/helpers/exceptions.hpp"
+#include "NeoFOAM/core/parallelAlgorithms.hpp"
 
 namespace NeoFOAM
 {
 
-// Forward declarition
+// Forward declaration
 template<typename ValueType>
 class Field;
 
 
-#define DECLARE_UNARY_FIELD_OP(Name, Kernel_Impl)                                                  \
-    template<typename T, typename Inner>                                                           \
-    struct Name##Op                                                                                \
-    {                                                                                              \
-        template<typename Executor>                                                                \
-        void operator()(const Executor& exec, Field<T>& a, const Inner in)                         \
-        {                                                                                          \
-            using executor = typename Executor::exec;                                              \
-            auto a_f = a.span();                                                                   \
-            Kokkos::parallel_for(                                                                  \
-                Kokkos::RangePolicy<executor>(0, a_f.size()),                                      \
-                KOKKOS_CLASS_LAMBDA(const int i) { a_f[i] = Kernel_Impl; }                         \
-            );                                                                                     \
-        }                                                                                          \
-                                                                                                   \
-        template<typename Executor>                                                                \
-        void operator()(const CPUExecutor& exec, Field<T>& a, const Inner in)                      \
-        {                                                                                          \
-            auto a_f = a.span();                                                                   \
-            for (int i = 0; i < a_f.size(); i++)                                                   \
-            {                                                                                      \
-                a_f[i] = Kernel_Impl;                                                              \
-            }                                                                                      \
-        }                                                                                          \
-    };                                                                                             \
-    template<typename T, typename Inner>                                                           \
-    void Name(Field<T>& a, const Inner inner)                                                      \
-    {                                                                                              \
-        Name##Op<T, Inner> op_;                                                                    \
-        std::visit([&](const auto& exec) { op_(exec, a, inner); }, a.exec());                      \
-    }
+template<typename T, typename Inner>
+void map(Field<T>& a, const Inner inner)
+{
+    parallelFor(a, inner);
+}
 
-DECLARE_UNARY_FIELD_OP(map, in(i));
-DECLARE_UNARY_FIELD_OP(fill, in);
-DECLARE_UNARY_FIELD_OP(setField, in[i]);
-DECLARE_UNARY_FIELD_OP(scalar_mul, a_f[i] *= in);
+template<typename ValueType>
+void fill(Field<ValueType>& a, const std::type_identity_t<ValueType> value)
+{
+    parallelFor(
+        a, KOKKOS_LAMBDA(const size_t) { return value; }
+    );
+}
 
-#undef DECLARE_UNARY_FIELD_OP
 
-#define DECLARE_BINARY_FIELD_OP(Name, Kernel_Impl)                                                 \
-    template<typename T>                                                                           \
-    struct Name##Op                                                                                \
-    {                                                                                              \
-        template<typename Executor>                                                                \
-        void operator()(const Executor& exec, Field<T>& a, const Field<T>& b)                      \
-        {                                                                                          \
-            using executor = typename Executor::exec;                                              \
-            auto a_f = a.span();                                                                   \
-            auto b_f = b.span();                                                                   \
-            Kokkos::parallel_for(                                                                  \
-                Kokkos::RangePolicy<executor>(0, a_f.size()),                                      \
-                KOKKOS_CLASS_LAMBDA(const int i) { a_f[i] = Kernel_Impl; }                         \
-            );                                                                                     \
-        }                                                                                          \
-                                                                                                   \
-        template<typename Executor>                                                                \
-        void operator()(const CPUExecutor& exec, Field<T>& a, const Field<T>& b)                   \
-        {                                                                                          \
-            auto a_f = a.span();                                                                   \
-            const auto b_f = b.span();                                                             \
-            for (int i = 0; i < a_f.size(); i++)                                                   \
-            {                                                                                      \
-                a_f[i] = Kernel_Impl;                                                              \
-            }                                                                                      \
-        }                                                                                          \
-    };                                                                                             \
-    template<typename T>                                                                           \
-    void Name(Field<T>& a, const Field<T>& b)                                                      \
-    {                                                                                              \
-        NeoFOAM_ASSERT_EQUAL_LENGTH(a, b);                                                         \
-        Name##Op<T> op_;                                                                           \
-        std::visit([&](const auto& exec) { op_(exec, a, b); }, a.exec());                          \
-    }
+template<typename ValueType>
+void setField(Field<ValueType>& a, const std::span<const std::type_identity_t<ValueType>> b)
+{
+    parallelFor(
+        a, KOKKOS_LAMBDA(const size_t i) { return b[i]; }
+    );
+}
 
-DECLARE_BINARY_FIELD_OP(add, a_f[i] + b_f[i]);
-DECLARE_BINARY_FIELD_OP(sub, a_f[i] - b_f[i]);
-DECLARE_BINARY_FIELD_OP(mul, a_f[i] * b_f[i]);
+template<typename ValueType>
+void scalarMul(Field<ValueType>& a, const std::type_identity_t<ValueType> value)
+{
+    auto spanA = a.span();
+    parallelFor(
+        a, KOKKOS_LAMBDA(const size_t i) { return spanA[i] * value; }
+    );
+}
 
-#undef DECLARE_BINARY_FIELD_OP
+namespace detail
+{
+template<typename ValueType, typename BinaryOp>
+void fieldBinaryOp(
+    Field<ValueType>& a, const Field<std::type_identity_t<ValueType>>& b, BinaryOp op
+)
+{
+    NeoFOAM_ASSERT_EQUAL_LENGTH(a, b);
+    auto spanA = a.span();
+    auto spanB = b.span();
+    parallelFor(
+        a, KOKKOS_LAMBDA(const size_t i) { return op(spanA[i], spanB[i]); }
+    );
+}
+}
+
+template<typename ValueType>
+void add(Field<ValueType>& a, const Field<std::type_identity_t<ValueType>>& b)
+{
+    detail::fieldBinaryOp(
+        a, b, KOKKOS_LAMBDA(ValueType va, ValueType vb) { return va + vb; }
+    );
+}
+
+
+template<typename ValueType>
+void sub(Field<ValueType>& a, const Field<std::type_identity_t<ValueType>>& b)
+{
+    detail::fieldBinaryOp(
+        a, b, KOKKOS_LAMBDA(ValueType va, ValueType vb) { return va - vb; }
+    );
+}
+
+template<typename ValueType>
+void mul(Field<ValueType>& a, const Field<std::type_identity_t<ValueType>>& b)
+{
+    detail::fieldBinaryOp(
+        a, b, KOKKOS_LAMBDA(ValueType va, ValueType vb) { return va * vb; }
+    );
+}
 
 
 } // namespace NeoFOAM

--- a/include/NeoFOAM/fields/operations/sum.hpp
+++ b/include/NeoFOAM/fields/operations/sum.hpp
@@ -19,7 +19,7 @@ struct SumKernel
         Kokkos::parallel_reduce(
             "sum",
             Kokkos::RangePolicy<executor>(0, end),
-            KOKKOS_LAMBDA(const int i, T& lsum) { lsum += field_f[i]; },
+            KOKKOS_LAMBDA(const size_t i, T& lsum) { lsum += field_f[i]; },
             sum
         );
     }
@@ -33,7 +33,7 @@ struct SumKernel
         Kokkos::parallel_reduce(
             "sum",
             Kokkos::RangePolicy<executor>(0, end),
-            KOKKOS_LAMBDA(const int i, T& lsum) { lsum += field_f[i]; },
+            KOKKOS_LAMBDA(const size_t i, T& lsum) { lsum += field_f[i]; },
             sum
         );
     }
@@ -47,7 +47,7 @@ struct SumKernel
         Kokkos::parallel_reduce(
             "sum",
             Kokkos::RangePolicy<executor>(0, end),
-            KOKKOS_LAMBDA(const int i, T& lsum) { lsum += field_f[i]; },
+            KOKKOS_LAMBDA(const size_t i, T& lsum) { lsum += field_f[i]; },
             sum
         );
     }

--- a/include/NeoFOAM/finiteVolume/cellCentred/boundary/boundaryPatchMixin.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/boundary/boundaryPatchMixin.hpp
@@ -29,12 +29,14 @@ public:
 
     BoundaryPatchMixin() {}
 
-    BoundaryPatchMixin(const UnstructuredMesh& mesh, int patchID)
-        : patchID_(patchID), start_(mesh.boundaryMesh().offset()[patchID_]),
-          end_(mesh.boundaryMesh().offset()[patchID_ + 1])
+    virtual ~BoundaryPatchMixin() = default;
+
+    BoundaryPatchMixin(const UnstructuredMesh& mesh, size_t patchID)
+        : patchID_(patchID), start_(static_cast<label>(mesh.boundaryMesh().offset()[patchID_])),
+          end_(static_cast<label>(mesh.boundaryMesh().offset()[patchID_ + 1]))
     {}
 
-    BoundaryPatchMixin(label start, label end, label patchID)
+    BoundaryPatchMixin(label start, label end, size_t patchID)
         : patchID_(patchID), start_(start), end_(end)
     {}
 
@@ -42,16 +44,16 @@ public:
 
     label patchEnd() const { return start_; };
 
-    label patchSize() const { return end_ - start_; }
+    size_t patchSize() const { return static_cast<size_t>(end_ - start_); }
 
-    label patchID() const { return patchID_; }
+    size_t patchID() const { return patchID_; }
 
     std::pair<size_t, size_t> range() { return {start_, end_}; }
 
 protected:
 
-    label patchID_; ///< The id of this patch
-    label start_;   ///< The start index of the patch in the boundaryField
-    label end_;     ///< The end  index of the patch in the boundaryField
+    size_t patchID_; ///< The id of this patch
+    label start_;    ///< The start index of the patch in the boundaryField
+    label end_;      ///< The end  index of the patch in the boundaryField
 };
 }

--- a/include/NeoFOAM/finiteVolume/cellCentred/boundary/surfaceBoundaryFactory.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/boundary/surfaceBoundaryFactory.hpp
@@ -17,7 +17,7 @@ template<typename ValueType>
 class SurfaceBoundaryFactory :
     public NeoFOAM::RuntimeSelectionFactory<
         SurfaceBoundaryFactory<ValueType>,
-        Parameters<const UnstructuredMesh&, const Dictionary&, int>>,
+        Parameters<const UnstructuredMesh&, const Dictionary&, size_t>>,
     public BoundaryPatchMixin
 {
 public:
@@ -25,7 +25,7 @@ public:
     static std::string name() { return "SurfaceBoundaryFactory"; }
 
     SurfaceBoundaryFactory(
-        const UnstructuredMesh& mesh, [[maybe_unused]] const Dictionary&, std::size_t patchID
+        const UnstructuredMesh& mesh, [[maybe_unused]] const Dictionary&, size_t patchID
     )
         : BoundaryPatchMixin(mesh, patchID) {};
 
@@ -43,10 +43,10 @@ class SurfaceBoundary : public BoundaryPatchMixin
 {
 public:
 
-    SurfaceBoundary(const UnstructuredMesh& mesh, const Dictionary& dict, int patchID)
+    SurfaceBoundary(const UnstructuredMesh& mesh, const Dictionary& dict, size_t patchID)
         : BoundaryPatchMixin(
-            mesh.boundaryMesh().offset()[patchID],
-            mesh.boundaryMesh().offset()[patchID + 1],
+            static_cast<label>(mesh.boundaryMesh().offset()[patchID]),
+            static_cast<label>(mesh.boundaryMesh().offset()[patchID + 1]),
             patchID
         ),
           boundaryCorrectionStrategy_(SurfaceBoundaryFactory<ValueType>::create(

--- a/include/NeoFOAM/finiteVolume/cellCentred/boundary/volume/empty.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/boundary/volume/empty.hpp
@@ -25,7 +25,9 @@ public:
         : Base(mesh, dict, patchID)
     {}
 
-    virtual void correctBoundaryCondition(DomainField<ValueType>& domainField) override {}
+    virtual void correctBoundaryCondition([[maybe_unused]] DomainField<ValueType>& domainField
+    ) override
+    {}
 
     static std::string name() { return "empty"; }
 

--- a/include/NeoFOAM/finiteVolume/cellCentred/boundary/volume/fixedGradient.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/boundary/volume/fixedGradient.hpp
@@ -21,15 +21,15 @@ void setGradientValue(
     DomainField<ValueType>& domainField,
     const UnstructuredMesh& mesh,
     std::pair<size_t, size_t> range,
-    std::size_t patchID,
+    size_t patchID,
     ValueType fixedGradient
 )
 {
     const auto iField = domainField.internalField().span();
     auto refGradient = domainField.boundaryField().refGrad().span();
     auto value = domainField.boundaryField().value().span();
-    auto faceCells = mesh.boundaryMesh().faceCells(patchID);
-    auto deltaCoeffs = mesh.boundaryMesh().deltaCoeffs(patchID);
+    auto faceCells = mesh.boundaryMesh().faceCells(static_cast<localIdx>(patchID));
+    auto deltaCoeffs = mesh.boundaryMesh().deltaCoeffs(static_cast<localIdx>(patchID));
 
     NeoFOAM::parallelFor(
         domainField.exec(),
@@ -37,7 +37,8 @@ void setGradientValue(
         KOKKOS_LAMBDA(const size_t i) {
             refGradient[i] = fixedGradient;
             // operator / is not defined for all ValueTypes
-            value[i] = iField[faceCells[i]] + fixedGradient * (1 / deltaCoeffs[i]);
+            value[i] =
+                iField[static_cast<size_t>(faceCells[i])] + fixedGradient * (1 / deltaCoeffs[i]);
         }
     );
 }

--- a/include/NeoFOAM/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp
@@ -16,7 +16,7 @@ template<typename ValueType>
 class VolumeBoundaryFactory :
     public NeoFOAM::RuntimeSelectionFactory<
         VolumeBoundaryFactory<ValueType>,
-        Parameters<const UnstructuredMesh&, const Dictionary&, int>>,
+        Parameters<const UnstructuredMesh&, const Dictionary&, size_t>>,
     public BoundaryPatchMixin
 {
 public:
@@ -24,7 +24,7 @@ public:
     static std::string name() { return "VolumeBoundaryFactory"; }
 
     VolumeBoundaryFactory(
-        const UnstructuredMesh& mesh, [[maybe_unused]] const Dictionary&, std::size_t patchID
+        const UnstructuredMesh& mesh, [[maybe_unused]] const Dictionary&, size_t patchID
     )
         : BoundaryPatchMixin(mesh, patchID) {};
 
@@ -42,10 +42,10 @@ class VolumeBoundary : public BoundaryPatchMixin
 {
 public:
 
-    VolumeBoundary(const UnstructuredMesh& mesh, const Dictionary& dict, int patchID)
+    VolumeBoundary(const UnstructuredMesh& mesh, const Dictionary& dict, size_t patchID)
         : BoundaryPatchMixin(
-            mesh.boundaryMesh().offset()[patchID],
-            mesh.boundaryMesh().offset()[patchID + 1],
+            static_cast<label>(mesh.boundaryMesh().offset()[patchID]),
+            static_cast<label>(mesh.boundaryMesh().offset()[patchID + 1]),
             patchID
         ),
           boundaryCorrectionStrategy_(VolumeBoundaryFactory<ValueType>::create(

--- a/include/NeoFOAM/mesh/unstructured/communicator.hpp
+++ b/include/NeoFOAM/mesh/unstructured/communicator.hpp
@@ -97,11 +97,11 @@ public:
         }
 
         CommBuffer_[commName]->initComm<valueType>(commName);
-        for (auto rank = 0; rank < mpiEnviron_.sizeRank(); ++rank)
+        for (size_t rank = 0; rank < mpiEnviron_.sizeRank(); ++rank)
         {
             auto rankBuffer = CommBuffer_[commName]->getSend<valueType>(rank);
-            for (auto data = 0; data < sendMap_[rank].size(); ++data)
-                rankBuffer[data] = field(sendMap_[rank][data].local_idx);
+            for (size_t data = 0; data < sendMap_[rank].size(); ++data)
+                rankBuffer[data] = field(static_cast<size_t>(sendMap_[rank][data].local_idx));
         }
         CommBuffer_[commName]->startComm();
     }
@@ -128,11 +128,11 @@ public:
         );
 
         CommBuffer_[commName]->waitComplete();
-        for (auto rank = 0; rank < mpiEnviron_.sizeRank(); ++rank)
+        for (size_t rank = 0; rank < mpiEnviron_.sizeRank(); ++rank)
         {
             auto rankBuffer = CommBuffer_[commName]->getReceive<valueType>(rank);
-            for (auto data = 0; data < receiveMap_[rank].size(); ++data)
-                field(receiveMap_[rank][data].local_idx) = rankBuffer[data];
+            for (size_t data = 0; data < receiveMap_[rank].size(); ++data)
+                field(static_cast<size_t>(receiveMap_[rank][data].local_idx)) = rankBuffer[data];
         }
         CommBuffer_[commName]->finaliseComm();
         CommBuffer_[commName] = nullptr;

--- a/include/NeoFOAM/mesh/unstructured/unstructuredMesh.hpp
+++ b/include/NeoFOAM/mesh/unstructured/unstructuredMesh.hpp
@@ -58,11 +58,11 @@ public:
         scalarField magFaceAreas,
         labelField faceOwner,
         labelField faceNeighbour,
-        localIdx nCells,
-        localIdx nInternalFaces,
-        localIdx nBoundaryFaces,
-        localIdx nBoundaries,
-        localIdx nFaces,
+        size_t nCells,
+        size_t nInternalFaces,
+        size_t nBoundaryFaces,
+        size_t nBoundaries,
+        size_t nFaces,
         BoundaryMesh boundaryMesh
     );
 
@@ -127,35 +127,35 @@ public:
      *
      * @return The number of cells in the mesh.
      */
-    localIdx nCells() const;
+    size_t nCells() const;
 
     /**
      * @brief Get the number of internal faces in the mesh.
      *
      * @return The number of internal faces in the mesh.
      */
-    localIdx nInternalFaces() const;
+    size_t nInternalFaces() const;
 
     /**
      * @brief Get the number of boundary faces in the mesh.
      *
      * @return The number of boundary faces in the mesh.
      */
-    localIdx nBoundaryFaces() const;
+    size_t nBoundaryFaces() const;
 
     /**
      * @brief Get the number of boundaries in the mesh.
      *
      * @return The number of boundaries in the mesh.
      */
-    localIdx nBoundaries() const;
+    size_t nBoundaries() const;
 
     /**
      * @brief Get the number of faces in the mesh.
      *
      * @return The number of faces in the mesh.
      */
-    localIdx nFaces() const;
+    size_t nFaces() const;
 
     /**
      * @brief Get the boundary mesh.
@@ -233,27 +233,27 @@ private:
     /**
      * @brief Number of cells in the mesh.
      */
-    label nCells_;
+    size_t nCells_;
 
     /**
      * @brief Number of internal faces in the mesh.
      */
-    label nInternalFaces_;
+    size_t nInternalFaces_;
 
     /**
      * @brief Number of boundary faces in the mesh.
      */
-    label nBoundaryFaces_;
+    size_t nBoundaryFaces_;
 
     /**
      * @brief Number of boundaries in the mesh.
      */
-    label nBoundaries_;
+    size_t nBoundaries_;
 
     /**
      * @brief Number of faces in the mesh.
      */
-    label nFaces_;
+    size_t nFaces_;
 
     /**
      * @brief Boundary mesh.

--- a/src/core/mpi/halfDuplexCommBuffer.cpp
+++ b/src/core/mpi/halfDuplexCommBuffer.cpp
@@ -26,13 +26,13 @@ void HalfDuplexCommBuffer::send()
 {
     NF_DEBUG_ASSERT(isCommInit(), "Communication buffer is not initialised.");
     NF_DEBUG_ASSERT(isComplete(), "Communication buffer is already active.");
-    for (auto rank = 0; rank < mpiEnviron_.sizeRank(); ++rank)
+    for (size_t rank = 0; rank < mpiEnviron_.sizeRank(); ++rank)
     {
         if (rankOffset_[rank + 1] - rankOffset_[rank] == 0) continue;
         isend<char>(
             rankBuffer_.data() + rankOffset_[rank],
-            rankOffset_[rank + 1] - rankOffset_[rank],
-            rank,
+            static_cast<mpi_label_t>(rankOffset_[rank + 1] - rankOffset_[rank]),
+            static_cast<mpi_label_t>(rank),
             tag_,
             mpiEnviron_.comm(),
             &request_[rank]
@@ -44,13 +44,13 @@ void HalfDuplexCommBuffer::receive()
 {
     NF_DEBUG_ASSERT(isCommInit(), "Communication buffer is not initialised.");
     NF_DEBUG_ASSERT(isComplete(), "Communication buffer is already active.");
-    for (auto rank = 0; rank < mpiEnviron_.sizeRank(); ++rank)
+    for (size_t rank = 0; rank < mpiEnviron_.sizeRank(); ++rank)
     {
         if (rankOffset_[rank + 1] - rankOffset_[rank] == 0) continue;
         irecv<char>(
             rankBuffer_.data() + rankOffset_[rank],
-            rankOffset_[rank + 1] - rankOffset_[rank],
-            rank,
+            static_cast<mpi_label_t>(rankOffset_[rank + 1] - rankOffset_[rank]),
+            static_cast<mpi_label_t>(rank),
             tag_,
             mpiEnviron_.comm(),
             &request_[rank]

--- a/src/mesh/unstructured/boundaryMesh.cpp
+++ b/src/mesh/unstructured/boundaryMesh.cpp
@@ -25,83 +25,76 @@ BoundaryMesh::BoundaryMesh(
 // Accessor methods
 const labelField& BoundaryMesh::faceCells() const { return faceCells_; }
 
+
+template<typename ValueType>
+std::span<const ValueType>
+extractSubSpan(const Field<ValueType>& field, const std::vector<localIdx>& offsets, localIdx i)
+{
+    auto start = static_cast<size_t>(offsets[i]);
+    auto end = static_cast<size_t>(offsets[i + 1]);
+    return field.span({start, end});
+}
+
+
 std::span<const label> BoundaryMesh::faceCells(const localIdx i) const
 {
-    const label& start = offset_[i];
-    const label& end = offset_[i + 1];
-    return faceCells_.span({start, end});
+    return extractSubSpan(faceCells_, offset_, i);
 }
 
 const vectorField& BoundaryMesh::cf() const { return Cf_; }
 
 std::span<const Vector> BoundaryMesh::cf(const localIdx i) const
 {
-    label start = offset_[i];
-    label end = offset_[i + 1];
-    return Cf_.span({start, end});
+    return extractSubSpan(Cf_, offset_, i);
 }
 
 const vectorField& BoundaryMesh::cn() const { return Cn_; }
 
 std::span<const Vector> BoundaryMesh::cn(const localIdx i) const
 {
-    label start = offset_[i];
-    label end = offset_[i + 1];
-    return Cn_.span({start, end});
+    return extractSubSpan(Cn_, offset_, i);
 }
 
 const vectorField& BoundaryMesh::sf() const { return Sf_; }
 
 std::span<const Vector> BoundaryMesh::sf(const localIdx i) const
 {
-    label start = offset_[i];
-    label end = offset_[i + 1];
-    return Sf_.span({start, end});
+    return extractSubSpan(Sf_, offset_, i);
 }
 
 const scalarField& BoundaryMesh::magSf() const { return magSf_; }
 
 std::span<const scalar> BoundaryMesh::magSf(const localIdx i) const
 {
-    label start = offset_[i];
-    label end = offset_[i + 1];
-    return magSf_.span({start, end});
+    return extractSubSpan(magSf_, offset_, i);
 }
 
 const vectorField& BoundaryMesh::nf() const { return nf_; }
 
 std::span<const Vector> BoundaryMesh::nf(const localIdx i) const
 {
-    label start = offset_[i];
-    label end = offset_[i + 1];
-    return nf_.span({start, end});
+    return extractSubSpan(nf_, offset_, i);
 }
 
 const vectorField& BoundaryMesh::delta() const { return delta_; }
 
 std::span<const Vector> BoundaryMesh::delta(const localIdx i) const
 {
-    label start = offset_[i];
-    label end = offset_[i + 1];
-    return delta_.span({start, end});
+    return extractSubSpan(delta_, offset_, i);
 }
 
 const scalarField& BoundaryMesh::weights() const { return weights_; }
 
 std::span<const scalar> BoundaryMesh::weights(const localIdx i) const
 {
-    label start = offset_[i];
-    label end = offset_[i + 1];
-    return weights_.span({start, end});
+    return extractSubSpan(weights_, offset_, i);
 }
 
 const scalarField& BoundaryMesh::deltaCoeffs() const { return deltaCoeffs_; }
 
 std::span<const scalar> BoundaryMesh::deltaCoeffs(const localIdx i) const
 {
-    label start = offset_[i];
-    label end = offset_[i + 1];
-    return deltaCoeffs_.span({start, end});
+    return extractSubSpan(deltaCoeffs_, offset_, i);
 }
 
 const std::vector<localIdx>& BoundaryMesh::offset() const { return offset_; }

--- a/src/mesh/unstructured/communicator.cpp
+++ b/src/mesh/unstructured/communicator.cpp
@@ -26,7 +26,7 @@ Communicator::bufferType* Communicator::createNewDuplexBuffer()
     // determine buffer size.
     std::vector<std::size_t> rankSendSize(mpiEnviron_.sizeRank());
     std::vector<std::size_t> rankReceiveSize(mpiEnviron_.sizeRank());
-    for (auto rank = 0; rank < mpiEnviron_.sizeRank(); ++rank)
+    for (size_t rank = 0; rank < mpiEnviron_.sizeRank(); ++rank)
     {
         rankSendSize[rank] = sendMap_[rank].size();
         rankReceiveSize[rank] = receiveMap_[rank].size();

--- a/src/mesh/unstructured/unstructuredMesh.cpp
+++ b/src/mesh/unstructured/unstructuredMesh.cpp
@@ -15,11 +15,11 @@ UnstructuredMesh::UnstructuredMesh(
     scalarField magFaceAreas,
     labelField faceOwner,
     labelField faceNeighbour,
-    localIdx nCells,
-    localIdx nInternalFaces,
-    localIdx nBoundaryFaces,
-    localIdx nBoundaries,
-    localIdx nFaces,
+    size_t nCells,
+    size_t nInternalFaces,
+    size_t nBoundaryFaces,
+    size_t nBoundaries,
+    size_t nFaces,
     BoundaryMesh boundaryMesh
 )
     : exec_(points.exec()), points_(points), cellVolumes_(cellVolumes), cellCentres_(cellCentres),
@@ -46,15 +46,15 @@ const labelField& UnstructuredMesh::faceOwner() const { return faceOwner_; }
 
 const labelField& UnstructuredMesh::faceNeighbour() const { return faceNeighbour_; }
 
-localIdx UnstructuredMesh::nCells() const { return nCells_; }
+size_t UnstructuredMesh::nCells() const { return nCells_; }
 
-localIdx UnstructuredMesh::nInternalFaces() const { return nInternalFaces_; }
+size_t UnstructuredMesh::nInternalFaces() const { return nInternalFaces_; }
 
-localIdx UnstructuredMesh::nBoundaryFaces() const { return nBoundaryFaces_; }
+size_t UnstructuredMesh::nBoundaryFaces() const { return nBoundaryFaces_; }
 
-localIdx UnstructuredMesh::nBoundaries() const { return nBoundaries_; }
+size_t UnstructuredMesh::nBoundaries() const { return nBoundaries_; }
 
-localIdx UnstructuredMesh::nFaces() const { return nFaces_; }
+size_t UnstructuredMesh::nFaces() const { return nFaces_; }
 
 const BoundaryMesh& UnstructuredMesh::boundaryMesh() const { return boundaryMesh_; }
 

--- a/test/catch2/mpiReporter.cpp
+++ b/test/catch2/mpiReporter.cpp
@@ -20,10 +20,6 @@
  */
 class NullStream : public std::ostream
 {
-public:
-
-    NullStream() : std::ostream(nullptr) {}
-    NullStream(const NullStream&) : std::ostream(nullptr) {}
 };
 
 /**

--- a/test/core/mpi/fullDuplexCommBuffer.cpp
+++ b/test/core/mpi/fullDuplexCommBuffer.cpp
@@ -39,19 +39,19 @@ TEST_CASE("fullDuplexBuffer")
     SECTION("Send and Receive")
     {
         buffer.initComm<int>("Send and Receive");
-        for (int rank = 0; rank < mpiEnviron.sizeRank(); ++rank)
+        for (size_t rank = 0; rank < mpiEnviron.sizeRank(); ++rank)
         {
             auto data = buffer.getSend<int>(rank);
-            data[0] = rank;
+            data[0] = static_cast<int>(rank);
         }
 
         buffer.startComm();
         buffer.waitComplete();
 
-        for (int rank = 0; rank < mpiEnviron.sizeRank(); ++rank)
+        for (size_t rank = 0; rank < mpiEnviron.sizeRank(); ++rank)
         {
             auto data = buffer.getReceive<int>(rank);
-            REQUIRE(data[0] == mpiEnviron.rank());
+            REQUIRE(data[0] == static_cast<int>(mpiEnviron.rank()));
         }
 
         buffer.finaliseComm();

--- a/test/core/mpi/halfDuplexCommBuffer.cpp
+++ b/test/core/mpi/halfDuplexCommBuffer.cpp
@@ -40,11 +40,11 @@ TEST_CASE("halfDuplexBuffer")
 
     SECTION("Set Comm Rank Size")
     {
-        for (int rank = 0; rank < mpiEnviron.sizeRank(); ++rank)
+        for (size_t rank = 0; rank < mpiEnviron.sizeRank(); ++rank)
             rankCommSize[rank] = rank;
         buffer.setCommRankSize<double>(rankCommSize);
         buffer.initComm<double>("Set Comm Rank Size");
-        for (int rank = 0; rank < mpiEnviron.sizeRank(); ++rank)
+        for (size_t rank = 0; rank < mpiEnviron.sizeRank(); ++rank)
         {
             auto data = buffer.get<double>(rank);
             REQUIRE(data.size() == rank);
@@ -60,10 +60,10 @@ TEST_CASE("halfDuplexBuffer")
 
         send.initComm<int>("Send and Receive");
         receive.initComm<int>("Send and Receive");
-        for (int rank = 0; rank < mpiEnviron.sizeRank(); ++rank)
+        for (size_t rank = 0; rank < mpiEnviron.sizeRank(); ++rank)
         {
             auto data = send.get<int>(rank);
-            data[0] = rank;
+            data[0] = static_cast<int>(rank);
         }
 
         send.send();
@@ -72,10 +72,10 @@ TEST_CASE("halfDuplexBuffer")
         send.waitComplete();
         receive.waitComplete();
 
-        for (int rank = 0; rank < mpiEnviron.sizeRank(); ++rank)
+        for (size_t rank = 0; rank < mpiEnviron.sizeRank(); ++rank)
         {
             auto data = receive.get<int>(rank);
-            REQUIRE(data[0] == mpiEnviron.rank());
+            REQUIRE(data[0] == static_cast<int>(mpiEnviron.rank()));
         }
 
         send.finaliseComm();

--- a/test/core/mpi/operators.cpp
+++ b/test/core/mpi/operators.cpp
@@ -69,7 +69,7 @@ TEST_CASE("allReduce value")
 
     SECTION("MPI_SUM")
     {
-        int value = 2.5;
+        int value = 2;
         int sendValue = value;
         allReduce(sendValue, ReduceOp::Sum, MPI_COMM_WORLD);
         REQUIRE(sendValue == value * ranks);
@@ -127,13 +127,13 @@ TEST_CASE("allReduce vectors")
     SECTION("MPI_MAX")
     {
         Vector values;
-        for (int ivalue = 0; ivalue < values.size(); ++ivalue)
+        for (size_t ivalue = 0; ivalue < values.size(); ++ivalue)
         {
             values[ivalue] = static_cast<scalar>(rank) + static_cast<scalar>(ivalue) * 10.0;
         }
         Vector sendValues = values;
         allReduce(sendValues, ReduceOp::Max, MPI_COMM_WORLD);
-        for (int ivalue = 0; ivalue < values.size(); ++ivalue)
+        for (size_t ivalue = 0; ivalue < values.size(); ++ivalue)
         {
             scalar expectedMaxValue =
                 static_cast<scalar>(ranks - 1) + static_cast<scalar>(ivalue) * 10.0;
@@ -144,32 +144,32 @@ TEST_CASE("allReduce vectors")
     SECTION("MPI_MIN")
     {
         Vector values;
-        for (int ivalue = 0; ivalue < values.size(); ++ivalue)
+        for (size_t ivalue = 0; ivalue < values.size(); ++ivalue)
         {
             values[ivalue] = static_cast<scalar>(rank) + static_cast<scalar>(ivalue) * 10.0;
         }
         Vector sendValues = values;
         allReduce(sendValues, ReduceOp::Min, MPI_COMM_WORLD);
-        for (int ivalue = 0; ivalue < values.size(); ++ivalue)
+        for (size_t ivalue = 0; ivalue < values.size(); ++ivalue)
         {
-            REQUIRE(sendValues[ivalue] == ivalue * 10.0);
+            REQUIRE(sendValues[ivalue] == static_cast<scalar>(ivalue) * 10.0);
         }
     }
 
     SECTION("MPI_SUM")
     {
         Vector values;
-        for (int ivalue = 0; ivalue < values.size(); ++ivalue)
+        for (size_t ivalue = 0; ivalue < values.size(); ++ivalue)
         {
             values[ivalue] = static_cast<scalar>(ivalue) * 10.0;
         }
         Vector sendValues = values;
         allReduce(sendValues, ReduceOp::Sum, MPI_COMM_WORLD);
-        for (int ivalue = 0; ivalue < values.size(); ++ivalue)
+        for (size_t ivalue = 0; ivalue < values.size(); ++ivalue)
         {
-            values[ivalue] = static_cast<scalar>(ranks * ivalue) * 10.0;
+            values[ivalue] = static_cast<scalar>(ranks) * static_cast<scalar>(ivalue) * 10.0;
         }
-        for (int ivalue = 0; ivalue < sendValues.size(); ++ivalue)
+        for (size_t ivalue = 0; ivalue < sendValues.size(); ++ivalue)
         {
             REQUIRE(sendValues[ivalue] == values[ivalue]);
         }
@@ -178,17 +178,17 @@ TEST_CASE("allReduce vectors")
     SECTION("MPI_PROD")
     {
         Vector values;
-        for (int ivalue = 0; ivalue < values.size(); ++ivalue)
+        for (size_t ivalue = 0; ivalue < values.size(); ++ivalue)
         {
             values[ivalue] = static_cast<scalar>(ivalue) * 10.0;
         }
         Vector sendValues = values;
         allReduce(sendValues, ReduceOp::Prod, MPI_COMM_WORLD);
-        for (int ivalue = 0; ivalue < values.size(); ++ivalue)
+        for (size_t ivalue = 0; ivalue < values.size(); ++ivalue)
         {
             values[ivalue] = std::pow(values[ivalue], static_cast<float>(ranks));
         }
-        for (int ivalue = 0; ivalue < sendValues.size(); ++ivalue)
+        for (size_t ivalue = 0; ivalue < sendValues.size(); ++ivalue)
         {
             REQUIRE(sendValues[ivalue] == values[ivalue]);
         }

--- a/test/core/parallelAlgorithms.cpp
+++ b/test/core/parallelAlgorithms.cpp
@@ -98,7 +98,7 @@ TEST_CASE("parallelReduce")
         NeoFOAM::fill(fieldB, 1.0);
         NeoFOAM::scalar sum = 0.0;
         NeoFOAM::parallelReduce(
-            exec, {0, 5}, KOKKOS_LAMBDA(const int i, double& lsum) { lsum += spanB[i]; }, sum
+            exec, {0, 5}, KOKKOS_LAMBDA(const size_t i, double& lsum) { lsum += spanB[i]; }, sum
         );
 
         REQUIRE(sum == 5.0);
@@ -114,7 +114,7 @@ TEST_CASE("parallelReduce")
         NeoFOAM::fill(fieldB, 1.0);
         NeoFOAM::scalar sum = 0.0;
         NeoFOAM::parallelReduce(
-            fieldA, KOKKOS_LAMBDA(const int i, double& lsum) { lsum += spanB[i]; }, sum
+            fieldA, KOKKOS_LAMBDA(const size_t i, double& lsum) { lsum += spanB[i]; }, sum
         );
 
         REQUIRE(sum == 5.0);

--- a/test/fields/field.cpp
+++ b/test/fields/field.cpp
@@ -23,7 +23,7 @@ TEST_CASE("Field Constructors")
 
     SECTION("Copy Constructor " + execName)
     {
-        int size = 10;
+        NeoFOAM::size_t size = 10;
         NeoFOAM::Field<NeoFOAM::scalar> a(exec, size);
         NeoFOAM::fill(a, 5.0);
         NeoFOAM::Field<NeoFOAM::scalar> b(a);
@@ -73,7 +73,7 @@ TEST_CASE("Field Operator Overloads")
 
     SECTION("Field Operator+= " + execName)
     {
-        int size = 10;
+        NeoFOAM::size_t size = 10;
         NeoFOAM::Field<NeoFOAM::scalar> a(exec, size);
         NeoFOAM::Field<NeoFOAM::scalar> b(exec, size);
         NeoFOAM::fill(a, 5.0);
@@ -90,7 +90,7 @@ TEST_CASE("Field Operator Overloads")
 
     SECTION("Field Operator-= " + execName)
     {
-        int size = 10;
+        NeoFOAM::size_t size = 10;
         NeoFOAM::Field<NeoFOAM::scalar> a(exec, size);
         NeoFOAM::Field<NeoFOAM::scalar> b(exec, size);
         NeoFOAM::fill(a, 5.0);
@@ -107,7 +107,7 @@ TEST_CASE("Field Operator Overloads")
 
     SECTION("Field Operator+ " + execName)
     {
-        int size = 10;
+        NeoFOAM::size_t size = 10;
         NeoFOAM::Field<NeoFOAM::scalar> a(exec, size);
         NeoFOAM::Field<NeoFOAM::scalar> b(exec, size);
         NeoFOAM::Field<NeoFOAM::scalar> c(exec, size);
@@ -124,7 +124,7 @@ TEST_CASE("Field Operator Overloads")
 
     SECTION("Field Operator-" + execName)
     {
-        int size = 10;
+        NeoFOAM::size_t size = 10;
         NeoFOAM::Field<NeoFOAM::scalar> a(exec, size);
         NeoFOAM::Field<NeoFOAM::scalar> b(exec, size);
         NeoFOAM::Field<NeoFOAM::scalar> c(exec, size);
@@ -153,7 +153,7 @@ TEST_CASE("Field Container Operations")
 
     SECTION("empty, size, range" + execName)
     {
-        int size = 10;
+        NeoFOAM::size_t size = 10;
         NeoFOAM::Field<NeoFOAM::scalar> a(exec, 0);
         NeoFOAM::Field<NeoFOAM::scalar> b(exec, size);
         REQUIRE(a.empty() == true);
@@ -221,7 +221,7 @@ TEST_CASE("Field Operations")
 
     SECTION("Field_" + execName)
     {
-        int size = 10;
+        NeoFOAM::size_t size = 10;
         NeoFOAM::Field<NeoFOAM::scalar> a(exec, size);
         auto sA = a.span();
         NeoFOAM::fill(a, 5.0);
@@ -251,8 +251,8 @@ TEST_CASE("Field Operations")
         a = a * b;
         REQUIRE(equal(a, 20.0));
 
-        auto s_b = b.span();
-        a.apply(KOKKOS_LAMBDA(int i) { return 2 * s_b[i]; });
+        auto sB = b.span();
+        a.apply(KOKKOS_LAMBDA(const NeoFOAM::size_t i) { return 2 * sB[i]; });
         REQUIRE(equal(a, 20.0));
     }
 }

--- a/test/finiteVolume/cellCentred/fields/surfaceField.cpp
+++ b/test/finiteVolume/cellCentred/fields/surfaceField.cpp
@@ -10,6 +10,9 @@
 #include "NeoFOAM/finiteVolume/cellCentred/fields/surfaceField.hpp"
 #include "NeoFOAM/finiteVolume/cellCentred/boundary/surfaceBoundaryFactory.hpp"
 
+template<typename T>
+using I = std::initializer_list<T>;
+
 TEST_CASE("surfaceField")
 {
     namespace fvcc = NeoFOAM::finiteVolume::cellCentred;
@@ -26,7 +29,7 @@ TEST_CASE("surfaceField")
     {
         NeoFOAM::UnstructuredMesh mesh = NeoFOAM::createSingleCellMesh(exec);
         std::vector<std::unique_ptr<fvcc::SurfaceBoundary<NeoFOAM::scalar>>> bcs {};
-        for (size_t patchi : {0, 1, 2, 3})
+        for (auto patchi : I<NeoFOAM::size_t> {0, 1, 2, 3})
         {
             NeoFOAM::Dictionary dict;
             dict.insert("type", std::string("fixedValue"));

--- a/test/finiteVolume/cellCentred/fields/volumeField.cpp
+++ b/test/finiteVolume/cellCentred/fields/volumeField.cpp
@@ -10,6 +10,9 @@
 #include "NeoFOAM/finiteVolume/cellCentred/fields/volumeField.hpp"
 #include "NeoFOAM/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp"
 
+template<typename T>
+using I = std::initializer_list<T>;
+
 TEST_CASE("volumeField")
 {
     namespace fvcc = NeoFOAM::finiteVolume::cellCentred;
@@ -26,7 +29,7 @@ TEST_CASE("volumeField")
     {
         NeoFOAM::UnstructuredMesh mesh = NeoFOAM::createSingleCellMesh(exec);
         std::vector<std::unique_ptr<fvcc::VolumeBoundary<NeoFOAM::scalar>>> bcs {};
-        for (size_t patchi : {0, 1, 2, 3})
+        for (auto patchi : I<size_t> {0, 1, 2, 3})
         {
             NeoFOAM::Dictionary dict;
             dict.insert("type", std::string("fixedValue"));

--- a/test/mesh/unstructured/communicator.cpp
+++ b/test/mesh/unstructured/communicator.cpp
@@ -23,13 +23,13 @@ TEST_CASE("Communicator Field Synchronization")
     // third block receive (size rank)
     Field<int> field(CPUExecutor(), 3 * mpiEnviron.sizeRank());
 
-    for (int rank = 0; rank < mpiEnviron.sizeRank(); rank++)
+    for (size_t rank = 0; rank < mpiEnviron.sizeRank(); rank++)
     {
         // we send the rank numbers
-        field(rank) = rank;
+        field(rank) = static_cast<int>(rank);
 
         // just make sure its not a communicated value.
-        field(rank + mpiEnviron.sizeRank()) = mpiEnviron.sizeRank() + rank;
+        field(rank + mpiEnviron.sizeRank()) = static_cast<int>(mpiEnviron.sizeRank() + rank);
 
         // set to 0.0 to check if the value is communicated
         field(rank + 2 * mpiEnviron.sizeRank()) = 0;
@@ -38,10 +38,10 @@ TEST_CASE("Communicator Field Synchronization")
     // Set up buffer to local map, we will ignore global_idx
     CommMap rankSendMap(mpiEnviron.sizeRank());
     CommMap rankReceiveMap(mpiEnviron.sizeRank());
-    for (int rank = 0; rank < mpiEnviron.sizeRank(); rank++)
+    for (size_t rank = 0; rank < mpiEnviron.sizeRank(); rank++)
     {
-        rankSendMap[rank].emplace_back(NodeCommMap {.local_idx = rank});
-        NodeCommMap newNode({.local_idx = 2 * mpiEnviron.sizeRank() + rank});
+        rankSendMap[rank].emplace_back(NodeCommMap {.local_idx = static_cast<label>(rank)});
+        NodeCommMap newNode({.local_idx = static_cast<label>(2 * mpiEnviron.sizeRank() + rank)});
         rankReceiveMap[rank].push_back(newNode); // got tired of fighting with clang-format.
     }
 
@@ -54,10 +54,12 @@ TEST_CASE("Communicator Field Synchronization")
     comm.finaliseComm(field, loc);
 
     // Check the values
-    for (int rank = 0; rank < mpiEnviron.sizeRank(); rank++)
+    for (size_t rank = 0; rank < mpiEnviron.sizeRank(); rank++)
     {
-        REQUIRE(field(rank) == rank);
-        REQUIRE(field(rank + mpiEnviron.sizeRank()) == mpiEnviron.sizeRank() + rank);
-        REQUIRE(field(rank + 2 * mpiEnviron.sizeRank()) == mpiEnviron.rank());
+        REQUIRE(field(rank) == static_cast<int>(rank));
+        REQUIRE(
+            field(rank + mpiEnviron.sizeRank()) == static_cast<int>(mpiEnviron.sizeRank() + rank)
+        );
+        REQUIRE(field(rank + 2 * mpiEnviron.sizeRank()) == static_cast<int>(mpiEnviron.rank()));
     }
 }


### PR DESCRIPTION
This PR fixes all compiler warnings that are present in the development build. Most of the warnings were due to conversion between signed and unsigned integer types. Right now, we have different types for indices (`label == int32_t`) and sizes (`size_t == std::size_t`). I will look into defining the integer types we use more consistently. 

To make fixing the warnings easier, this also implements the `operationMacros` for fields with the `parallelFor` functions.