### PR TITLE
add fixme workflow

### DIFF
--- a/.github/workflows/static_checks.yaml
+++ b/.github/workflows/static_checks.yaml
@@ -125,3 +125,12 @@ jobs:
     - uses: dangoslen/changelog-enforcer@v3
       with:
         changeLogPath: CHANGELOG.md
+  fixmes:
+    name: FIXME check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: greole/action-fixme-check@master # or @ the latest release
+      with:
+        terms: 'FIXME' # optional, defaults to `FIXME`
+        case-sensitive: false  # optional, defaults to `true`

--- a/test/finiteVolume/cellCentred/operator/divOperator.cpp
+++ b/test/finiteVolume/cellCentred/operator/divOperator.cpp
@@ -26,7 +26,7 @@ TEST_CASE("DivOperator")
     );
 
     std::string execName = std::visit([](auto e) { return e.print(); }, exec);
-    // FIXME: take 1d mesh
+    // TODO: take 1d mesh
     NeoFOAM::UnstructuredMesh mesh = NeoFOAM::createSingleCellMesh(exec);
     auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<NeoFOAM::scalar>>(mesh);
 


### PR DESCRIPTION
This PR adds a workflow to check for `FIXME:` notes in the code to avoid accidentally merging unfinished things.

Currently it requires the FIXME note to be followed by a colon, we could however also remove it. 