### PR TITLE
added launch json to debug unit test in vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "(ctest) Launch",
+      "type": "cppdbg",
+      "cwd": "${cmake.testWorkingDirectory}",
+      "request": "launch",
+      "program": "${cmake.testProgram}",
+      "args": [
+        "${cmake.testArgs}"
+      ],
+      "setupCommands": [
+        {
+          "text": "-enable-pretty-printing"
+        }
+      ]
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Version 0.1.0 (unreleased)
-
+- added launch json to debug unit test in vscode [#135](https://github.com/exasim-project/NeoFOAM/pull/135)
 - Add a basic implementation of operators [#100](https://github.com/exasim-project/NeoFOAM/pull/100)
 - Changes executor meanings, the CPUExecutor was renamed to SerialExecutor and  the OMPExecutor was renamed to CPUExecutor. [PR #120](https://github.com/exasim-project/NeoFOAM/pull/120)
 - Minor cleanup of MPI operator names, added vector version of allReduce, and updates mpi and thread support operations. [PR #105](https://github.com/exasim-project/NeoFOAM/pull/105)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,31 @@ add_subdirectory(catch2)
 # * WORKING_DIRECTORY: the working directory for the test, defaults to CMAKE_BINARY_DIR/bin
 function(neofoam_unit_test TEST)
   set(options "")
+  set(oneValueKeywords "COMMAND" "WORKING_DIRECTORY")
+  set(multiValueKeywords "")
+  cmake_parse_arguments("neofoam" "${options}" "${oneValueKeywords}" "${multiValueKeywords}"
+                        ${ARGN})
+  if(NOT DEFINED "neofoam_WORKING_DIRECTORY")
+    set(neofoam_WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/tests)
+  endif()
+  if(NOT DEFINED "neofoam_COMMAND")
+    set(neofoam_COMMAND ${TEST})
+  endif()
+
+  add_executable(${TEST} "${TEST}.cpp")
+  target_link_libraries(${TEST} PRIVATE neofoam_catch_main neofoam_warnings neofoam_options
+                                        Kokkos::kokkos NeoFOAM cpptrace::cpptrace)
+  set_target_properties(${TEST} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${neofoam_WORKING_DIRECTORY})
+
+  add_test(
+    NAME ${TEST}
+    COMMAND ${neofoam_COMMAND}
+    WORKING_DIRECTORY ${neofoam_WORKING_DIRECTORY})
+
+endfunction()
+
+function(neofoam_unit_test_mpi TEST)
+  set(options "")
   set(oneValueKeywords "MPI_SIZE" "COMMAND" "WORKING_DIRECTORY")
   set(multiValueKeywords "")
   cmake_parse_arguments("neofoam" "${options}" "${oneValueKeywords}" "${multiValueKeywords}"
@@ -21,14 +46,14 @@ function(neofoam_unit_test TEST)
     set(neofoam_MPI_SIZE 1)
   endif()
   if(NOT DEFINED "neofoam_WORKING_DIRECTORY")
-    set(neofoam_WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/bin/tests)
+    set(neofoam_WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/tests)
   endif()
   if(NOT DEFINED "neofoam_COMMAND")
     set(neofoam_COMMAND ${TEST})
   endif()
 
   add_executable(${TEST} "${TEST}.cpp")
-  target_link_libraries(${TEST} PRIVATE neofoam_catch_main neofoam_warnings neofoam_options
+  target_link_libraries(${TEST} PRIVATE neofoam_catch_main_mpi neofoam_warnings neofoam_options
                                         Kokkos::kokkos NeoFOAM cpptrace::cpptrace)
   set_target_properties(${TEST} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${neofoam_WORKING_DIRECTORY})
 

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -1,7 +1,13 @@
 # SPDX-License-Identifier: Unlicense
 # SPDX-FileCopyrightText: 2023-2024 NeoFOAM authors
 
-add_library(neofoam_catch_main test_main.cpp mpiReporter.cpp mpiGlobals.cpp mpiSerialization.cpp)
+add_library(neofoam_catch_main_mpi test_main_mpi.cpp mpiReporter.cpp mpiGlobals.cpp
+                                   mpiSerialization.cpp)
+target_link_libraries(neofoam_catch_main_mpi PUBLIC Catch2::Catch2 cpptrace::cpptrace
+                                                    Kokkos::kokkos MPI::MPI_CXX NeoFOAM)
+target_link_libraries(neofoam_catch_main_mpi PRIVATE neofoam_warnings neofoam_options)
+
+add_library(neofoam_catch_main test_main.cpp)
 target_link_libraries(neofoam_catch_main PUBLIC Catch2::Catch2 cpptrace::cpptrace Kokkos::kokkos
-                                                MPI::MPI_CXX NeoFOAM)
+                                                NeoFOAM)
 target_link_libraries(neofoam_catch_main PRIVATE neofoam_warnings neofoam_options)

--- a/test/catch2/test_main_mpi.cpp
+++ b/test/catch2/test_main_mpi.cpp
@@ -1,17 +1,30 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2023 NeoFOAM authors
 
-#include <iostream>
-
 #include "catch2/catch_session.hpp"
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/generators/catch_generators_adapters.hpp"
 #include "catch2/reporters/catch_reporter_registrars.hpp"
 #include "Kokkos_Core.hpp"
 
+#include "NeoFOAM/core/mpi/environment.hpp"
+
+#include "mpiReporter.hpp"
+#include "mpiSerialization.hpp"
+
+CATCH_REGISTER_REPORTER("mpi", MpiReporter);
 
 int main(int argc, char* argv[])
 {
+    NeoFOAM::mpi::MPIInit mpi(argc, argv);
+
+    MPI_Comm_rank(COMM, &RANK);
+    MPI_Comm_size(COMM, &COMM_SIZE);
+    IS_ROOT = RANK == ROOT;
+
+    // create a thread (on the root process) that serializes the IO
+    bool threadShutdown = false;
+    std::thread sequalizeIOThread {serializeIO, &threadShutdown};
 
     // Initialize Catch2
     Kokkos::initialize(argc, argv);
@@ -19,6 +32,7 @@ int main(int argc, char* argv[])
     // ensure any kokkos initialization output will appear first
     std::cout << std::flush;
     std::cerr << std::flush;
+    MPI_Barrier(COMM);
 
     Catch::Session session;
 
@@ -28,6 +42,13 @@ int main(int argc, char* argv[])
         return returnCode;
 
     int result = session.run();
+    MPI_Allreduce(MPI_IN_PLACE, &result, 1, MPI_INT, MPI_MAX, COMM);
+
+    MPI_Barrier(COMM);
+    threadShutdown = true;
+    sequalizeIOThread.join();
+
+    Kokkos::finalize();
 
     return result;
 }

--- a/test/core/mpi/CMakeLists.txt
+++ b/test/core/mpi/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2023 NeoFOAM authors
 
-neofoam_unit_test(fullDuplexCommBuffer MPI_SIZE 3)
-neofoam_unit_test(halfDuplexCommBuffer MPI_SIZE 3)
-neofoam_unit_test(operators MPI_SIZE 3)
+neofoam_unit_test_mpi(fullDuplexCommBuffer MPI_SIZE 3)
+neofoam_unit_test_mpi(halfDuplexCommBuffer MPI_SIZE 3)
+neofoam_unit_test_mpi(operators MPI_SIZE 3)

--- a/test/mesh/unstructured/CMakeLists.txt
+++ b/test/mesh/unstructured/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Unlicense
 # SPDX-FileCopyrightText: 2023-2024 NeoFOAM authors
 
-neofoam_unit_test(communicator MPI_SIZE 3)
+neofoam_unit_test_mpi(communicator MPI_SIZE 3)
 neofoam_unit_test(unstructuredMesh)


### PR DESCRIPTION
debug unit tests with vscode:

In the testing view in vscode, the unit test can be debugged by clicking the corresponding debug icon.

However this is currently not doable as all test run with MPI
@greole 
I would propose to run only the test that require MPI to simplify debugging