### PR TITLE
build adapter with alternative branch if possible

### DIFF
--- a/.github/workflows/build_adapter.yaml
+++ b/.github/workflows/build_adapter.yaml
@@ -33,12 +33,20 @@ jobs:
             CXX: g++
     runs-on: ubuntu-24.04
     steps:
+     - name: Select branch to checkout
+       run: |
+         if [[ $(git ls-remote --heads https://github.com/exasim-project/FoamAdapter ${{ github.head_ref }}) ]]
+         then
+           echo checkout=${{ env.branch }} >> $GITHUB_ENV
+         else
+           echo checkout=main >> $GITHUB_ENV
+         fi
 
      - name: Checkout FoamAdapter
        uses: actions/checkout@v4
        with:
         repository: exasim-project/FoamAdapter
-        ref: '${{ github.head_ref }}'
+        ref: '${{ env.branch }}'
 
      - name: Checkout NeoFOAM submodule
        uses: actions/checkout@v4

--- a/.github/workflows/build_adapter.yaml
+++ b/.github/workflows/build_adapter.yaml
@@ -33,10 +33,12 @@ jobs:
             CXX: g++
     runs-on: ubuntu-24.04
     steps:
+
      - name: Checkout FoamAdapter
        uses: actions/checkout@v4
        with:
         repository: exasim-project/FoamAdapter
+        ref: '${{ github.head_ref }}'
 
      - name: Checkout NeoFOAM submodule
        uses: actions/checkout@v4

--- a/test/finiteVolume/cellCentred/operator/divOperator.cpp
+++ b/test/finiteVolume/cellCentred/operator/divOperator.cpp
@@ -26,7 +26,7 @@ TEST_CASE("DivOperator")
     );
 
     std::string execName = std::visit([](auto e) { return e.print(); }, exec);
-    // FIXME: take 1d mesh
+    // TODO take 1d mesh
     NeoFOAM::UnstructuredMesh mesh = NeoFOAM::createSingleCellMesh(exec);
     auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<NeoFOAM::scalar>>(mesh);
 


### PR DESCRIPTION
# Motivation
If we have PRs that need changes on the FoamAdapter side it should be possible to run the integration test against that branch.
# Approach
The workflow will try to git clone foam adapter with the same branch name as used for the PR. If it fails it proceeds with `main`. Thus if you know that your changes are breaking FoamAdapter please create a branch/PR with the same name on the FoamAdapter side.