### PR TITLE
Cache build folder

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,6 +52,12 @@ jobs:
          wget https://apt.llvm.org/llvm-snapshot.gpg.key
          sudo apt-key add llvm-snapshot.gpg.key
 
+     - name: Set up cache
+       uses: actions/cache@v4
+       with:
+         path: build
+         key: build_PR_${{ github.event.pull_request.number }}_${{matrix.compiler.CC}}_${{matrix.preset}}
+
      - name: Install dependencies
        run: |
          sudo apt update
@@ -70,7 +76,6 @@ jobs:
          sudo rm /usr/bin/clang++
          sudo ln -s /usr/bin/clang-16 /usr/bin/clang
          sudo ln -s /usr/bin/clang++-16 /usr/bin/clang++
-
 
      - name: Get versions
        run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,6 +54,7 @@ jobs:
 
      - name: Set up cache
        uses: actions/cache@v4
+       if: ${{!contains(github.event.pull_request.labels.*.name, 'Skip-cache')}}
        with:
          path: build
          key: build_PR_${{ github.event.pull_request.number }}_${{matrix.compiler.CC}}_${{matrix.preset}}

--- a/.github/workflows/build_on_aws.yml
+++ b/.github/workflows/build_on_aws.yml
@@ -73,6 +73,11 @@ jobs:
     steps:
       - name: Checkout NeoFOAM
         uses: actions/checkout@v2
+      - name: Set up cache
+        uses: actions/cache@v4
+        with:
+          path: build
+          key: aws_PR_${{ github.event.pull_request.number }}_${{matrix.preset}}
       - name: Build NeoFOAM
         shell: bash -i {0}
         run: |

--- a/.github/workflows/build_on_aws.yml
+++ b/.github/workflows/build_on_aws.yml
@@ -75,6 +75,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Set up cache
         uses: actions/cache@v4
+        if: ${{!contains(github.event.pull_request.labels.*.name, 'Skip-cache')}}
         with:
           path: build
           key: aws_PR_${{ github.event.pull_request.number }}_${{matrix.preset}}

--- a/.github/workflows/build_on_aws.yml
+++ b/.github/workflows/build_on_aws.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Checkout NeoFOAM
         uses: actions/checkout@v2
       - name: Set up cache
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         if: ${{!contains(github.event.pull_request.labels.*.name, 'Skip-cache')}}
         with:
           path: build

--- a/.github/workflows/static_checks.yaml
+++ b/.github/workflows/static_checks.yaml
@@ -29,6 +29,12 @@ jobs:
            libopenmpi-dev \
            openmpi-bin
 
+    - name: Set up cache
+      uses: actions/cache@v4
+      with:
+        path: build
+        key: static_PR_${{ github.event.pull_request.number }}
+
     - name: Create Compilation Database
       run: |
         cmake --preset develop \

--- a/.github/workflows/static_checks.yaml
+++ b/.github/workflows/static_checks.yaml
@@ -32,6 +32,7 @@ jobs:
     - name: Set up cache
       uses: actions/cache@v4
       with:
+        if: ${{!contains(github.event.pull_request.labels.*.name, 'Skip-cache')}}
         path: build
         key: static_PR_${{ github.event.pull_request.number }}
 

--- a/include/NeoFOAM/fields/field.hpp
+++ b/include/NeoFOAM/fields/field.hpp
@@ -77,8 +77,7 @@ public:
     {
         void* ptr = nullptr;
         std::visit(
-            [this, &ptr, size](const auto& exec)
-            { ptr = exec.alloc(size * sizeof(ValueType)); },
+            [this, &ptr, size](const auto& exec) { ptr = exec.alloc(size * sizeof(ValueType)); },
             exec_
         );
         data_ = static_cast<ValueType*>(ptr);


### PR DESCRIPTION
This PR enables caching of the build folder to reduce build times by repeatedly compiling kokkos for example. Currently the whole `build` folder gets cached on a per PR basis. I.e. the full build is executed at least once.