### PR TITLE
Windows build - passing tests by going static

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ doc/Doxygen/DTAGS
 NeoFOAM/*
 
 _build
+
+.vs/
+build/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
   "cmake.environment": {
     "CC": "gcc",
     "CXX": "g++"
-  }
+  },
+  "cmake.useVsDeveloperEnvironment": "always"
 }

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,3 +7,4 @@ Henning Scheufler <henning.scheufler@web.de>\
 Marcel Koch <marcel.koch@kit.edu>, Karlsruhe Institute of Technology
 Chih-Ta Wang <chihta.wang@tum.de> Technical University of Munich
 Feiteng Meng <fitanium2018@outlook.com>, Harbin Engineering University\
+Roman Mishchuk <roman.mishchuk@tum.de> Technical University of Munich

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,15 @@ mark_as_advanced(NEOFOAM_ENABLE_WARNINGS)
 option(NEOFOAM_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
 mark_as_advanced(NEOFOAM_WARNINGS_AS_ERRORS)
 
+if(WIN32)
+  set(NeoFOAM_LIB_TYPE "STATIC")
+else()
+  set(NeoFOAM_LIB_TYPE "SHARED")
+endif()
+set(NeoFOAM_LIB_TYPE
+    ${NeoFOAM_LIB_TYPE}
+    PARENT_SCOPE)
+
 if(NOT DEFINED CPM_USE_LOCAL_PACKAGES)
   message(STATUS "Set CPM_USE_LOCAL_PACKAGES=ON by default.")
   set(CPM_USE_LOCAL_PACKAGES ON)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -40,7 +40,9 @@
         "NEOFOAM_BUILD_BENCHMARKS": "ON",
         "NEOFOAM_ENABLE_WARNINGS": "ON",
         "Kokkos_ENABLE_DEBUG": "ON",
-        "Kokkos_ENABLE_DEBUG_BOUNDS_CHECK": "ON"
+        "Kokkos_ENABLE_DEBUG_BOUNDS_CHECK": "ON",
+        "Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE": "ON",
+        "CMAKE_CUDA_ARCHITECTURES": "86"
       },
       "warnings": {
         "dev": true,

--- a/benchmarks/fields/CMakeLists.txt
+++ b/benchmarks/fields/CMakeLists.txt
@@ -13,13 +13,6 @@ if(WIN32)
     PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/benchmarks/$<0:>
                LIBRARY_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/benchmarks/$<0:>
                ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/benchmarks/$<0:>)
-
-  add_custom_command(
-    TARGET bench_fields
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/NeoFOAM.dll
-            ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/benchmarks/NeoFOAM.dll
-    COMMENT "Copy NeoFOAM.dll, benchmarks program(s) need it on Windows.")
 else()
   set_property(TARGET bench_fields PROPERTY RUNTIME_OUTPUT_DIRECTORY
                                             ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/benchmarks)

--- a/include/NeoFOAM/core/runtimeSelectionFactory.hpp
+++ b/include/NeoFOAM/core/runtimeSelectionFactory.hpp
@@ -397,7 +397,9 @@ private:
 // Initialize the static variable and register the class
 template<class Base, class... Args>
 template<class derivedClass>
-bool RuntimeSelectionFactory<Base, Parameters<Args...>>::Register<derivedClass>::REGISTERED =
-    RuntimeSelectionFactory<Base, Parameters<Args...>>::Register<derivedClass>::addSubType();
+bool RuntimeSelectionFactory<Base, Parameters<Args...>>::template Register<
+    derivedClass>::REGISTERED =
+    RuntimeSelectionFactory<Base, Parameters<Args...>>::template Register<derivedClass>::addSubType(
+    );
 
 }; // namespace NeoFOAM

--- a/include/NeoFOAM/finiteVolume/cellCentred/boundary.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/boundary.hpp
@@ -11,3 +11,37 @@
 #include "boundary/surface/empty.hpp"
 #include "boundary/surface/calculated.hpp"
 #include "boundary/surface/fixedValue.hpp"
+
+namespace NeoFOAM
+{
+
+namespace fvcc = finiteVolume::cellCentred;
+
+template class fvcc::VolumeBoundaryFactory<scalar>;
+template class fvcc::VolumeBoundaryFactory<Vector>;
+
+template class fvcc::volumeBoundary::FixedValue<scalar>;
+template class fvcc::volumeBoundary::FixedValue<Vector>;
+
+template class fvcc::volumeBoundary::FixedGradient<scalar>;
+template class fvcc::volumeBoundary::FixedGradient<Vector>;
+
+template class fvcc::volumeBoundary::Calculated<scalar>;
+template class fvcc::volumeBoundary::Calculated<Vector>;
+
+template class fvcc::volumeBoundary::Empty<scalar>;
+template class fvcc::volumeBoundary::Empty<Vector>;
+
+template class fvcc::SurfaceBoundaryFactory<scalar>;
+template class fvcc::SurfaceBoundaryFactory<Vector>;
+
+template class fvcc::surfaceBoundary::FixedValue<scalar>;
+template class fvcc::surfaceBoundary::FixedValue<Vector>;
+
+template class fvcc::surfaceBoundary::Calculated<scalar>;
+template class fvcc::surfaceBoundary::Calculated<Vector>;
+
+template class fvcc::surfaceBoundary::Empty<scalar>;
+template class fvcc::surfaceBoundary::Empty<Vector>;
+
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2023 NeoFOAM authors
 # add_subdirectory(DSL)
 
-add_library(NeoFOAM SHARED)
+add_library(NeoFOAM STATIC)
 
 include(GNUInstallDirs)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2023 NeoFOAM authors
 # add_subdirectory(DSL)
 
-add_library(NeoFOAM STATIC)
+add_library(NeoFOAM ${NeoFOAM_LIB_TYPE})
 
 include(GNUInstallDirs)
 

--- a/src/finiteVolume/cellCentred/boundary/boundary.cpp
+++ b/src/finiteVolume/cellCentred/boundary/boundary.cpp
@@ -2,38 +2,3 @@
 // SPDX-FileCopyrightText: 2024 NeoFOAM authors
 
 #include "NeoFOAM/finiteVolume/cellCentred/boundary.hpp"
-#include "NeoFOAM/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp"
-
-namespace NeoFOAM
-{
-
-namespace fvcc = finiteVolume::cellCentred;
-
-template class fvcc::VolumeBoundaryFactory<scalar>;
-template class fvcc::VolumeBoundaryFactory<Vector>;
-
-template class fvcc::volumeBoundary::FixedValue<scalar>;
-template class fvcc::volumeBoundary::FixedValue<Vector>;
-
-template class fvcc::volumeBoundary::FixedGradient<scalar>;
-template class fvcc::volumeBoundary::FixedGradient<Vector>;
-
-template class fvcc::volumeBoundary::Calculated<scalar>;
-template class fvcc::volumeBoundary::Calculated<Vector>;
-
-template class fvcc::volumeBoundary::Empty<scalar>;
-template class fvcc::volumeBoundary::Empty<Vector>;
-
-template class fvcc::SurfaceBoundaryFactory<scalar>;
-template class fvcc::SurfaceBoundaryFactory<Vector>;
-
-template class fvcc::surfaceBoundary::FixedValue<scalar>;
-template class fvcc::surfaceBoundary::FixedValue<Vector>;
-
-template class fvcc::surfaceBoundary::Calculated<scalar>;
-template class fvcc::surfaceBoundary::Calculated<Vector>;
-
-template class fvcc::surfaceBoundary::Empty<scalar>;
-template class fvcc::surfaceBoundary::Empty<Vector>;
-
-}

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -20,11 +20,3 @@ endif()
 target_link_libraries(neofoam_catch_main PUBLIC Catch2::Catch2 cpptrace::cpptrace Kokkos::kokkos
                                                 NeoFOAM)
 target_link_libraries(neofoam_catch_main PRIVATE neofoam_warnings neofoam_options)
-if(WIN32)
-  add_custom_command(
-    TARGET neofoam_catch_main
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/NeoFOAM.dll
-            ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/tests/NeoFOAM.dll
-    COMMENT "Copy NeoFOAM.dll, test programs need it on Windows.")
-endif()

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -15,7 +15,7 @@ neofoam_unit_test(parallelAlgorithms)
 
 # The registerClass test has to be created without linking against neofoam. Otherwise, it will pick
 # up the factories registered in neofoam, which will make the test hard to maintain.
-add_library(testRegister STATIC)
+add_library(testRegister ${NeoFOAM_LIB_TYPE})
 target_sources(testRegister PRIVATE "testRegister.cpp")
 target_link_libraries(testRegister PRIVATE NeoFOAM_public_api cpptrace::cpptrace NeoFOAM)
 if(NEOFOAM_ENABLE_MPI_SUPPORT)

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -15,7 +15,7 @@ neofoam_unit_test(parallelAlgorithms)
 
 # The registerClass test has to be created without linking against neofoam. Otherwise, it will pick
 # up the factories registered in neofoam, which will make the test hard to maintain.
-add_library(testRegister SHARED)
+add_library(testRegister STATIC)
 target_sources(testRegister PRIVATE "testRegister.cpp")
 target_link_libraries(testRegister PRIVATE NeoFOAM_public_api cpptrace::cpptrace NeoFOAM)
 if(NEOFOAM_ENABLE_MPI_SUPPORT)

--- a/test/core/registerClass.cpp
+++ b/test/core/registerClass.cpp
@@ -7,31 +7,43 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators_adapters.hpp>
 
+#include <set>
+
 #include "testRegister.hpp"
 
 TEST_CASE("Register")
 {
     std::cout << "Table size: " << NeoFOAM::BaseClassDocumentation::docTable().size() << std::endl;
 
-    CHECK(NeoFOAM::BaseClassDocumentation::docTable().size() == 2);
+    std::set<std::string> customClasses = {BaseClass::name(), BaseClass2::name()};
+
+    int presentCustomClasses = 0;
     for (const auto& it : NeoFOAM::BaseClassDocumentation::docTable())
-    {
-        std::string baseClassName = it.first;
-        std::cout << "baseClassName " << baseClassName << std::endl;
-        auto entries = NeoFOAM::BaseClassDocumentation::entries(baseClassName);
-        for (const auto& derivedClass : entries)
+        presentCustomClasses += customClasses.contains(it.first);
+
+    bool customClassesArePresent = presentCustomClasses == customClasses.size();
+
+    CHECK(customClassesArePresent);
+    if (!customClassesArePresent)
+        for (const auto& it : NeoFOAM::BaseClassDocumentation::docTable())
         {
-            std::cout << "   - " << derivedClass << std::endl;
-            std::cout << "     doc: "
-                      << NeoFOAM::BaseClassDocumentation::doc(baseClassName, derivedClass)
-                      << std::endl;
-            std::cout << "     schema: "
-                      << NeoFOAM::BaseClassDocumentation::schema(baseClassName, derivedClass)
-                      << std::endl;
-            CHECK(!NeoFOAM::BaseClassDocumentation::doc(baseClassName, derivedClass).empty());
-            CHECK(!NeoFOAM::BaseClassDocumentation::schema(baseClassName, derivedClass).empty());
+            std::string baseClassName = it.first;
+            std::cout << "baseClassName " << baseClassName << std::endl;
+            auto entries = NeoFOAM::BaseClassDocumentation::entries(baseClassName);
+            for (const auto& derivedClass : entries)
+            {
+                std::cout << "   - " << derivedClass << std::endl;
+                std::cout << "     doc: "
+                          << NeoFOAM::BaseClassDocumentation::doc(baseClassName, derivedClass)
+                          << std::endl;
+                std::cout << "     schema: "
+                          << NeoFOAM::BaseClassDocumentation::schema(baseClassName, derivedClass)
+                          << std::endl;
+                CHECK(!NeoFOAM::BaseClassDocumentation::doc(baseClassName, derivedClass).empty());
+                CHECK(!NeoFOAM::BaseClassDocumentation::schema(baseClassName, derivedClass).empty()
+                );
+            }
         }
-    }
 
     CHECK(BaseClass::table().size() == 1);
     CHECK(BaseClass2::table().size() == 1);

--- a/test/finiteVolume/cellCentred/boundary/surface/surfFixedValue.cpp
+++ b/test/finiteVolume/cellCentred/boundary/surface/surfFixedValue.cpp
@@ -11,6 +11,8 @@
 #include "NeoFOAM/mesh/unstructured/unstructuredMesh.hpp"
 #include "NeoFOAM/finiteVolume/cellCentred/boundary/surface/fixedValue.hpp"
 
+#include "NeoFOAM/finiteVolume/cellCentred/boundary.hpp"
+
 TEST_CASE("fixedValue")
 {
     NeoFOAM::Executor exec = GENERATE(

--- a/test/finiteVolume/cellCentred/boundary/volume/volFixedGradient.cpp
+++ b/test/finiteVolume/cellCentred/boundary/volume/volFixedGradient.cpp
@@ -11,6 +11,8 @@
 #include "NeoFOAM/mesh/unstructured/unstructuredMesh.hpp"
 #include "NeoFOAM/core/dictionary.hpp"
 
+#include "NeoFOAM/finiteVolume/cellCentred/boundary.hpp"
+
 TEST_CASE("fixedGradient")
 {
     NeoFOAM::Executor exec = GENERATE(

--- a/test/finiteVolume/cellCentred/boundary/volume/volFixedValue.cpp
+++ b/test/finiteVolume/cellCentred/boundary/volume/volFixedValue.cpp
@@ -11,6 +11,8 @@
 #include "NeoFOAM/mesh/unstructured/unstructuredMesh.hpp"
 #include "NeoFOAM/finiteVolume/cellCentred/boundary/volume/fixedValue.hpp"
 
+#include "NeoFOAM/finiteVolume/cellCentred/boundary.hpp"
+
 TEST_CASE("fixedValue")
 {
     NeoFOAM::Executor exec = GENERATE(

--- a/test/finiteVolume/cellCentred/fields/surfaceField.cpp
+++ b/test/finiteVolume/cellCentred/fields/surfaceField.cpp
@@ -10,6 +10,8 @@
 #include "NeoFOAM/finiteVolume/cellCentred/fields/surfaceField.hpp"
 #include "NeoFOAM/finiteVolume/cellCentred/boundary/surfaceBoundaryFactory.hpp"
 
+#include "NeoFOAM/finiteVolume/cellCentred/boundary.hpp"
+
 template<typename T>
 using I = std::initializer_list<T>;
 

--- a/test/finiteVolume/cellCentred/fields/volumeField.cpp
+++ b/test/finiteVolume/cellCentred/fields/volumeField.cpp
@@ -10,6 +10,8 @@
 #include "NeoFOAM/finiteVolume/cellCentred/fields/volumeField.hpp"
 #include "NeoFOAM/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp"
 
+#include "NeoFOAM/finiteVolume/cellCentred/boundary.hpp"
+
 template<typename T>
 using I = std::initializer_list<T>;
 

--- a/test/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/test/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -11,6 +11,8 @@
 #include "NeoFOAM/mesh/unstructured/unstructuredMesh.hpp"
 #include "NeoFOAM/finiteVolume/cellCentred/interpolation/linear.hpp"
 
+#include "NeoFOAM/finiteVolume/cellCentred/boundary.hpp"
+
 using NeoFOAM::finiteVolume::cellCentred::SurfaceInterpolation;
 using NeoFOAM::finiteVolume::cellCentred::VolumeField;
 using NeoFOAM::finiteVolume::cellCentred::SurfaceField;


### PR DESCRIPTION
**TL;DR**: All Windows workflow tests [pass on a fork](https://github.com/roma160/NeoFOAM/actions/runs/12302262114) by changing `NeoFOAM` from `SHARED` to `STATIC`.

**Reasoning**:
As per debugging in #178, it happened so that all the singleton symbols declared in the SHARED NeoFOAM library were, by default, copied to the executable, making them not singleton anymore. That was the case for all symbols declared in [`src/finiteVolume/cellCentred/boundary/boundary.cpp`](https://github.com/exasim-project/NeoFOAM/blob/main/src/finiteVolume/cellCentred/boundary/boundary.cpp). That is the case for [the following reason](https://learn.microsoft.com/en-us/cpp/build/importing-into-an-application-using-declspec-dllimport?view=msvc-170#:~:text=DllImport%20void%20func()%3B-,Using%20__declspec(dllimport)%20is,with%20an%20import%20library.,-You%20can%20use):
> Using __declspec(dllimport) is optional on function declarations, but the compiler produces more efficient code if you use this keyword. However, you must use __declspec(dllimport) for the importing executable to access the DLL's public data symbols and objects. Note that the users of your DLL still need to link with an import library.

A perfect solution would have been to introduce the macro to use `__declspec(dllimport)` and `__declspec(dllexport)`, when working with those specific symbols. Yet, when I have tried to do that, the tests with multithreading would still not pass. That is for the reason, that `Kokkos`, one of the dependencies of `NeoFOAM`, has the same issue. Because it is linked statically to the original library, and has singleton objects that should be initialized in the beginning of the tests, the static dependency is automatically passed by Cmake down to the client, creating two instances of those singleton objects.

This PR implements a quick and dirty fix of an issue: just linking everything statically. Using that compiler leaves only one copy of each singleton symbol.