### PR TITLE
Relax openmp requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Version 0.1.0 (unreleased)
+- Changes executor meanings, the CPUExecutor was renamed to SerialExecutor and  the OMPExecutor was renamed to CPUExecutor. [PR #120](https://github.com/exasim-project/NeoFOAM/pull/120)
 - Minor cleanup of MPI operator names, added vector version of allReduce, and updates mpi and thread support operations. [PR #105](https://github.com/exasim-project/NeoFOAM/pull/105)
 - Implementation of surface BCs and improvements to volume BCs  [PR #104](https://github.com/exasim-project/NeoFOAM/pull/104)
 - improvements to vector and dictionary; fix of the hanging issue with cuda  [PR #108](https://github.com/exasim-project/NeoFOAM/pull/108)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -11,8 +11,7 @@
       "hidden": true,
       "binaryDir": "${sourceDir}/build/${presetName}",
       "cacheVariables": {
-        "Kokkos_ENABLE_SERIAL": "ON",
-        "Kokkos_ENABLE_OPENMP": "ON"
+        "Kokkos_ENABLE_SERIAL": "ON"
       },
       "generator": "Ninja"
     },

--- a/benchmarks/fields/bench_fields.cpp
+++ b/benchmarks/fields/bench_fields.cpp
@@ -59,7 +59,7 @@ TEST_CASE("Vector addition [benchmark]")
 }
 
 {
-    NeoFOAM::OMPExecutor ompExec {};
+    NeoFOAM::CPUExecutor ompExec {};
     NeoFOAM::Field<NeoFOAM::scalar> ompA(ompExec, size);
     NeoFOAM::fill(ompA, 1.0);
     NeoFOAM::Field<NeoFOAM::scalar> ompB(ompExec, size);
@@ -106,7 +106,7 @@ TEST_CASE("Vector addition [benchmark]")
 }
 
 {
-    NeoFOAM::OMPExecutor ompExec {};
+    NeoFOAM::CPUExecutor ompExec {};
     NeoFOAM::Field<NeoFOAM::scalar> ompA(ompExec, size);
     NeoFOAM::fill(ompA, 1.0);
     NeoFOAM::Field<NeoFOAM::scalar> ompB(ompExec, size);

--- a/benchmarks/fields/bench_fields.cpp
+++ b/benchmarks/fields/bench_fields.cpp
@@ -47,7 +47,7 @@ TEST_CASE("Vector addition [benchmark]")
     CAPTURE(size); // Capture the value of size
 
     // capture the value of size as section name
-    DYNAMIC_SECTION("" << size) {{NeoFOAM::CPUExecutor cpuExec {};
+    DYNAMIC_SECTION("" << size) {{NeoFOAM::SerialExecutor cpuExec {};
     NeoFOAM::Field<NeoFOAM::scalar> cpuA(cpuExec, size);
     NeoFOAM::fill(cpuA, 1.0);
     NeoFOAM::Field<NeoFOAM::scalar> cpuB(cpuExec, size);

--- a/cmake/AutoEnableDevice.cmake
+++ b/cmake/AutoEnableDevice.cmake
@@ -3,6 +3,24 @@
 
 include(CheckLanguage)
 
+if(NOT DEFINED Kokkos_ENABLE_OPENMP AND NOT DEFINED Kokkos_ENABLE_THREADS)
+  find_package(OpenMP QUIET)
+
+  if(OpenMP_FOUND)
+    set(Kokkos_ENABLE_OPENMP
+        ON
+        CACHE INTERNAL "")
+  else()
+    find_package(Threads QUIET)
+
+    if(Threads_FOUND)
+      set(Kokkos_ENABLE_THREADS
+          ON
+          CACHE INTERNAL "")
+    endif()
+  endif()
+endif()
+
 if(NOT DEFINED Kokkos_ENABLE_CUDA)
   check_language(CUDA)
 

--- a/doc/api/executor.rst
+++ b/doc/api/executor.rst
@@ -9,7 +9,7 @@ Overview
 NeoFOAM uses the MPI+X approach for parallelism, where X is the execution space used for parallelism. The `Executor` class uses Kokkos and provides an interface for memory management and specifics were to execute the operations:
 
 - `SerialExecutor`: run on the CPU with MPI
-- `CPUExecutor`: run on the CPU with OpenMP and MPI
+- `CPUExecutor`: run on the CPU with either OpenMP or C++ Threads in Combination and MPI
 - `GPUExecutor`: run on the GPU with MPI
 
 Design

--- a/doc/api/executor.rst
+++ b/doc/api/executor.rst
@@ -8,7 +8,7 @@ Overview
 
 NeoFOAM uses the MPI+X approach for parallelism, where X is the execution space used for parallelism. The `Executor` class uses Kokkos and provides an interface for memory management and specifics were to execute the operations:
 
-- `CPUExecutor`: run on the CPU with MPI
+- `SerialExecutor`: run on the CPU with MPI
 - `OMPExecutor`: run on the CPU with OpenMP and MPI
 - `GPUExecutor`: run on the GPU with MPI
 
@@ -21,7 +21,7 @@ One of the design goals is the ability to quickly switch between the executor mo
 .. code-block:: cpp
 
         NeoFOAM::GPUExecutor gpuExec {};
-        NeoFOAM::CPUExecutor cpuExec {};
+        NeoFOAM::SerialExecutor cpuExec {};
 
         NeoFOAM::Field<NeoFOAM::scalar> GPUField(gpuExec, 10);
         NeoFOAM::Field<NeoFOAM::scalar> CPUField(cpuExec, 10);
@@ -31,13 +31,13 @@ The `Executor` is a std::variant
 
 .. code-block:: cpp
 
-    using executor = std::variant<OMPExecutor, GPUExecutor, CPUExecutor>;
+    using executor = std::variant<OMPExecutor, GPUExecutor, SerialExecutor>;
 
 and allows to switch between the different strategies for memory allocation and execution at runtime. We use `std::visit` to switch between the different strategies:
 
 .. code-block:: cpp
 
-    NeoFOAM::CPUExecutor exec{};
+    NeoFOAM::SerialExecutor exec{};
     std::visit([&](const auto& exec)
                { Functor(exec); },
                exec);
@@ -48,9 +48,9 @@ that are provided by a functor
 
     struct Functor
     {
-        void operator()(const CPUExecutor& exec)
+        void operator()(const SerialExecutor& exec)
         {
-            std::cout << "CPUExecutor" << std::endl;
+            std::cout << "SerialExecutor" << std::endl;
         }
 
         void operator()(const OMPExecutor& exec)

--- a/doc/api/executor.rst
+++ b/doc/api/executor.rst
@@ -9,7 +9,7 @@ Overview
 NeoFOAM uses the MPI+X approach for parallelism, where X is the execution space used for parallelism. The `Executor` class uses Kokkos and provides an interface for memory management and specifics were to execute the operations:
 
 - `SerialExecutor`: run on the CPU with MPI
-- `OMPExecutor`: run on the CPU with OpenMP and MPI
+- `CPUExecutor`: run on the CPU with OpenMP and MPI
 - `GPUExecutor`: run on the GPU with MPI
 
 Design
@@ -31,7 +31,7 @@ The `Executor` is a std::variant
 
 .. code-block:: cpp
 
-    using executor = std::variant<OMPExecutor, GPUExecutor, SerialExecutor>;
+    using executor = std::variant<CPUExecutor, GPUExecutor, SerialExecutor>;
 
 and allows to switch between the different strategies for memory allocation and execution at runtime. We use `std::visit` to switch between the different strategies:
 
@@ -53,9 +53,9 @@ that are provided by a functor
             std::cout << "SerialExecutor" << std::endl;
         }
 
-        void operator()(const OMPExecutor& exec)
+        void operator()(const CPUExecutor& exec)
         {
-            std::cout << "OMPExecutor" << std::endl;
+            std::cout << "CPUExecutor" << std::endl;
         }
 
         void operator()(const GPUExecutor& exec)

--- a/doc/basics/containers.rst
+++ b/doc/basics/containers.rst
@@ -20,7 +20,7 @@ The following example shows how to use the field function to access the data of 
 
 .. code-block:: cpp
 
-     NeoFOAM::CPUExecutor cpuExec {};
+     NeoFOAM::SerialExecutor cpuExec {};
      NeoFOAM::Field<NeoFOAM::scalar> a(cpuExec, size);
      std::span<double> sA = a.field();
      // for loop

--- a/doc/basics/executor.rst
+++ b/doc/basics/executor.rst
@@ -9,7 +9,7 @@ Overview
 NeoFOAM uses the MPI+X approach for parallelism, where X is the execution space used for device parallelism. The `Executor` class uses Kokkos and provides an interface for memory management and specifics were to execute the operations:
 
 - `SerialExecutor`: run on the CPU with MPI
-- `CPUExecutor`: run on the CPU with either OpenMP or Threads, and MPI
+- `CPUExecutor`: run on the CPU with either OpenMP or C++ Threads in Combination and MPI
 - `GPUExecutor`: run on the GPU with MPI
 
 Design

--- a/doc/basics/executor.rst
+++ b/doc/basics/executor.rst
@@ -8,7 +8,7 @@ Overview
 
 NeoFOAM uses the MPI+X approach for parallelism, where X is the execution space used for device parallelism. The `Executor` class uses Kokkos and provides an interface for memory management and specifics were to execute the operations:
 
-- `CPUExecutor`: run on the CPU with MPI
+- `SerialExecutor`: run on the CPU with MPI
 - `OMPExecutor`: run on the CPU with OpenMP and MPI
 - `GPUExecutor`: run on the GPU with MPI
 
@@ -22,7 +22,7 @@ One of the design goals is the ability to easily switch between different execut
 .. code-block:: cpp
 
         NeoFOAM::GPUExecutor gpuExec {};
-        NeoFOAM::CPUExecutor cpuExec {};
+        NeoFOAM::SerialExecutor cpuExec {};
 
         NeoFOAM::Field<NeoFOAM::scalar> GPUField(gpuExec, 10);
         NeoFOAM::Field<NeoFOAM::scalar> CPUField(cpuExec, 10);
@@ -32,13 +32,13 @@ The `Executor` is a `std::variant <https://en.cppreference.com/w/cpp/utility/var
 
 .. code-block:: cpp
 
-    using executor = std::variant<OMPExecutor, GPUExecutor, CPUExecutor>;
+    using executor = std::variant<OMPExecutor, GPUExecutor, SerialExecutor>;
 
 and allows to switch between the different strategies for memory allocation and execution at runtime. We use `std::visit <https://en.cppreference.com/w/cpp/utility/variant/visit>`_ to switch between the different strategies:
 
 .. code-block:: cpp
 
-    NeoFOAM::CPUExecutor exec{};
+    NeoFOAM::SerialExecutor exec{};
     std::visit([&](const auto& exec)
                { Functor(exec); },
                exec);
@@ -49,9 +49,9 @@ that are provided by a functor
 
     struct Functor
     {
-        void operator()(const CPUExecutor& exec)
+        void operator()(const SerialExecutor& exec)
         {
-            std::cout << "CPUExecutor" << std::endl;
+            std::cout << "SerialExecutor" << std::endl;
         }
 
         void operator()(const OMPExecutor& exec)

--- a/doc/basics/executor.rst
+++ b/doc/basics/executor.rst
@@ -9,7 +9,7 @@ Overview
 NeoFOAM uses the MPI+X approach for parallelism, where X is the execution space used for device parallelism. The `Executor` class uses Kokkos and provides an interface for memory management and specifics were to execute the operations:
 
 - `SerialExecutor`: run on the CPU with MPI
-- `OMPExecutor`: run on the CPU with OpenMP and MPI
+- `CPUExecutor`: run on the CPU with either OpenMP or Threads, and MPI
 - `GPUExecutor`: run on the GPU with MPI
 
 Design
@@ -22,7 +22,7 @@ One of the design goals is the ability to easily switch between different execut
 .. code-block:: cpp
 
         NeoFOAM::GPUExecutor gpuExec {};
-        NeoFOAM::SerialExecutor cpuExec {};
+        NeoFOAM::CPUExecutor cpuExec {};
 
         NeoFOAM::Field<NeoFOAM::scalar> GPUField(gpuExec, 10);
         NeoFOAM::Field<NeoFOAM::scalar> CPUField(cpuExec, 10);
@@ -32,7 +32,7 @@ The `Executor` is a `std::variant <https://en.cppreference.com/w/cpp/utility/var
 
 .. code-block:: cpp
 
-    using executor = std::variant<OMPExecutor, GPUExecutor, SerialExecutor>;
+    using executor = std::variant<CPUExecutor, GPUExecutor, SerialExecutor>;
 
 and allows to switch between the different strategies for memory allocation and execution at runtime. We use `std::visit <https://en.cppreference.com/w/cpp/utility/variant/visit>`_ to switch between the different strategies:
 
@@ -54,9 +54,9 @@ that are provided by a functor
             std::cout << "SerialExecutor" << std::endl;
         }
 
-        void operator()(const OMPExecutor& exec)
+        void operator()(const CPUExecutor& exec)
         {
-            std::cout << "OMPExecutor" << std::endl;
+            std::cout << "CPUExecutor" << std::endl;
         }
 
         void operator()(const GPUExecutor& exec)

--- a/doc/basics/mpi_architecture.rst
+++ b/doc/basics/mpi_architecture.rst
@@ -174,7 +174,7 @@ It is worth noting that there may be more than one field being synchronized at a
     mpi::MPIEnvironment MPIEnviron;
     Communicator comm;
 
-    Field<int> field(CPUExecutor());
+    Field<int> field(SerialExecutor());
 
     // ...
     // Size and populate field data.

--- a/include/NeoFOAM/core/executor/CPUExecutor.hpp
+++ b/include/NeoFOAM/core/executor/CPUExecutor.hpp
@@ -9,8 +9,8 @@ namespace NeoFOAM
 {
 
 /**
- * @class OMPExecutor
- * @brief Executor for handling OpenMP based parallelization.
+ * @class CPUExecutor
+ * @brief Executor for handling multicore CPU based parallelization.
  *
  *
  * @ingroup Executor

--- a/include/NeoFOAM/core/executor/CPUExecutor.hpp
+++ b/include/NeoFOAM/core/executor/CPUExecutor.hpp
@@ -15,14 +15,14 @@ namespace NeoFOAM
  *
  * @ingroup Executor
  */
-class OMPExecutor
+class CPUExecutor
 {
 public:
 
     using exec = Kokkos::DefaultHostExecutionSpace;
 
-    OMPExecutor();
-    ~OMPExecutor();
+    CPUExecutor();
+    ~CPUExecutor();
 
     template<typename T>
     T* alloc(size_t size) const
@@ -60,7 +60,7 @@ public:
 
     void free(void* ptr) const noexcept { Kokkos::kokkos_free<exec>(ptr); };
 
-    std::string name() const { return "OMPExecutor"; };
+    std::string name() const { return "CPUExecutor"; };
 };
 
 } // namespace NeoFOAM

--- a/include/NeoFOAM/core/executor/OMPExecutor.hpp
+++ b/include/NeoFOAM/core/executor/OMPExecutor.hpp
@@ -19,7 +19,7 @@ class OMPExecutor
 {
 public:
 
-    using exec = Kokkos::OpenMP;
+    using exec = Kokkos::DefaultHostExecutionSpace;
 
     OMPExecutor();
     ~OMPExecutor();

--- a/include/NeoFOAM/core/executor/executor.hpp
+++ b/include/NeoFOAM/core/executor/executor.hpp
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2023 NeoFOAM authors
 #pragma once
 
-#include "NeoFOAM/core/executor/CPUExecutor.hpp"
+#include "NeoFOAM/core/executor/serialExecutor.hpp"
 #include "NeoFOAM/core/executor/GPUExecutor.hpp"
 #include "NeoFOAM/core/executor/OMPExecutor.hpp"
 #include <variant>
@@ -10,7 +10,7 @@
 namespace NeoFOAM
 {
 
-using Executor = std::variant<OMPExecutor, GPUExecutor, CPUExecutor>;
+using Executor = std::variant<OMPExecutor, GPUExecutor, SerialExecutor>;
 
 /**
  * @brief Checks if two executors are equal, i.e. they are of the same type.

--- a/include/NeoFOAM/core/executor/executor.hpp
+++ b/include/NeoFOAM/core/executor/executor.hpp
@@ -4,13 +4,13 @@
 
 #include "NeoFOAM/core/executor/serialExecutor.hpp"
 #include "NeoFOAM/core/executor/GPUExecutor.hpp"
-#include "NeoFOAM/core/executor/OMPExecutor.hpp"
+#include "NeoFOAM/core/executor/CPUExecutor.hpp"
 #include <variant>
 
 namespace NeoFOAM
 {
 
-using Executor = std::variant<OMPExecutor, GPUExecutor, SerialExecutor>;
+using Executor = std::variant<CPUExecutor, GPUExecutor, SerialExecutor>;
 
 /**
  * @brief Checks if two executors are equal, i.e. they are of the same type.

--- a/include/NeoFOAM/core/executor/serialExecutor.hpp
+++ b/include/NeoFOAM/core/executor/serialExecutor.hpp
@@ -9,7 +9,7 @@ namespace NeoFOAM
 {
 
 /**
- * @class CPUExecutor
+ * @class SerialExecutor
  * @brief Reference executor for serial CPU execution.
  *
  * @ingroup Executor

--- a/include/NeoFOAM/core/executor/serialExecutor.hpp
+++ b/include/NeoFOAM/core/executor/serialExecutor.hpp
@@ -14,14 +14,14 @@ namespace NeoFOAM
  *
  * @ingroup Executor
  */
-class CPUExecutor
+class SerialExecutor
 {
 public:
 
     using exec = Kokkos::Serial;
 
-    CPUExecutor();
-    ~CPUExecutor();
+    SerialExecutor();
+    ~SerialExecutor();
 
     template<typename T>
     T* alloc(size_t size) const
@@ -60,7 +60,7 @@ public:
 
     void free(void* ptr) const noexcept { Kokkos::kokkos_free<exec>(ptr); };
 
-    std::string name() const { return "CPUExecutor"; };
+    std::string name() const { return "SerialExecutor"; };
 };
 
 } // namespace NeoFOAM

--- a/include/NeoFOAM/core/parallelAlgorithms.hpp
+++ b/include/NeoFOAM/core/parallelAlgorithms.hpp
@@ -29,7 +29,7 @@ void parallelFor(
 )
 {
     auto [start, end] = range;
-    if constexpr (std::is_same<std::remove_reference_t<Executor>, CPUExecutor>::value)
+    if constexpr (std::is_same<std::remove_reference_t<Executor>, SerialExecutor>::value)
     {
         for (size_t i = start; i < end; i++)
         {
@@ -66,7 +66,7 @@ template<typename Executor, typename ValueType, parallelForFieldKernel<ValueType
 void parallelFor([[maybe_unused]] const Executor& exec, Field<ValueType>& field, Kernel kernel)
 {
     auto span = field.span();
-    if constexpr (std::is_same<std::remove_reference_t<Executor>, CPUExecutor>::value)
+    if constexpr (std::is_same<std::remove_reference_t<Executor>, SerialExecutor>::value)
     {
         for (size_t i = 0; i < field.size(); i++)
         {
@@ -97,7 +97,7 @@ void parallelReduce(
 )
 {
     auto [start, end] = range;
-    if constexpr (std::is_same<std::remove_reference_t<Executor>, CPUExecutor>::value)
+    if constexpr (std::is_same<std::remove_reference_t<Executor>, SerialExecutor>::value)
     {
         for (size_t i = start; i < end; i++)
         {
@@ -127,7 +127,7 @@ void parallelReduce(
     [[maybe_unused]] const Executor& exec, Field<ValueType>& field, Kernel kernel, T& value
 )
 {
-    if constexpr (std::is_same<std::remove_reference_t<Executor>, CPUExecutor>::value)
+    if constexpr (std::is_same<std::remove_reference_t<Executor>, SerialExecutor>::value)
     {
         for (size_t i = 0; i < field.size(); i++)
         {

--- a/include/NeoFOAM/fields/field.hpp
+++ b/include/NeoFOAM/fields/field.hpp
@@ -74,7 +74,7 @@ public:
     Field(const Executor& exec, std::vector<ValueType> in)
         : size_(in.size()), data_(nullptr), exec_(exec)
     {
-        Executor hostExec = CPUExecutor();
+        Executor hostExec = SerialExecutor();
         void* ptr = nullptr;
         std::visit(
             [this, &ptr](const auto& concreteExec)
@@ -135,7 +135,7 @@ public:
      * @brief Returns a copy of the field back to the host.
      * @returns A copy of the field on the host.
      */
-    [[nodiscard]] Field<ValueType> copyToHost() const { return copyToExecutor(CPUExecutor()); }
+    [[nodiscard]] Field<ValueType> copyToHost() const { return copyToExecutor(SerialExecutor()); }
 
     /**
      * @brief Copies the data (from anywhere) to a parsed host field.
@@ -150,7 +150,7 @@ public:
         NF_DEBUG_ASSERT(
             result.size() == size_, "Parsed Field size not the same as current field size"
         );
-        result = copyToExecutor(CPUExecutor());
+        result = copyToExecutor(SerialExecutor());
     }
 
     /**

--- a/include/NeoFOAM/fields/operations/sum.hpp
+++ b/include/NeoFOAM/fields/operations/sum.hpp
@@ -39,9 +39,9 @@ struct SumKernel
     }
 
     template<typename T>
-    void operator()(const CPUExecutor& exec, const Field<T>& field, T& sum)
+    void operator()(const SerialExecutor& exec, const Field<T>& field, T& sum)
     {
-        using executor = typename CPUExecutor::exec;
+        using executor = typename SerialExecutor::exec;
         auto field_f = field.span();
         auto end = field.size();
         Kokkos::parallel_reduce(

--- a/include/NeoFOAM/fields/operations/sum.hpp
+++ b/include/NeoFOAM/fields/operations/sum.hpp
@@ -25,9 +25,9 @@ struct SumKernel
     }
 
     template<typename T>
-    void operator()(const OMPExecutor& exec, const Field<T>& field, T& sum)
+    void operator()(const CPUExecutor& exec, const Field<T>& field, T& sum)
     {
-        using executor = typename OMPExecutor::exec;
+        using executor = typename CPUExecutor::exec;
         auto field_f = field.span();
         auto end = field.size();
         Kokkos::parallel_reduce(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,7 +15,7 @@ target_sources(
           "core/kokkos.cpp"
           "executor/OMPExecutor.cpp"
           "executor/GPUExecutor.cpp"
-          "executor/CPUExecutor.cpp"
+          "executor/serialExecutor.cpp"
           "mesh/unstructured/boundaryMesh.cpp"
           "mesh/unstructured/communicator.cpp"
           "mesh/unstructured/unstructuredMesh.cpp"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,7 @@ target_sources(
           "core/time.cpp"
           "core/dictionary.cpp"
           "core/kokkos.cpp"
-          "executor/OMPExecutor.cpp"
+          "executor/CPUExecutor.cpp"
           "executor/GPUExecutor.cpp"
           "executor/serialExecutor.cpp"
           "mesh/unstructured/boundaryMesh.cpp"

--- a/src/executor/CPUExecutor.cpp
+++ b/src/executor/CPUExecutor.cpp
@@ -1,8 +1,0 @@
-// SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoFOAM authors
-
-#include "NeoFOAM/core/executor/CPUExecutor.hpp"
-
-NeoFOAM::CPUExecutor::CPUExecutor() {};
-
-NeoFOAM::CPUExecutor::~CPUExecutor() {};

--- a/src/executor/CPUExecutor.cpp
+++ b/src/executor/CPUExecutor.cpp
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 NeoFOAM authors
+
+#include "NeoFOAM/core/executor/CPUExecutor.hpp"
+#include <Kokkos_Core.hpp>
+
+NeoFOAM::CPUExecutor::CPUExecutor() {};
+
+NeoFOAM::CPUExecutor::~CPUExecutor() {};

--- a/src/executor/OMPExecutor.cpp
+++ b/src/executor/OMPExecutor.cpp
@@ -1,9 +1,0 @@
-// SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoFOAM authors
-
-#include "NeoFOAM/core/executor/OMPExecutor.hpp"
-#include <Kokkos_Core.hpp>
-
-NeoFOAM::OMPExecutor::OMPExecutor() {};
-
-NeoFOAM::OMPExecutor::~OMPExecutor() {};

--- a/src/executor/serialExecutor.cpp
+++ b/src/executor/serialExecutor.cpp
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 NeoFOAM authors
+
+#include "NeoFOAM/core/executor/serialExecutor.hpp"
+
+NeoFOAM::SerialExecutor::SerialExecutor() {};
+
+NeoFOAM::SerialExecutor::~SerialExecutor() {};

--- a/test/core/executor.cpp
+++ b/test/core/executor.cpp
@@ -12,11 +12,11 @@
 TEST_CASE("Executor Equality")
 {
     NeoFOAM::Executor cpuExec0(NeoFOAM::SerialExecutor {});
-    NeoFOAM::Executor ompExec0(NeoFOAM::OMPExecutor {});
+    NeoFOAM::Executor ompExec0(NeoFOAM::CPUExecutor {});
     NeoFOAM::Executor gpuExec0(NeoFOAM::GPUExecutor {});
 
     NeoFOAM::Executor cpuExec1(NeoFOAM::SerialExecutor {});
-    NeoFOAM::Executor ompExec1(NeoFOAM::OMPExecutor {});
+    NeoFOAM::Executor ompExec1(NeoFOAM::CPUExecutor {});
     NeoFOAM::Executor gpuExec1(NeoFOAM::GPUExecutor {});
 
     REQUIRE(cpuExec0 == cpuExec1);

--- a/test/core/executor.cpp
+++ b/test/core/executor.cpp
@@ -11,11 +11,11 @@
 
 TEST_CASE("Executor Equality")
 {
-    NeoFOAM::Executor cpuExec0(NeoFOAM::CPUExecutor {});
+    NeoFOAM::Executor cpuExec0(NeoFOAM::SerialExecutor {});
     NeoFOAM::Executor ompExec0(NeoFOAM::OMPExecutor {});
     NeoFOAM::Executor gpuExec0(NeoFOAM::GPUExecutor {});
 
-    NeoFOAM::Executor cpuExec1(NeoFOAM::CPUExecutor {});
+    NeoFOAM::Executor cpuExec1(NeoFOAM::SerialExecutor {});
     NeoFOAM::Executor ompExec1(NeoFOAM::OMPExecutor {});
     NeoFOAM::Executor gpuExec1(NeoFOAM::GPUExecutor {});
 

--- a/test/core/parallelAlgorithms.cpp
+++ b/test/core/parallelAlgorithms.cpp
@@ -16,7 +16,7 @@ TEST_CASE("parallelFor")
 {
     NeoFOAM::Executor exec = GENERATE(
         NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
-        NeoFOAM::Executor(NeoFOAM::OMPExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
         NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );
     std::string execName = std::visit([](auto e) { return e.print(); }, exec);
@@ -83,7 +83,7 @@ TEST_CASE("parallelReduce")
 {
     NeoFOAM::Executor exec = GENERATE(
         NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
-        NeoFOAM::Executor(NeoFOAM::OMPExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
         NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );
     std::string execName = std::visit([](auto e) { return e.print(); }, exec);

--- a/test/core/parallelAlgorithms.cpp
+++ b/test/core/parallelAlgorithms.cpp
@@ -15,7 +15,7 @@
 TEST_CASE("parallelFor")
 {
     NeoFOAM::Executor exec = GENERATE(
-        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
         NeoFOAM::Executor(NeoFOAM::OMPExecutor {}),
         NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );
@@ -82,7 +82,7 @@ TEST_CASE("parallelFor")
 TEST_CASE("parallelReduce")
 {
     NeoFOAM::Executor exec = GENERATE(
-        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
         NeoFOAM::Executor(NeoFOAM::OMPExecutor {}),
         NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );

--- a/test/fields/domainField.cpp
+++ b/test/fields/domainField.cpp
@@ -14,7 +14,7 @@ TEST_CASE("Boundaries")
 {
 
     NeoFOAM::Executor exec = GENERATE(
-        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
         NeoFOAM::Executor(NeoFOAM::OMPExecutor {}),
         NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );

--- a/test/fields/domainField.cpp
+++ b/test/fields/domainField.cpp
@@ -15,7 +15,7 @@ TEST_CASE("Boundaries")
 
     NeoFOAM::Executor exec = GENERATE(
         NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
-        NeoFOAM::Executor(NeoFOAM::OMPExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
         NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );
 

--- a/test/fields/field.cpp
+++ b/test/fields/field.cpp
@@ -15,7 +15,7 @@ TEST_CASE("Field Constructors")
 {
     NeoFOAM::Executor exec = GENERATE(
         NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
-        NeoFOAM::Executor(NeoFOAM::OMPExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
         NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );
 
@@ -65,7 +65,7 @@ TEST_CASE("Field Operator Overloads")
 
     NeoFOAM::Executor exec = GENERATE(
         NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
-        NeoFOAM::Executor(NeoFOAM::OMPExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
         NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );
 
@@ -145,7 +145,7 @@ TEST_CASE("Field Container Operations")
 {
     NeoFOAM::Executor exec = GENERATE(
         NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
-        NeoFOAM::Executor(NeoFOAM::OMPExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
         NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );
 
@@ -213,7 +213,7 @@ TEST_CASE("Field Operations")
 {
     NeoFOAM::Executor exec = GENERATE(
         NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
-        NeoFOAM::Executor(NeoFOAM::OMPExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
         NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );
 

--- a/test/fields/field.cpp
+++ b/test/fields/field.cpp
@@ -14,7 +14,7 @@
 TEST_CASE("Field Constructors")
 {
     NeoFOAM::Executor exec = GENERATE(
-        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
         NeoFOAM::Executor(NeoFOAM::OMPExecutor {}),
         NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );
@@ -64,7 +64,7 @@ TEST_CASE("Field Operator Overloads")
 {
 
     NeoFOAM::Executor exec = GENERATE(
-        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
         NeoFOAM::Executor(NeoFOAM::OMPExecutor {}),
         NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );
@@ -144,7 +144,7 @@ TEST_CASE("Field Operator Overloads")
 TEST_CASE("Field Container Operations")
 {
     NeoFOAM::Executor exec = GENERATE(
-        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
         NeoFOAM::Executor(NeoFOAM::OMPExecutor {}),
         NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );
@@ -212,7 +212,7 @@ TEST_CASE("Field Container Operations")
 TEST_CASE("Field Operations")
 {
     NeoFOAM::Executor exec = GENERATE(
-        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
         NeoFOAM::Executor(NeoFOAM::OMPExecutor {}),
         NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );

--- a/test/finiteVolume/cellCentred/boundary/surface/surfFixedValue.cpp
+++ b/test/finiteVolume/cellCentred/boundary/surface/surfFixedValue.cpp
@@ -15,7 +15,7 @@ TEST_CASE("fixedValue")
 {
     NeoFOAM::Executor exec = GENERATE(
         NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
-        NeoFOAM::Executor(NeoFOAM::OMPExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
         NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );
 

--- a/test/finiteVolume/cellCentred/boundary/surface/surfFixedValue.cpp
+++ b/test/finiteVolume/cellCentred/boundary/surface/surfFixedValue.cpp
@@ -14,7 +14,7 @@
 TEST_CASE("fixedValue")
 {
     NeoFOAM::Executor exec = GENERATE(
-        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
         NeoFOAM::Executor(NeoFOAM::OMPExecutor {}),
         NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );

--- a/test/finiteVolume/cellCentred/boundary/volume/volFixedGradient.cpp
+++ b/test/finiteVolume/cellCentred/boundary/volume/volFixedGradient.cpp
@@ -14,7 +14,7 @@
 TEST_CASE("fixedGradient")
 {
     NeoFOAM::Executor exec = GENERATE(
-        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
         NeoFOAM::Executor(NeoFOAM::OMPExecutor {}),
         NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );

--- a/test/finiteVolume/cellCentred/boundary/volume/volFixedGradient.cpp
+++ b/test/finiteVolume/cellCentred/boundary/volume/volFixedGradient.cpp
@@ -15,7 +15,7 @@ TEST_CASE("fixedGradient")
 {
     NeoFOAM::Executor exec = GENERATE(
         NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
-        NeoFOAM::Executor(NeoFOAM::OMPExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
         NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );
 

--- a/test/finiteVolume/cellCentred/boundary/volume/volFixedValue.cpp
+++ b/test/finiteVolume/cellCentred/boundary/volume/volFixedValue.cpp
@@ -15,7 +15,7 @@ TEST_CASE("fixedValue")
 {
     NeoFOAM::Executor exec = GENERATE(
         NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
-        NeoFOAM::Executor(NeoFOAM::OMPExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
         NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );
 

--- a/test/finiteVolume/cellCentred/boundary/volume/volFixedValue.cpp
+++ b/test/finiteVolume/cellCentred/boundary/volume/volFixedValue.cpp
@@ -14,7 +14,7 @@
 TEST_CASE("fixedValue")
 {
     NeoFOAM::Executor exec = GENERATE(
-        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
         NeoFOAM::Executor(NeoFOAM::OMPExecutor {}),
         NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );

--- a/test/finiteVolume/cellCentred/fields/surfaceField.cpp
+++ b/test/finiteVolume/cellCentred/fields/surfaceField.cpp
@@ -19,7 +19,7 @@ TEST_CASE("surfaceField")
 
     NeoFOAM::Executor exec = GENERATE(
         NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
-        NeoFOAM::Executor(NeoFOAM::OMPExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
         NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );
 

--- a/test/finiteVolume/cellCentred/fields/surfaceField.cpp
+++ b/test/finiteVolume/cellCentred/fields/surfaceField.cpp
@@ -18,7 +18,7 @@ TEST_CASE("surfaceField")
     namespace fvcc = NeoFOAM::finiteVolume::cellCentred;
 
     NeoFOAM::Executor exec = GENERATE(
-        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
         NeoFOAM::Executor(NeoFOAM::OMPExecutor {}),
         NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );

--- a/test/finiteVolume/cellCentred/fields/volumeField.cpp
+++ b/test/finiteVolume/cellCentred/fields/volumeField.cpp
@@ -19,7 +19,7 @@ TEST_CASE("volumeField")
 
     NeoFOAM::Executor exec = GENERATE(
         NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
-        NeoFOAM::Executor(NeoFOAM::OMPExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
         NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );
 

--- a/test/finiteVolume/cellCentred/fields/volumeField.cpp
+++ b/test/finiteVolume/cellCentred/fields/volumeField.cpp
@@ -18,7 +18,7 @@ TEST_CASE("volumeField")
     namespace fvcc = NeoFOAM::finiteVolume::cellCentred;
 
     NeoFOAM::Executor exec = GENERATE(
-        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
         NeoFOAM::Executor(NeoFOAM::OMPExecutor {}),
         NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );

--- a/test/mesh/unstructured/communicator.cpp
+++ b/test/mesh/unstructured/communicator.cpp
@@ -21,7 +21,7 @@ TEST_CASE("Communicator Field Synchronization")
     // first block send (size rank)
     // second block remains the same
     // third block receive (size rank)
-    Field<int> field(CPUExecutor(), 3 * mpiEnviron.sizeRank());
+    Field<int> field(SerialExecutor(), 3 * mpiEnviron.sizeRank());
 
     for (size_t rank = 0; rank < mpiEnviron.sizeRank(); rank++)
     {

--- a/test/mesh/unstructured/unstructuredMesh.cpp
+++ b/test/mesh/unstructured/unstructuredMesh.cpp
@@ -13,7 +13,7 @@
 TEST_CASE("Unstructured Mesh")
 {
     NeoFOAM::Executor exec = GENERATE(
-        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
         NeoFOAM::Executor(NeoFOAM::OMPExecutor {}),
         NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );

--- a/test/mesh/unstructured/unstructuredMesh.cpp
+++ b/test/mesh/unstructured/unstructuredMesh.cpp
@@ -14,7 +14,7 @@ TEST_CASE("Unstructured Mesh")
 {
     NeoFOAM::Executor exec = GENERATE(
         NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
-        NeoFOAM::Executor(NeoFOAM::OMPExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
         NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );
 


### PR DESCRIPTION
This PR allows using Threads instead of OpenMP to parallelize on multicore CPUs. As a consequence, there has been some renaming, to properly reflect the capabilities of the executors.