### PR TITLE
fix compiler warnings

### DIFF
--- a/include/NeoFOAM/fields/field.hpp
+++ b/include/NeoFOAM/fields/field.hpp
@@ -59,7 +59,7 @@ public:
     {
         void* ptr = nullptr;
         std::visit(
-            [this, &ptr, size](const auto& concreteExec)
+            [&ptr, size](const auto& concreteExec)
             { ptr = concreteExec.alloc(size * sizeof(ValueType)); },
             exec_
         );
@@ -77,8 +77,7 @@ public:
     {
         void* ptr = nullptr;
         std::visit(
-            [this, &ptr, size](const auto& exec) { ptr = exec.alloc(size * sizeof(ValueType)); },
-            exec_
+            [&ptr, size](const auto& exec) { ptr = exec.alloc(size * sizeof(ValueType)); }, exec_
         );
         data_ = static_cast<ValueType*>(ptr);
         NeoFOAM::fill(*this, value);
@@ -288,15 +287,14 @@ public:
         {
             std::visit(
                 [this, &ptr, size](const auto& exec)
-                { ptr = exec.realloc(data_, size * sizeof(ValueType)); },
+                { ptr = exec.realloc(this->data_, size * sizeof(ValueType)); },
                 exec_
             );
         }
         else
         {
             std::visit(
-                [this, &ptr, size](const auto& exec)
-                { ptr = exec.alloc(size * sizeof(ValueType)); },
+                [&ptr, size](const auto& exec) { ptr = exec.alloc(size * sizeof(ValueType)); },
                 exec_
             );
         }

--- a/include/NeoFOAM/finiteVolume/cellCentred/boundary/surfaceBoundaryFactory.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/boundary/surfaceBoundaryFactory.hpp
@@ -76,10 +76,9 @@ private:
 template<typename ValueType>
 std::vector<SurfaceBoundary<ValueType>> createCalculatedBCs(const UnstructuredMesh& mesh)
 {
-    const auto& bMesh = mesh.boundaryMesh();
     std::vector<SurfaceBoundary<ValueType>> bcs;
 
-    for (int patchID = 0; patchID < mesh.nBoundaries(); patchID++)
+    for (size_t patchID = 0; patchID < mesh.nBoundaries(); patchID++)
     {
         Dictionary patchDict({{"type", std::string("calculated")}});
         bcs.push_back(SurfaceBoundary<ValueType>(mesh, patchDict, patchID));

--- a/include/NeoFOAM/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp
@@ -29,7 +29,6 @@ public:
 
 private:
 
-    [[maybe_unused]] const UnstructuredMesh& mesh_;
     SurfaceInterpolation surfaceInterpolation_;
 };
 

--- a/include/NeoFOAM/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp
@@ -29,7 +29,7 @@ public:
 
 private:
 
-    const UnstructuredMesh& mesh_;
+    [[maybe_unused]] const UnstructuredMesh& mesh_;
     SurfaceInterpolation surfaceInterpolation_;
 };
 

--- a/include/NeoFOAM/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp
@@ -28,7 +28,6 @@ public:
 private:
 
     SurfaceInterpolation surfaceInterpolation_;
-    [[maybe_unused]] const UnstructuredMesh& mesh_;
 };
 
 } // namespace NeoFOAM

--- a/include/NeoFOAM/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp
@@ -28,7 +28,7 @@ public:
 private:
 
     SurfaceInterpolation surfaceInterpolation_;
-    const UnstructuredMesh& mesh_;
+    [[maybe_unused]] const UnstructuredMesh& mesh_;
 };
 
 } // namespace NeoFOAM

--- a/include/NeoFOAM/finiteVolume/cellCentred/stencil/geometryScheme.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/stencil/geometryScheme.hpp
@@ -20,6 +20,8 @@ public:
 
     GeometrySchemeFactory(const UnstructuredMesh& mesh);
 
+    virtual ~GeometrySchemeFactory() = default;
+
     virtual void updateWeights(const Executor& exec, SurfaceField<scalar>& weights) = 0;
 
     virtual void updateDeltaCoeffs(const Executor& exec, SurfaceField<scalar>& deltaCoeffs) = 0;
@@ -55,6 +57,8 @@ public:
 
     GeometryScheme(const UnstructuredMesh& mesh // will lookup the kernel
     );
+
+    virtual ~GeometryScheme() = default;
 
     const SurfaceField<scalar>& weights() const;
 

--- a/src/core/tokenList.cpp
+++ b/src/core/tokenList.cpp
@@ -10,7 +10,10 @@ TokenList::TokenList(const std::initializer_list<std::any>& initList) : data_(in
 
 void TokenList::insert(const std::any& value) { data_.push_back(value); }
 
-void TokenList::remove(size_t index) { data_.erase(data_.begin() + index); }
+void TokenList::remove(size_t index)
+{
+    data_.erase(data_.begin() + static_cast<std::vector<double>::difference_type>(index));
+}
 
 [[nodiscard]] bool TokenList::empty() const { return data_.empty(); }
 

--- a/src/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -27,14 +27,14 @@ void computeLinearInterpolation(
     const auto sBField = volField.boundaryField().value().span();
     const auto sOwner = owner.span();
     const auto sNeighbour = neighbour.span();
-    int nInternalFaces = mesh.nInternalFaces();
+    size_t nInternalFaces = mesh.nInternalFaces();
 
     NeoFOAM::parallelFor(
         exec,
         {0, sfield.size()},
         KOKKOS_LAMBDA(const size_t facei) {
-            int32_t own = sOwner[facei];
-            int32_t nei = sNeighbour[facei];
+            size_t own = static_cast<size_t>(sOwner[facei]);
+            size_t nei = static_cast<size_t>(sNeighbour[facei]);
             if (facei < nInternalFaces)
             {
                 sfield[facei] =
@@ -42,8 +42,7 @@ void computeLinearInterpolation(
             }
             else
             {
-                int pfacei = facei - nInternalFaces;
-                sfield[facei] = sWeight[facei] * sBField[pfacei];
+                sfield[facei] = sWeight[facei] * sBField[facei - nInternalFaces];
             }
         }
     );
@@ -60,7 +59,7 @@ void Linear::interpolate(const VolumeField<scalar>& volField, SurfaceField<scala
 }
 
 void Linear::interpolate(
-    const SurfaceField<scalar>& faceFlux,
+    [[maybe_unused]] const SurfaceField<scalar>& faceFlux,
     const VolumeField<scalar>& volField,
     SurfaceField<scalar>& surfaceField
 ) const

--- a/src/finiteVolume/cellCentred/interpolation/upwind.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/upwind.cpp
@@ -61,9 +61,9 @@ Upwind::Upwind(const Executor& exec, const UnstructuredMesh& mesh)
       geometryScheme_(GeometryScheme::readOrCreate(mesh)) {};
 
 void Upwind::interpolate(
-    [[maybe_unused]] const VolumeField<scalar>& volField
-    [[maybe_unused]] SurfaceField<scalar>& surfaceField,
-)
+    [[maybe_unused]] const VolumeField<scalar>& volField,
+    [[maybe_unused]] SurfaceField<scalar>& surfaceField
+) const
 {
     NF_ERROR_EXIT("limited scheme require a faceFlux");
 }

--- a/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
@@ -40,13 +40,13 @@ void computeDiv(
         for (size_t i = 0; i < nInternalFaces; i++)
         {
             scalar flux = surfFaceFlux[i] * surfPhif[i];
-            surfDivPhi[surfOwner[i]] += flux;
-            surfDivPhi[surfNeighbour[i]] -= flux;
+            surfDivPhi[static_cast<size_t>(surfOwner[i])] += flux;
+            surfDivPhi[static_cast<size_t>(surfNeighbour[i])] -= flux;
         }
 
         for (size_t i = nInternalFaces; i < surfPhif.size(); i++)
         {
-            int32_t own = surfFaceCells[i - nInternalFaces];
+            size_t own = static_cast<size_t>(surfFaceCells[i - nInternalFaces]);
             scalar valueOwn = surfFaceFlux[i] * surfPhif[i];
             surfDivPhi[own] += valueOwn;
         }
@@ -64,8 +64,8 @@ void computeDiv(
             {0, nInternalFaces},
             KOKKOS_LAMBDA(const size_t i) {
                 scalar flux = surfFaceFlux[i] * surfPhif[i];
-                Kokkos::atomic_add(&surfDivPhi[surfOwner[i]], flux);
-                Kokkos::atomic_sub(&surfDivPhi[surfNeighbour[i]], flux);
+                Kokkos::atomic_add(&surfDivPhi[static_cast<size_t>(surfOwner[i])], flux);
+                Kokkos::atomic_sub(&surfDivPhi[static_cast<size_t>(surfNeighbour[i])], flux);
             }
         );
 
@@ -73,7 +73,7 @@ void computeDiv(
             exec,
             {nInternalFaces, surfPhif.size()},
             KOKKOS_LAMBDA(const size_t i) {
-                int32_t own = surfFaceCells[i - nInternalFaces];
+                size_t own = static_cast<size_t>(surfFaceCells[i - nInternalFaces]);
                 scalar valueOwn = surfFaceFlux[i] * surfPhif[i];
                 Kokkos::atomic_add(&surfDivPhi[own], valueOwn);
             }
@@ -88,7 +88,9 @@ void computeDiv(
 }
 
 GaussGreenDiv::GaussGreenDiv(
-    const Executor& exec, const UnstructuredMesh& mesh, const SurfaceInterpolation& surfInterp
+    [[maybe_unused]] const Executor& exec,
+    const UnstructuredMesh& mesh,
+    const SurfaceInterpolation& surfInterp
 )
     : mesh_(mesh), surfaceInterpolation_(surfInterp) {};
 

--- a/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
@@ -92,7 +92,7 @@ GaussGreenDiv::GaussGreenDiv(
     const UnstructuredMesh& mesh,
     const SurfaceInterpolation& surfInterp
 )
-    : mesh_(mesh), surfaceInterpolation_(surfInterp) {};
+    : surfaceInterpolation_(surfInterp) {};
 
 void GaussGreenDiv::div(
     VolumeField<scalar>& divPhi, const SurfaceField<scalar>& faceFlux, VolumeField<scalar>& phi

--- a/src/finiteVolume/cellCentred/operators/gaussGreenGrad.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenGrad.cpp
@@ -84,7 +84,7 @@ void computeGrad(
 }
 
 GaussGreenGrad::GaussGreenGrad(const Executor& exec, const UnstructuredMesh& mesh)
-    : surfaceInterpolation_(exec, mesh, std::make_unique<Linear>(exec, mesh)), mesh_(mesh) {};
+    : surfaceInterpolation_(exec, mesh, std::make_unique<Linear>(exec, mesh)) {};
 
 
 void GaussGreenGrad::grad(const VolumeField<scalar>& phi, VolumeField<Vector>& gradPhi)

--- a/src/finiteVolume/cellCentred/operators/gaussGreenGrad.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenGrad.cpp
@@ -37,13 +37,13 @@ void computeGrad(
         for (size_t i = 0; i < nInternalFaces; i++)
         {
             Vector flux = sSf[i] * surfPhif[i];
-            surfGradPhi[surfOwner[i]] += flux;
-            surfGradPhi[surfNeighbour[i]] -= flux;
+            surfGradPhi[static_cast<size_t>(surfOwner[i])] += flux;
+            surfGradPhi[static_cast<size_t>(surfNeighbour[i])] -= flux;
         }
 
         for (size_t i = nInternalFaces; i < surfPhif.size(); i++)
         {
-            int32_t own = surfFaceCells[i - nInternalFaces];
+            size_t own = static_cast<size_t>(surfFaceCells[i - nInternalFaces]);
             Vector valueOwn = sBSf[i - nInternalFaces] * surfPhif[i];
             surfGradPhi[own] += valueOwn;
         }
@@ -60,8 +60,8 @@ void computeGrad(
             {0, nInternalFaces},
             KOKKOS_LAMBDA(const size_t i) {
                 Vector flux = sSf[i] * surfPhif[i];
-                Kokkos::atomic_add(&surfGradPhi[surfOwner[i]], flux);
-                Kokkos::atomic_sub(&surfGradPhi[surfNeighbour[i]], flux);
+                Kokkos::atomic_add(&surfGradPhi[static_cast<size_t>(surfOwner[i])], flux);
+                Kokkos::atomic_sub(&surfGradPhi[static_cast<size_t>(surfNeighbour[i])], flux);
             }
         );
 
@@ -69,7 +69,7 @@ void computeGrad(
             exec,
             {nInternalFaces, surfPhif.size()},
             KOKKOS_LAMBDA(const size_t i) {
-                size_t own = surfFaceCells[i - nInternalFaces];
+                size_t own = static_cast<size_t>(surfFaceCells[i - nInternalFaces]);
                 Vector valueOwn = sSf[i] * surfPhif[i];
                 Kokkos::atomic_add(&surfGradPhi[own], valueOwn);
             }
@@ -84,7 +84,7 @@ void computeGrad(
 }
 
 GaussGreenGrad::GaussGreenGrad(const Executor& exec, const UnstructuredMesh& mesh)
-    : mesh_(mesh), surfaceInterpolation_(exec, mesh, std::make_unique<Linear>(exec, mesh)) {};
+    : surfaceInterpolation_(exec, mesh, std::make_unique<Linear>(exec, mesh)), mesh_(mesh) {};
 
 
 void GaussGreenGrad::grad(const VolumeField<scalar>& phi, VolumeField<Vector>& gradPhi)

--- a/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
@@ -24,14 +24,14 @@ void BasicGeometryScheme::updateWeights(const Executor& exec, SurfaceField<scala
     parallelFor(
         exec,
         {0, mesh_.nInternalFaces()},
-        KOKKOS_LAMBDA(const int facei) {
+        KOKKOS_LAMBDA(const size_t facei) {
             // Note: mag in the dot-product.
             // For all valid meshes, the non-orthogonality will be less than
             // 90 deg and the dot-product will be positive.  For invalid
             // meshes (d & s <= 0), this will stabilise the calculation
             // but the result will be poor.
-            scalar sfdOwn = mag(sf[facei] & (cf[facei] - c[owner[facei]]));
-            scalar sfdNei = mag(sf[facei] & (c[neighbour[facei]] - cf[facei]));
+            scalar sfdOwn = mag(sf[facei] & (cf[facei] - c[static_cast<size_t>(owner[facei])]));
+            scalar sfdNei = mag(sf[facei] & (c[static_cast<size_t>(neighbour[facei])] - cf[facei]));
 
             if (std::abs(sfdOwn + sfdNei) > ROOTVSMALL)
             {
@@ -45,18 +45,14 @@ void BasicGeometryScheme::updateWeights(const Executor& exec, SurfaceField<scala
     );
 
     parallelFor(
-        exec, {mesh_.nInternalFaces(), w.size()}, KOKKOS_LAMBDA(const int facei) { w[facei] = 1.0; }
+        exec,
+        {mesh_.nInternalFaces(), w.size()},
+        KOKKOS_LAMBDA(const size_t facei) { w[facei] = 1.0; }
     );
 }
 
-void BasicGeometryScheme::updateDeltaCoeffs(const Executor& exec, SurfaceField<scalar>& deltaCoeffs)
-{
-    NF_ERROR_EXIT("Not implemented");
-}
-
-
-void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
-    const Executor& exec, SurfaceField<scalar>& nonOrthDeltaCoeffs
+void BasicGeometryScheme::updateDeltaCoeffs(
+    [[maybe_unused]] const Executor& exec, [[maybe_unused]] SurfaceField<scalar>& deltaCoeffs
 )
 {
     NF_ERROR_EXIT("Not implemented");
@@ -64,7 +60,15 @@ void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
 
 
 void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
-    const Executor& exec, SurfaceField<Vector>& nonOrthDeltaCoeffs
+    [[maybe_unused]] const Executor& exec, [[maybe_unused]] SurfaceField<scalar>& nonOrthDeltaCoeffs
+)
+{
+    NF_ERROR_EXIT("Not implemented");
+}
+
+
+void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
+    [[maybe_unused]] const Executor& exec, [[maybe_unused]] SurfaceField<Vector>& nonOrthDeltaCoeffs
 )
 {
     NF_ERROR_EXIT("Not implemented");

--- a/test/core/parallelAlgorithms.cpp
+++ b/test/core/parallelAlgorithms.cpp
@@ -64,7 +64,6 @@ TEST_CASE("parallelFor")
         NeoFOAM::Field<NeoFOAM::scalar> fieldA(exec, 5);
         NeoFOAM::fill(fieldA, 0.0);
         NeoFOAM::Field<NeoFOAM::scalar> fieldB(exec, 5);
-        auto spanA = fieldA.span();
         auto spanB = fieldB.span();
         NeoFOAM::fill(fieldB, 1.0);
         NeoFOAM::parallelFor(
@@ -93,7 +92,6 @@ TEST_CASE("parallelReduce")
         NeoFOAM::Field<NeoFOAM::scalar> fieldA(exec, 5);
         NeoFOAM::fill(fieldA, 0.0);
         NeoFOAM::Field<NeoFOAM::scalar> fieldB(exec, 5);
-        auto spanA = fieldA.span();
         auto spanB = fieldB.span();
         NeoFOAM::fill(fieldB, 1.0);
         NeoFOAM::scalar sum = 0.0;
@@ -109,7 +107,6 @@ TEST_CASE("parallelReduce")
         NeoFOAM::Field<NeoFOAM::scalar> fieldA(exec, 5);
         NeoFOAM::fill(fieldA, 0.0);
         NeoFOAM::Field<NeoFOAM::scalar> fieldB(exec, 5);
-        auto spanA = fieldA.span();
         auto spanB = fieldB.span();
         NeoFOAM::fill(fieldB, 1.0);
         NeoFOAM::scalar sum = 0.0;


### PR DESCRIPTION
This PR fixes a number of compiler warnings. Mostly unused variables, implicit conversion, and initialization order.

In order to fix all the implicit conversion warnings we need to add many `static_cast<size_t>` since we use the owner/neighbour values from our mesh classes which are `int`s. For example here: `surfDivPhi[static_cast<size_t>(surfNeighbour[i])]`.

So the question which arises is, if surfNeighbour, owner, neighbour fields should just store `size_t`. This would make it harder to store special values for owner, neighbour like -1. But do we need to?