### PR TITLE
Add executor generator for tests and benchmarks

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -5,6 +5,7 @@ function(neofoam_benchmark BENCH)
 
   add_executable(bench_${BENCH} "${BENCH}.cpp")
   target_link_libraries(bench_${BENCH} PRIVATE Catch2::Catch2 NeoFOAM)
+  target_include_directories(bench_${BENCH} PRIVATE "${CMAKE_SOURCE_DIR}")
 
   if(WIN32)
     set_target_properties(

--- a/benchmarks/fields/field.cpp
+++ b/benchmarks/fields/field.cpp
@@ -4,17 +4,14 @@
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main
 
-#include "../catch_main.hpp"
 #include "NeoFOAM/NeoFOAM.hpp"
+#include "benchmarks/catch_main.hpp"
+#include "test/catch2/executorGenerator.hpp"
 
 TEST_CASE("Field<scalar>::addition", "[bench]")
 {
     auto size = GENERATE(1 << 16, 1 << 17, 1 << 18, 1 << 19, 1 << 20);
-    NeoFOAM::Executor exec = GENERATE(
-        NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
-        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
-        NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
-    );
+    NeoFOAM::Executor exec = GENERATE(allAvailableExecutor());
     std::string execName = std::visit([](auto e) { return e.name(); }, exec);
 
     DYNAMIC_SECTION("" << size)
@@ -34,11 +31,7 @@ TEST_CASE("Field<scalar>::multiplication", "[bench]")
 {
     auto size = GENERATE(1 << 16, 1 << 17, 1 << 18, 1 << 19, 1 << 20);
 
-    NeoFOAM::Executor exec = GENERATE(
-        NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
-        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
-        NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
-    );
+    NeoFOAM::Executor exec = GENERATE(allAvailableExecutor());
     std::string execName = std::visit([](auto e) { return e.name(); }, exec);
 
     DYNAMIC_SECTION("" << size)

--- a/benchmarks/finiteVolume/cellCentred/operator/divOperator.cpp
+++ b/benchmarks/finiteVolume/cellCentred/operator/divOperator.cpp
@@ -5,19 +5,15 @@
                             // a custom main
 
 #include "NeoFOAM/NeoFOAM.hpp"
-#include "../../../catch_main.hpp"
+#include "benchmarks/catch_main.hpp"
+#include "test/catch2/executorGenerator.hpp"
 
 using Operator = NeoFOAM::dsl::Operator;
 
 TEST_CASE("DivOperator::div", "[bench]")
 {
     auto size = GENERATE(1 << 16, 1 << 17, 1 << 18, 1 << 19, 1 << 20);
-
-    NeoFOAM::Executor exec = GENERATE(
-        NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
-        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
-        NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
-    );
+    NeoFOAM::Executor exec = GENERATE(allAvailableExecutor());
 
     std::string execName = std::visit([](auto e) { return e.name(); }, exec);
     NeoFOAM::UnstructuredMesh mesh = NeoFOAM::create1DUniformMesh(exec, size);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,6 +29,8 @@ function(neofoam_unit_test TEST)
   target_link_libraries(${TEST} PRIVATE neofoam_catch_main neofoam_warnings neofoam_options
                                         Kokkos::kokkos NeoFOAM cpptrace::cpptrace)
 
+  target_include_directories(${TEST} PRIVATE "${CMAKE_SOURCE_DIR}/test/catch2")
+
   if(NEOFOAM_WITH_SUNDIALS)
     target_link_libraries(${TEST} PRIVATE SUNDIALS::arkode)
   endif()

--- a/test/catch2/executorGenerator.hpp
+++ b/test/catch2/executorGenerator.hpp
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 NeoFOAM authors
+
+#pragma once
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <catch2/generators/catch_generators_adapters.hpp>
+
+#include "NeoFOAM/NeoFOAM.hpp"
+
+// This class shows how to implement a simple generator for Catch tests
+class ExecutorGenerator final : public Catch::Generators::IGenerator<NeoFOAM::Executor>
+{
+public:
+
+    int i = 1;
+    std::vector<NeoFOAM::Executor> execs {NeoFOAM::CPUExecutor {}, NeoFOAM::GPUExecutor {}};
+    NeoFOAM::Executor current_exec = NeoFOAM::SerialExecutor {};
+
+    ExecutorGenerator() {}
+
+    NeoFOAM::Executor const& get() const override;
+    bool next() override
+    {
+        if (i >= 2) return false;
+        current_exec = execs[i];
+        i++;
+        return true;
+    }
+};
+
+// Avoids -Wweak-vtables
+NeoFOAM::Executor const& ExecutorGenerator::get() const { return current_exec; }
+
+Catch::Generators::GeneratorWrapper<NeoFOAM::Executor> allAvailableExecutor()
+{
+    return Catch::Generators::GeneratorWrapper<NeoFOAM::Executor>(
+        // Another possibility:
+        Catch::Detail::make_unique<ExecutorGenerator>()
+    );
+}

--- a/test/catch2/executorGenerator.hpp
+++ b/test/catch2/executorGenerator.hpp
@@ -16,7 +16,7 @@ class ExecutorGenerator final : public Catch::Generators::IGenerator<NeoFOAM::Ex
 {
 public:
 
-    int i = 1;
+    int i = 0;
     std::vector<NeoFOAM::Executor> execs {};
     NeoFOAM::Executor current_exec = NeoFOAM::SerialExecutor {};
 

--- a/test/mesh/unstructured/unstructuredMesh.cpp
+++ b/test/mesh/unstructured/unstructuredMesh.cpp
@@ -9,14 +9,11 @@
 
 #include "NeoFOAM/mesh/unstructured/unstructuredMesh.hpp"
 #include "NeoFOAM/fields/domainField.hpp"
+#include "executorGenerator.hpp"
 
 TEST_CASE("Unstructured Mesh")
 {
-    NeoFOAM::Executor exec = GENERATE(
-        NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
-        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
-        NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
-    );
+    NeoFOAM::Executor exec = GENERATE(allAvailableExecutor());
 
     std::string execName = std::visit([](auto e) { return e.name(); }, exec);
 


### PR DESCRIPTION
This PR adds a custom generator to generate available Executors. This allows to replace

```
    NeoFOAM::Executor exec = GENERATE(
        NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
        NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
    );
```
by
```
NeoFOAM::Executor exec = GENERATE(allAvailableExecutor());
```

TODO:
 -  [x]  only yield every executor once. Currently, if compiled without `GPUExecutor`  the fallback `NeoFOAM::CPUExecutor` is used.