### PR TITLE
Fix CMake benchmark targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Additionally, we provide several Cmake presets to set commmonly required flags i
 NeoFOAM provides a set of benchmarks which can be executed and plotted by the following commands
 
     cmake --build . --target execute_benchmarks # runs the benchmark suite
-    cmake --build . --target execute_execute_plot_benchmark # plots the benchmark results
+    cmake --build . --target execute_plot_benchmark # plots the benchmark results
 
 
 ## Executing Tests

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -15,8 +15,8 @@ find_package(
 
 add_custom_command(
   OUTPUT ${PROJECT_BINARY_DIR}/benchmarks/fields.png
-  COMMAND python ${PROJECT_SOURCE_DIR}/scripts/plotBenchmarks.py
-          /benchmarks/fields/${CMAKE_BUILD_TYPE}/fields.xml
+  COMMAND Python3::Interpreter ${PROJECT_SOURCE_DIR}/scripts/plotBenchmarks.py
+          ${PROJECT_BINARY_DIR}/benchmarks/fields.xml
   COMMENT "Plot benchmark results")
 
 add_custom_target(

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -5,8 +5,7 @@ add_subdirectory(fields)
 
 add_custom_command(
   OUTPUT ${PROJECT_BINARY_DIR}/benchmarks/fields.xml
-  COMMAND ${PROJECT_BINARY_DIR}/benchmarks/fields/${CMAKE_BUILD_TYPE}/bench_fields -r XML >
-          fields.xml
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/benchmarks/bench_fields -r XML > fields.xml
   COMMENT "Execute benchmarks")
 
 find_package(

--- a/benchmarks/fields/CMakeLists.txt
+++ b/benchmarks/fields/CMakeLists.txt
@@ -4,3 +4,5 @@
 add_executable(bench_fields "bench_fields.cpp")
 
 target_link_libraries(bench_fields PRIVATE Catch2::Catch2 NeoFOAM Kokkos::kokkos)
+set_property(TARGET bench_fields PROPERTY RUNTIME_OUTPUT_DIRECTORY
+                                          ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/benchmarks)

--- a/scripts/plotBenchmarks.py
+++ b/scripts/plotBenchmarks.py
@@ -7,6 +7,8 @@ import matplotlib.pyplot as plt
 import seaborn as sns
 import sys
 
+xml_file = sys.argv[1]
+
 # Parse the XML file
 tree = ET.parse(xml_file)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,7 +21,7 @@ function(neofoam_unit_test TEST)
     set(neofoam_MPI_SIZE 1)
   endif()
   if(NOT DEFINED "neofoam_WORKING_DIRECTORY")
-    set(neofoam_WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+    set(neofoam_WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/bin/tests)
   endif()
   if(NOT DEFINED "neofoam_COMMAND")
     set(neofoam_COMMAND ${TEST})
@@ -30,6 +30,8 @@ function(neofoam_unit_test TEST)
   add_executable(${TEST} "${TEST}.cpp")
   target_link_libraries(${TEST} PRIVATE neofoam_catch_main neofoam_warnings neofoam_options
                                         Kokkos::kokkos NeoFOAM cpptrace::cpptrace)
+  set_target_properties(${TEST} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${neofoam_WORKING_DIRECTORY})
+
   add_test(
     NAME ${TEST}
     COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${neofoam_MPI_SIZE} ${neofoam_COMMAND}


### PR DESCRIPTION
This fixes the CMake benchmark targets. It additionally moves the tests into the subdirectory `bin/tests`.

Closes #115 