### PR TITLE
Fix the order of in/out parameters

### DIFF
--- a/include/NeoFOAM/finiteVolume/cellCentred/interpolation/linear.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/interpolation/linear.hpp
@@ -31,13 +31,14 @@ public:
 
     static std::string schema() { return "none"; }
 
-    void interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField) const;
+    void interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField)
+        const override;
 
     void interpolate(
         const SurfaceField<scalar>& faceFlux,
         const VolumeField<scalar>& volField,
         SurfaceField<scalar>& surfaceField
-    ) const;
+    ) const override;
 
     std::unique_ptr<SurfaceInterpolationFactory> clone() const override;
 

--- a/include/NeoFOAM/finiteVolume/cellCentred/interpolation/linear.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/interpolation/linear.hpp
@@ -31,14 +31,15 @@ public:
 
     static std::string schema() { return "none"; }
 
+    void SurfaceField<scalar> interpolate(const VolumeField<scalar>& volField, ) override;
 
     void
-    interpolate(SurfaceField<scalar>& surfaceField, const VolumeField<scalar>& volField) override;
+    interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField) override;
 
     void interpolate(
-        SurfaceField<scalar>& surfaceField,
         const SurfaceField<scalar>& faceFlux,
-        const VolumeField<scalar>& volField
+        const VolumeField<scalar>& volField,
+        SurfaceField<scalar>& surfaceField
     ) override;
 
     std::unique_ptr<SurfaceInterpolationFactory> clone() const override;

--- a/include/NeoFOAM/finiteVolume/cellCentred/interpolation/linear.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/interpolation/linear.hpp
@@ -31,7 +31,7 @@ public:
 
     static std::string schema() { return "none"; }
 
-    void SurfaceField<scalar> interpolate(const VolumeField<scalar>& volField, ) override;
+    //    void SurfaceField<scalar> interpolate(const VolumeField<scalar>& volField, ) override;
 
     void
     interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField) override;

--- a/include/NeoFOAM/finiteVolume/cellCentred/interpolation/linear.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/interpolation/linear.hpp
@@ -31,16 +31,13 @@ public:
 
     static std::string schema() { return "none"; }
 
-    //    void SurfaceField<scalar> interpolate(const VolumeField<scalar>& volField, ) override;
-
-    void
-    interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField) override;
+    void interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField) const;
 
     void interpolate(
         const SurfaceField<scalar>& faceFlux,
         const VolumeField<scalar>& volField,
         SurfaceField<scalar>& surfaceField
-    ) override;
+    ) const;
 
     std::unique_ptr<SurfaceInterpolationFactory> clone() const override;
 

--- a/include/NeoFOAM/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
@@ -69,6 +69,14 @@ public:
     )
         : exec_(exec), mesh_(mesh), interpolationKernel_(std::move(interpolationKernel)) {};
 
+    SurfaceInterpolation(
+        const Executor& exec, const UnstructuredMesh& mesh, std::string interpolationName
+    )
+        : exec_(exec), mesh_(mesh),
+          interpolationKernel_(SurfaceInterpolationFactory::create(interpolationName, exec, mesh)) {
+          };
+
+
     void interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField) const
     {
         interpolationKernel_->interpolate(volField, surfaceField);

--- a/include/NeoFOAM/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
@@ -31,7 +31,7 @@ public:
 
     virtual ~SurfaceInterpolationFactory() {} // Virtual destructor
 
-    virtual SurfaceField<scalar> interpolate(const VolumeField<scalar>& volField) = 0;
+    //    virtual SurfaceField<scalar> interpolate(const VolumeField<scalar>& volField) = 0;
 
     virtual void
     interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField) = 0;

--- a/include/NeoFOAM/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
@@ -32,13 +32,13 @@ public:
     virtual ~SurfaceInterpolationFactory() {} // Virtual destructor
 
     virtual void
-    interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField) = 0;
+    interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField) const = 0;
 
     virtual void interpolate(
         const SurfaceField<scalar>& faceFlux,
         const VolumeField<scalar>& volField,
         SurfaceField<scalar>& surfaceField
-    ) = 0;
+    ) const = 0;
 
     // Pure virtual function for cloning
     virtual std::unique_ptr<SurfaceInterpolationFactory> clone() const = 0;

--- a/include/NeoFOAM/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
@@ -71,18 +71,18 @@ public:
     )
         : exec_(exec), mesh_(mesh), interpolationKernel_(std::move(interpolationKernel)) {};
 
-    void interpolate(SurfaceField<scalar>& surfaceField, const VolumeField<scalar>& volField) const
+    void interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField) const
     {
-        interpolationKernel_->interpolate(surfaceField, volField);
+        interpolationKernel_->interpolate(volField, surfaceField);
     }
 
     void interpolate(
-        SurfaceField<scalar>& surfaceField,
         const SurfaceField<scalar>& faceFlux,
-        const VolumeField<scalar>& volField
+        const VolumeField<scalar>& volField,
+        SurfaceField<scalar>& surfaceField
     ) const
     {
-        interpolationKernel_->interpolate(surfaceField, faceFlux, volField);
+        interpolationKernel_->interpolate(faceFlux, volField, surfaceField);
     }
 
 private:

--- a/include/NeoFOAM/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
@@ -32,8 +32,9 @@ public:
     virtual ~SurfaceInterpolationFactory() {} // Virtual destructor
 
     virtual void
-    interpolate(SurfaceField<scalar>& surfaceField, const VolumeField<scalar>& volField) = 0;
+    interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField) = 0;
 
+    virtual SurfaceField<scalar> interpolate(const VolumeField<scalar>& volField) = 0;
 
     virtual void interpolate(
         SurfaceField<scalar>& surfaceField,

--- a/include/NeoFOAM/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
@@ -31,15 +31,15 @@ public:
 
     virtual ~SurfaceInterpolationFactory() {} // Virtual destructor
 
+    virtual SurfaceField<scalar> interpolate(const VolumeField<scalar>& volField) = 0;
+
     virtual void
     interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField) = 0;
 
-    virtual SurfaceField<scalar> interpolate(const VolumeField<scalar>& volField) = 0;
-
     virtual void interpolate(
-        SurfaceField<scalar>& surfaceField,
         const SurfaceField<scalar>& faceFlux,
-        const VolumeField<scalar>& volField
+        const VolumeField<scalar>& volField,
+        SurfaceField<scalar>& surfaceField
     ) = 0;
 
     // Pure virtual function for cloning

--- a/include/NeoFOAM/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
@@ -31,8 +31,6 @@ public:
 
     virtual ~SurfaceInterpolationFactory() {} // Virtual destructor
 
-    //    virtual SurfaceField<scalar> interpolate(const VolumeField<scalar>& volField) = 0;
-
     virtual void
     interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField) = 0;
 

--- a/include/NeoFOAM/finiteVolume/cellCentred/interpolation/upwind.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/interpolation/upwind.hpp
@@ -32,18 +32,15 @@ public:
 
     //    void SurfaceField<scalar> interpolate(const VolumeField<scalar>& volField ) override;
 
-    void
-    interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField) override;
+    void interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField) const;
 
     void interpolate(
         const SurfaceField<scalar>& faceFlux,
         const VolumeField<scalar>& volField,
         SurfaceField<scalar>& surfaceField
-    ) override;
-
+    ) const;
 
     std::unique_ptr<SurfaceInterpolationFactory> clone() const override;
-
 
 private:
 

--- a/include/NeoFOAM/finiteVolume/cellCentred/interpolation/upwind.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/interpolation/upwind.hpp
@@ -30,8 +30,6 @@ public:
 
     static std::string schema() { return "none"; }
 
-    //    void SurfaceField<scalar> interpolate(const VolumeField<scalar>& volField ) override;
-
     void interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField) const;
 
     void interpolate(

--- a/include/NeoFOAM/finiteVolume/cellCentred/interpolation/upwind.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/interpolation/upwind.hpp
@@ -30,7 +30,7 @@ public:
 
     static std::string schema() { return "none"; }
 
-    void SurfaceField<scalar> interpolate(const VolumeField<scalar>& volField, ) override;
+    //    void SurfaceField<scalar> interpolate(const VolumeField<scalar>& volField ) override;
 
     void
     interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField) override;

--- a/include/NeoFOAM/finiteVolume/cellCentred/interpolation/upwind.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/interpolation/upwind.hpp
@@ -23,7 +23,6 @@ public:
 
     Upwind(const Executor& exec, const UnstructuredMesh& mesh);
 
-
     static std::string name() { return "upwind"; }
 
     static std::string doc() { return "upwind interpolation"; }

--- a/include/NeoFOAM/finiteVolume/cellCentred/interpolation/upwind.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/interpolation/upwind.hpp
@@ -30,14 +30,17 @@ public:
 
     static std::string schema() { return "none"; }
 
+    void SurfaceField<scalar> interpolate(const VolumeField<scalar>& volField, ) override;
+
     void
-    interpolate(SurfaceField<scalar>& surfaceField, const VolumeField<scalar>& volField) override;
+    interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField) override;
 
     void interpolate(
-        SurfaceField<scalar>& surfaceField,
         const SurfaceField<scalar>& faceFlux,
-        const VolumeField<scalar>& volField
+        const VolumeField<scalar>& volField,
+        SurfaceField<scalar>& surfaceField
     ) override;
+
 
     std::unique_ptr<SurfaceInterpolationFactory> clone() const override;
 

--- a/include/NeoFOAM/finiteVolume/cellCentred/interpolation/upwind.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/interpolation/upwind.hpp
@@ -30,13 +30,14 @@ public:
 
     static std::string schema() { return "none"; }
 
-    void interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField) const;
+    void interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField)
+        const override;
 
     void interpolate(
         const SurfaceField<scalar>& faceFlux,
         const VolumeField<scalar>& volField,
         SurfaceField<scalar>& surfaceField
-    ) const;
+    ) const override;
 
     std::unique_ptr<SurfaceInterpolationFactory> clone() const override;
 

--- a/src/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -53,14 +53,8 @@ Linear::Linear(const Executor& exec, const UnstructuredMesh& mesh)
     : SurfaceInterpolationFactory::Register<Linear>(exec, mesh),
       geometryScheme_(GeometryScheme::readOrCreate(mesh)) {};
 
-// SurfaceField<scalar> surfaceField Linear::interpolate(const VolumeField<scalar>& volField)
-//{
-//     auto surfaceField = SurfaceField(exec_, mesh_, );
-//     computeLinearInterpolation(volField, geometryScheme_, surfaceField);
-//     return ret;
-// }
-
 void Linear::interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField)
+    const
 {
     computeLinearInterpolation(volField, geometryScheme_, surfaceField);
 }
@@ -69,7 +63,7 @@ void Linear::interpolate(
     const SurfaceField<scalar>& faceFlux,
     const VolumeField<scalar>& volField,
     SurfaceField<scalar>& surfaceField
-)
+) const
 {
     interpolate(volField, surfaceField);
 }
@@ -78,6 +72,5 @@ std::unique_ptr<SurfaceInterpolationFactory> Linear::clone() const
 {
     return std::make_unique<Linear>(*this);
 }
-
 
 } // namespace NeoFOAM

--- a/src/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -53,6 +53,13 @@ Linear::Linear(const Executor& exec, const UnstructuredMesh& mesh)
     : SurfaceInterpolationFactory::Register<Linear>(exec, mesh),
       geometryScheme_(GeometryScheme::readOrCreate(mesh)) {};
 
+// SurfaceField<scalar> surfaceField Linear::interpolate(const VolumeField<scalar>& volField)
+//{
+//     auto surfaceField = SurfaceField(exec_, mesh_, );
+//     computeLinearInterpolation(volField, geometryScheme_, surfaceField);
+//     return ret;
+// }
+
 void Linear::interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField)
 {
     computeLinearInterpolation(volField, geometryScheme_, surfaceField);

--- a/src/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -11,9 +11,9 @@ namespace NeoFOAM::finiteVolume::cellCentred
 {
 
 void computeLinearInterpolation(
-    SurfaceField<scalar>& surfaceField,
     const VolumeField<scalar>& volField,
-    const std::shared_ptr<GeometryScheme> geometryScheme
+    const std::shared_ptr<GeometryScheme> geometryScheme,
+    SurfaceField<scalar>& surfaceField
 )
 {
     const UnstructuredMesh& mesh = surfaceField.mesh();
@@ -51,22 +51,20 @@ void computeLinearInterpolation(
 
 Linear::Linear(const Executor& exec, const UnstructuredMesh& mesh)
     : SurfaceInterpolationFactory::Register<Linear>(exec, mesh),
-      geometryScheme_(GeometryScheme::readOrCreate(mesh)) {
+      geometryScheme_(GeometryScheme::readOrCreate(mesh)) {};
 
-      };
-
-void Linear::interpolate(SurfaceField<scalar>& surfaceField, const VolumeField<scalar>& volField)
+void Linear::interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField)
 {
-    computeLinearInterpolation(surfaceField, volField, geometryScheme_);
+    computeLinearInterpolation(volField, geometryScheme_, surfaceField);
 }
 
 void Linear::interpolate(
-    SurfaceField<scalar>& surfaceField,
     const SurfaceField<scalar>& faceFlux,
-    const VolumeField<scalar>& volField
+    const VolumeField<scalar>& volField,
+    SurfaceField<scalar>& surfaceField
 )
 {
-    interpolate(surfaceField, volField);
+    interpolate(volField, surfaceField);
 }
 
 std::unique_ptr<SurfaceInterpolationFactory> Linear::clone() const

--- a/src/finiteVolume/cellCentred/interpolation/upwind.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/upwind.cpp
@@ -11,10 +11,10 @@ namespace NeoFOAM::finiteVolume::cellCentred
 {
 
 void computeUpwindInterpolation(
-    SurfaceField<scalar>& surfaceField,
     const SurfaceField<scalar>& faceFlux,
     const VolumeField<scalar>& volField,
-    const std::shared_ptr<GeometryScheme> geometryScheme
+    const std::shared_ptr<GeometryScheme> geometryScheme,
+    SurfaceField<scalar>& surfaceField
 )
 {
     const UnstructuredMesh& mesh = surfaceField.mesh();
@@ -59,12 +59,10 @@ void computeUpwindInterpolation(
 
 Upwind::Upwind(const Executor& exec, const UnstructuredMesh& mesh)
     : SurfaceInterpolationFactory::Register<Upwind>(exec, mesh),
-      geometryScheme_(GeometryScheme::readOrCreate(mesh)) {
-
-      };
+      geometryScheme_(GeometryScheme::readOrCreate(mesh)) {};
 
 
-void Upwind::interpolate(SurfaceField<scalar>& surfaceField, const VolumeField<scalar>& volField)
+void Upwind::interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField)
 {
     NF_ERROR_EXIT("limited scheme require a faceFlux");
 }
@@ -75,7 +73,7 @@ void Upwind::interpolate(
     const VolumeField<scalar>& volField
 )
 {
-    computeUpwindInterpolation(surfaceField, faceFlux, volField, geometryScheme_);
+    computeUpwindInterpolation(faceFlux, volField, geometryScheme_, surfaceField);
 }
 
 std::unique_ptr<SurfaceInterpolationFactory> Upwind::clone() const

--- a/src/finiteVolume/cellCentred/interpolation/upwind.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/upwind.cpp
@@ -61,8 +61,8 @@ Upwind::Upwind(const Executor& exec, const UnstructuredMesh& mesh)
     : SurfaceInterpolationFactory::Register<Upwind>(exec, mesh),
       geometryScheme_(GeometryScheme::readOrCreate(mesh)) {};
 
-
 void Upwind::interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField)
+    const
 {
     NF_ERROR_EXIT("limited scheme require a faceFlux");
 }
@@ -71,7 +71,7 @@ void Upwind::interpolate(
     SurfaceField<scalar>& surfaceField,
     const SurfaceField<scalar>& faceFlux,
     const VolumeField<scalar>& volField
-)
+) const
 {
     computeUpwindInterpolation(faceFlux, volField, geometryScheme_, surfaceField);
 }
@@ -80,6 +80,5 @@ std::unique_ptr<SurfaceInterpolationFactory> Upwind::clone() const
 {
     return std::make_unique<Upwind>(*this);
 }
-
 
 } // namespace NeoFOAM

--- a/src/finiteVolume/cellCentred/interpolation/upwind.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/upwind.cpp
@@ -68,9 +68,9 @@ void Upwind::interpolate(const VolumeField<scalar>& volField, SurfaceField<scala
 }
 
 void Upwind::interpolate(
-    SurfaceField<scalar>& surfaceField,
     const SurfaceField<scalar>& faceFlux,
-    const VolumeField<scalar>& volField
+    const VolumeField<scalar>& volField,
+    SurfaceField<scalar>& surfaceField
 ) const
 {
     computeUpwindInterpolation(faceFlux, volField, geometryScheme_, surfaceField);

--- a/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
@@ -22,7 +22,7 @@ void computeDiv(
     const auto exec = divPhi.exec();
     SurfaceField<scalar> phif(exec, mesh, createCalculatedBCs<scalar>(mesh));
     const auto surfFaceCells = mesh.boundaryMesh().faceCells().span();
-    surfInterp.interpolate(phif, faceFlux, phi);
+    surfInterp.interpolate(faceFlux, phi, phif);
 
     auto surfDivPhi = divPhi.internalField().span();
 

--- a/src/finiteVolume/cellCentred/operators/gaussGreenGrad.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenGrad.cpp
@@ -23,7 +23,7 @@ void computeGrad(
     const auto sBSf = mesh.boundaryMesh().sf().span();
     auto surfGradPhi = gradPhi.internalField().span();
 
-    surfInterp.interpolate(phif, phi);
+    surfInterp.interpolate(phi, phif);
     const auto surfPhif = phif.internalField().span();
     const auto surfOwner = mesh.faceOwner().span();
     const auto surfNeighbour = mesh.faceNeighbour().span();

--- a/test/finiteVolume/CMakeLists.txt
+++ b/test/finiteVolume/CMakeLists.txt
@@ -3,3 +3,4 @@
 
 add_subdirectory(cellCentred/fields)
 add_subdirectory(cellCentred/boundary)
+add_subdirectory(cellCentred/interpolation)

--- a/test/finiteVolume/cellCentred/interpolation/CMakeLists.txt
+++ b/test/finiteVolume/cellCentred/interpolation/CMakeLists.txt
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Unlicense
+# SPDX-FileCopyrightText: 2024 NeoFOAM authors
+
+neofoam_unit_test(linear)

--- a/test/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/test/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -29,6 +29,4 @@ TEST_CASE("linear")
 
     auto in = VolumeField<NeoFOAM::scalar>(exec, mesh, {});
     auto out = SurfaceField<NeoFOAM::scalar>(exec, mesh, {});
-
-    SECTION("can call interpolate" + execName) { linear.interpolate(in, out); }
 }

--- a/test/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/test/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2024 NeoFOAM authors
+
+#define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
+                            // a custom main
+#include <catch2/catch_session.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators_all.hpp>
+
+#include "NeoFOAM/core/dictionary.hpp"
+#include "NeoFOAM/mesh/unstructured/unstructuredMesh.hpp"
+#include "NeoFOAM/finiteVolume/cellCentred/interpolation/linear.hpp"
+
+using NeoFOAM::finiteVolume::cellCentred::SurfaceInterpolation;
+using NeoFOAM::finiteVolume::cellCentred::VolumeField;
+using NeoFOAM::finiteVolume::cellCentred::SurfaceField;
+
+TEST_CASE("linear")
+{
+    NeoFOAM::Executor exec = GENERATE(
+        NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
+    );
+
+    std::string execName = std::visit([](auto e) { return e.print(); }, exec);
+    auto mesh = NeoFOAM::createSingleCellMesh(exec);
+    auto linear = SurfaceInterpolation(exec, mesh, "linear");
+
+    auto in = VolumeField<NeoFOAM::scalar>(exec, mesh, {});
+    auto out = SurfaceField<NeoFOAM::scalar>(exec, mesh, {});
+
+    SECTION("can call interpolate" + execName) { linear.interpolate(in, out); }
+}


### PR DESCRIPTION
This PR fixes the order of parameters for the interpolation functions, ie the inout parameters are placed at the end of the parameters list.

Additionally:
- marked interpolation functions as `const`
- adds a dummy unit test for linear interpolation. In order to fully implement this we would need a mesh with more than a single cell.