### PR TITLE
Add comparison run to benchmark workflow

### DIFF
--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -135,18 +135,30 @@ jobs:
           module spider libfabric-aws
           module load cmake
           cmake --version
+          python3 -m pip install xmltodict
+          CC=clang \
+          CXX=clang++ \
+          cmake --preset profilinj
+          cmake --build --preset profiling
+          ctest --preset profiling
+          mkdir -p ${{github.event.number}}/main
+          cd build/profiling/bin/benchmarks
+          python3 ../../../../scripts/catch2json.py
+          cd ../../../..
+          cp build/profiling/bin/benchmarks/*.json ${{github.event.number}}/
+          lscpu > ${{github.event.number}}/lscpu.log
+          rm -rf build
+          git fetch origin
+          git checkout main
           CC=clang \
           CXX=clang++ \
           cmake --preset profiling
           cmake --build --preset profiling
           ctest --preset profiling
-          mkdir -p ${{github.event.number}}/
           cd build/profiling/bin/benchmarks
-          python3 -m pip install xmltodict
           python3 ../../../../scripts/catch2json.py
-          cd ../../../..
-          cp build/profiling/bin/benchmarks/*.json ${{github.event.number}}/
-          lscpu > ${{github.event.number}}/lscpu.log
+          cp build/profiling/bin/benchmarks/*.json ${{github.event.number}}/main/
+
       - name: Push Benchmark Data
         uses: cpina/github-action-push-to-another-repository@main
         env:

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -157,6 +157,7 @@ jobs:
           ctest --preset profiling
           cd build/profiling/bin/benchmarks
           python3 ../../../../scripts/catch2json.py
+          cd ../../../..
           cp build/profiling/bin/benchmarks/*.json ${{github.event.number}}/main/
 
       - name: Push Benchmark Data

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -138,7 +138,7 @@ jobs:
           python3 -m pip install xmltodict
           CC=clang \
           CXX=clang++ \
-          cmake --preset profilinj
+          cmake --preset profiling
           cmake --build --preset profiling
           ctest --preset profiling
           mkdir -p ${{github.event.number}}/main


### PR DESCRIPTION
# Motivation
After merging #241 we now have a workflow that can execute benchmarks and stores results as .json files. For checking the impact of a given PR we also need to run the benchmarks on main. This PR simply checks out main, then builds and runs the benchmark again. 

The json files are post-processed at NeoFOAM-BenchmarkData [see](https://github.com/exasim-project/NeoFOAM-BenchmarkData/tree/main/244/gdnxlarge) for an example.

