### PR TITLE
make Kokkos_ENABLE_SERIAL a default

### DIFF
--- a/cmake/AutoEnableDevice.cmake
+++ b/cmake/AutoEnableDevice.cmake
@@ -65,3 +65,9 @@ if(NOT DEFINED Kokkos_ENABLE_HIP)
 else()
   message(STATUS "Skip HIP detection Kokkos_ENABLE_HIP=${Kokkos_ENABLE_HIP}")
 endif()
+
+if(NOT DEFINED Kokkos_ENABLE_SERIAL)
+  set(Kokkos_ENABLE_SERIAL
+      ON
+      CACHE INTERNAL "")
+endif()


### PR DESCRIPTION
Currently, `Kokkos_ENABLE_SERIAL` needs to be set explicitly. This PR sets it as a default.