### PR TITLE
handle Kokkos reducers in parallelReduce

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,6 +6,7 @@ Chih-Ta Wang <chihta.wang@tum.de> Technical University of Munich\
 Feiteng Meng <fitanium2018@outlook.com>, Harbin Engineering University\
 Gabriel Gerlero <ggerlero@cimec.unl.edu.ar> Research Center for Computational Methods (CIMEC)\
 Gregor Olenik  <gregor.olenik@kit.edu>, Karlsruhe Institute of Technology\
+Gregor Weiss <gregor.weiss@hlrs.de>, High-Performance Computing Center Stuttgart (HLRS)\
 Henning Scheufler <henning.scheufler@web.de>\
 Marcel Koch <marcel.koch@kit.edu>, Karlsruhe Institute of Technology\
 Roman Mishchuk <roman.mishchuk@tum.de> Technical University of Munich\

--- a/include/NeoFOAM/core/parallelAlgorithms.hpp
+++ b/include/NeoFOAM/core/parallelAlgorithms.hpp
@@ -101,7 +101,14 @@ void parallelReduce(
     {
         for (size_t i = start; i < end; i++)
         {
-            kernel(i, value);
+            if constexpr (Kokkos::is_reducer<T>::value)
+            {
+                kernel(i, value.reference());
+            }
+            else
+            {
+                kernel(i, value);
+            }
         }
     }
     else
@@ -131,7 +138,14 @@ void parallelReduce(
     {
         for (size_t i = 0; i < field.size(); i++)
         {
-            kernel(i, value);
+            if constexpr (Kokkos::is_reducer<T>::value)
+            {
+                kernel(i, value.reference());
+            }
+            else
+            {
+                kernel(i, value);
+            }
         }
     }
     else

--- a/test/core/parallelAlgorithms.cpp
+++ b/test/core/parallelAlgorithms.cpp
@@ -7,6 +7,9 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators_all.hpp>
 
+#include <limits>
+#include <Kokkos_Core.hpp>
+
 #include "NeoFOAM/fields/field.hpp"
 #include "NeoFOAM/core/executor/executor.hpp"
 #include "NeoFOAM/core/parallelAlgorithms.hpp"
@@ -102,6 +105,27 @@ TEST_CASE("parallelReduce")
         REQUIRE(sum == 5.0);
     }
 
+    SECTION("parallelReduce_MaxValue" + execName)
+    {
+        NeoFOAM::Field<NeoFOAM::scalar> fieldA(exec, 5);
+        NeoFOAM::fill(fieldA, 0.0);
+        NeoFOAM::Field<NeoFOAM::scalar> fieldB(exec, 5);
+        auto spanB = fieldB.span();
+        NeoFOAM::fill(fieldB, 1.0);
+        auto max = std::numeric_limits<NeoFOAM::scalar>::lowest();
+        Kokkos::Max<NeoFOAM::scalar> reducer(max);
+        NeoFOAM::parallelReduce(
+            exec,
+            {0, 5},
+            KOKKOS_LAMBDA(const size_t i, NeoFOAM::scalar& lmax) {
+                if (lmax < spanB[i]) lmax = spanB[i];
+            },
+            reducer
+        );
+
+        REQUIRE(max == 1.0);
+    }
+
     SECTION("parallelReduce_Field_" + execName)
     {
         NeoFOAM::Field<NeoFOAM::scalar> fieldA(exec, 5);
@@ -115,5 +139,25 @@ TEST_CASE("parallelReduce")
         );
 
         REQUIRE(sum == 5.0);
+    }
+
+    SECTION("parallelReduce_Field_MaxValue" + execName)
+    {
+        NeoFOAM::Field<NeoFOAM::scalar> fieldA(exec, 5);
+        NeoFOAM::fill(fieldA, 0.0);
+        NeoFOAM::Field<NeoFOAM::scalar> fieldB(exec, 5);
+        auto spanB = fieldB.span();
+        NeoFOAM::fill(fieldB, 1.0);
+        auto max = std::numeric_limits<NeoFOAM::scalar>::lowest();
+        Kokkos::Max<NeoFOAM::scalar> reducer(max);
+        NeoFOAM::parallelReduce(
+            fieldA,
+            KOKKOS_LAMBDA(const size_t i, NeoFOAM::scalar& lmax) {
+                if (lmax < spanB[i]) lmax = spanB[i];
+            },
+            reducer
+        );
+
+        REQUIRE(max == 1.0);
     }
 };


### PR DESCRIPTION
Handling the case if a Kokkos reducer (ReducerConcept) is used instead of a scalar return value in parallelReduce.

This PR also adds a test for Kokkos reducer Kokkos::Max.
