### PR TITLE
Adding basic traits for  One<T> and Zero<T>

### DIFF
--- a/include/NeoFOAM/core/primitives/label.hpp
+++ b/include/NeoFOAM/core/primitives/label.hpp
@@ -4,6 +4,9 @@
 
 #include <cstdint>
 
+#include "NeoFOAM/core/primitives/traits.hpp"
+
+
 namespace NeoFOAM
 {
 #ifdef NEOFOAM_DP_LABEL
@@ -16,4 +19,19 @@ using localIdx = uint32_t;
 using globalIdx = uint64_t;
 using size_t = std::size_t;
 using mpi_label_t = int;
+
+// traits for vector
+template<>
+struct one<localIdx>
+{
+    static const inline localIdx value = 1;
+};
+
+
+template<>
+struct zero<localIdx>
+{
+    static const inline localIdx value = 0;
+};
+
 }

--- a/include/NeoFOAM/core/primitives/scalar.hpp
+++ b/include/NeoFOAM/core/primitives/scalar.hpp
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: 2023 NeoFOAM authors
 #pragma once
 
+#include "NeoFOAM/core/primitives/traits.hpp"
+
 // TODO this needs to be implemented in the corresponding cmake file
 namespace NeoFOAM
 {
@@ -12,5 +14,19 @@ typedef float scalar;
 #endif
 
 constexpr scalar ROOTVSMALL = 1e-18;
+
+// traits for vector
+template<>
+struct one<scalar>
+{
+    static const inline scalar value = 1.0;
+};
+
+
+template<>
+struct zero<scalar>
+{
+    static const inline scalar value = 0.0;
+};
 
 } // namespace NeoFOAM

--- a/include/NeoFOAM/core/primitives/traits.hpp
+++ b/include/NeoFOAM/core/primitives/traits.hpp
@@ -1,20 +1,21 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2023 NeoFOAM authors
 
+#pragma once
 
 namespace NeoFOAM
 {
+
 template<typename T>
 struct one
 {
-    static const T value = 1;
+    static const T value;
 };
 
 template<typename T>
 struct zero
 {
-    static const T value = 0;
+    static const T value;
 };
-
 
 }

--- a/include/NeoFOAM/core/primitives/traits.hpp
+++ b/include/NeoFOAM/core/primitives/traits.hpp
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 NeoFOAM authors
+
+
+namespace NeoFOAM
+{
+template<typename T>
+struct one
+{
+    static const T value = 1;
+};
+
+template<typename T>
+struct zero
+{
+    static const T value = 0;
+};
+
+
+}

--- a/include/NeoFOAM/core/primitives/vector.hpp
+++ b/include/NeoFOAM/core/primitives/vector.hpp
@@ -7,6 +7,8 @@
 
 #include "NeoFOAM/core/primitives/scalar.hpp"
 #include "NeoFOAM/core/primitives/label.hpp"
+#include "NeoFOAM/core/primitives/traits.hpp"
+
 
 namespace NeoFOAM
 {
@@ -152,5 +154,20 @@ KOKKOS_INLINE_FUNCTION
 scalar mag(const Vector& vec) { return sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2]); }
 
 std::ostream& operator<<(std::ostream& out, const Vector& vec);
+
+
+// traits for vector
+template<>
+struct one<Vector>
+{
+    static const inline Vector value = {1.0, 1.0, 1.0};
+};
+
+
+template<>
+struct zero<Vector>
+{
+    static const inline Vector value = {0.0, 0.0, 0.0};
+};
 
 } // namespace NeoFOAM

--- a/test/core/primitives/CMakeLists.txt
+++ b/test/core/primitives/CMakeLists.txt
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Unlicense
 # SPDX-FileCopyrightText: 2024 NeoFOAM authors
 
+neofoam_unit_test(scalar)
 neofoam_unit_test(vector)

--- a/test/core/primitives/scalar.cpp
+++ b/test/core/primitives/scalar.cpp
@@ -11,57 +11,25 @@
 
 TEST_CASE("Primitives")
 {
-    SECTION("Vector")
+    SECTION("Scalar", "[Traits]")
     {
-        SECTION("CPU")
-        {
-            NeoFOAM::Vector a(1.0, 2.0, 3.0);
-            REQUIRE(a(0) == 1.0);
-            REQUIRE(a(1) == 2.0);
-            REQUIRE(a(2) == 3.0);
+        auto one = NeoFOAM::one<NeoFOAM::scalar>::value;
 
-            NeoFOAM::Vector b(1.0, 2.0, 3.0);
-            REQUIRE(a == b);
+        REQUIRE(one == 1.0);
 
-            NeoFOAM::Vector c(2.0, 4.0, 6.0);
+        auto zero = NeoFOAM::zero<NeoFOAM::scalar>::value;
 
-            REQUIRE(a + b == c);
-
-            REQUIRE((a - b) == NeoFOAM::Vector(0.0, 0.0, 0.0));
-
-            a += b;
-            REQUIRE(a == c);
-
-            a -= b;
-            REQUIRE(a == b);
-            a *= 2;
-            REQUIRE(a == c);
-            a = b;
-
-            REQUIRE(a == b);
-
-            NeoFOAM::Vector d(4.0, 8.0, 12.0);
-            REQUIRE((a + a + a + a) == d);
-            REQUIRE((4 * a) == d);
-            REQUIRE((a * 4) == d);
-            REQUIRE((a + 3 * a) == d);
-            REQUIRE((a + 2 * a + a) == d);
-        }
+        REQUIRE(zero == 0.0);
     }
 
-    SECTION("Traits")
+    SECTION("LocalIdx", "[Traits]")
     {
+        auto one = NeoFOAM::one<NeoFOAM::localIdx>::value;
 
-        auto one = NeoFOAM::one<NeoFOAM::Vector>::value;
+        REQUIRE(one == 1);
 
-        REQUIRE(one(0) == 1.0);
-        REQUIRE(one(1) == 1.0);
-        REQUIRE(one(2) == 1.0);
+        auto zero = NeoFOAM::zero<NeoFOAM::localIdx>::value;
 
-        auto zero = NeoFOAM::zero<NeoFOAM::Vector>::value;
-
-        REQUIRE(zero(0) == 0.0);
-        REQUIRE(zero(1) == 0.0);
-        REQUIRE(zero(2) == 0.0);
+        REQUIRE(zero == 0);
     }
 }

--- a/test/core/primitives/scalar.cpp
+++ b/test/core/primitives/scalar.cpp
@@ -11,7 +11,6 @@
 
 TEST_CASE("Primitives")
 {
-
     SECTION("Vector")
     {
         SECTION("CPU")
@@ -50,7 +49,7 @@ TEST_CASE("Primitives")
         }
     }
 
-    SECTION("Vector", "[Traits]")
+    SECTION("Traits")
     {
 
         auto one = NeoFOAM::one<NeoFOAM::Vector>::value;

--- a/test/core/primitives/vector.cpp
+++ b/test/core/primitives/vector.cpp
@@ -48,4 +48,20 @@ TEST_CASE("Primitives")
             REQUIRE((a + 2 * a + a) == d);
         }
     }
+
+    SECTION("Traits")
+    {
+
+        auto one = NeoFOAM::one<NeoFOAM::Vector>::value;
+
+        REQUIRE(one(0) == 1.0);
+        REQUIRE(one(1) == 1.0);
+        REQUIRE(one(2) == 1.0);
+
+        auto zero = NeoFOAM::zero<NeoFOAM::Vector>::value;
+
+        REQUIRE(zero(0) == 0.0);
+        REQUIRE(zero(1) == 0.0);
+        REQUIRE(zero(2) == 0.0);
+    }
 }


### PR DESCRIPTION
For templated tests we need a uniform way to initialize values to zero/one. This PR adds a basic type trait so that `one<T>::value` gives  1 for scalar and index types and {1,1,1} for our vector type.

I think the standard way is to use `::value`, however we could also implement `traits<T>::zero `and `traits<T>::one`.