### PR TITLE
disable span from tempory objects and simplification related to fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Version 0.1.0 (unreleased)
+- disable span from temporary objects and simplification related to fields [#139](https://github.com/exasim-project/NeoFOAM/pull/139)
 - added launch json to debug unit test in vscode [#135](https://github.com/exasim-project/NeoFOAM/pull/135)
 - Add a basic implementation of operators [#100](https://github.com/exasim-project/NeoFOAM/pull/100)
 - Changes executor meanings, the CPUExecutor was renamed to SerialExecutor and  the OMPExecutor was renamed to CPUExecutor. [PR #120](https://github.com/exasim-project/NeoFOAM/pull/120)

--- a/cmake/AutoEnableDevice.cmake
+++ b/cmake/AutoEnableDevice.cmake
@@ -4,17 +4,17 @@
 include(CheckLanguage)
 
 if(NOT DEFINED Kokkos_ENABLE_OPENMP AND NOT DEFINED Kokkos_ENABLE_THREADS)
-  find_package(OpenMP QUIET)
+  find_package(Threads QUIET)
 
-  if(OpenMP_FOUND)
-    set(Kokkos_ENABLE_OPENMP
+  if(Threads_FOUND)
+    set(Kokkos_ENABLE_THREADS
         ON
         CACHE INTERNAL "")
   else()
-    find_package(Threads QUIET)
+    find_package(OpenMP QUIET)
 
-    if(Threads_FOUND)
-      set(Kokkos_ENABLE_THREADS
+    if(OpenMP_FOUND)
+      set(Kokkos_ENABLE_OPENMP
           ON
           CACHE INTERNAL "")
     endif()

--- a/include/NeoFOAM/fields/field.hpp
+++ b/include/NeoFOAM/fields/field.hpp
@@ -334,17 +334,23 @@ public:
      */
     [[nodiscard]] bool empty() const { return size() == 0; }
 
-    /**
-     * @brief Gets the field as a span.
-     * @return Span of the field.
-     */
-    [[nodiscard]] std::span<ValueType> span() { return std::span<ValueType>(data_, size_); }
+    // ensures no return a span of a temporary object --> invalid memory access
+    std::span<ValueType> span() && = delete;
+
+    // ensures no return a span of a temporary object --> invalid memory access
+    std::span<const ValueType> span() const&& = delete;
 
     /**
      * @brief Gets the field as a span.
      * @return Span of the field.
      */
-    [[nodiscard]] std::span<const ValueType> span() const
+    [[nodiscard]] std::span<ValueType> span() & { return std::span<ValueType>(data_, size_); }
+
+    /**
+     * @brief Gets the field as a span.
+     * @return Span of the field.
+     */
+    [[nodiscard]] std::span<const ValueType> span() const&
     {
         return std::span<const ValueType>(data_, size_);
     }

--- a/include/NeoFOAM/fields/field.hpp
+++ b/include/NeoFOAM/fields/field.hpp
@@ -67,6 +67,24 @@ public:
     }
 
     /**
+     * @brief Create a Field with a given size on an executor and uniform value
+     * @param exec  Executor associated to the matrix
+     * @param size  size of the matrix
+     */
+    Field(const Executor& exec, size_t size, ValueType value)
+        : size_(size), data_(nullptr), exec_(exec)
+    {
+        void* ptr = nullptr;
+        std::visit(
+            [this, &ptr, size](const auto& concreteExec)
+            { ptr = concreteExec.alloc(size * sizeof(ValueType)); },
+            exec_
+        );
+        data_ = static_cast<ValueType*>(ptr);
+        NeoFOAM::fill(*this, value);
+    }
+
+    /**
      * @brief Create a Field with a given size on an executor
      * @param exec  Executor associated to the matrix
      * @param in a vector of elements to copy over
@@ -158,7 +176,7 @@ public:
      * @param i The index of cell in the field
      * @returns The value at the index i
      */
-    KOKKOS_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     ValueType& operator[](const size_t i) { return data_[i]; }
 
     /**
@@ -166,7 +184,7 @@ public:
      * @param i The index of cell in the field
      * @returns The value at the index i
      */
-    KOKKOS_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     const ValueType& operator[](const size_t i) const { return data_[i]; }
 
     /**
@@ -174,7 +192,7 @@ public:
      * @param i The index of cell in the field
      * @returns The value at the index i
      */
-    KOKKOS_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     ValueType& operator()(const size_t i) { return data_[i]; }
 
     /**
@@ -182,7 +200,7 @@ public:
      * @param i The index of cell in the field
      * @returns The value at the index i
      */
-    KOKKOS_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     const ValueType& operator()(const size_t i) const { return data_[i]; }
 
     /**

--- a/include/NeoFOAM/fields/field.hpp
+++ b/include/NeoFOAM/fields/field.hpp
@@ -70,14 +70,15 @@ public:
      * @brief Create a Field with a given size on an executor and uniform value
      * @param exec  Executor associated to the matrix
      * @param size  size of the matrix
+     * @param value  the  default value
      */
     Field(const Executor& exec, size_t size, ValueType value)
         : size_(size), data_(nullptr), exec_(exec)
     {
         void* ptr = nullptr;
         std::visit(
-            [this, &ptr, size](const auto& concreteExec)
-            { ptr = concreteExec.alloc(size * sizeof(ValueType)); },
+            [this, &ptr, size](const auto& exec)
+            { ptr = exec.alloc(size * sizeof(ValueType)); },
             exec_
         );
         data_ = static_cast<ValueType*>(ptr);

--- a/include/NeoFOAM/fields/field.hpp
+++ b/include/NeoFOAM/fields/field.hpp
@@ -355,11 +355,17 @@ public:
         return std::span<const ValueType>(data_, size_);
     }
 
+    // ensures no return a span of a temporary object --> invalid memory access
+    [[nodiscard]] std::span<ValueType> span(std::pair<size_t, size_t> range) && = delete;
+
+    // ensures no return a span of a temporary object --> invalid memory access
+    [[nodiscard]] std::span<const ValueType> span(std::pair<size_t, size_t> range) const&& = delete;
+
     /**
      * @brief Gets a sub view of the field as a span.
      * @return Span of the field.
      */
-    [[nodiscard]] std::span<ValueType> span(std::pair<size_t, size_t> range)
+    [[nodiscard]] std::span<ValueType> span(std::pair<size_t, size_t> range) &
     {
         return std::span<ValueType>(data_ + range.first, range.second - range.first);
     }
@@ -368,7 +374,7 @@ public:
      * @brief Gets a sub view of the field as a span.
      * @return Span of the field.
      */
-    [[nodiscard]] std::span<const ValueType> span(std::pair<size_t, size_t> range) const
+    [[nodiscard]] std::span<const ValueType> span(std::pair<size_t, size_t> range) const&
     {
         return std::span<const ValueType>(data_ + range.first, range.second - range.first);
     }

--- a/include/NeoFOAM/fields/operations/comparison.hpp
+++ b/include/NeoFOAM/fields/operations/comparison.hpp
@@ -12,7 +12,8 @@ namespace NeoFOAM
 template<typename T>
 bool equal(Field<T>& field, T value)
 {
-    auto hostSpan = field.copyToHost().span();
+    auto hostField = field.copyToHost();
+    auto hostSpan = hostField.span();
     for (size_t i = 0; i < hostSpan.size(); i++)
     {
         if (hostSpan[i] != value)
@@ -26,8 +27,8 @@ bool equal(Field<T>& field, T value)
 template<typename T>
 bool equal(const Field<T>& field, const Field<T>& field2)
 {
-    auto hostSpan = field.copyToHost().span();
-    auto hostSpan2 = field2.copyToHost().span();
+    auto [hostField, hostField2] = copyToHosts(field, field2);
+    auto [hostSpan, hostSpan2] = spans(hostField, hostField2);
 
     if (hostSpan.size() != hostSpan2.size())
     {

--- a/include/NeoFOAM/fields/operations/operationsMacros.hpp
+++ b/include/NeoFOAM/fields/operations/operationsMacros.hpp
@@ -96,5 +96,10 @@ auto spans(Args&... fields)
     return std::make_tuple(fields.span()...);
 }
 
+template<typename... Args>
+auto copyToHosts(Args&... fields)
+{
+    return std::make_tuple(fields.copyToHost()...);
+}
 
 } // namespace NeoFOAM

--- a/include/NeoFOAM/fields/operations/operationsMacros.hpp
+++ b/include/NeoFOAM/fields/operations/operationsMacros.hpp
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: 2023 NeoFOAM authors
 #pragma once
 
+#include <tuple>
+
 #include <Kokkos_Core.hpp>
 #include "NeoFOAM/core/primitives/label.hpp"
 #include "NeoFOAM/helpers/exceptions.hpp"
@@ -86,6 +88,12 @@ void mul(Field<ValueType>& a, const Field<std::type_identity_t<ValueType>>& b)
     detail::fieldBinaryOp(
         a, b, KOKKOS_LAMBDA(ValueType va, ValueType vb) { return va * vb; }
     );
+}
+
+template<typename... Args>
+auto spans(Args&... fields)
+{
+    return std::make_tuple(fields.span()...);
 }
 
 

--- a/test/catch2/test_main.cpp
+++ b/test/catch2/test_main.cpp
@@ -29,5 +29,7 @@ int main(int argc, char* argv[])
 
     int result = session.run();
 
+    Kokkos::finalize();
+
     return result;
 }

--- a/test/core/parallelAlgorithms.cpp
+++ b/test/core/parallelAlgorithms.cpp
@@ -32,8 +32,8 @@ TEST_CASE("parallelFor")
         NeoFOAM::parallelFor(
             exec, {0, 5}, KOKKOS_LAMBDA(const size_t i) { spanA[i] = spanB[i] + 2.0; }
         );
-        auto hostSpanA = fieldA.copyToHost().span();
-        for (auto value : hostSpanA)
+        auto hostSpanA = fieldA.copyToHost();
+        for (auto value : hostSpanA.span())
         {
             REQUIRE(value == 3.0);
         }
@@ -52,8 +52,8 @@ TEST_CASE("parallelFor")
             {0, 5},
             KOKKOS_LAMBDA(const size_t i) { spanA[i] = spanB[i] + NeoFOAM::Vector(2.0, 2.0, 2.0); }
         );
-        auto hostSpanA = fieldA.copyToHost().span();
-        for (auto value : hostSpanA)
+        auto hostSpanA = fieldA.copyToHost();
+        for (auto value : hostSpanA.span())
         {
             REQUIRE(value == NeoFOAM::Vector(3.0, 3.0, 3.0));
         }
@@ -70,8 +70,8 @@ TEST_CASE("parallelFor")
         NeoFOAM::parallelFor(
             fieldA, KOKKOS_LAMBDA(const size_t i) { return spanB[i] + 2.0; }
         );
-        auto hostSpanA = fieldA.copyToHost().span();
-        for (auto value : hostSpanA)
+        auto hostSpanA = fieldA.copyToHost();
+        for (auto value : hostSpanA.span())
         {
             REQUIRE(value == 3.0);
         }

--- a/test/core/parallelAlgorithms.cpp
+++ b/test/core/parallelAlgorithms.cpp
@@ -32,8 +32,8 @@ TEST_CASE("parallelFor")
         NeoFOAM::parallelFor(
             exec, {0, 5}, KOKKOS_LAMBDA(const size_t i) { spanA[i] = spanB[i] + 2.0; }
         );
-        auto hostSpanA = fieldA.copyToHost();
-        for (auto value : hostSpanA.span())
+        auto hostA = fieldA.copyToHost();
+        for (auto value : hostA.span())
         {
             REQUIRE(value == 3.0);
         }
@@ -52,8 +52,8 @@ TEST_CASE("parallelFor")
             {0, 5},
             KOKKOS_LAMBDA(const size_t i) { spanA[i] = spanB[i] + NeoFOAM::Vector(2.0, 2.0, 2.0); }
         );
-        auto hostSpanA = fieldA.copyToHost();
-        for (auto value : hostSpanA.span())
+        auto hostA = fieldA.copyToHost();
+        for (auto value : hostA.span())
         {
             REQUIRE(value == NeoFOAM::Vector(3.0, 3.0, 3.0));
         }
@@ -70,8 +70,8 @@ TEST_CASE("parallelFor")
         NeoFOAM::parallelFor(
             fieldA, KOKKOS_LAMBDA(const size_t i) { return spanB[i] + 2.0; }
         );
-        auto hostSpanA = fieldA.copyToHost();
-        for (auto value : hostSpanA.span())
+        auto hostA = fieldA.copyToHost();
+        for (auto value : hostA.span())
         {
             REQUIRE(value == 3.0);
         }

--- a/test/fields/field.cpp
+++ b/test/fields/field.cpp
@@ -30,8 +30,8 @@ TEST_CASE("Field Constructors")
 
         REQUIRE(b.size() == size);
 
-        auto hostSpanB = b.copyToHost().span();
-        for (auto value : hostSpanB)
+        auto hostSpanB = b.copyToHost();
+        for (auto value : hostSpanB.span())
         {
             REQUIRE(value == 5.0);
         }
@@ -39,8 +39,8 @@ TEST_CASE("Field Constructors")
         NeoFOAM::Field<NeoFOAM::scalar> initWith5(exec, size, 5.0);
         REQUIRE(initWith5.size() == size);
 
-        auto hostInitWith5 = initWith5.copyToHost().span();
-        for (auto value : hostInitWith5)
+        auto hostInitWith5 = initWith5.copyToHost();
+        for (auto value : hostInitWith5.span())
         {
             REQUIRE(value == 5.0);
         }
@@ -91,8 +91,8 @@ TEST_CASE("Field Operator Overloads")
 
         a += b;
 
-        auto hostSpanA = a.copyToHost().span();
-        for (auto value : hostSpanA)
+        auto hostSpanA = a.copyToHost();
+        for (auto value : hostSpanA.span())
         {
             REQUIRE(value == 15.0);
         }
@@ -108,8 +108,8 @@ TEST_CASE("Field Operator Overloads")
 
         a -= b;
 
-        auto hostSpanA = a.copyToHost().span();
-        for (auto value : hostSpanA)
+        auto hostSpanA = a.copyToHost();
+        for (auto value : hostSpanA.span())
         {
             REQUIRE(value == -5.0);
         }
@@ -125,8 +125,8 @@ TEST_CASE("Field Operator Overloads")
         NeoFOAM::fill(b, 10.0);
 
         c = a + b;
-        auto hostSpanC = c.copyToHost().span();
-        for (auto value : hostSpanC)
+        auto hostSpanC = c.copyToHost();
+        for (auto value : hostSpanC.span())
         {
             REQUIRE(value == 15.0);
         }
@@ -143,8 +143,8 @@ TEST_CASE("Field Operator Overloads")
 
         c = a - b;
 
-        auto hostSpanC = c.copyToHost().span();
-        for (auto value : hostSpanC)
+        auto hostSpanC = c.copyToHost();
+        for (auto value : hostSpanC.span())
         {
             REQUIRE(value == -5.0);
         }

--- a/test/fields/field.cpp
+++ b/test/fields/field.cpp
@@ -108,7 +108,7 @@ TEST_CASE("Field Operator Overloads")
 
         a -= b;
 
-        auto host = a.copyToHost();
+        auto hostA = a.copyToHost();
         for (auto value : hostA.span())
         {
             REQUIRE(value == -5.0);

--- a/test/fields/field.cpp
+++ b/test/fields/field.cpp
@@ -35,6 +35,15 @@ TEST_CASE("Field Constructors")
         {
             REQUIRE(value == 5.0);
         }
+
+        NeoFOAM::Field<NeoFOAM::scalar> initWith5(exec, size, 5.0);
+        REQUIRE(initWith5.size() == size);
+
+        auto hostInitWith5 = initWith5.copyToHost().span();
+        for (auto value : hostInitWith5)
+        {
+            REQUIRE(value == 5.0);
+        }
     }
 
     SECTION("Initialiser List Constructor " + execName)
@@ -59,6 +68,7 @@ TEST_CASE("Field Constructors")
         REQUIRE(hostB.data()[2] == 3);
     }
 }
+
 
 TEST_CASE("Field Operator Overloads")
 {
@@ -255,4 +265,23 @@ TEST_CASE("Field Operations")
         a.apply(KOKKOS_LAMBDA(const NeoFOAM::size_t i) { return 2 * sB[i]; });
         REQUIRE(equal(a, 20.0));
     }
+}
+
+TEST_CASE("getSpans")
+{
+    NeoFOAM::Executor exec = NeoFOAM::SerialExecutor {};
+
+    NeoFOAM::Field<NeoFOAM::scalar> a(exec, 3, 1.0);
+    NeoFOAM::Field<NeoFOAM::scalar> b(exec, 3, 2.0);
+    NeoFOAM::Field<NeoFOAM::scalar> c(exec, 3, 3.0);
+
+    auto [spanA, spanB, spanC] = NeoFOAM::spans(a, b, c);
+
+    REQUIRE(spanA[0] == 1.0);
+    REQUIRE(spanB[0] == 2.0);
+    REQUIRE(spanC[0] == 3.0);
+
+    auto [spanA2] = NeoFOAM::spans(a);
+
+    REQUIRE(spanA[0] == 1.0);
 }

--- a/test/fields/field.cpp
+++ b/test/fields/field.cpp
@@ -269,7 +269,12 @@ TEST_CASE("Field Operations")
 
 TEST_CASE("getSpans")
 {
-    NeoFOAM::Executor exec = NeoFOAM::SerialExecutor {};
+    NeoFOAM::Executor exec = GENERATE(
+        NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
+    );
+
 
     NeoFOAM::Field<NeoFOAM::scalar> a(exec, 3, 1.0);
     NeoFOAM::Field<NeoFOAM::scalar> b(exec, 3, 2.0);
@@ -284,4 +289,15 @@ TEST_CASE("getSpans")
     auto [spanA2] = NeoFOAM::spans(a);
 
     REQUIRE(spanA[0] == 1.0);
+
+    NeoFOAM::parallelFor(
+        a, KOKKOS_LAMBDA(const NeoFOAM::size_t i) { return spanB[i] + spanC[i]; }
+    );
+
+    auto [hostA] = NeoFOAM::copyToHosts(a);
+
+    for (auto value : hostA.span())
+    {
+        REQUIRE(value == 5.0);
+    }
 }

--- a/test/fields/field.cpp
+++ b/test/fields/field.cpp
@@ -30,8 +30,8 @@ TEST_CASE("Field Constructors")
 
         REQUIRE(b.size() == size);
 
-        auto hostSpanB = b.copyToHost();
-        for (auto value : hostSpanB.span())
+        auto hostB = b.copyToHost();
+        for (auto value : hostB.span())
         {
             REQUIRE(value == 5.0);
         }
@@ -108,8 +108,8 @@ TEST_CASE("Field Operator Overloads")
 
         a -= b;
 
-        auto hostSpanA = a.copyToHost();
-        for (auto value : hostSpanA.span())
+        auto host = a.copyToHost();
+        for (auto value : hostA.span())
         {
             REQUIRE(value == -5.0);
         }
@@ -125,8 +125,8 @@ TEST_CASE("Field Operator Overloads")
         NeoFOAM::fill(b, 10.0);
 
         c = a + b;
-        auto hostSpanC = c.copyToHost();
-        for (auto value : hostSpanC.span())
+        auto hostC = c.copyToHost();
+        for (auto value : hostC.span())
         {
             REQUIRE(value == 15.0);
         }
@@ -143,8 +143,8 @@ TEST_CASE("Field Operator Overloads")
 
         c = a - b;
 
-        auto hostSpanC = c.copyToHost();
-        for (auto value : hostSpanC.span())
+        auto hostC = c.copyToHost();
+        for (auto value : hostC.span())
         {
             REQUIRE(value == -5.0);
         }


### PR DESCRIPTION
The current design allows the return of the span on a temporary object

```cpp
    auto hostSpan = field.copyToHost().span();
```
This results in a dangling reference as copyToHost is immediately deallocated.
Consequently, span of temporary fields can not longer be returned and the syntax needs to be adapted:
```cpp
    auto hostField = field.copyToHost();
    auto hostSpan = hostField.span();
```
Additionals change:
In numerous places the span of multiple fields are required, structured bindings help to reduce the code complexity

```cpp
    auto [hostField, hostField2] = copyToHosts(field, field2);
    auto [hostSpan, hostSpan2] = spans(hostField, hostField2);
```

Field can be instantiated with constant Values
```
    NeoFOAM::Field<NeoFOAM::scalar> fieldA(exec, size);
    NeoFOAM::fill(fieldA, 1.0);
    // simplifies to:
    NeoFOAM::Field<NeoFOAM::scalar> fieldB(exec, size,1.0);
```
