### PR TITLE
- added std::exit back into `NF_ERROR_EXIT`.

### DIFF
--- a/include/NeoFOAM/core/error.hpp
+++ b/include/NeoFOAM/core/error.hpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2023-2024 NeoFOAM authors
 #pragma once
 
+#include <stdlib>
 #include <exception>
 #include <iostream>
 #include <string>
@@ -108,6 +109,7 @@ private:
     do                                                                                             \
     {                                                                                              \
         std::cerr << NF_ERROR_MESSAGE(message);                                                    \
+        std::exit(1);                                                                              \
     }                                                                                              \
     while (false)
 #endif

--- a/include/NeoFOAM/core/error.hpp
+++ b/include/NeoFOAM/core/error.hpp
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2023-2024 NeoFOAM authors
 #pragma once
 
-#include <stdlib>
+#include <cstdlib>
 #include <exception>
 #include <iostream>
 #include <string>


### PR DESCRIPTION
# Motivation
So we exit when we call error exit :)