### PR TITLE
Interpolation for vector fields

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -28,3 +28,4 @@ endfunction()
 
 add_subdirectory(fields)
 add_subdirectory(finiteVolume/cellCentred/operator)
+add_subdirectory(finiteVolume/cellCentred/interpolation)

--- a/benchmarks/finiteVolume/cellCentred/interpolation/CMakeLists.txt
+++ b/benchmarks/finiteVolume/cellCentred/interpolation/CMakeLists.txt
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Unlicense
+# SPDX-FileCopyrightText: 2025 NeoFOAM authors
+
+neofoam_benchmark(linear)
+neofoam_benchmark(upwind)

--- a/benchmarks/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/benchmarks/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -37,7 +37,6 @@ TEST_CASE("linear", "[bench]")
     // capture the value of size as section name
     DYNAMIC_SECTION("" << size)
     {
-
         BENCHMARK(std::string(execName)) { return (linear.interpolate(in, out)); };
     }
 }

--- a/benchmarks/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/benchmarks/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -1,20 +1,20 @@
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoFOAM authors
+// SPDX-FileCopyrightText: 2025 NeoFOAM authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main
 
 #include "NeoFOAM/NeoFOAM.hpp"
 #include "../../../catch_main.hpp"
+#include <catch2/catch_template_test_macros.hpp>
 
 using NeoFOAM::finiteVolume::cellCentred::SurfaceInterpolation;
 using NeoFOAM::finiteVolume::cellCentred::VolumeField;
 using NeoFOAM::finiteVolume::cellCentred::SurfaceField;
 using NeoFOAM::Input;
 
-TEST_CASE("linear", "[bench]")
+TEMPLATE_TEST_CASE("linear", "", NeoFOAM::scalar, NeoFOAM::Vector)
 {
-    using TestType = NeoFOAM::scalar;
     auto size = GENERATE(1 << 16, 1 << 17, 1 << 18, 1 << 19, 1 << 20);
 
     NeoFOAM::Executor exec = GENERATE(
@@ -25,14 +25,14 @@ TEST_CASE("linear", "[bench]")
 
     std::string execName = std::visit([](auto e) { return e.name(); }, exec);
     NeoFOAM::UnstructuredMesh mesh = NeoFOAM::create1DUniformMesh(exec, size);
-    auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<NeoFOAM::scalar>>(mesh);
+    auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<TestType>>(mesh);
     Input input = NeoFOAM::TokenList({std::string("linear")});
     auto linear = SurfaceInterpolation(exec, mesh, input);
 
     auto in = VolumeField<TestType>(exec, "in", mesh, {});
     auto out = SurfaceField<TestType>(exec, "out", mesh, surfaceBCs);
 
-    fill(in.internalField(), NeoFOAM::one<NeoFOAM::scalar>::value);
+    fill(in.internalField(), NeoFOAM::one<TestType>::value);
 
     // capture the value of size as section name
     DYNAMIC_SECTION("" << size)

--- a/benchmarks/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/benchmarks/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 NeoFOAM authors
+
+#define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
+                            // a custom main
+
+#include "NeoFOAM/NeoFOAM.hpp"
+#include "../../../catch_main.hpp"
+
+using NeoFOAM::finiteVolume::cellCentred::SurfaceInterpolation;
+using NeoFOAM::finiteVolume::cellCentred::VolumeField;
+using NeoFOAM::finiteVolume::cellCentred::SurfaceField;
+
+TEST_CASE("DivOperator::div", "[bench]")
+{
+    auto size = GENERATE(1 << 16, 1 << 17, 1 << 18, 1 << 19, 1 << 20);
+
+    NeoFOAM::Executor exec = GENERATE(
+        NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
+    );
+
+    std::string execName = std::visit([](auto e) { return e.name(); }, exec);
+    NeoFOAM::UnstructuredMesh mesh = NeoFOAM::create1DUniformMesh(exec, size);
+    auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<NeoFOAM::scalar>>(mesh);
+
+    auto in = VolumeField<TestType>(exec, "in", mesh, {});
+    auto out = SurfaceField<TestType>(exec, "out", mesh, surfaceBCs);
+
+    fill(in.internalField(), NeoFOAM::one<NeoFOAM::scalar>::value);
+
+    // capture the value of size as section name
+    DYNAMIC_SECTION("" << size)
+    {
+
+        BENCHMARK(std::string(execName)) {return (linear.interpolate(in, out); };
+    }
+}

--- a/benchmarks/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/benchmarks/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -12,7 +12,9 @@
 using NeoFOAM::finiteVolume::cellCentred::SurfaceInterpolation;
 using NeoFOAM::finiteVolume::cellCentred::VolumeField;
 using NeoFOAM::finiteVolume::cellCentred::SurfaceField;
-using NeoFOAM::Input;
+
+namespace NeoFOAM
+{
 
 TEMPLATE_TEST_CASE("linear", "", NeoFOAM::scalar, NeoFOAM::Vector)
 {
@@ -25,19 +27,21 @@ TEMPLATE_TEST_CASE("linear", "", NeoFOAM::scalar, NeoFOAM::Vector)
     );
 
     std::string execName = std::visit([](auto e) { return e.name(); }, exec);
-    NeoFOAM::UnstructuredMesh mesh = NeoFOAM::create1DUniformMesh(exec, size);
+    UnstructuredMesh mesh = create1DUniformMesh(exec, size);
     auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<TestType>>(mesh);
-    Input input = NeoFOAM::TokenList({std::string("linear")});
+    Input input = TokenList({std::string("linear")});
     auto linear = SurfaceInterpolation(exec, mesh, input);
 
     auto in = VolumeField<TestType>(exec, "in", mesh, {});
     auto out = SurfaceField<TestType>(exec, "out", mesh, surfaceBCs);
 
-    fill(in.internalField(), NeoFOAM::one<TestType>::value);
+    fill(in.internalField(), one<TestType>::value);
 
     // capture the value of size as section name
     DYNAMIC_SECTION("" << size)
     {
         BENCHMARK(std::string(execName)) { return (linear.interpolate(in, out)); };
     }
+}
+
 }

--- a/benchmarks/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/benchmarks/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -6,6 +6,7 @@
 
 #include "NeoFOAM/NeoFOAM.hpp"
 #include "../../../catch_main.hpp"
+
 #include <catch2/catch_template_test_macros.hpp>
 
 using NeoFOAM::finiteVolume::cellCentred::SurfaceInterpolation;

--- a/benchmarks/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/benchmarks/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -34,6 +34,6 @@ TEST_CASE("DivOperator::div", "[bench]")
     DYNAMIC_SECTION("" << size)
     {
 
-        BENCHMARK(std::string(execName)) {return (linear.interpolate(in, out); };
+        BENCHMARK(std::string(execName)) { return (linear.interpolate(in, out)); };
     }
 }

--- a/benchmarks/finiteVolume/cellCentred/interpolation/upwind.cpp
+++ b/benchmarks/finiteVolume/cellCentred/interpolation/upwind.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoFOAM authors
+// SPDX-FileCopyrightText: 2025 NeoFOAM authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/benchmarks/finiteVolume/cellCentred/interpolation/upwind.cpp
+++ b/benchmarks/finiteVolume/cellCentred/interpolation/upwind.cpp
@@ -36,7 +36,7 @@ TEMPLATE_TEST_CASE("upwind", "", NeoFOAM::scalar, NeoFOAM::Vector)
     auto out = SurfaceField<TestType>(exec, "out", mesh, surfaceBCs);
 
     fill(flux.internalField(), NeoFOAM::one<NeoFOAM::scalar>::value);
-    fill(in.internalField(), NeoFOAM::one<NeoFOAM::TestType>::value);
+    fill(in.internalField(), NeoFOAM::one<TestType>::value);
 
     // capture the value of size as section name
     DYNAMIC_SECTION("" << size)

--- a/benchmarks/finiteVolume/cellCentred/interpolation/upwind.cpp
+++ b/benchmarks/finiteVolume/cellCentred/interpolation/upwind.cpp
@@ -12,7 +12,7 @@ using NeoFOAM::finiteVolume::cellCentred::VolumeField;
 using NeoFOAM::finiteVolume::cellCentred::SurfaceField;
 using NeoFOAM::Input;
 
-TEST_CASE("linear", "[bench]")
+TEST_CASE("upwind", "[bench]")
 {
     using TestType = NeoFOAM::scalar;
     auto size = GENERATE(1 << 16, 1 << 17, 1 << 18, 1 << 19, 1 << 20);
@@ -26,18 +26,20 @@ TEST_CASE("linear", "[bench]")
     std::string execName = std::visit([](auto e) { return e.name(); }, exec);
     NeoFOAM::UnstructuredMesh mesh = NeoFOAM::create1DUniformMesh(exec, size);
     auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<NeoFOAM::scalar>>(mesh);
-    Input input = NeoFOAM::TokenList({std::string("linear")});
-    auto linear = SurfaceInterpolation(exec, mesh, input);
+    Input input = NeoFOAM::TokenList({std::string("upwind")});
+    auto upwind = SurfaceInterpolation(exec, mesh, input);
 
     auto in = VolumeField<TestType>(exec, "in", mesh, {});
+    auto flux = SurfaceField<NeoFOAM::scalar>(exec, "flux", mesh, {});
     auto out = SurfaceField<TestType>(exec, "out", mesh, surfaceBCs);
 
+    fill(flux.internalField(), NeoFOAM::one<NeoFOAM::scalar>::value);
     fill(in.internalField(), NeoFOAM::one<NeoFOAM::scalar>::value);
 
     // capture the value of size as section name
     DYNAMIC_SECTION("" << size)
     {
 
-        BENCHMARK(std::string(execName)) { return (linear.interpolate(in, out)); };
+        BENCHMARK(std::string(execName)) { return (upwind.interpolate(flux, in, out)); };
     }
 }

--- a/benchmarks/finiteVolume/cellCentred/interpolation/upwind.cpp
+++ b/benchmarks/finiteVolume/cellCentred/interpolation/upwind.cpp
@@ -7,12 +7,14 @@
 #include "NeoFOAM/NeoFOAM.hpp"
 #include "../../../catch_main.hpp"
 
+#include <catch2/catch_template_test_macros.hpp>
+
 using NeoFOAM::finiteVolume::cellCentred::SurfaceInterpolation;
 using NeoFOAM::finiteVolume::cellCentred::VolumeField;
 using NeoFOAM::finiteVolume::cellCentred::SurfaceField;
 using NeoFOAM::Input;
 
-TEST_CASE("upwind", "[bench]")
+TEMPLATE_TEST_CASE("upwind", "", NeoFOAM::scalar, NeoFOAM::Vector)
 {
     using TestType = NeoFOAM::scalar;
     auto size = GENERATE(1 << 16, 1 << 17, 1 << 18, 1 << 19, 1 << 20);
@@ -25,7 +27,7 @@ TEST_CASE("upwind", "[bench]")
 
     std::string execName = std::visit([](auto e) { return e.name(); }, exec);
     NeoFOAM::UnstructuredMesh mesh = NeoFOAM::create1DUniformMesh(exec, size);
-    auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<NeoFOAM::scalar>>(mesh);
+    auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<TestType>>(mesh);
     Input input = NeoFOAM::TokenList({std::string("upwind")});
     auto upwind = SurfaceInterpolation(exec, mesh, input);
 
@@ -34,7 +36,7 @@ TEST_CASE("upwind", "[bench]")
     auto out = SurfaceField<TestType>(exec, "out", mesh, surfaceBCs);
 
     fill(flux.internalField(), NeoFOAM::one<NeoFOAM::scalar>::value);
-    fill(in.internalField(), NeoFOAM::one<NeoFOAM::scalar>::value);
+    fill(in.internalField(), NeoFOAM::one<NeoFOAM::TestType>::value);
 
     // capture the value of size as section name
     DYNAMIC_SECTION("" << size)

--- a/benchmarks/finiteVolume/cellCentred/interpolation/upwind.cpp
+++ b/benchmarks/finiteVolume/cellCentred/interpolation/upwind.cpp
@@ -39,7 +39,6 @@ TEST_CASE("upwind", "[bench]")
     // capture the value of size as section name
     DYNAMIC_SECTION("" << size)
     {
-
         BENCHMARK(std::string(execName)) { return (upwind.interpolate(flux, in, out)); };
     }
 }

--- a/include/NeoFOAM/finiteVolume/cellCentred/interpolation/linear.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/interpolation/linear.hpp
@@ -42,6 +42,16 @@ public:
         SurfaceField<scalar>& surfaceField
     ) const override;
 
+    void interpolate(const VolumeField<Vector>& volField, SurfaceField<Vector>& surfaceField)
+        const override;
+
+    void interpolate(
+        const SurfaceField<scalar>& faceFlux,
+        const VolumeField<Vector>& volField,
+        SurfaceField<Vector>& surfaceField
+    ) const override;
+
+
     std::unique_ptr<SurfaceInterpolationFactory> clone() const override;
 
 private:

--- a/include/NeoFOAM/finiteVolume/cellCentred/interpolation/linear.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/interpolation/linear.hpp
@@ -33,22 +33,16 @@ public:
 
     static std::string schema() { return "none"; }
 
-    void interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField)
-        const override;
+    void interpolate(const VolumeField<scalar>& src, SurfaceField<scalar>& dst) const override;
+
+    void interpolate(const VolumeField<Vector>& src, SurfaceField<Vector>& dst) const override;
 
     void interpolate(
-        const SurfaceField<scalar>& faceFlux,
-        const VolumeField<scalar>& volField,
-        SurfaceField<scalar>& surfaceField
+        const SurfaceField<scalar>& flux, const VolumeField<scalar>& src, SurfaceField<scalar>& dst
     ) const override;
 
-    void interpolate(const VolumeField<Vector>& volField, SurfaceField<Vector>& surfaceField)
-        const override;
-
     void interpolate(
-        const SurfaceField<scalar>& faceFlux,
-        const VolumeField<Vector>& volField,
-        SurfaceField<Vector>& surfaceField
+        const SurfaceField<scalar>& flux, const VolumeField<Vector>& src, SurfaceField<Vector>& dst
     ) const override;
 
 

--- a/include/NeoFOAM/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
@@ -108,6 +108,12 @@ public:
         interpolationKernel_->interpolate(volField, surfaceField);
     }
 
+    void interpolate(const VolumeField<Vector>& volField, SurfaceField<Vector>& surfaceField) const
+    {
+        interpolationKernel_->interpolate(volField, surfaceField);
+    }
+
+
     ScalarSurfaceField interpolate(const VolumeField<scalar>& volField) const
     {
         std::string nameInterpolated = "interpolated_" + volField.name;

--- a/include/NeoFOAM/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
@@ -50,22 +50,16 @@ public:
 
     virtual ~SurfaceInterpolationFactory() {} // Virtual destructor
 
-    virtual void
-    interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField) const = 0;
+    virtual void interpolate(const VolumeField<scalar>& src, SurfaceField<scalar>& dst) const = 0;
 
     virtual void interpolate(
-        const ScalarSurfaceField& faceFlux,
-        const VolumeField<scalar>& volField,
-        SurfaceField<scalar>& surfaceField
+        const ScalarSurfaceField& flux, const VolumeField<scalar>& src, SurfaceField<scalar>& dst
     ) const = 0;
 
-    virtual void
-    interpolate(const VolumeField<Vector>& volField, SurfaceField<Vector>& surfaceField) const = 0;
+    virtual void interpolate(const VolumeField<Vector>& src, SurfaceField<Vector>& dst) const = 0;
 
     virtual void interpolate(
-        const ScalarSurfaceField& faceFlux,
-        const VolumeField<Vector>& volField,
-        SurfaceField<Vector>& surfaceField
+        const ScalarSurfaceField& flux, const VolumeField<Vector>& src, SurfaceField<Vector>& dst
     ) const = 0;
 
     // Pure virtual function for cloning
@@ -122,7 +116,7 @@ public:
     }
 
     void interpolate(
-        const ScalarSurfaceField& flux, const VolumeField<Vector>& src, VolumeField<Vector>& dst
+        const ScalarSurfaceField& flux, const VolumeField<Vector>& src, SurfaceField<Vector>& dst
     ) const
     {
         interpolationKernel_->interpolate(flux, src, dst);
@@ -130,7 +124,7 @@ public:
 
     ScalarSurfaceField interpolate(const VolumeField<scalar>& src) const
     {
-        std::string nameInterpolated = "interpolated_" + volField.name;
+        std::string nameInterpolated = "interpolated_" + src.name;
         ScalarSurfaceField dst(
             exec_, nameInterpolated, mesh_, createCalculatedBCs<SurfaceBoundary<scalar>>(mesh_)
         );

--- a/include/NeoFOAM/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
@@ -103,45 +103,50 @@ public:
           interpolationKernel_(SurfaceInterpolationFactory::create(exec, mesh, input)) {};
 
 
-    void interpolate(const VolumeField<scalar>& volField, ScalarSurfaceField& surfaceField) const
+    void interpolate(const VolumeField<scalar>& src, ScalarSurfaceField& dst) const
     {
-        interpolationKernel_->interpolate(volField, surfaceField);
+        interpolationKernel_->interpolate(src, dst);
     }
 
-    void interpolate(const VolumeField<Vector>& volField, SurfaceField<Vector>& surfaceField) const
+    void interpolate(const VolumeField<Vector>& src, SurfaceField<Vector>& dst) const
     {
-        interpolationKernel_->interpolate(volField, surfaceField);
+        interpolationKernel_->interpolate(src, dst);
     }
 
 
-    ScalarSurfaceField interpolate(const VolumeField<scalar>& volField) const
+    void interpolate(
+        const ScalarSurfaceField& flux, const VolumeField<scalar>& src, ScalarSurfaceField& dst
+    ) const
     {
-        std::string nameInterpolated = "interpolated_" + volField.name;
-        ScalarSurfaceField surfaceField(
-            exec_, nameInterpolated, mesh_, createCalculatedBCs<SurfaceBoundary<scalar>>(mesh_)
-        );
-        interpolate(surfaceField, volField);
-        return surfaceField;
+        interpolationKernel_->interpolate(flux, src, dst);
     }
 
     void interpolate(
-        const ScalarSurfaceField& faceFlux,
-        const VolumeField<scalar>& volField,
-        ScalarSurfaceField& surfaceField
+        const ScalarSurfaceField& flux, const VolumeField<Vector>& src, VolumeField<Vector>& dst
     ) const
     {
-        interpolationKernel_->interpolate(faceFlux, volField, surfaceField);
+        interpolationKernel_->interpolate(flux, src, dst);
+    }
+
+    ScalarSurfaceField interpolate(const VolumeField<scalar>& src) const
+    {
+        std::string nameInterpolated = "interpolated_" + volField.name;
+        ScalarSurfaceField dst(
+            exec_, nameInterpolated, mesh_, createCalculatedBCs<SurfaceBoundary<scalar>>(mesh_)
+        );
+        interpolate(dst, src);
+        return dst;
     }
 
     ScalarSurfaceField
-    interpolate(const ScalarSurfaceField& faceFlux, const VolumeField<scalar>& volField) const
+    interpolate(const ScalarSurfaceField& flux, const VolumeField<scalar>& src) const
     {
-        std::string name = "interpolated_" + volField.name;
-        ScalarSurfaceField surfaceField(
+        std::string name = "interpolated_" + src.name;
+        ScalarSurfaceField dst(
             exec_, name, mesh_, createCalculatedBCs<SurfaceBoundary<scalar>>(mesh_)
         );
-        interpolate(faceFlux, volField, surfaceField);
-        return surfaceField;
+        interpolate(flux, src, dst);
+        return dst;
     }
 
 private:

--- a/include/NeoFOAM/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
@@ -18,8 +18,11 @@
 namespace NeoFOAM::finiteVolume::cellCentred
 {
 
+/* @class SurfaceInterpolationFactor
+**
+*/
 class SurfaceInterpolationFactory :
-    public NeoFOAM::RuntimeSelectionFactory<
+    public RuntimeSelectionFactory<
         SurfaceInterpolationFactory,
         Parameters<const Executor&, const UnstructuredMesh&, Input>>
 {
@@ -48,12 +51,21 @@ public:
     virtual ~SurfaceInterpolationFactory() {} // Virtual destructor
 
     virtual void
-    interpolate(const VolumeField<scalar>& volField, ScalarSurfaceField& surfaceField) const = 0;
+    interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField) const = 0;
 
     virtual void interpolate(
         const ScalarSurfaceField& faceFlux,
         const VolumeField<scalar>& volField,
-        ScalarSurfaceField& surfaceField
+        SurfaceField<scalar>& surfaceField
+    ) const = 0;
+
+    virtual void
+    interpolate(const VolumeField<Vector>& volField, SurfaceField<Vector>& surfaceField) const = 0;
+
+    virtual void interpolate(
+        const ScalarSurfaceField& faceFlux,
+        const VolumeField<Vector>& volField,
+        SurfaceField<Vector>& surfaceField
     ) const = 0;
 
     // Pure virtual function for cloning

--- a/include/NeoFOAM/finiteVolume/cellCentred/interpolation/upwind.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/interpolation/upwind.hpp
@@ -29,22 +29,16 @@ public:
 
     static std::string schema() { return "none"; }
 
-    void interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField)
-        const override;
+    void interpolate(const VolumeField<scalar>& src, SurfaceField<scalar>& dst) const override;
+
+    void interpolate(const VolumeField<Vector>& src, SurfaceField<Vector>& dst) const override;
 
     void interpolate(
-        const SurfaceField<scalar>& faceFlux,
-        const VolumeField<scalar>& volField,
-        SurfaceField<scalar>& surfaceField
+        const SurfaceField<scalar>& flux, const VolumeField<scalar>& src, SurfaceField<scalar>& dst
     ) const override;
 
-    void interpolate(const VolumeField<Vector>& volField, SurfaceField<Vector>& surfaceField)
-        const override;
-
     void interpolate(
-        const SurfaceField<scalar>& faceFlux,
-        const VolumeField<Vector>& volField,
-        SurfaceField<Vector>& surfaceField
+        const SurfaceField<scalar>& flux, const VolumeField<Vector>& src, SurfaceField<Vector>& dst
     ) const override;
 
     std::unique_ptr<SurfaceInterpolationFactory> clone() const override;

--- a/include/NeoFOAM/finiteVolume/cellCentred/interpolation/upwind.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/interpolation/upwind.hpp
@@ -38,6 +38,15 @@ public:
         SurfaceField<scalar>& surfaceField
     ) const override;
 
+    void interpolate(const VolumeField<Vector>& volField, SurfaceField<Vector>& surfaceField)
+        const override;
+
+    void interpolate(
+        const SurfaceField<scalar>& faceFlux,
+        const VolumeField<Vector>& volField,
+        SurfaceField<Vector>& surfaceField
+    ) const override;
+
     std::unique_ptr<SurfaceInterpolationFactory> clone() const override;
 
 private:

--- a/scripts/catch2json.py
+++ b/scripts/catch2json.py
@@ -15,7 +15,12 @@ def parse_xml_dict(d):
         data = [data]
     records = []
     for cases in data:
-        test_case = cases["@name"]
+        test_case_raw_name = cases["@name"].split(" - ")
+        test_case = test_case_raw_name[0]
+        if len(test_case_raw_name) > 1:
+            test_type = test_case_raw_name[-1]
+        else:
+            test_type = ""
         for d in cases["Section"]:
             size = d["@name"]
             res = {}
@@ -33,6 +38,7 @@ def parse_xml_dict(d):
                     continue
             res["size"] = size
             res["test_case"] = test_case
+            res["test_type"] = test_type
             records.append(res)
     return records
 

--- a/src/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -58,7 +58,8 @@ Linear::Linear(const Executor& exec, const UnstructuredMesh& mesh)
 void Linear::interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField)
     const
 {
-    computeLinearInterpolation(volField, geometryScheme_, surfaceField);
+    // FIXME:
+    // computeLinearInterpolation(volField, geometryScheme_, surfaceField);
 }
 
 void Linear::interpolate(
@@ -69,6 +70,23 @@ void Linear::interpolate(
 {
     interpolate(volField, surfaceField);
 }
+
+void Linear::interpolate(const VolumeField<Vector>& volField, SurfaceField<Vector>& surfaceField)
+    const
+{
+    // FIXME:
+    // computeLinearInterpolation(volField, geometryScheme_, surfaceField);
+}
+
+void Linear::interpolate(
+    [[maybe_unused]] const SurfaceField<scalar>& faceFlux,
+    const VolumeField<Vector>& volField,
+    SurfaceField<Vector>& surfaceField
+) const
+{
+    interpolate(volField, surfaceField);
+}
+
 
 std::unique_ptr<SurfaceInterpolationFactory> Linear::clone() const
 {

--- a/src/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -41,10 +41,10 @@ void computeLinearInterpolation(
         exec,
         {0, dstS.size()},
         KOKKOS_LAMBDA(const size_t facei) {
-            size_t own = static_cast<size_t>(ownerS[facei]);
-            size_t nei = static_cast<size_t>(neighS[facei]);
             if (facei < nInternalFaces)
             {
+                size_t own = static_cast<size_t>(ownerS[facei]);
+                size_t nei = static_cast<size_t>(neighS[facei]);
                 dstS[facei] = weightS[facei] * srcS[own] + (1 - weightS[facei]) * srcS[nei];
             }
             else

--- a/src/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -28,11 +28,13 @@ void computeLinearInterpolation(
 {
     const auto exec = dst.exec();
     auto dstS = dst.internalField().span();
-    const auto srcS = src.internalField().span();
-    const auto weightS = weights.internalField().span();
-    const auto ownerS = dst.mesh().faceOwner().span();
-    const auto neighS = dst.mesh().faceNeighbour().span();
-    const auto boundS = src.boundaryField().value().span();
+    const auto [srcS, weightS, ownerS, neighS, boundS] = spans(
+        src.internalField(),
+        weights.internalField(),
+        dst.mesh().faceOwner(),
+        dst.mesh().faceNeighbour(),
+        src.boundaryField().value()
+    );
     size_t nInternalFaces = dst.mesh().nInternalFaces();
 
     NeoFOAM::parallelFor(

--- a/src/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -9,10 +9,11 @@
 namespace NeoFOAM::finiteVolume::cellCentred
 {
 
+template<typename ValueType>
 void computeLinearInterpolation(
-    const VolumeField<scalar>& volField,
+    const VolumeField<ValueType>& volField,
     const std::shared_ptr<GeometryScheme> geometryScheme,
-    SurfaceField<scalar>& surfaceField
+    SurfaceField<ValueType>& surfaceField
 )
 {
     const UnstructuredMesh& mesh = surfaceField.mesh();
@@ -36,8 +37,12 @@ void computeLinearInterpolation(
             size_t nei = static_cast<size_t>(sNeighbour[facei]);
             if (facei < nInternalFaces)
             {
+                std::cout << __FILE__ << " sWeight" << sWeight[facei] << "\n";
+                std::cout << __FILE__ << " sVolfield[own]" << sVolField[own] << "\n";
+                std::cout << __FILE__ << " sVolfield[nei]" << sVolField[nei] << "\n";
                 sfield[facei] =
                     sWeight[facei] * sVolField[own] + (1 - sWeight[facei]) * sVolField[nei];
+                std::cout << __FILE__ << " sfield[facei]" << sfield[facei] << "\n";
             }
             else
             {
@@ -58,8 +63,7 @@ Linear::Linear(const Executor& exec, const UnstructuredMesh& mesh)
 void Linear::interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField)
     const
 {
-    // FIXME:
-    // computeLinearInterpolation(volField, geometryScheme_, surfaceField);
+    computeLinearInterpolation(volField, geometryScheme_, surfaceField);
 }
 
 void Linear::interpolate(
@@ -74,8 +78,7 @@ void Linear::interpolate(
 void Linear::interpolate(const VolumeField<Vector>& volField, SurfaceField<Vector>& surfaceField)
     const
 {
-    // FIXME:
-    // computeLinearInterpolation(volField, geometryScheme_, surfaceField);
+    computeLinearInterpolation(volField, geometryScheme_, surfaceField);
 }
 
 void Linear::interpolate(

--- a/src/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -9,44 +9,45 @@
 namespace NeoFOAM::finiteVolume::cellCentred
 {
 
+/* @brief computional kernel to perform a linear interpolation
+** from a source volumeField to a surface field. It performs an interpolation
+** of the form
+**
+** d_f = w_f * s_O + ( 1 - w_f ) * s_N
+**
+**@param src the input field
+**@param weights weights for the interpolation
+**@param dst the target field
+*/
 template<typename ValueType>
 void computeLinearInterpolation(
-    const VolumeField<ValueType>& volField,
-    const std::shared_ptr<GeometryScheme> geometryScheme,
-    SurfaceField<ValueType>& surfaceField
+    const VolumeField<ValueType>& src,
+    const SurfaceField<scalar>& weights,
+    SurfaceField<ValueType>& dst
 )
 {
-    const UnstructuredMesh& mesh = surfaceField.mesh();
-    const auto& exec = surfaceField.exec();
-    auto sfield = surfaceField.internalField().span();
-    const NeoFOAM::labelField& owner = mesh.faceOwner();
-    const NeoFOAM::labelField& neighbour = mesh.faceNeighbour();
-
-    const auto sWeight = geometryScheme->weights().internalField().span();
-    const auto sVolField = volField.internalField().span();
-    const auto sBField = volField.boundaryField().value().span();
-    const auto sOwner = owner.span();
-    const auto sNeighbour = neighbour.span();
-    size_t nInternalFaces = mesh.nInternalFaces();
+    const auto exec = dst.exec();
+    auto dstS = dst.internalField().span();
+    const auto srcS = src.internalField().span();
+    const auto weightS = weights.internalField().span();
+    const auto ownerS = dst.mesh().faceOwner().span();
+    const auto neighS = dst.mesh().faceNeighbour().span();
+    const auto boundS = src.boundaryField().value().span();
+    size_t nInternalFaces = dst.mesh().nInternalFaces();
 
     NeoFOAM::parallelFor(
         exec,
-        {0, sfield.size()},
+        {0, dstS.size()},
         KOKKOS_LAMBDA(const size_t facei) {
-            size_t own = static_cast<size_t>(sOwner[facei]);
-            size_t nei = static_cast<size_t>(sNeighbour[facei]);
+            size_t own = static_cast<size_t>(ownerS[facei]);
+            size_t nei = static_cast<size_t>(neighS[facei]);
             if (facei < nInternalFaces)
             {
-                std::cout << __FILE__ << " sWeight" << sWeight[facei] << "\n";
-                std::cout << __FILE__ << " sVolfield[own]" << sVolField[own] << "\n";
-                std::cout << __FILE__ << " sVolfield[nei]" << sVolField[nei] << "\n";
-                sfield[facei] =
-                    sWeight[facei] * sVolField[own] + (1 - sWeight[facei]) * sVolField[nei];
-                std::cout << __FILE__ << " sfield[facei]" << sfield[facei] << "\n";
+                dstS[facei] = weightS[facei] * srcS[own] + (1 - weightS[facei]) * srcS[nei];
             }
             else
             {
-                sfield[facei] = sWeight[facei] * sBField[facei - nInternalFaces];
+                dstS[facei] = weightS[facei] * boundS[facei - nInternalFaces];
             }
         }
     );
@@ -60,34 +61,32 @@ Linear::Linear(const Executor& exec, const UnstructuredMesh& mesh)
     : SurfaceInterpolationFactory::Register<Linear>(exec, mesh),
       geometryScheme_(GeometryScheme::readOrCreate(mesh)) {};
 
-void Linear::interpolate(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField)
-    const
+void Linear::interpolate(const VolumeField<scalar>& src, SurfaceField<scalar>& dst) const
 {
-    computeLinearInterpolation(volField, geometryScheme_, surfaceField);
+    computeLinearInterpolation(src, geometryScheme_->weights(), dst);
+}
+
+void Linear::interpolate(const VolumeField<Vector>& src, SurfaceField<Vector>& dst) const
+{
+    computeLinearInterpolation(src, geometryScheme_->weights(), dst);
 }
 
 void Linear::interpolate(
-    [[maybe_unused]] const SurfaceField<scalar>& faceFlux,
-    const VolumeField<scalar>& volField,
-    SurfaceField<scalar>& surfaceField
+    [[maybe_unused]] const SurfaceField<scalar>& flux,
+    const VolumeField<Vector>& src,
+    SurfaceField<Vector>& dst
 ) const
 {
-    interpolate(volField, surfaceField);
-}
-
-void Linear::interpolate(const VolumeField<Vector>& volField, SurfaceField<Vector>& surfaceField)
-    const
-{
-    computeLinearInterpolation(volField, geometryScheme_, surfaceField);
+    interpolate(src, dst);
 }
 
 void Linear::interpolate(
-    [[maybe_unused]] const SurfaceField<scalar>& faceFlux,
-    const VolumeField<Vector>& volField,
-    SurfaceField<Vector>& surfaceField
+    [[maybe_unused]] const SurfaceField<scalar>& flux,
+    const VolumeField<scalar>& src,
+    SurfaceField<scalar>& dst
 ) const
 {
-    interpolate(volField, surfaceField);
+    interpolate(src, dst);
 }
 
 

--- a/src/finiteVolume/cellCentred/interpolation/upwind.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/upwind.cpp
@@ -30,12 +30,14 @@ void computeUpwindInterpolation(
 {
     const auto exec = dst.exec();
     auto dstS = dst.internalField().span();
-    const auto srcS = src.internalField().span();
-    const auto weightS = weights.internalField().span();
-    const auto ownerS = dst.mesh().faceOwner().span();
-    const auto neighS = dst.mesh().faceNeighbour().span();
-    const auto boundS = src.boundaryField().value().span();
-    const auto fluxS = flux.internalField().span();
+    const auto [srcS, weightS, ownerS, neighS, boundS, fluxS] = spans(
+        src.internalField(),
+        weights.internalField(),
+        dst.mesh().faceOwner(),
+        dst.mesh().faceNeighbour(),
+        src.boundaryField().value(),
+        flux.internalField()
+    );
     size_t nInternalFaces = dst.mesh().nInternalFaces();
 
     NeoFOAM::parallelFor(

--- a/src/finiteVolume/cellCentred/interpolation/upwind.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/upwind.cpp
@@ -73,7 +73,26 @@ void Upwind::interpolate(
     SurfaceField<scalar>& surfaceField
 ) const
 {
-    computeUpwindInterpolation(faceFlux, volField, geometryScheme_, surfaceField);
+    // FIXME:
+    // computeUpwindInterpolation(faceFlux, volField, geometryScheme_, surfaceField);
+}
+
+void Upwind::interpolate(
+    [[maybe_unused]] const VolumeField<Vector>& volField,
+    [[maybe_unused]] SurfaceField<Vector>& surfaceField
+) const
+{
+    NF_ERROR_EXIT("limited scheme require a faceFlux");
+}
+
+void Upwind::interpolate(
+    const SurfaceField<scalar>& faceFlux,
+    const VolumeField<Vector>& volField,
+    SurfaceField<Vector>& surfaceField
+) const
+{
+    // FIXME:
+    // computeUpwindInterpolation(faceFlux, volField, geometryScheme_, surfaceField);
 }
 
 std::unique_ptr<SurfaceInterpolationFactory> Upwind::clone() const

--- a/test/finiteVolume/cellCentred/interpolation/CMakeLists.txt
+++ b/test/finiteVolume/cellCentred/interpolation/CMakeLists.txt
@@ -2,4 +2,5 @@
 # SPDX-FileCopyrightText: 2024 NeoFOAM authors
 
 neofoam_unit_test(linear)
+neofoam_unit_test(upwind)
 neofoam_unit_test(surfaceInterpolation)

--- a/test/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/test/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -14,6 +14,9 @@ using NeoFOAM::finiteVolume::cellCentred::SurfaceInterpolation;
 using NeoFOAM::finiteVolume::cellCentred::VolumeField;
 using NeoFOAM::finiteVolume::cellCentred::SurfaceField;
 
+namespace NeoFOAM
+{
+
 template<typename T>
 using I = std::initializer_list<T>;
 
@@ -26,22 +29,22 @@ TEMPLATE_TEST_CASE("linear", "", NeoFOAM::scalar, NeoFOAM::Vector)
     );
 
     std::string execName = std::visit([](auto e) { return e.name(); }, exec);
-    auto mesh = NeoFOAM::create1DUniformMesh(exec, 10);
-    NeoFOAM::Input input = NeoFOAM::TokenList({std::string("linear")});
+    auto mesh = create1DUniformMesh(exec, 10);
+    Input input = TokenList({std::string("linear")});
     auto linear = SurfaceInterpolation(exec, mesh, input);
     std::vector<fvcc::SurfaceBoundary<TestType>> bcs {};
     for (auto patchi : I<size_t> {0, 1})
     {
-        NeoFOAM::Dictionary dict;
+        Dictionary dict;
         dict.insert("type", std::string("fixedValue"));
-        dict.insert("fixedValue", NeoFOAM::one<TestType>::value);
+        dict.insert("fixedValue", one<TestType>::value);
         bcs.push_back(fvcc::SurfaceBoundary<TestType>(mesh, dict, patchi));
     }
 
     auto in = VolumeField<TestType>(exec, "in", mesh, {});
     auto out = SurfaceField<TestType>(exec, "out", mesh, bcs);
 
-    fill(in.internalField(), NeoFOAM::one<TestType>::value);
+    fill(in.internalField(), one<TestType>::value);
 
     linear.interpolate(in, out);
     out.correctBoundaryConditions();
@@ -49,6 +52,7 @@ TEMPLATE_TEST_CASE("linear", "", NeoFOAM::scalar, NeoFOAM::Vector)
     auto outHost = out.internalField().copyToHost();
     for (int i = 0; i < out.internalField().size(); i++)
     {
-        REQUIRE(outHost[i] == NeoFOAM::one<TestType>::value);
+        REQUIRE(outHost[i] == one<TestType>::value);
     }
+}
 }

--- a/test/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/test/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -30,11 +30,12 @@ TEMPLATE_TEST_CASE("linear", "", NeoFOAM::scalar, NeoFOAM::Vector)
     auto in = VolumeField<TestType>(exec, "in", mesh, {});
     auto out = SurfaceField<TestType>(exec, "out", mesh, {});
 
-    // FIXME add fill
-    // fill(in.internalField(), 1);
+    fill(in.internalField(), NeoFOAM::one<TestType>::value);
 
     linear.interpolate(in, out);
 
-    // FIXME add fill
-    // REQUIRE(out.internalField()[0] == one<TestType>::value);
+    for (int i = 0; i < out.internalField().size(); i++)
+    {
+        REQUIRE(out.internalField()[i] == NeoFOAM::one<TestType>::value);
+    }
 }

--- a/test/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/test/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -14,6 +14,9 @@ using NeoFOAM::finiteVolume::cellCentred::SurfaceInterpolation;
 using NeoFOAM::finiteVolume::cellCentred::VolumeField;
 using NeoFOAM::finiteVolume::cellCentred::SurfaceField;
 
+template<typename T>
+using I = std::initializer_list<T>;
+
 TEMPLATE_TEST_CASE("linear", "", NeoFOAM::scalar, NeoFOAM::Vector)
 {
     NeoFOAM::Executor exec = GENERATE(
@@ -26,13 +29,22 @@ TEMPLATE_TEST_CASE("linear", "", NeoFOAM::scalar, NeoFOAM::Vector)
     auto mesh = NeoFOAM::create1DUniformMesh(exec, 10);
     NeoFOAM::Input input = NeoFOAM::TokenList({std::string("linear")});
     auto linear = SurfaceInterpolation(exec, mesh, input);
+    std::vector<fvcc::SurfaceBoundary<TestType>> bcs {};
+    for (auto patchi : I<size_t> {0, 1})
+    {
+        NeoFOAM::Dictionary dict;
+        dict.insert("type", std::string("fixedValue"));
+        dict.insert("fixedValue", NeoFOAM::one<TestType>::value);
+        bcs.push_back(fvcc::SurfaceBoundary<TestType>(mesh, dict, patchi));
+    }
 
     auto in = VolumeField<TestType>(exec, "in", mesh, {});
-    auto out = SurfaceField<TestType>(exec, "out", mesh, {});
+    auto out = SurfaceField<TestType>(exec, "out", mesh, bcs);
 
     fill(in.internalField(), NeoFOAM::one<TestType>::value);
 
     linear.interpolate(in, out);
+    out.correctBoundaryConditions();
 
     for (int i = 0; i < out.internalField().size(); i++)
     {

--- a/test/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/test/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -22,10 +22,12 @@ TEST_CASE("linear")
     );
 
     std::string execName = std::visit([](auto e) { return e.name(); }, exec);
-    auto mesh = NeoFOAM::createSingleCellMesh(exec);
+    auto mesh = NeoFOAM::create1DUniformMesh(exec, 10);
     NeoFOAM::Input input = NeoFOAM::TokenList({std::string("linear")});
     auto linear = SurfaceInterpolation(exec, mesh, input);
 
     auto in = VolumeField<NeoFOAM::scalar>(exec, "in", mesh, {});
     auto out = SurfaceField<NeoFOAM::scalar>(exec, "out", mesh, {});
+
+    linear.interpolate(in, out);
 }

--- a/test/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/test/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -6,6 +6,7 @@
 #include <catch2/catch_session.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators_all.hpp>
+#include <catch2/catch_template_test_macros.hpp>
 
 #include "NeoFOAM/NeoFOAM.hpp"
 
@@ -13,7 +14,7 @@ using NeoFOAM::finiteVolume::cellCentred::SurfaceInterpolation;
 using NeoFOAM::finiteVolume::cellCentred::VolumeField;
 using NeoFOAM::finiteVolume::cellCentred::SurfaceField;
 
-TEST_CASE("linear")
+TEMPLATE_TEST_CASE("linear", "", NeoFOAM::scalar, NeoFOAM::Vector)
 {
     NeoFOAM::Executor exec = GENERATE(
         NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
@@ -26,8 +27,14 @@ TEST_CASE("linear")
     NeoFOAM::Input input = NeoFOAM::TokenList({std::string("linear")});
     auto linear = SurfaceInterpolation(exec, mesh, input);
 
-    auto in = VolumeField<NeoFOAM::scalar>(exec, "in", mesh, {});
-    auto out = SurfaceField<NeoFOAM::scalar>(exec, "out", mesh, {});
+    auto in = VolumeField<TestType>(exec, "in", mesh, {});
+    auto out = SurfaceField<TestType>(exec, "out", mesh, {});
+
+    // FIXME add fill
+    // fill(in.internalField(), 1);
 
     linear.interpolate(in, out);
+
+    // FIXME add fill
+    // REQUIRE(out.internalField()[0] == one<TestType>::value);
 }

--- a/test/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/test/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -46,9 +46,9 @@ TEMPLATE_TEST_CASE("linear", "", NeoFOAM::scalar, NeoFOAM::Vector)
     linear.interpolate(in, out);
     out.correctBoundaryConditions();
 
-    // FIXME: needs to copy back to host
+    auto outHost = out.internalField().copyToHost();
     for (int i = 0; i < out.internalField().size(); i++)
     {
-        REQUIRE(out.internalField()[i] == NeoFOAM::one<TestType>::value);
+        REQUIRE(outHost[i] == NeoFOAM::one<TestType>::value);
     }
 }

--- a/test/finiteVolume/cellCentred/interpolation/upwind.cpp
+++ b/test/finiteVolume/cellCentred/interpolation/upwind.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoFOAM authors
+// SPDX-FileCopyrightText: 2025 NeoFOAM authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/finiteVolume/cellCentred/interpolation/upwind.cpp
+++ b/test/finiteVolume/cellCentred/interpolation/upwind.cpp
@@ -13,7 +13,9 @@
 using NeoFOAM::finiteVolume::cellCentred::SurfaceInterpolation;
 using NeoFOAM::finiteVolume::cellCentred::VolumeField;
 using NeoFOAM::finiteVolume::cellCentred::SurfaceField;
-using NeoFOAM::Input;
+
+namespace NeoFOAM
+{
 
 template<typename T>
 using I = std::initializer_list<T>;
@@ -27,24 +29,24 @@ TEMPLATE_TEST_CASE("upwind", "", NeoFOAM::scalar, NeoFOAM::Vector)
     );
 
     std::string execName = std::visit([](auto e) { return e.name(); }, exec);
-    auto mesh = NeoFOAM::create1DUniformMesh(exec, 10);
-    Input input = NeoFOAM::TokenList({std::string("upwind")});
+    auto mesh = create1DUniformMesh(exec, 10);
+    Input input = TokenList({std::string("upwind")});
     auto upwind = SurfaceInterpolation(exec, mesh, input);
     std::vector<fvcc::SurfaceBoundary<TestType>> bcs {};
     for (auto patchi : I<size_t> {0, 1})
     {
-        NeoFOAM::Dictionary dict;
+        Dictionary dict;
         dict.insert("type", std::string("fixedValue"));
-        dict.insert("fixedValue", NeoFOAM::one<TestType>::value);
+        dict.insert("fixedValue", one<TestType>::value);
         bcs.push_back(fvcc::SurfaceBoundary<TestType>(mesh, dict, patchi));
     }
 
     auto in = VolumeField<TestType>(exec, "in", mesh, {});
-    auto flux = SurfaceField<NeoFOAM::scalar>(exec, "flux", mesh, {});
+    auto flux = SurfaceField<scalar>(exec, "flux", mesh, {});
     auto out = SurfaceField<TestType>(exec, "out", mesh, bcs);
 
-    fill(flux.internalField(), NeoFOAM::one<NeoFOAM::scalar>::value);
-    fill(in.internalField(), NeoFOAM::one<TestType>::value);
+    fill(flux.internalField(), one<scalar>::value);
+    fill(in.internalField(), one<TestType>::value);
 
     upwind.interpolate(flux, in, out);
     out.correctBoundaryConditions();
@@ -52,6 +54,8 @@ TEMPLATE_TEST_CASE("upwind", "", NeoFOAM::scalar, NeoFOAM::Vector)
     auto outHost = out.internalField().copyToHost();
     for (int i = 0; i < out.internalField().size(); i++)
     {
-        REQUIRE(outHost[i] == NeoFOAM::one<TestType>::value);
+        REQUIRE(outHost[i] == one<TestType>::value);
     }
+}
+
 }

--- a/test/finiteVolume/cellCentred/interpolation/upwind.cpp
+++ b/test/finiteVolume/cellCentred/interpolation/upwind.cpp
@@ -49,8 +49,9 @@ TEMPLATE_TEST_CASE("upwind", "", NeoFOAM::scalar, NeoFOAM::Vector)
     upwind.interpolate(flux, in, out);
     out.correctBoundaryConditions();
 
+    auto outHost = out.internalField().copyToHost();
     for (int i = 0; i < out.internalField().size(); i++)
     {
-        REQUIRE(out.internalField()[i] == NeoFOAM::one<TestType>::value);
+        REQUIRE(outHost[i] == NeoFOAM::one<TestType>::value);
     }
 }


### PR DESCRIPTION
This PR adds interpolation kernels for `Field<Vector>` for upwind and linear interpolations. Currently, overloading of `interpolate(src, dst)` is used to implement the functionality on the operator. The reason is that template functions seems to not work well with the runTimeSelection mechanism and the static create functions and the virtual interpolate members.

This PR is required for https://github.com/exasim-project/NeoFOAM/pull/256.

Additional changes:
- the implementation of the interpolation tests are improved and benchmarks are added.
- renamed `volField`, `surfaceField` to `src` and `dst`. To make the purpose clearer.