### PR TITLE
Remove partially initializing volumeField constructor.

### DIFF
--- a/include/NeoFOAM/core/database/database.hpp
+++ b/include/NeoFOAM/core/database/database.hpp
@@ -12,7 +12,6 @@
 namespace NeoFOAM
 {
 
-
 class Database
 {
 public:

--- a/include/NeoFOAM/core/database/fieldCollection.hpp
+++ b/include/NeoFOAM/core/database/fieldCollection.hpp
@@ -355,9 +355,7 @@ public:
 
     FieldDocument operator()(Database& db)
     {
-        VolumeField<scalar> vf(
-            field.exec(), name, field.mesh(), field.boundaryConditions(), db, "", ""
-        );
+        FieldType vf(field.exec(), name, field.mesh(), field.boundaryConditions(), db, "", "");
 
         if (field.registered())
         {

--- a/include/NeoFOAM/core/database/fieldCollection.hpp
+++ b/include/NeoFOAM/core/database/fieldCollection.hpp
@@ -14,6 +14,7 @@
 
 namespace NeoFOAM::finiteVolume::cellCentred
 {
+
 /**
  * @brief Validates a FieldDocument.
  *
@@ -354,15 +355,8 @@ public:
 
     FieldDocument operator()(Database& db)
     {
-        FieldType vf(
-            field.exec(),
-            name,
-            field.mesh(),
-            field.internalField(),
-            field.boundaryConditions(),
-            db,
-            "",
-            ""
+        VolumeField<scalar> vf(
+            field.exec(), name, field.mesh(), field.boundaryConditions(), db, "", ""
         );
 
         if (field.registered())

--- a/include/NeoFOAM/fields/domainField.hpp
+++ b/include/NeoFOAM/fields/domainField.hpp
@@ -18,9 +18,10 @@ namespace NeoFOAM
 
 /**
  * @class DomainField
- * @brief Represents the domain fields for a computational domain.
+ * @brief Represents a field that expands over the full computational domain ie the internal field
+ * including boundary data.
  *
- * The DomainField class stores the internal fields and boundary information for
+ * The DomainField class stores the internal field and the field data on the boundary for
  * a computational domain. It provides access to the computed values, reference
  * values, value fractions, reference gradients, boundary types, offsets, and
  * the number of boundaries and boundary faces.
@@ -32,15 +33,41 @@ class DomainField
 {
 public:
 
+    /**
+     * @brief Constructor for an uninitialized DomainField with zero size
+     *
+     * @param exec The executor object.
+     */
     DomainField(const Executor& exec)
         : exec_(exec), internalField_(exec, 0), boundaryFields_(exec, 0, 0)
     {}
 
+    /**
+     * @brief Constructor for an uninitialized but preallocated DomainField with given size
+     *
+     * @param exec The executor object.
+     */
     DomainField(const Executor& exec, size_t nCells, size_t nBoundaryFaces, size_t nBoundaries)
         : exec_(exec), internalField_(exec, nCells),
           boundaryFields_(exec, nBoundaryFaces, nBoundaries)
     {}
 
+    /**
+     * @brief Convenience constructor for an uninitialized but preallocated DomainField with given
+     * size
+     *
+     * @param exec The executor object.
+     * @param mesh The mesh from which the field sizes can be determined.
+     */
+    DomainField(const Executor& exec, const UnstructuredMesh& mesh)
+        : DomainField(exec, mesh.nCells(), mesh.nBoundaryFaces(), mesh.nBoundaries())
+    {}
+
+    /**
+     * @brief Constructor for a DomainField with preexisting internal and boundary data
+     *
+     * @param exec The executor object.
+     */
     DomainField(
         const Executor& exec,
         const Field<ValueType>& internalField,
@@ -49,32 +76,38 @@ public:
         : exec_(exec), internalField_(exec, internalField), boundaryFields_(exec, boundaryFields)
     {}
 
+    /**
+     * @brief Constructor for a DomainField with preexisting internal and boundary data
+     *
+     * @param exec The executor object.
+     */
     DomainField(
         const Executor& exec,
-        const Field<ValueType>& internalField,
-        size_t nBoundaryFaces,
-        size_t nBoundaries
+        const Field<ValueType>&& internalField,
+        const BoundaryFields<ValueType>&& boundaryFields
     )
-        : exec_(exec), internalField_(exec, internalField),
-          boundaryFields_(exec, nBoundaryFaces, nBoundaries)
+        : exec_(exec), internalField_(exec, std::move(internalField)),
+          boundaryFields_(exec, std::move(boundaryFields))
     {}
 
-    DomainField(const Executor& exec, const UnstructuredMesh& mesh)
-        : exec_(exec), internalField_(exec, mesh.nCells()),
-          boundaryFields_(exec, mesh.nBoundaryFaces(), mesh.nBoundaries())
-    {}
-
-
+    /**
+     * @brief Copy constructor for the DomainField
+     *
+     * @param rhs The field to copy.
+     */
     DomainField(const DomainField<ValueType>& rhs)
         : exec_(rhs.exec_), internalField_(rhs.internalField_), boundaryFields_(rhs.boundaryFields_)
     {}
 
-
+    /**
+     * @brief Copy constructor for the DomainField
+     *
+     * @param rhs The field to copy.
+     */
     DomainField(DomainField<ValueType>&& rhs)
         : exec_(std::move(rhs.exec_)), internalField_(std::move(rhs.internalField_)),
           boundaryFields_(std::move(rhs.boundaryFields_))
     {}
-
 
     DomainField<ValueType>& operator=(const DomainField<ValueType>& rhs)
     {
@@ -82,7 +115,6 @@ public:
         boundaryFields_ = rhs.boundaryFields_;
         return *this;
     }
-
 
     DomainField<ValueType>& operator=(DomainField<ValueType>&& rhs)
     {

--- a/include/NeoFOAM/finiteVolume/cellCentred/fields/geometricField.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/fields/geometricField.hpp
@@ -28,6 +28,18 @@ class GeometricFieldMixin
 public:
 
     /**
+     * @brief Constructor for an uninitialized GeometricFieldMixin.
+     *
+     * @param exec The executor object.
+     * @param fieldName The name of the field.
+     * @param mesh The unstructured mesh object.
+     * @param domainField The domain field object.
+     */
+    GeometricFieldMixin(const Executor& exec, std::string fieldName, const UnstructuredMesh& mesh)
+        : name(fieldName), exec_(exec), mesh_(mesh), field_(exec, mesh)
+    {}
+
+    /**
      * @brief Constructor for GeometricFieldMixin.
      *
      * @param exec The executor object.
@@ -123,7 +135,8 @@ protected:
 
     Executor exec_;                // The executor object
     const UnstructuredMesh& mesh_; // The unstructured mesh object
-    DomainField<ValueType> field_; // The domain field object
+    DomainField<ValueType>
+        field_; // The domain field object, ie combination of internal and boundary data
 };
 
 } // namespace NeoFOAM

--- a/include/NeoFOAM/finiteVolume/cellCentred/fields/volumeField.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/fields/volumeField.hpp
@@ -56,34 +56,6 @@ public:
           db_(std::nullopt)
     {}
 
-
-    // /**
-    //  * @brief Constructor for a VolumeField with a given internal field
-    //  *
-    //  * @param exec The executor
-    //  * @param name The name of the field
-    //  * @param mesh The underlying mesh
-    //  * @param internalField the underlying internal field
-    //  * @param boundaryConditions a vector of boundary conditions
-    //  */
-    // VolumeField(
-    //     const Executor& exec,
-    //     std::string name,
-    //     const UnstructuredMesh& mesh,
-    //     const Field<ValueType>& internalField,
-    //     const std::vector<VolumeBoundary<ValueType>>& boundaryConditions
-    // )
-    //     : GeometricFieldMixin<ValueType>(
-    //         exec,
-    //         name,
-    //         mesh,
-    //         DomainField<ValueType>(exec, internalField, mesh.nBoundaryFaces(),
-    //         mesh.nBoundaries())
-    //     ),
-    //       key(""), fieldCollectionName(""), boundaryConditions_(boundaryConditions),
-    //       db_(std::nullopt)
-    // {}
-
     /**
      * @brief Constructor for a VolumeField with a given internal and boundary field
      *

--- a/include/NeoFOAM/finiteVolume/cellCentred/fields/volumeField.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/fields/volumeField.hpp
@@ -77,6 +77,27 @@ public:
           fieldCollectionName(""), boundaryConditions_(boundaryConditions), db_(std::nullopt)
     {}
 
+    // /**
+    //  * @brief Constructor for a VolumeField with a given internal and boundary field
+    //  *
+    //  * @param name The name of the field
+    //  * @param mesh The underlying mesh
+    //  * @param internalField the underlying internal field
+    //  * @param boundaryFields the underlying boundary data fields
+    //  * @param boundaryConditions a vector of boundary conditions
+    //  */
+    // VolumeField(
+    //     const Executor& exec,
+    //     std::string name,
+    //     const UnstructuredMesh& mesh,
+    //     const Field<ValueType>& internalField,
+    //     const std::vector<VolumeBoundary<ValueType>>& boundaryConditions
+    // )
+    //     : GeometricFieldMixin<ValueType>(exec, name, mesh, internalField, boundaryFields),
+    //     key(""),
+    //       fieldCollectionName(""), boundaryConditions_(boundaryConditions), db_(std::nullopt)
+    // {correctBoundaryConditions();}
+
     /**
      * @brief Constructor for a VolumeField with a given internal field and database
      *
@@ -102,6 +123,11 @@ public:
           fieldCollectionName(collectionName), boundaryConditions_(boundaryConditions), db_(&db)
     {}
 
+    /**
+     * @brief Copy constructor
+     *
+     * @param other The volumeField from which to copy
+     */
     VolumeField(const VolumeField& other)
         : GeometricFieldMixin<ValueType>(other), key(other.key),
           fieldCollectionName(other.fieldCollectionName),

--- a/include/NeoFOAM/finiteVolume/cellCentred/fields/volumeField.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/fields/volumeField.hpp
@@ -12,9 +12,10 @@
 namespace NeoFOAM::finiteVolume::cellCentred
 {
 
+
 /**
  * @class VolumeField
- * @brief Represents a volume field in a finite volume method.
+ * @brief Represents the finite volume specific version of a GeometricField.
  *
  * The VolumeField class is a template class that represents a cell-centered field in a finite
  * volume method. It inherits from the GeometricFieldMixin class and provides methods for correcting
@@ -56,31 +57,32 @@ public:
     {}
 
 
-    /**
-     * @brief Constructor for a VolumeField with a given internal field
-     *
-     * @param exec The executor
-     * @param name The name of the field
-     * @param mesh The underlying mesh
-     * @param internalField the underlying internal field
-     * @param boundaryConditions a vector of boundary conditions
-     */
-    VolumeField(
-        const Executor& exec,
-        std::string name,
-        const UnstructuredMesh& mesh,
-        const Field<ValueType>& internalField,
-        const std::vector<VolumeBoundary<ValueType>>& boundaryConditions
-    )
-        : GeometricFieldMixin<ValueType>(
-            exec,
-            name,
-            mesh,
-            DomainField<ValueType>(exec, internalField, mesh.nBoundaryFaces(), mesh.nBoundaries())
-        ),
-          key(""), fieldCollectionName(""), boundaryConditions_(boundaryConditions),
-          db_(std::nullopt)
-    {}
+    // /**
+    //  * @brief Constructor for a VolumeField with a given internal field
+    //  *
+    //  * @param exec The executor
+    //  * @param name The name of the field
+    //  * @param mesh The underlying mesh
+    //  * @param internalField the underlying internal field
+    //  * @param boundaryConditions a vector of boundary conditions
+    //  */
+    // VolumeField(
+    //     const Executor& exec,
+    //     std::string name,
+    //     const UnstructuredMesh& mesh,
+    //     const Field<ValueType>& internalField,
+    //     const std::vector<VolumeBoundary<ValueType>>& boundaryConditions
+    // )
+    //     : GeometricFieldMixin<ValueType>(
+    //         exec,
+    //         name,
+    //         mesh,
+    //         DomainField<ValueType>(exec, internalField, mesh.nBoundaryFaces(),
+    //         mesh.nBoundaries())
+    //     ),
+    //       key(""), fieldCollectionName(""), boundaryConditions_(boundaryConditions),
+    //       db_(std::nullopt)
+    // {}
 
     /**
      * @brief Constructor for a VolumeField with a given internal and boundary field
@@ -119,20 +121,13 @@ public:
         const Executor& exec,
         std::string fieldName,
         const UnstructuredMesh& mesh,
-        const Field<ValueType>& internalField,
         const std::vector<VolumeBoundary<ValueType>>& boundaryConditions,
         Database& db,
         std::string dbKey,
         std::string collectionName
     )
-        : GeometricFieldMixin<ValueType>(
-            exec,
-            fieldName,
-            mesh,
-            DomainField<ValueType>(exec, internalField, mesh.nBoundaryFaces(), mesh.nBoundaries())
-        ),
-          key(dbKey), fieldCollectionName(collectionName), boundaryConditions_(boundaryConditions),
-          db_(&db)
+        : GeometricFieldMixin<ValueType>(exec, fieldName, mesh), key(dbKey),
+          fieldCollectionName(collectionName), boundaryConditions_(boundaryConditions), db_(&db)
     {}
 
     VolumeField(const VolumeField& other)

--- a/test/core/database/fieldCollection.cpp
+++ b/test/core/database/fieldCollection.cpp
@@ -44,11 +44,7 @@ struct CreateField
             dict.insert("fixedValue", 2.0);
             bcs.push_back(fvcc::VolumeBoundary<NeoFOAM::scalar>(mesh, dict, patchi));
         }
-        NeoFOAM::Field internalField =
-            NeoFOAM::Field<NeoFOAM::scalar>(mesh.exec(), mesh.nCells(), 1.0);
-        fvcc::VolumeField<NeoFOAM::scalar> vf(
-            mesh.exec(), name, mesh, internalField, bcs, db, "", ""
-        );
+        fvcc::VolumeField<NeoFOAM::scalar> vf(mesh.exec(), name, mesh, bcs, db, "", "");
         return NeoFOAM::Document(
             {{"name", vf.name},
              {"timeIndex", timeIndex},

--- a/test/core/database/oldTimeCollection.cpp
+++ b/test/core/database/oldTimeCollection.cpp
@@ -45,10 +45,8 @@ struct CreateField
             dict.insert("fixedValue", 2.0);
             bcs.push_back(fvcc::VolumeBoundary<NeoFOAM::scalar>(mesh, dict, patchi));
         }
-        NeoFOAM::Field<NeoFOAM::scalar> internalField(mesh.exec(), mesh.nCells(), 1.0);
-        fvcc::VolumeField<NeoFOAM::scalar> vf(
-            mesh.exec(), name, mesh, internalField, bcs, db, "", ""
-        );
+        fvcc::VolumeField<NeoFOAM::scalar> vf(mesh.exec(), name, mesh, bcs, db, "", "");
+
         return NeoFOAM::Document(
             {{"name", vf.name},
              {"timeIndex", timeIndex},

--- a/test/finiteVolume/cellCentred/fields/volumeField.cpp
+++ b/test/finiteVolume/cellCentred/fields/volumeField.cpp
@@ -71,7 +71,9 @@ TEST_CASE("volumeField")
     {
         NeoFOAM::Field<NeoFOAM::scalar> internalField(mesh.exec(), mesh.nCells(), 1.0);
 
-        fvcc::VolumeField<NeoFOAM::scalar> vf(exec, "vf", mesh, internalField, bcs);
+        fvcc::VolumeField<NeoFOAM::scalar> vf(exec, "vf", mesh, bcs);
+        NeoFOAM::fill(vf.internalField(), 1.0);
+        vf.correctBoundaryConditions();
 
         auto internalValues = vf.internalField().copyToHost();
         for (size_t i = 0; i < internalValues.size(); ++i)

--- a/test/finiteVolume/cellCentred/fields/volumeField.cpp
+++ b/test/finiteVolume/cellCentred/fields/volumeField.cpp
@@ -71,7 +71,9 @@ TEST_CASE("volumeField")
     {
         NeoFOAM::Field<NeoFOAM::scalar> internalField(mesh.exec(), mesh.nCells(), 1.0);
 
-        fvcc::VolumeField<NeoFOAM::scalar> vf(exec, "vf", mesh, internalField, bcs);
+        fvcc::VolumeField<NeoFOAM::scalar> vf(exec, "vf", mesh, bcs);
+        NeoFOAM::fill(vf.internalField(), 1.0);
+
         vf.correctBoundaryConditions();
 
         auto internalValues = vf.internalField().copyToHost();

--- a/test/finiteVolume/cellCentred/fields/volumeField.cpp
+++ b/test/finiteVolume/cellCentred/fields/volumeField.cpp
@@ -71,10 +71,7 @@ TEST_CASE("volumeField")
     {
         NeoFOAM::Field<NeoFOAM::scalar> internalField(mesh.exec(), mesh.nCells(), 1.0);
 
-        fvcc::VolumeField<NeoFOAM::scalar> vf(exec, "vf", mesh, bcs);
-        NeoFOAM::fill(vf.internalField(), 1.0);
-
-        vf.correctBoundaryConditions();
+        fvcc::VolumeField<NeoFOAM::scalar> vf(exec, "vf", mesh, internalField, bcs);
 
         auto internalValues = vf.internalField().copyToHost();
         for (size_t i = 0; i < internalValues.size(); ++i)

--- a/test/timeIntegration/rungeKutta.cpp
+++ b/test/timeIntegration/rungeKutta.cpp
@@ -61,6 +61,7 @@ struct CreateField
         std::vector<fvcc::VolumeBoundary<NeoFOAM::scalar>> bcs {};
         fvcc::VolumeField<NeoFOAM::scalar> vf(mesh.exec(), name, mesh, bcs, db, "", "");
         NeoFOAM::fill(vf.internalField(), 0.0);
+        vf.correctBoundaryCondition();
         return NeoFOAM::Document(
             {{"name", vf.name},
              {"timeIndex", timeIndex},

--- a/test/timeIntegration/rungeKutta.cpp
+++ b/test/timeIntegration/rungeKutta.cpp
@@ -61,7 +61,7 @@ struct CreateField
         std::vector<fvcc::VolumeBoundary<NeoFOAM::scalar>> bcs {};
         fvcc::VolumeField<NeoFOAM::scalar> vf(mesh.exec(), name, mesh, bcs, db, "", "");
         NeoFOAM::fill(vf.internalField(), 0.0);
-        vf.correctBoundaryCondition();
+        vf.correctBoundaryConditions();
         return NeoFOAM::Document(
             {{"name", vf.name},
              {"timeIndex", timeIndex},

--- a/test/timeIntegration/rungeKutta.cpp
+++ b/test/timeIntegration/rungeKutta.cpp
@@ -59,10 +59,8 @@ struct CreateField
     NeoFOAM::Document operator()(NeoFOAM::Database& db)
     {
         std::vector<fvcc::VolumeBoundary<NeoFOAM::scalar>> bcs {};
-        NeoFOAM::Field<NeoFOAM::scalar> internalField(mesh.exec(), mesh.nCells(), 0.0);
-        fvcc::VolumeField<NeoFOAM::scalar> vf(
-            mesh.exec(), name, mesh, internalField, bcs, db, "", ""
-        );
+        fvcc::VolumeField<NeoFOAM::scalar> vf(mesh.exec(), name, mesh, bcs, db, "", "");
+        NeoFOAM::fill(vf.internalField(), 0.0);
         return NeoFOAM::Document(
             {{"name", vf.name},
              {"timeIndex", timeIndex},

--- a/test/timeIntegration/timeIntegration.cpp
+++ b/test/timeIntegration/timeIntegration.cpp
@@ -25,10 +25,8 @@ struct CreateField
     NeoFOAM::Document operator()(NeoFOAM::Database& db)
     {
         std::vector<fvcc::VolumeBoundary<NeoFOAM::scalar>> bcs {};
-        NeoFOAM::Field<NeoFOAM::scalar> internalField(mesh.exec(), mesh.nCells(), value);
-        fvcc::VolumeField<NeoFOAM::scalar> vf(
-            mesh.exec(), name, mesh, internalField, bcs, db, "", ""
-        );
+        fvcc::VolumeField<NeoFOAM::scalar> vf(mesh.exec(), name, mesh, bcs, db, "", "");
+        NeoFOAM::fill(vf.internalField(), value);
         return NeoFOAM::Document(
             {{"name", vf.name},
              {"timeIndex", timeIndex},

--- a/test/timeIntegration/timeIntegration.cpp
+++ b/test/timeIntegration/timeIntegration.cpp
@@ -27,6 +27,7 @@ struct CreateField
         std::vector<fvcc::VolumeBoundary<NeoFOAM::scalar>> bcs {};
         fvcc::VolumeField<NeoFOAM::scalar> vf(mesh.exec(), name, mesh, bcs, db, "", "");
         NeoFOAM::fill(vf.internalField(), value);
+        vf.correctBoundaryConditions();
         return NeoFOAM::Document(
             {{"name", vf.name},
              {"timeIndex", timeIndex},


### PR DESCRIPTION
# Motivation
This PR removes a constructor from `VolumeField` with a given `internalField.` The constructor would copy only the given `internalField` but doesn't specifically set the `boundaryFields`. This seems like a partially initialized state which is rather unintuitive.

# Additional changes:
- added further docstrings