### PR TITLE
Ci/setup of

### DIFF
--- a/.github/workflows/build_adapter.yaml
+++ b/.github/workflows/build_adapter.yaml
@@ -53,7 +53,7 @@ jobs:
      - name: Install dependencies
        uses: gerlero/apt-install@v1
        with:
-         packages: >
+         packages: >-
            ninja-build
            clang-16
            gcc-10

--- a/.github/workflows/build_adapter.yaml
+++ b/.github/workflows/build_adapter.yaml
@@ -9,7 +9,7 @@ on:
   pull_request:
     types: synchronize
   schedule:
-    - cron: "* 0 * * 0"
+    - cron: "0 6 * * 1"
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1

--- a/.github/workflows/build_adapter.yaml
+++ b/.github/workflows/build_adapter.yaml
@@ -45,25 +45,24 @@ jobs:
         path: NeoFOAM
         ref: '${{ github.head_ref }}'
 
-     - name: Add repos
-       run: |
-         sudo add-apt-repository 'deb https://dl.openfoam.com/repos/deb noble main'
-         sudo apt-key add .github/workflows/pubkey.gpg
+     - name: Set up OpenFOAM
+       uses: gerlero/setup-openfoam@v1
+       with:
+         openfoam-version: 2406
 
      - name: Install dependencies
-       run: |
-         sudo apt update
-         sudo apt install \
-           ninja-build \
-           clang-16 \
-           gcc-10 \
-           libomp-16-dev \
-           python3 \
-           python3-dev \
-           build-essential \
-           libopenmpi-dev \
-           openmpi-bin \
-           openfoam2406-dev
+       uses: gerlero/apt-install@v1
+       with:
+         packages: >
+           ninja-build
+           clang-16
+           gcc-10
+           libomp-16-dev
+           python3
+           python3-dev
+           build-essential
+           libopenmpi-dev
+           openmpi-bin
 
      - name: Get versions
        run: |

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,3 +6,4 @@ Gregor Olenik  <gregor.olenik@kit.edu>, Karlsruhe Institute of Technology\
 Henning Scheufler <henning.scheufler@web.de>\
 Marcel Koch <marcel.koch@kit.edu>, Karlsruhe Institute of Technology
 Chih-Ta Wang <chihta.wang@tum.de> Technical University of Munich
+Gabriel Gerlero <ggerlero@cimec.unl.edu.ar> Research Center for Computational Methods (CIMEC)


### PR DESCRIPTION
This PR uses the [setup-openfoam](https://github.com/gerlero/setup-openfoam) workflow to handle openfoam installation and setup.