### PR TITLE
faster project configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Version 0.1.0 (unreleased)
+- faster project configuration [#179](https://github.com/exasim-project/NeoFOAM/pull/179)
 - improved error handling and addition of tokenList and Input [#134](https://github.com/exasim-project/NeoFOAM/pull/134)
 - disable span from temporary objects and simplification related to fields [#139](https://github.com/exasim-project/NeoFOAM/pull/139)
 - added launch json to debug unit test in vscode [#135](https://github.com/exasim-project/NeoFOAM/pull/135)

--- a/cmake/CxxThirdParty.cmake
+++ b/cmake/CxxThirdParty.cmake
@@ -32,9 +32,9 @@ cpmaddpackage(
   NAME
   cpptrace
   URL
-  https://github.com/jeremy-rifkin/cpptrace/archive/refs/tags/v0.5.4.zip
+  https://github.com/jeremy-rifkin/cpptrace/archive/refs/tags/v0.7.3.zip
   VERSION
-  0.5.4
+  0.7.3
   SYSTEM)
 
 cpmaddpackage(

--- a/cmake/CxxThirdParty.cmake
+++ b/cmake/CxxThirdParty.cmake
@@ -31,8 +31,8 @@ include(cmake/CPM.cmake)
 cpmaddpackage(
   NAME
   cpptrace
-  GITHUB_REPOSITORY
-  jeremy-rifkin/cpptrace
+  URL
+  https://github.com/jeremy-rifkin/cpptrace/archive/refs/tags/v0.5.4.zip
   VERSION
   0.5.4
   SYSTEM)
@@ -40,8 +40,8 @@ cpmaddpackage(
 cpmaddpackage(
   NAME
   nlohmann_json
-  GITHUB_REPOSITORY
-  nlohmann/json
+  URL
+  https://github.com/nlohmann/json/releases/download/v3.11.3/include.zip
   VERSION
   3.11.3
   SYSTEM)
@@ -49,8 +49,8 @@ cpmaddpackage(
 cpmaddpackage(
   NAME
   spdlog
-  GITHUB_REPOSITORY
-  gabime/spdlog
+  URL
+  https://github.com/gabime/spdlog/archive/refs/tags/v1.13.0.zip
   VERSION
   1.13.0
   SYSTEM)
@@ -58,8 +58,8 @@ cpmaddpackage(
 cpmaddpackage(
   NAME
   cxxopts
-  GITHUB_REPOSITORY
-  jarro2783/cxxopts
+  URL
+  https://github.com/jarro2783/cxxopts/archive/refs/tags/v3.2.0.zip
   VERSION
   3.2.0
   SYSTEM)
@@ -68,8 +68,8 @@ if(NEOFOAM_BUILD_TESTS OR NEOFOAM_BUILD_BENCHMARKS)
   cpmaddpackage(
     NAME
     Catch2
-    GITHUB_REPOSITORY
-    catchorg/Catch2
+    URL
+    https://github.com/catchorg/Catch2/archive/refs/tags/v3.4.0.zip
     VERSION
     3.4.0
     SYSTEM)


### PR DESCRIPTION
CPM currently clones the github repo leading to increased download times compared to downloading the zip files:

```
time cmake --preset develop # with cpmaddpackage --> GITHUB_REPOSITORY
real    2m0,627s
user    0m16,555s
sys     0m6,525s

time cmake --preset develop   # with cpmaddpackage --> URL

real    0m30,557s
user    0m5,519s
sys     0m3,345s
```

First introduces by 

@Fitanium 

in PR #163 
