### PR TITLE
Add fields from existing memory and internal fields

### DIFF
--- a/include/NeoFOAM/fields/boundaryFields.hpp
+++ b/include/NeoFOAM/fields/boundaryFields.hpp
@@ -44,6 +44,18 @@ public:
     {}
 
 
+    /**
+     * @brief Copy constructor.
+     * @param rhs The boundaryFields object to be copied.
+     */
+    BoundaryFields(const Executor& exec, const BoundaryFields<T>& rhs)
+        : exec_(rhs.exec_), value_(exec, rhs.value_), refValue_(exec, rhs.refValue_),
+          valueFraction_(exec, rhs.valueFraction_), refGrad_(exec, rhs.refGrad_),
+          boundaryTypes_(exec, rhs.boundaryTypes_), offset_(exec, rhs.offset_),
+          nBoundaries_(rhs.nBoundaries_), nBoundaryFaces_(rhs.nBoundaryFaces_)
+    {}
+
+
     BoundaryFields(const Executor& exec, size_t nBoundaryFaces, size_t nBoundaries)
         : exec_(exec), value_(exec, nBoundaryFaces), refValue_(exec, nBoundaryFaces),
           valueFraction_(exec, nBoundaryFaces), refGrad_(exec, nBoundaryFaces),

--- a/include/NeoFOAM/fields/domainField.hpp
+++ b/include/NeoFOAM/fields/domainField.hpp
@@ -41,6 +41,9 @@ public:
           boundaryFields_(exec, nBoundaryFaces, nBoundaries)
     {}
 
+    DomainField(const Executor& exec, const Field<ValueType>& internalField, const boundaryFields&)
+        : exec_(exec), internalField_(exec, internalField), boundaryFields_(exec, boundaryFields)
+    {}
 
     DomainField(const Executor& exec, const UnstructuredMesh& mesh)
         : exec_(exec), internalField_(exec, mesh.nCells()),

--- a/include/NeoFOAM/fields/domainField.hpp
+++ b/include/NeoFOAM/fields/domainField.hpp
@@ -41,7 +41,11 @@ public:
           boundaryFields_(exec, nBoundaryFaces, nBoundaries)
     {}
 
-    DomainField(const Executor& exec, const Field<ValueType>& internalField, const boundaryFields&)
+    DomainField(
+        const Executor& exec,
+        const Field<ValueType>& internalField,
+        const BoundaryFields<ValueType>& boundaryFields
+    )
         : exec_(exec), internalField_(exec, internalField), boundaryFields_(exec, boundaryFields)
     {}
 

--- a/include/NeoFOAM/fields/field.hpp
+++ b/include/NeoFOAM/fields/field.hpp
@@ -51,7 +51,7 @@ class Field
 public:
 
     /**
-     * @brief Create a Field with a given size on an executor
+     * @brief Create an uninitialized Field with a given size on an executor
      * @param exec  Executor associated to the matrix
      * @param size  size of the matrix
      */
@@ -72,10 +72,11 @@ public:
      * @param size  size of the matrix
      * @param in    Pointer to existing data
      */
-    Field(const Executor& exec, const ValueType* in, size_t size)
+    Field(
+        const Executor& exec, const ValueType* in, size_t size, Executor hostExec = SerialExecutor()
+    )
         : size_(size), data_(nullptr), exec_(exec)
     {
-        Executor hostExec = SerialExecutor();
         void* ptr = nullptr;
         std::visit(
             [this, &ptr, size](const auto& concreteExec)
@@ -109,6 +110,15 @@ public:
      * @param in a vector of elements to copy over
      */
     Field(const Executor& exec, std::vector<ValueType> in) : Field(exec, in.data(), in.size()) {}
+
+    /**
+     * @brief Create a Field as a copy of a Field on a specified executor
+     * @param exec  Executor associated to the matrix
+     * @param in a vector of elements to copy over
+     */
+    Field(const Executor& exec, const Field<ValueType>& in)
+        : Field(exec, in.data(), in.size(), in.exec())
+    {}
 
     /**
      * @brief Copy constructor, creates a new field with the same size and data as the parsed field.

--- a/include/NeoFOAM/fields/field.hpp
+++ b/include/NeoFOAM/fields/field.hpp
@@ -108,20 +108,7 @@ public:
      * @param exec  Executor associated to the matrix
      * @param in a vector of elements to copy over
      */
-    Field(const Executor& exec, std::vector<ValueType> in)
-        : size_(in.size()), data_(nullptr), exec_(exec)
-    {
-        Executor hostExec = SerialExecutor();
-        void* ptr = nullptr;
-        std::visit(
-            [this, &ptr](const auto& concreteExec)
-            { ptr = concreteExec.alloc(this->size_ * sizeof(ValueType)); },
-            exec_
-        );
-        data_ = static_cast<ValueType*>(ptr);
-
-        std::visit(detail::deepCopyVisitor(size_, in.data(), data_), hostExec, exec);
-    }
+    Field(const Executor& exec, std::vector<ValueType> in) : Field(exec, in.data(), in.size()) {}
 
     /**
      * @brief Copy constructor, creates a new field with the same size and data as the parsed field.

--- a/include/NeoFOAM/fields/field.hpp
+++ b/include/NeoFOAM/fields/field.hpp
@@ -75,6 +75,7 @@ public:
     Field(const Executor& exec, size_t size, const ValueType* in)
         : size_(size), data_(nullptr), exec_(exec)
     {
+        Executor hostExec = SerialExecutor();
         void* ptr = nullptr;
         std::visit(
             [this, &ptr, size](const auto& concreteExec)
@@ -82,7 +83,7 @@ public:
             exec_
         );
         data_ = static_cast<ValueType*>(ptr);
-        std::visit(detail::deepCopyVisitor(size_, in, data_), NeoFOAM::CPUExecutor {}, exec_);
+        std::visit(detail::deepCopyVisitor<ValueType>(size_, in, data_), hostExec, exec_);
     }
 
     /**

--- a/include/NeoFOAM/fields/field.hpp
+++ b/include/NeoFOAM/fields/field.hpp
@@ -72,7 +72,7 @@ public:
      * @param size  size of the matrix
      * @param in    Pointer to existing data
      */
-    Field(const Executor& exec, size_t size, const ValueType* in)
+    Field(const Executor& exec, const ValueType* in, size_t size)
         : size_(size), data_(nullptr), exec_(exec)
     {
         Executor hostExec = SerialExecutor();

--- a/include/NeoFOAM/finiteVolume/cellCentred/fields/surfaceField.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/fields/surfaceField.hpp
@@ -45,6 +45,16 @@ public:
           boundaryConditions_(boundaryConditions)
     {}
 
+    SurfaceField(
+        const Executor& exec,
+        const UnstructuredMesh& mesh,
+        const Field<ValueType>& internalField,
+        const std::vector<SurfaceBoundary<ValueType>>& boundaryConditions
+    )
+        : GeometricFieldMixin<ValueType>(exec, mesh, {exec, mesh, internalField}),
+          boundaryConditions_(boundaryConditions)
+    {}
+
 
     SurfaceField(const SurfaceField& other)
         : GeometricFieldMixin<ValueType>(other), boundaryConditions_(other.boundaryConditions_)

--- a/include/NeoFOAM/finiteVolume/cellCentred/fields/surfaceField.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/fields/surfaceField.hpp
@@ -45,6 +45,13 @@ public:
           boundaryConditions_(boundaryConditions)
     {}
 
+    /* @brief Constructor for a surfaceField with a given internal field
+     *
+     * @param exec The executor
+     * @param mesh The underlying mesh
+     * @param internalField the underlying internal field
+     * @param boundaryConditions a vector of boundary conditions
+     */
     SurfaceField(
         const Executor& exec,
         const UnstructuredMesh& mesh,

--- a/include/NeoFOAM/finiteVolume/cellCentred/fields/volumeField.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/fields/volumeField.hpp
@@ -27,6 +27,12 @@ class VolumeField : public GeometricFieldMixin<ValueType>
 
 public:
 
+    /* @brief Constructor for a uninitialized VolumeField
+     *
+     * @param exec The executor
+     * @param mesh The underlying mesh
+     * @param boundaryConditions a vector of boundary conditions
+     */
     VolumeField(
         const Executor& exec,
         const UnstructuredMesh& mesh,
@@ -40,11 +46,11 @@ public:
           boundaryConditions_(boundaryConditions)
     {}
 
-    /* @brief Constructor for a VolumeField
+    /* @brief Constructor for a VolumeField with a given internal field
      *
      * @param mesh The underlying mesh
-     * @param domainField Combination of internal field and boundary information
-     * @param reference to boundary conditions
+     * @param internalField the underlying internal field
+     * @param boundaryConditions a vector of boundary conditions
      */
     VolumeField(
         const Executor& exec,

--- a/include/NeoFOAM/finiteVolume/cellCentred/fields/volumeField.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/fields/volumeField.hpp
@@ -40,6 +40,22 @@ public:
           boundaryConditions_(boundaryConditions)
     {}
 
+    /* @brief Constructor for a VolumeField
+     *
+     * @param mesh The underlying mesh
+     * @param domainField Combination of internal field and boundary information
+     * @param reference to boundary conditions
+     */
+    VolumeField(
+        const Executor& exec,
+        const UnstructuredMesh& mesh,
+        const Field<ValueType>& internalField,
+        const std::vector<VolumeBoundary<ValueType>>& boundaryConditions
+    )
+        : GeometricFieldMixin<ValueType>(exec, mesh, {exec, mesh, internalField}),
+          boundaryConditions_(boundaryConditions)
+    {}
+
     VolumeField(const VolumeField& other)
         : GeometricFieldMixin<ValueType>(other), boundaryConditions_(other.boundaryConditions_)
     {}


### PR DESCRIPTION
This PR adds a Field constructor that allows to copy construct from existing host memory data. 
The motivation for this PR is to simplify creating NeoFOAM fields from existing OpenFOAM data structures. Additionally it adds constructor for VolumeField which allows to construct with given data.


For a future PR we should add constructor that allow to move data in instead of copying.