### PR TITLE
Fix shadowing warnings

### DIFF
--- a/.github/workflows/build_on_aws.yml
+++ b/.github/workflows/build_on_aws.yml
@@ -69,7 +69,7 @@ jobs:
                  nvm install v16.20.2
                  echo "NVM_DIR=/share/ec2-user/.nvm" >> $GITHUB_ENV
                  echo "NVM_BIN=/share/ec2-user/.nvm/versions/node/v16.20.2/bin" >> $GITHUB_ENV
-                 
+
   build-on-aws:
     name: Build on aws
     needs: start-runner # required to start the main job when the runner is ready

--- a/.github/workflows/build_on_aws.yml
+++ b/.github/workflows/build_on_aws.yml
@@ -108,7 +108,8 @@ jobs:
           cmake --preset ${{matrix.preset}} \
             -DNEOFOAM_BUILD_TESTS=ON \
             -DNEOFOAM_DEVEL_TOOLS=OFF \
-            -DNEOFOAM_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF
+            -DNEOFOAM_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF \
+            -DKokkos_ENABLE_CUDA=ON
           cmake --build --preset ${{matrix.preset}}
       - name: Test NeoFOAM
         shell: bash -i {0}

--- a/cmake/AutoEnableDevice.cmake
+++ b/cmake/AutoEnableDevice.cmake
@@ -1,12 +1,14 @@
 # SPDX-License-Identifier: Unlicense
 # SPDX-FileCopyrightText: 2023 NeoFOAM authors
 
+message(STATUS "Auto detecting accelerator devices")
 include(CheckLanguage)
 
 if(NOT DEFINED Kokkos_ENABLE_OPENMP AND NOT DEFINED Kokkos_ENABLE_THREADS)
   find_package(Threads QUIET)
 
   if(Threads_FOUND)
+    message(STATUS "Set Kokkos_ENABLE_Threads=ON")
     set(Kokkos_ENABLE_THREADS
         ON
         CACHE INTERNAL "")
@@ -14,6 +16,7 @@ if(NOT DEFINED Kokkos_ENABLE_OPENMP AND NOT DEFINED Kokkos_ENABLE_THREADS)
     find_package(OpenMP QUIET)
 
     if(OpenMP_FOUND)
+      message(STATUS "Set Kokkos_ENABLE_OPENMP=ON")
       set(Kokkos_ENABLE_OPENMP
           ON
           CACHE INTERNAL "")
@@ -21,16 +24,29 @@ if(NOT DEFINED Kokkos_ENABLE_OPENMP AND NOT DEFINED Kokkos_ENABLE_THREADS)
   endif()
 endif()
 
-# if(NOT DEFINED Kokkos_ENABLE_CUDA) check_language(CUDA)
-
-# if(CMAKE_CUDA_COMPILER) set(Kokkos_ENABLE_CUDA ON CACHE INTERNAL "")
-# set(Kokkos_ENABLE_CUDA_CONSTEXPR ON CACHE INTERNAL "") else() set(Kokkos_ENABLE_CUDA OFF CACHE
-# INTERNAL "") endif() endif()
+if(NOT DEFINED Kokkos_ENABLE_CUDA)
+  check_language(CUDA)
+  if(CMAKE_CUDA_COMPILER)
+    message(STATUS "Set Kokkos_ENABLE_CUDA=ON")
+    set(Kokkos_ENABLE_CUDA
+        ON
+        CACHE INTERNAL "")
+    set(Kokkos_ENABLE_CUDA_CONSTEXPR
+        ON
+        CACHE INTERNAL "")
+  else()
+    set(Kokkos_ENABLE_CUDA
+        OFF
+        CACHE INTERNAL "")
+  endif()
+else()
+  message(STATUS "Skip CUDA detection Kokkos_ENABLE_CUDA=${Kokko_ENABLE_CUDA}")
+endif()
 
 if(NOT DEFINED Kokkos_ENABLE_HIP)
   check_language(HIP)
-
   if(CMAKE_HIP_COMPILER)
+    message(STATUS "Set Kokkos_ENABLE_HIP=ON")
     set(Kokkos_ENABLE_HIP
         ON
         CACHE INTERNAL "")
@@ -39,4 +55,6 @@ if(NOT DEFINED Kokkos_ENABLE_HIP)
         OFF
         CACHE INTERNAL "")
   endif()
+else()
+  message(STATUS "Skip HIP detection Kokkos_ENABLE_HIP=${Kokko_ENABLE_HIP}")
 endif()

--- a/cmake/CxxThirdParty.cmake
+++ b/cmake/CxxThirdParty.cmake
@@ -13,7 +13,6 @@ find_package(Kokkos ${NEOFOAM_KOKKOS_CHECKOUT_VERSION} QUIET)
 
 if(NOT ${Kokkos_FOUND})
   include(FetchContent)
-
   include(cmake/AutoEnableDevice.cmake)
 
   FetchContent_Declare(
@@ -24,6 +23,8 @@ if(NOT ${Kokkos_FOUND})
     GIT_TAG ${NEOFOAM_KOKKOS_CHECKOUT_VERSION})
 
   FetchContent_MakeAvailable(Kokkos)
+else()
+  message(STATUS "Found Kokkos ${NEOFOAM_KOKKOS_CHECKOUT_VERSION}")
 endif()
 
 include(cmake/CPM.cmake)

--- a/include/NeoFOAM/core/database/oldTimeCollection.hpp
+++ b/include/NeoFOAM/core/database/oldTimeCollection.hpp
@@ -120,7 +120,8 @@ public:
         }
         else
         {
-            NF_THROW("Old field not found");
+            // TODO replace with NF_THROW
+            NF_ERROR_EXIT("Old field not found");
         }
     }
 

--- a/test/fields/field.cpp
+++ b/test/fields/field.cpp
@@ -279,6 +279,7 @@ TEST_CASE("getSpans")
     NeoFOAM::Field<NeoFOAM::scalar> c(exec, 3, 3.0);
 
     auto [hostA, hostB, hostC] = NeoFOAM::copyToHosts(a, b, c);
+    auto [spanB, spanC] = NeoFOAM::spans(b, c);
 
     REQUIRE(hostA[0] == 1.0);
     REQUIRE(hostB[0] == 2.0);
@@ -288,9 +289,9 @@ TEST_CASE("getSpans")
         a, KOKKOS_LAMBDA(const NeoFOAM::size_t i) { return spanB[i] + spanC[i]; }
     );
 
-    std::tie(hostA) = NeoFOAM::copyToHosts(a);
+    auto hostD = a.copyToHost();
 
-    for (auto value : hostA.span())
+    for (auto value : hostD.span())
     {
         REQUIRE(value == 5.0);
     }

--- a/test/fields/field.cpp
+++ b/test/fields/field.cpp
@@ -279,7 +279,6 @@ TEST_CASE("getSpans")
     NeoFOAM::Field<NeoFOAM::scalar> c(exec, 3, 3.0);
 
     auto [hostA, hostB, hostC] = NeoFOAM::copyToHosts(a, b, c);
-    auto [spanA, spanB, spanC] = NeoFOAM::spans(a, b, c);
 
     REQUIRE(hostA[0] == 1.0);
     REQUIRE(hostB[0] == 2.0);


### PR DESCRIPTION
This PR fixes several compiler warnings, mostly by renaming ctr arguments name which coincides with the public name members of several field classes.

Additional fixes:
- reactivates automatic cuda detection