### PR TITLE
Follow up fix compiler warnings.

### DIFF
--- a/include/NeoFOAM/finiteVolume/cellCentred/boundary/surface/calculated.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/boundary/surface/calculated.hpp
@@ -22,13 +22,13 @@ public:
 
     using CalculatedType = Calculated<ValueType>;
 
-    Calculated(
-        const UnstructuredMesh& mesh, [[maybe_unused]] const Dictionary& dict, std::size_t patchID
-    )
+    Calculated(const UnstructuredMesh& mesh, const Dictionary& dict, std::size_t patchID)
         : Base(mesh, dict, patchID)
     {}
 
-    virtual void correctBoundaryCondition(DomainField<ValueType>& domainField) override {}
+    virtual void correctBoundaryCondition([[maybe_unused]] DomainField<ValueType>& domainField
+    ) override
+    {}
 
     static std::string name() { return "calculated"; }
 

--- a/include/NeoFOAM/finiteVolume/cellCentred/boundary/surface/empty.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/boundary/surface/empty.hpp
@@ -19,13 +19,13 @@ class Empty : public SurfaceBoundaryFactory<ValueType>::template Register<Empty<
 
 public:
 
-    Empty(
-        const UnstructuredMesh& mesh, [[maybe_unused]] const Dictionary& dict, std::size_t patchID
-    )
+    Empty(const UnstructuredMesh& mesh, const Dictionary& dict, std::size_t patchID)
         : Base(mesh, dict, patchID)
     {}
 
-    virtual void correctBoundaryCondition(DomainField<ValueType>& domainField) override {}
+    virtual void correctBoundaryCondition([[maybe_unused]] DomainField<ValueType>& domainField
+    ) override
+    {}
 
     static std::string name() { return "empty"; }
 

--- a/include/NeoFOAM/finiteVolume/cellCentred/boundary/volume/calculated.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/boundary/volume/calculated.hpp
@@ -21,13 +21,13 @@ public:
 
     using CalculatedType = Calculated<ValueType>;
 
-    Calculated(
-        const UnstructuredMesh& mesh, [[maybe_unused]] const Dictionary& dict, std::size_t patchID
-    )
+    Calculated(const UnstructuredMesh& mesh, const Dictionary& dict, std::size_t patchID)
         : Base(mesh, dict, patchID)
     {}
 
-    virtual void correctBoundaryCondition(DomainField<ValueType>& domainField) final {}
+    virtual void correctBoundaryCondition([[maybe_unused]] DomainField<ValueType>& domainField
+    ) final
+    {}
 
     static std::string name() { return "calculated"; }
 

--- a/include/NeoFOAM/finiteVolume/cellCentred/boundary/volume/empty.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/boundary/volume/empty.hpp
@@ -19,9 +19,7 @@ class Empty : public VolumeBoundaryFactory<ValueType>::template Register<Empty<V
 
 public:
 
-    Empty(
-        const UnstructuredMesh& mesh, [[maybe_unused]] const Dictionary& dict, std::size_t patchID
-    )
+    Empty(const UnstructuredMesh& mesh, const Dictionary& dict, std::size_t patchID)
         : Base(mesh, dict, patchID)
     {}
 

--- a/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
@@ -89,7 +89,7 @@ void computeDiv(
 
 GaussGreenDiv::GaussGreenDiv(
     [[maybe_unused]] const Executor& exec,
-    const UnstructuredMesh& mesh,
+    [[maybe_unused]] const UnstructuredMesh& mesh,
     const SurfaceInterpolation& surfInterp
 )
     : surfaceInterpolation_(surfInterp) {};

--- a/src/finiteVolume/cellCentred/stencil/geometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/geometryScheme.cpp
@@ -9,7 +9,7 @@
 namespace NeoFOAM::finiteVolume::cellCentred
 {
 
-GeometrySchemeFactory::GeometrySchemeFactory(const UnstructuredMesh& mesh) {}
+GeometrySchemeFactory::GeometrySchemeFactory([[maybe_unused]] const UnstructuredMesh& mesh) {}
 
 
 const std::shared_ptr<GeometryScheme> GeometryScheme::readOrCreate(const UnstructuredMesh& mesh)

--- a/test/fields/field.cpp
+++ b/test/fields/field.cpp
@@ -233,7 +233,6 @@ TEST_CASE("Field Operations")
     {
         NeoFOAM::size_t size = 10;
         NeoFOAM::Field<NeoFOAM::scalar> a(exec, size);
-        auto sA = a.span();
         NeoFOAM::fill(a, 5.0);
 
         REQUIRE(equal(a, 5.0));
@@ -285,10 +284,6 @@ TEST_CASE("getSpans")
     REQUIRE(spanA[0] == 1.0);
     REQUIRE(spanB[0] == 2.0);
     REQUIRE(spanC[0] == 3.0);
-
-    auto [spanA2] = NeoFOAM::spans(a);
-
-    REQUIRE(spanA[0] == 1.0);
 
     NeoFOAM::parallelFor(
         a, KOKKOS_LAMBDA(const NeoFOAM::size_t i) { return spanB[i] + spanC[i]; }


### PR DESCRIPTION
This PR fixes more compiler warnings, which have been missed by https://github.com/exasim-project/NeoFOAM/pull/146. Mostly fixing unused variables.