### PR TITLE
implicit BCs and Laplacian operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Version 0.2.0 (unreleased)
 ## Features
+- implicit BCs and Laplacian operator [#262](https://github.com/exasim-project/NeoFOAM/pull/262)
 - add basic vectorField implementation  [#260](https://github.com/exasim-project/NeoFOAM/pull/260)
 - add temporal operators inside expressions and the ability to solve linear system [#259 ](https://github.com/exasim-project/NeoFOAM/pull/259)
 - Add basic Ginkgo solver interface [#250](https://github.com/exasim-project/NeoFOAM/pull/250)

--- a/include/NeoFOAM/core/primitives/vector.hpp
+++ b/include/NeoFOAM/core/primitives/vector.hpp
@@ -143,9 +143,9 @@ Vector operator*(const scalar& sclr, Vector rhs)
 }
 
 KOKKOS_INLINE_FUNCTION
-Vector operator&(const Vector& lhs, Vector rhs)
+scalar operator&(const Vector& lhs, Vector rhs)
 {
-    return Vector(rhs[0] * lhs[0], rhs[1] * lhs[1], rhs[2] * lhs[2]);
+    return lhs[0] * rhs[0] + lhs[1] * rhs[1] + lhs[2] * rhs[2];
 }
 
 KOKKOS_INLINE_FUNCTION

--- a/include/NeoFOAM/core/tokenList.hpp
+++ b/include/NeoFOAM/core/tokenList.hpp
@@ -11,6 +11,11 @@ namespace NeoFOAM
 {
 
 
+void logOutRange(
+    const std::out_of_range& e, const std::size_t& key, const std::vector<std::any>& data
+);
+
+
 /**
  * @class TokenList
  * @brief A class representing a list of tokens.
@@ -22,7 +27,9 @@ class TokenList
 {
 public:
 
-    TokenList() = default;
+    TokenList();
+
+    TokenList(const TokenList&);
 
     /**
      * @brief Construct a TokenList object from a vector of std::any.
@@ -94,6 +101,11 @@ public:
             logBadAnyCast<ReturnType>(e, idx, data_);
             throw e;
         }
+        catch (const std::out_of_range& e)
+        {
+            logOutRange(e, idx, data_);
+            throw e;
+        }
     }
 
     /**
@@ -129,6 +141,11 @@ public:
         catch (const std::bad_any_cast& e)
         {
             logBadAnyCast<ReturnType>(e, idx, data_);
+            throw e;
+        }
+        catch (const std::out_of_range& e)
+        {
+            logOutRange(e, idx, data_);
             throw e;
         }
     }

--- a/include/NeoFOAM/core/tokenList.hpp
+++ b/include/NeoFOAM/core/tokenList.hpp
@@ -28,7 +28,7 @@ public:
      * @brief Construct a TokenList object from a vector of std::any.
      * @param data A vector of std::any.
      */
-    TokenList(const std::vector<std::any>& data);
+    TokenList(const std::vector<std::any>& data, size_t nextIndex = 0);
 
     /**
      * @brief Construct a TokenList object from an initializer list of std::any.
@@ -96,6 +96,20 @@ public:
         }
     }
 
+    /**
+     * @brief Retrieves the value associated with the nextIndex, casting it to
+     * the specified type.
+     * @tparam T The type to cast the value to.
+     * @return A reference to the value associated with the index, casted to
+     * type T.
+     */
+    template<typename ReturnType>
+    ReturnType& next()
+    {
+        ReturnType& retValue = get<ReturnType&>(nextIndex_);
+        nextIndex_++;
+        return retValue;
+    }
 
     /**
      * @brief Retrieves the value associated with the given index, casting it to
@@ -120,6 +134,21 @@ public:
     }
 
     /**
+     * @brief Retrieves the value associated with the nextIndex, casting it to
+     * the specified type.
+     * @tparam T The type to cast the value to.
+     * @return A const reference to the value associated with the index, casted to
+     * type T.
+     */
+    template<typename ReturnType>
+    const ReturnType& next() const
+    {
+        const ReturnType& retValue = get<ReturnType>(nextIndex_);
+        nextIndex_++;
+        return retValue;
+    }
+
+    /**
      * @brief Retrieves the value associated with the given index.
      * @param idx The index to retrieve the value for.
      * @return A reference to the value associated with the index.
@@ -132,6 +161,7 @@ public:
 private:
 
     std::vector<std::any> data_;
+    mutable size_t nextIndex_;
 };
 
 } // namespace NeoFOAM

--- a/include/NeoFOAM/dsl/expression.hpp
+++ b/include/NeoFOAM/dsl/expression.hpp
@@ -195,6 +195,15 @@ template<typename leftOperator, typename rightOperator>
     return lhs;
 }
 
+template<typename leftOperator, typename rightOperator>
+[[nodiscard]] inline Expression operator-(leftOperator lhs, rightOperator rhs)
+{
+    Expression expr(lhs.exec());
+    expr.addOperator(lhs);
+    expr.addOperator(Coeff(-1) * rhs);
+    return expr;
+}
+
 [[nodiscard]] inline Expression operator-(const SpatialOperator& lhs, const SpatialOperator& rhs)
 {
     Expression expr(lhs.exec());

--- a/include/NeoFOAM/dsl/implicit.hpp
+++ b/include/NeoFOAM/dsl/implicit.hpp
@@ -35,4 +35,10 @@ div(fvcc::SurfaceField<NeoFOAM::scalar>& faceFlux, fvcc::VolumeField<NeoFOAM::sc
     return SpatialOperator(fvcc::DivOperator(dsl::Operator::Type::Implicit, faceFlux, phi));
 }
 
+SpatialOperator
+laplacian(fvcc::SurfaceField<NeoFOAM::scalar>& gamma, fvcc::VolumeField<NeoFOAM::scalar>& phi)
+{
+    return SpatialOperator(fvcc::LaplacianOperator(dsl::Operator::Type::Implicit, gamma, phi));
+}
+
 } // namespace NeoFOAM

--- a/include/NeoFOAM/dsl/operator.hpp
+++ b/include/NeoFOAM/dsl/operator.hpp
@@ -16,4 +16,49 @@ public:
     };
 };
 
+
+/* @class OperatorMixin
+ * @brief A mixin class to simplify implementations of concrete operators
+ * in NeoFOAMs dsl
+ *
+ * @ingroup dsl
+ */
+template<typename FieldType>
+class OperatorMixin
+{
+
+public:
+
+    OperatorMixin(const Executor exec, const Coeff& coeffs, FieldType& field, Operator::Type type)
+        : exec_(exec), coeffs_(coeffs), field_(field), type_(type) {};
+
+
+    Operator::Type getType() const { return type_; }
+
+    virtual ~OperatorMixin() = default;
+
+    virtual const Executor& exec() const final { return exec_; }
+
+    Coeff& getCoefficient() { return coeffs_; }
+
+    const Coeff& getCoefficient() const { return coeffs_; }
+
+    FieldType& getField() { return field_; }
+
+    const FieldType& getField() const { return field_; }
+
+    /* @brief Given an input this function reads required coeffs */
+    void build([[maybe_unused]] const Input& input) {}
+
+protected:
+
+    const Executor exec_; //!< Executor associated with the field. (CPU, GPU, openMP, etc.)
+
+    Coeff coeffs_;
+
+    FieldType& field_;
+
+    Operator::Type type_;
+};
+
 } // namespace NeoFOAM::dsl

--- a/include/NeoFOAM/dsl/spatialOperator.hpp
+++ b/include/NeoFOAM/dsl/spatialOperator.hpp
@@ -58,6 +58,8 @@ public:
 
     SpatialOperator(SpatialOperator&& eqnOperator);
 
+    SpatialOperator& operator=(const SpatialOperator& eqnOperator);
+
     void explicitOperation(Field<scalar>& source);
 
     void implicitOperation(la::LinearSystem<scalar, localIdx>& ls);
@@ -213,46 +215,4 @@ SpatialOperator operator*([[maybe_unused]] CoeffFunction coeffFunc, const Spatia
     return result;
 }
 
-/* @class OperatorMixin
- * @brief A mixin class to simplify implementations of concrete operators
- * in NeoFOAMs dsl
- *
- * @ingroup dsl
- */
-template<typename FieldType>
-class OperatorMixin
-{
-
-public:
-
-    OperatorMixin(const Executor exec, FieldType& field, Operator::Type type)
-        : exec_(exec), coeffs_(), field_(field), type_(type) {};
-
-    Operator::Type getType() const { return type_; }
-
-    virtual ~OperatorMixin() = default;
-
-    virtual const Executor& exec() const final { return exec_; }
-
-    Coeff& getCoefficient() { return coeffs_; }
-
-    const Coeff& getCoefficient() const { return coeffs_; }
-
-    FieldType& getField() { return field_; }
-
-    const FieldType& getField() const { return field_; }
-
-    /* @brief Given an input this function reads required coeffs */
-    void build([[maybe_unused]] const Input& input) {}
-
-protected:
-
-    const Executor exec_; //!< Executor associated with the field. (CPU, GPU, openMP, etc.)
-
-    Coeff coeffs_;
-
-    FieldType& field_;
-
-    Operator::Type type_;
-};
 } // namespace NeoFOAM::dsl

--- a/include/NeoFOAM/fields/boundaryFields.hpp
+++ b/include/NeoFOAM/fields/boundaryFields.hpp
@@ -90,7 +90,7 @@ public:
      * @brief Get the view storing the fraction of the boundary value.
      * @return The view storing the fraction of the boundary value.
      */
-    NeoFOAM::Field<scalar>& valueFraction() { return refValue_; }
+    NeoFOAM::Field<scalar>& valueFraction() { return valueFraction_; }
 
     /** @copydoc BoundaryFields::refGrad()*/
     const NeoFOAM::Field<T>& refGrad() const { return refGrad_; }

--- a/include/NeoFOAM/finiteVolume/cellCentred.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred.hpp
@@ -12,6 +12,7 @@
 #include "cellCentred/fields/surfaceField.hpp"
 #include "cellCentred/fields/volumeField.hpp"
 
+#include "cellCentred/operators/linearSystem.hpp"
 #include "cellCentred/operators/divOperator.hpp"
 #include "cellCentred/operators/gaussGreenDiv.hpp"
 

--- a/include/NeoFOAM/finiteVolume/cellCentred.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred.hpp
@@ -14,8 +14,15 @@
 
 #include "cellCentred/operators/divOperator.hpp"
 #include "cellCentred/operators/gaussGreenDiv.hpp"
+
 #include "cellCentred/operators/ddtOperator.hpp"
+
 #include "cellCentred/operators/sourceTerm.hpp"
+
+#include "cellCentred/operators/laplacianOperator.hpp"
+#include "cellCentred/operators/gaussGreenLaplacian.hpp"
 
 #include "cellCentred/interpolation/linear.hpp"
 #include "cellCentred/interpolation/upwind.hpp"
+
+#include "cellCentred/faceNormalGradient/uncorrected.hpp"

--- a/include/NeoFOAM/finiteVolume/cellCentred/boundary/volume/fixedValue.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/boundary/volume/fixedValue.hpp
@@ -22,8 +22,12 @@ void setFixedValue(
     DomainField<ValueType>& domainField, std::pair<size_t, size_t> range, ValueType fixedValue
 )
 {
-    auto refValue = domainField.boundaryField().refValue().span();
-    auto value = domainField.boundaryField().value().span();
+    auto [refGradient, value, valueFraction, refValue] = spans(
+        domainField.boundaryField().refGrad(),
+        domainField.boundaryField().value(),
+        domainField.boundaryField().valueFraction(),
+        domainField.boundaryField().refValue()
+    );
 
     NeoFOAM::parallelFor(
         domainField.exec(),
@@ -31,6 +35,8 @@ void setFixedValue(
         KOKKOS_LAMBDA(const size_t i) {
             refValue[i] = fixedValue;
             value[i] = fixedValue;
+            valueFraction[i] = 1.0;      // only used refValue
+            refGradient[i] = fixedValue; // not used
         }
     );
 }

--- a/include/NeoFOAM/finiteVolume/cellCentred/faceNormalGradient/faceNormalGradient.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/faceNormalGradient/faceNormalGradient.hpp
@@ -21,20 +21,20 @@ namespace NeoFOAM::finiteVolume::cellCentred
 class FaceNormalGradientFactory :
     public NeoFOAM::RuntimeSelectionFactory<
         FaceNormalGradientFactory,
-        Parameters<const Executor&, const UnstructuredMesh&, Input>>
+        Parameters<const Executor&, const UnstructuredMesh&, const Input&>>
 {
     using ScalarSurfaceField = SurfaceField<scalar>;
 
 public:
 
     static std::unique_ptr<FaceNormalGradientFactory>
-    create(const Executor& exec, const UnstructuredMesh& uMesh, Input inputs)
+    create(const Executor& exec, const UnstructuredMesh& uMesh, const Input& inputs)
     {
         // input is dictionary the key is "interpolation"
         std::string key =
             (std::holds_alternative<NeoFOAM::Dictionary>(inputs))
                 ? std::get<NeoFOAM::Dictionary>(inputs).get<std::string>("faceNormalGradient")
-                : std::get<NeoFOAM::TokenList>(inputs).get<std::string>(0);
+                : std::get<NeoFOAM::TokenList>(inputs).next<std::string>();
 
         keyExistsOrError(key);
         return table().at(key)(exec, uMesh, inputs);
@@ -65,13 +65,13 @@ class FaceNormalGradient
 
 public:
 
-    FaceNormalGradient(const FaceNormalGradient& surfInterp)
-        : exec_(surfInterp.exec_), mesh_(surfInterp.mesh_),
-          faceNormalGradKernel_(surfInterp.faceNormalGradKernel_->clone()) {};
+    FaceNormalGradient(const FaceNormalGradient& faceNGrad)
+        : exec_(faceNGrad.exec_), mesh_(faceNGrad.mesh_),
+          faceNormalGradKernel_(faceNGrad.faceNormalGradKernel_->clone()) {};
 
-    FaceNormalGradient(FaceNormalGradient&& surfInterp)
-        : exec_(surfInterp.exec_), mesh_(surfInterp.mesh_),
-          faceNormalGradKernel_(std::move(surfInterp.faceNormalGradKernel_)) {};
+    FaceNormalGradient(FaceNormalGradient&& faceNGrad)
+        : exec_(faceNGrad.exec_), mesh_(faceNGrad.mesh_),
+          faceNormalGradKernel_(std::move(faceNGrad.faceNormalGradKernel_)) {};
 
     FaceNormalGradient(
         const Executor& exec,
@@ -80,7 +80,7 @@ public:
     )
         : exec_(exec), mesh_(mesh), faceNormalGradKernel_(std::move(interpolationKernel)) {};
 
-    FaceNormalGradient(const Executor& exec, const UnstructuredMesh& mesh, Input input)
+    FaceNormalGradient(const Executor& exec, const UnstructuredMesh& mesh, const Input& input)
         : exec_(exec), mesh_(mesh),
           faceNormalGradKernel_(FaceNormalGradientFactory::create(exec, mesh, input)) {};
 

--- a/include/NeoFOAM/finiteVolume/cellCentred/faceNormalGradient/faceNormalGradient.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/faceNormalGradient/faceNormalGradient.hpp
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 NeoFOAM authors
+
+#pragma once
+
+#include <functional>
+
+#include <Kokkos_Core.hpp>
+
+#include "NeoFOAM/core/executor/executor.hpp"
+#include "NeoFOAM/core/input.hpp"
+#include "NeoFOAM/core/runtimeSelectionFactory.hpp"
+#include "NeoFOAM/mesh/unstructured.hpp"
+#include "NeoFOAM/finiteVolume/cellCentred/fields/surfaceField.hpp"
+#include "NeoFOAM/finiteVolume/cellCentred/fields/volumeField.hpp"
+#include "NeoFOAM/finiteVolume/cellCentred/boundary.hpp"
+
+namespace NeoFOAM::finiteVolume::cellCentred
+{
+
+class FaceNormalGradientFactory :
+    public NeoFOAM::RuntimeSelectionFactory<
+        FaceNormalGradientFactory,
+        Parameters<const Executor&, const UnstructuredMesh&, Input>>
+{
+    using ScalarSurfaceField = SurfaceField<scalar>;
+
+public:
+
+    static std::unique_ptr<FaceNormalGradientFactory>
+    create(const Executor& exec, const UnstructuredMesh& uMesh, Input inputs)
+    {
+        // input is dictionary the key is "interpolation"
+        std::string key =
+            (std::holds_alternative<NeoFOAM::Dictionary>(inputs))
+                ? std::get<NeoFOAM::Dictionary>(inputs).get<std::string>("faceNormalGradient")
+                : std::get<NeoFOAM::TokenList>(inputs).get<std::string>(0);
+
+        keyExistsOrError(key);
+        return table().at(key)(exec, uMesh, inputs);
+    }
+
+    static std::string name() { return "FaceNormalGradientFactory"; }
+
+    FaceNormalGradientFactory(const Executor& exec, const UnstructuredMesh& mesh)
+        : exec_(exec), mesh_(mesh) {};
+
+    virtual ~FaceNormalGradientFactory() {} // Virtual destructor
+
+    virtual void
+    faceNormalGrad(const VolumeField<scalar>& volField, ScalarSurfaceField& surfaceField) const = 0;
+
+
+    // Pure virtual function for cloning
+    virtual std::unique_ptr<FaceNormalGradientFactory> clone() const = 0;
+
+protected:
+
+    const Executor exec_;
+    const UnstructuredMesh& mesh_;
+};
+
+class FaceNormalGradient
+{
+
+public:
+
+    FaceNormalGradient(const FaceNormalGradient& surfInterp)
+        : exec_(surfInterp.exec_), mesh_(surfInterp.mesh_),
+          faceNormalGradKernel_(surfInterp.faceNormalGradKernel_->clone()) {};
+
+    FaceNormalGradient(FaceNormalGradient&& surfInterp)
+        : exec_(surfInterp.exec_), mesh_(surfInterp.mesh_),
+          faceNormalGradKernel_(std::move(surfInterp.faceNormalGradKernel_)) {};
+
+    FaceNormalGradient(
+        const Executor& exec,
+        const UnstructuredMesh& mesh,
+        std::unique_ptr<FaceNormalGradientFactory> interpolationKernel
+    )
+        : exec_(exec), mesh_(mesh), faceNormalGradKernel_(std::move(interpolationKernel)) {};
+
+    FaceNormalGradient(const Executor& exec, const UnstructuredMesh& mesh, Input input)
+        : exec_(exec), mesh_(mesh),
+          faceNormalGradKernel_(FaceNormalGradientFactory::create(exec, mesh, input)) {};
+
+
+    void
+    faceNormalGrad(const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField) const
+    {
+        faceNormalGradKernel_->faceNormalGrad(volField, surfaceField);
+    }
+
+    SurfaceField<scalar> faceNormalGrad(const VolumeField<scalar>& volField) const
+    {
+        std::string nameInterpolated = "interpolated_" + volField.name;
+        SurfaceField<scalar> surfaceField(
+            exec_, nameInterpolated, mesh_, createCalculatedBCs<SurfaceBoundary<scalar>>(mesh_)
+        );
+        faceNormalGrad(volField, surfaceField);
+        return surfaceField;
+    }
+
+private:
+
+    const Executor exec_;
+    const UnstructuredMesh& mesh_;
+    std::unique_ptr<FaceNormalGradientFactory> faceNormalGradKernel_;
+};
+
+
+} // namespace NeoFOAM

--- a/include/NeoFOAM/finiteVolume/cellCentred/faceNormalGradient/faceNormalGradient.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/faceNormalGradient/faceNormalGradient.hpp
@@ -23,7 +23,6 @@ class FaceNormalGradientFactory :
         FaceNormalGradientFactory,
         Parameters<const Executor&, const UnstructuredMesh&, const Input&>>
 {
-    using ScalarSurfaceField = SurfaceField<scalar>;
 
 public:
 
@@ -47,9 +46,11 @@ public:
 
     virtual ~FaceNormalGradientFactory() {} // Virtual destructor
 
-    virtual void
-    faceNormalGrad(const VolumeField<scalar>& volField, ScalarSurfaceField& surfaceField) const = 0;
+    virtual void faceNormalGrad(
+        const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField
+    ) const = 0;
 
+    virtual const SurfaceField<scalar>& deltaCoeffs() const = 0;
 
     // Pure virtual function for cloning
     virtual std::unique_ptr<FaceNormalGradientFactory> clone() const = 0;
@@ -90,6 +91,9 @@ public:
     {
         faceNormalGradKernel_->faceNormalGrad(volField, surfaceField);
     }
+
+    const SurfaceField<scalar>& deltaCoeffs() const { return faceNormalGradKernel_->deltaCoeffs(); }
+
 
     SurfaceField<scalar> faceNormalGrad(const VolumeField<scalar>& volField) const
     {

--- a/include/NeoFOAM/finiteVolume/cellCentred/faceNormalGradient/uncorrected.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/faceNormalGradient/uncorrected.hpp
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 NeoFOAM authors
+
+#pragma once
+
+#include "NeoFOAM/core/executor/executor.hpp"
+#include "NeoFOAM/finiteVolume/cellCentred/faceNormalGradient/faceNormalGradient.hpp"
+#include "NeoFOAM/finiteVolume/cellCentred/fields/volumeField.hpp"
+#include "NeoFOAM/finiteVolume/cellCentred/stencil/geometryScheme.hpp"
+#include "NeoFOAM/mesh/unstructured.hpp"
+
+#include <Kokkos_Core.hpp>
+
+#include <functional>
+
+
+namespace NeoFOAM::finiteVolume::cellCentred
+{
+
+
+class Uncorrected : public FaceNormalGradientFactory::Register<Uncorrected>
+{
+
+public:
+
+    Uncorrected(const Executor& exec, const UnstructuredMesh& mesh, Input input);
+
+    Uncorrected(const Executor& exec, const UnstructuredMesh& mesh);
+
+    static std::string name() { return "uncorrected"; }
+
+    static std::string doc() { return "Uncorrected interpolation"; }
+
+    static std::string schema() { return "none"; }
+
+    virtual void faceNormalGrad(
+        const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField
+    ) const override;
+
+    std::unique_ptr<FaceNormalGradientFactory> clone() const override;
+
+private:
+
+    const std::shared_ptr<GeometryScheme> geometryScheme_;
+};
+
+} // namespace NeoFOAM

--- a/include/NeoFOAM/finiteVolume/cellCentred/faceNormalGradient/uncorrected.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/faceNormalGradient/uncorrected.hpp
@@ -37,6 +37,8 @@ public:
         const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField
     ) const override;
 
+    virtual const SurfaceField<scalar>& deltaCoeffs() const override;
+
     std::unique_ptr<FaceNormalGradientFactory> clone() const override;
 
 private:

--- a/include/NeoFOAM/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
@@ -21,20 +21,20 @@ namespace NeoFOAM::finiteVolume::cellCentred
 class SurfaceInterpolationFactory :
     public NeoFOAM::RuntimeSelectionFactory<
         SurfaceInterpolationFactory,
-        Parameters<const Executor&, const UnstructuredMesh&, Input>>
+        Parameters<const Executor&, const UnstructuredMesh&, const Input&>>
 {
     using ScalarSurfaceField = SurfaceField<scalar>;
 
 public:
 
     static std::unique_ptr<SurfaceInterpolationFactory>
-    create(const Executor& exec, const UnstructuredMesh& uMesh, Input inputs)
+    create(const Executor& exec, const UnstructuredMesh& uMesh, const Input& inputs)
     {
         // input is dictionary the key is "interpolation"
         std::string key =
             (std::holds_alternative<NeoFOAM::Dictionary>(inputs))
                 ? std::get<NeoFOAM::Dictionary>(inputs).get<std::string>("surfaceInterpolation")
-                : std::get<NeoFOAM::TokenList>(inputs).get<std::string>(0);
+                : std::get<NeoFOAM::TokenList>(inputs).next<std::string>();
 
         keyExistsOrError(key);
         return table().at(key)(exec, uMesh, inputs);
@@ -86,7 +86,7 @@ public:
     )
         : exec_(exec), mesh_(mesh), interpolationKernel_(std::move(interpolationKernel)) {};
 
-    SurfaceInterpolation(const Executor& exec, const UnstructuredMesh& mesh, Input input)
+    SurfaceInterpolation(const Executor& exec, const UnstructuredMesh& mesh, const Input& input)
         : exec_(exec), mesh_(mesh),
           interpolationKernel_(SurfaceInterpolationFactory::create(exec, mesh, input)) {};
 

--- a/include/NeoFOAM/finiteVolume/cellCentred/operators/ddtOperator.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/operators/ddtOperator.hpp
@@ -21,7 +21,7 @@ class DdtOperator : public dsl::OperatorMixin<VolumeField<scalar>>
 public:
 
     DdtOperator(dsl::Operator::Type termType, VolumeField<scalar>& field)
-        : dsl::OperatorMixin<VolumeField<scalar>>(field.exec(), field, termType),
+        : dsl::OperatorMixin<VolumeField<scalar>>(field.exec(), dsl::Coeff(1.0), field, termType),
           sparsityPattern_(SparsityPattern::readOrCreate(field.mesh())) {
 
           };

--- a/include/NeoFOAM/finiteVolume/cellCentred/operators/divOperator.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/operators/divOperator.hpp
@@ -26,11 +26,11 @@ class DivOperatorFactory :
 public:
 
     static std::unique_ptr<DivOperatorFactory>
-    create(const Executor& exec, const UnstructuredMesh& uMesh, Input inputs)
+    create(const Executor& exec, const UnstructuredMesh& uMesh, const Input& inputs)
     {
         std::string key = (std::holds_alternative<Dictionary>(inputs))
                             ? std::get<Dictionary>(inputs).get<std::string>("DivOperator")
-                            : std::get<TokenList>(inputs).popFront<std::string>();
+                            : std::get<TokenList>(inputs).next<std::string>();
         keyExistsOrError(key);
         return table().at(key)(exec, uMesh, inputs);
     }

--- a/include/NeoFOAM/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp
@@ -29,31 +29,44 @@ public:
 
 
     virtual void
-    div(VolumeField<scalar>& divPhi, const SurfaceField<scalar>& faceFlux, VolumeField<scalar>& phi
-    ) override;
+    div(VolumeField<scalar>& divPhi,
+        const SurfaceField<scalar>& faceFlux,
+        VolumeField<scalar>& phi,
+        const dsl::Coeff operatorScaling) override;
 
     virtual void
     div(la::LinearSystem<scalar, localIdx>& ls,
         const SurfaceField<scalar>& faceFlux,
-        VolumeField<scalar>& phi) override;
+        VolumeField<scalar>& phi,
+        const dsl::Coeff operatorScaling) override;
 
     virtual void
-    div(Field<scalar>& divPhi, const SurfaceField<scalar>& faceFlux, VolumeField<scalar>& phi
-    ) override;
+    div(Field<scalar>& divPhi,
+        const SurfaceField<scalar>& faceFlux,
+        VolumeField<scalar>& phi,
+        const dsl::Coeff operatorScaling) override;
 
     virtual VolumeField<scalar>
-    div(const SurfaceField<scalar>& faceFlux, VolumeField<scalar>& phi) override;
+    div(const SurfaceField<scalar>& faceFlux,
+        VolumeField<scalar>& phi,
+        const dsl::Coeff operatorScaling) override;
 
     virtual void
-    div(VolumeField<Vector>& divPhi, const SurfaceField<scalar>& faceFlux, VolumeField<Vector>& phi
-    ) override;
+    div(VolumeField<Vector>& divPhi,
+        const SurfaceField<scalar>& faceFlux,
+        VolumeField<Vector>& phi,
+        const dsl::Coeff operatorScaling) override;
 
     virtual void
-    div(Field<Vector>& divPhi, const SurfaceField<scalar>& faceFlux, VolumeField<Vector>& phi
-    ) override;
+    div(Field<Vector>& divPhi,
+        const SurfaceField<scalar>& faceFlux,
+        VolumeField<Vector>& phi,
+        const dsl::Coeff operatorScaling) override;
 
     virtual VolumeField<Vector>
-    div(const SurfaceField<scalar>& faceFlux, VolumeField<Vector>& phi) override;
+    div(const SurfaceField<scalar>& faceFlux,
+        VolumeField<Vector>& phi,
+        const dsl::Coeff operatorScaling) override;
 
     std::unique_ptr<DivOperatorFactory> clone() const override;
 

--- a/include/NeoFOAM/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp
@@ -36,6 +36,12 @@ public:
         Field<scalar>& lapPhi, const SurfaceField<scalar>& gamma, VolumeField<scalar>& phi
     ) override;
 
+    virtual void laplacian(
+        la::LinearSystem<scalar, localIdx>& ls,
+        const SurfaceField<scalar>& gamma,
+        VolumeField<scalar>& phi
+    ) override;
+
     std::unique_ptr<LaplacianOperatorFactory> clone() const override;
 
 private:

--- a/include/NeoFOAM/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp
@@ -8,6 +8,7 @@
 #include "NeoFOAM/mesh/unstructured.hpp"
 #include "NeoFOAM/finiteVolume/cellCentred/operators/laplacianOperator.hpp"
 #include "NeoFOAM/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp"
+#include "NeoFOAM/finiteVolume/cellCentred/faceNormalGradient/faceNormalGradient.hpp"
 #include "NeoFOAM/finiteVolume/cellCentred/operators/sparsityPattern.hpp"
 
 namespace NeoFOAM::finiteVolume::cellCentred
@@ -31,11 +32,16 @@ public:
         VolumeField<scalar>& lapPhi, const SurfaceField<scalar>& gamma, VolumeField<scalar>& phi
     ) override;
 
+    virtual void laplacian(
+        Field<scalar>& lapPhi, const SurfaceField<scalar>& gamma, VolumeField<scalar>& phi
+    ) override;
+
     std::unique_ptr<LaplacianOperatorFactory> clone() const override;
 
 private:
 
     SurfaceInterpolation surfaceInterpolation_;
+    FaceNormalGradient faceNormalGradient_;
     const std::shared_ptr<SparsityPattern> sparsityPattern_;
 };
 

--- a/include/NeoFOAM/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2024 NeoFOAM authors
+
+#pragma once
+
+#include "NeoFOAM/fields/field.hpp"
+#include "NeoFOAM/core/executor/executor.hpp"
+#include "NeoFOAM/mesh/unstructured.hpp"
+#include "NeoFOAM/finiteVolume/cellCentred/operators/laplacianOperator.hpp"
+#include "NeoFOAM/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp"
+#include "NeoFOAM/finiteVolume/cellCentred/operators/sparsityPattern.hpp"
+
+namespace NeoFOAM::finiteVolume::cellCentred
+{
+
+class GaussGreenLaplacian : public LaplacianOperatorFactory::Register<GaussGreenLaplacian>
+{
+public:
+
+    static std::string name() { return "Gauss"; }
+
+    static std::string doc() { return "Gauss-Green Divergence"; }
+
+    static std::string schema() { return "none"; }
+
+    GaussGreenLaplacian(const Executor& exec, const UnstructuredMesh& mesh, const Input& inputs);
+
+    la::LinearSystem<scalar, localIdx> createEmptyLinearSystem() const override;
+
+    virtual void laplacian(
+        VolumeField<scalar>& lapPhi, const SurfaceField<scalar>& gamma, VolumeField<scalar>& phi
+    ) override;
+
+    std::unique_ptr<LaplacianOperatorFactory> clone() const override;
+
+private:
+
+    SurfaceInterpolation surfaceInterpolation_;
+    const std::shared_ptr<SparsityPattern> sparsityPattern_;
+};
+
+} // namespace NeoFOAM

--- a/include/NeoFOAM/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp
@@ -29,17 +29,24 @@ public:
     la::LinearSystem<scalar, localIdx> createEmptyLinearSystem() const override;
 
     virtual void laplacian(
-        VolumeField<scalar>& lapPhi, const SurfaceField<scalar>& gamma, VolumeField<scalar>& phi
+        VolumeField<scalar>& lapPhi,
+        const SurfaceField<scalar>& gamma,
+        VolumeField<scalar>& phi,
+        const dsl::Coeff operatorScaling
     ) override;
 
     virtual void laplacian(
-        Field<scalar>& lapPhi, const SurfaceField<scalar>& gamma, VolumeField<scalar>& phi
+        Field<scalar>& lapPhi,
+        const SurfaceField<scalar>& gamma,
+        VolumeField<scalar>& phi,
+        const dsl::Coeff operatorScaling
     ) override;
 
     virtual void laplacian(
         la::LinearSystem<scalar, localIdx>& ls,
         const SurfaceField<scalar>& gamma,
-        VolumeField<scalar>& phi
+        VolumeField<scalar>& phi,
+        const dsl::Coeff operatorScaling
     ) override;
 
     std::unique_ptr<LaplacianOperatorFactory> clone() const override;

--- a/include/NeoFOAM/finiteVolume/cellCentred/operators/laplacianOperator.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/operators/laplacianOperator.hpp
@@ -158,8 +158,8 @@ public:
         if (std::holds_alternative<NeoFOAM::Dictionary>(input))
         {
             auto dict = std::get<NeoFOAM::Dictionary>(input);
-            std::string schemeName = "div(" + gamma_.name + "," + field_.name + ")";
-            auto tokens = dict.subDict("divSchemes").get<NeoFOAM::TokenList>(schemeName);
+            std::string schemeName = "laplacian(" + gamma_.name + "," + field_.name + ")";
+            auto tokens = dict.subDict("laplacianSchemes").get<NeoFOAM::TokenList>(schemeName);
             laplacianOperatorStrategy_ = LaplacianOperatorFactory::create(exec(), mesh, tokens);
         }
         else

--- a/include/NeoFOAM/finiteVolume/cellCentred/operators/laplacianOperator.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/operators/laplacianOperator.hpp
@@ -53,6 +53,12 @@ public:
         Field<scalar>& lapPhi, const SurfaceField<scalar>& gamma, VolumeField<scalar>& phi
     ) = 0;
 
+    virtual void laplacian(
+        la::LinearSystem<scalar, localIdx>& ls,
+        const SurfaceField<scalar>& gamma,
+        VolumeField<scalar>& phi
+    ) = 0;
+
     // Pure virtual function for cloning
     virtual std::unique_ptr<LaplacianOperatorFactory> clone() const = 0;
 
@@ -123,11 +129,11 @@ public:
 
     void implicitOperation(la::LinearSystem<scalar, localIdx>& ls)
     {
-        // if (laplacianOperatorStrategy_ == nullptr)
-        // {
-        //     NF_ERROR_EXIT("LaplacianOperatorStrategy not initialized");
-        // }
-        // laplacianOperatorStrategy_->div(ls, gamma_, field_);
+        if (laplacianOperatorStrategy_ == nullptr)
+        {
+            NF_ERROR_EXIT("LaplacianOperatorStrategy not initialized");
+        }
+        laplacianOperatorStrategy_->laplacian(ls, gamma_, field_);
     }
 
     // void laplacian(Field<scalar>& lapPhi)

--- a/include/NeoFOAM/finiteVolume/cellCentred/operators/laplacianOperator.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/operators/laplacianOperator.hpp
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 NeoFOAM authors
+
+#pragma once
+
+#include "NeoFOAM/fields/field.hpp"
+#include "NeoFOAM/core/runtimeSelectionFactory.hpp"
+#include "NeoFOAM/linearAlgebra/linearSystem.hpp"
+#include "NeoFOAM/core/executor/executor.hpp"
+#include "NeoFOAM/core/input.hpp"
+#include "NeoFOAM/dsl/spatialOperator.hpp"
+#include "NeoFOAM/mesh/unstructured.hpp"
+#include "NeoFOAM/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp"
+
+namespace NeoFOAM::finiteVolume::cellCentred
+{
+
+/* @class Factory class to create divergence operators by a given name using
+ * using NeoFOAMs runTimeFactory mechanism
+ */
+class LaplacianOperatorFactory :
+    public RuntimeSelectionFactory<
+        LaplacianOperatorFactory,
+        Parameters<const Executor&, const UnstructuredMesh&, const Input&>>
+{
+
+public:
+
+    static std::unique_ptr<LaplacianOperatorFactory>
+    create(const Executor& exec, const UnstructuredMesh& uMesh, Input inputs)
+    {
+        std::string key = (std::holds_alternative<Dictionary>(inputs))
+                            ? std::get<Dictionary>(inputs).get<std::string>("LaplacianOperator")
+                            : std::get<TokenList>(inputs).popFront<std::string>();
+        keyExistsOrError(key);
+        return table().at(key)(exec, uMesh, inputs);
+    }
+
+    static std::string name() { return "LaplacianOperatorFactory"; }
+
+    LaplacianOperatorFactory(const Executor& exec, const UnstructuredMesh& mesh)
+        : exec_(exec), mesh_(mesh) {};
+
+    virtual ~LaplacianOperatorFactory() {} // Virtual destructor
+
+    virtual la::LinearSystem<scalar, localIdx> createEmptyLinearSystem() const = 0;
+
+    virtual void laplacian(
+        VolumeField<scalar>& lapPhi, const SurfaceField<scalar>& gamma, VolumeField<scalar>& phi
+    ) = 0;
+
+
+    // Pure virtual function for cloning
+    virtual std::unique_ptr<LaplacianOperatorFactory> clone() const = 0;
+
+protected:
+
+    const Executor exec_;
+
+    const UnstructuredMesh& mesh_;
+};
+
+class LaplacianOperator : public dsl::OperatorMixin<VolumeField<scalar>>
+{
+
+public:
+
+    // copy constructor
+    LaplacianOperator(const LaplacianOperator& divOp)
+        : dsl::OperatorMixin<VolumeField<scalar>>(divOp.exec_, divOp.field_, divOp.type_),
+          gamma_(divOp.gamma_),
+          laplacianOperatorStrategy_(
+              divOp.laplacianOperatorStrategy_ ? divOp.laplacianOperatorStrategy_->clone() : nullptr
+          ) {};
+
+    LaplacianOperator(
+        dsl::Operator::Type termType,
+        const SurfaceField<scalar>& gamma,
+        VolumeField<scalar>& phi,
+        Input input
+    )
+        : dsl::OperatorMixin<VolumeField<scalar>>(phi.exec(), phi, termType), gamma_(gamma),
+          laplacianOperatorStrategy_(LaplacianOperatorFactory::create(exec_, phi.mesh(), input)) {};
+
+    LaplacianOperator(
+        dsl::Operator::Type termType,
+        const SurfaceField<scalar>& gamma,
+        VolumeField<scalar>& phi,
+        std::unique_ptr<LaplacianOperatorFactory> laplacianOperatorStrategy
+    )
+        : dsl::OperatorMixin<VolumeField<scalar>>(phi.exec(), phi, termType), gamma_(gamma),
+          laplacianOperatorStrategy_(std::move(laplacianOperatorStrategy)) {};
+
+    LaplacianOperator(
+        dsl::Operator::Type termType, const SurfaceField<scalar>& gamma, VolumeField<scalar>& phi
+    )
+        : dsl::OperatorMixin<VolumeField<scalar>>(phi.exec(), phi, termType), gamma_(gamma),
+          laplacianOperatorStrategy_(nullptr) {};
+
+
+    void explicitOperation(Field<scalar>& source)
+    {
+        // if (laplacianOperatorStrategy_ == nullptr)
+        // {
+        //     NF_ERROR_EXIT("LaplacianOperatorStrategy not initialized");
+        // }
+        // NeoFOAM::Field<NeoFOAM::scalar> tmpsource(source.exec(), source.size(), 0.0);
+        // laplacianOperatorStrategy_->div(tmpsource, gamma_, field_);
+        // source += tmpsource;
+    }
+
+    la::LinearSystem<scalar, localIdx> createEmptyLinearSystem() const
+    {
+        if (laplacianOperatorStrategy_ == nullptr)
+        {
+            NF_ERROR_EXIT("LaplacianOperatorStrategy not initialized");
+        }
+        return laplacianOperatorStrategy_->createEmptyLinearSystem();
+    }
+
+    void implicitOperation(la::LinearSystem<scalar, localIdx>& ls)
+    {
+        // if (laplacianOperatorStrategy_ == nullptr)
+        // {
+        //     NF_ERROR_EXIT("LaplacianOperatorStrategy not initialized");
+        // }
+        // laplacianOperatorStrategy_->div(ls, gamma_, field_);
+    }
+
+    // void laplacian(Field<scalar>& lapPhi)
+    // {
+    //     laplacianOperatorStrategy_->laplacian(lapPhi, gamma_, getField());
+    // }
+
+    // void laplacian(la::LinearSystem<scalar, localIdx>& ls)
+    // {
+    //     laplacianOperatorStrategy_->laplacian(ls, gamma_, getField());
+    // };
+
+    void laplacian(VolumeField<scalar>& lapPhi)
+    {
+        laplacianOperatorStrategy_->laplacian(lapPhi, gamma_, getField());
+    }
+
+
+    void build(const Input& input)
+    {
+        const UnstructuredMesh& mesh = field_.mesh();
+        if (std::holds_alternative<NeoFOAM::Dictionary>(input))
+        {
+            auto dict = std::get<NeoFOAM::Dictionary>(input);
+            std::string schemeName = "div(" + gamma_.name + "," + field_.name + ")";
+            auto tokens = dict.subDict("divSchemes").get<NeoFOAM::TokenList>(schemeName);
+            laplacianOperatorStrategy_ = LaplacianOperatorFactory::create(exec(), mesh, tokens);
+        }
+        else
+        {
+            auto tokens = std::get<NeoFOAM::TokenList>(input);
+            laplacianOperatorStrategy_ = LaplacianOperatorFactory::create(exec(), mesh, tokens);
+        }
+    }
+
+    std::string getName() const { return "LaplacianOperator"; }
+
+private:
+
+    const SurfaceField<NeoFOAM::scalar>& gamma_;
+
+    std::unique_ptr<LaplacianOperatorFactory> laplacianOperatorStrategy_;
+};
+
+
+} // namespace NeoFOAM

--- a/include/NeoFOAM/finiteVolume/cellCentred/operators/sourceTerm.hpp
+++ b/include/NeoFOAM/finiteVolume/cellCentred/operators/sourceTerm.hpp
@@ -23,7 +23,7 @@ public:
     SourceTerm(
         dsl::Operator::Type termType, VolumeField<scalar>& coefficients, VolumeField<scalar>& field
     )
-        : dsl::OperatorMixin<VolumeField<scalar>>(field.exec(), field, termType),
+        : dsl::OperatorMixin<VolumeField<scalar>>(field.exec(), dsl::Coeff(1.0), field, termType),
           coefficients_(coefficients),
           sparsityPattern_(SparsityPattern::readOrCreate(field.mesh())) {};
 

--- a/include/NeoFOAM/linearAlgebra/ginkgo.hpp
+++ b/include/NeoFOAM/linearAlgebra/ginkgo.hpp
@@ -49,7 +49,7 @@ public:
             gkoExec_,
             detail::createGkoMtx(gkoExec_, sys),
             size_t(solverDict_.get<int>("maxIters")),
-            solverDict_.get<float>("relTol")
+            float(solverDict_.get<double>("relTol"))
         );
 
         auto rhs = detail::createGkoDense(gkoExec_, sys.rhs().data(), nrows);

--- a/include/NeoFOAM/timeIntegration/backwardEuler.hpp
+++ b/include/NeoFOAM/timeIntegration/backwardEuler.hpp
@@ -56,14 +56,8 @@ public:
         eqn.implicitOperation(ls, t, dt);
         auto ginkgoLs = NeoFOAM::dsl::ginkgoMatrix(ls, solutionField);
 
-        NeoFOAM::Dictionary fvSolutionDict {};
-        fvSolutionDict.insert("maxIters", 100);
-        fvSolutionDict.insert("relTol", float(1e-8));
 
-        auto internalFieldSpan = solutionField.internalField().span();
-
-
-        NeoFOAM::la::ginkgo::BiCGStab<ValueType> solver(solutionField.exec(), fvSolutionDict);
+        NeoFOAM::la::ginkgo::BiCGStab<ValueType> solver(solutionField.exec(), this->solutionDict_);
         solver.solve(ginkgoLs, solutionField.internalField());
 
         // check if executor is GPU

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,9 +38,11 @@ target_sources(
           "finiteVolume/cellCentred/boundary/boundary.cpp"
           "finiteVolume/cellCentred/operators/gaussGreenGrad.cpp"
           "finiteVolume/cellCentred/operators/gaussGreenDiv.cpp"
+          "finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp"
           "finiteVolume/cellCentred/operators/sparsityPattern.cpp"
           "finiteVolume/cellCentred/interpolation/linear.cpp"
           "finiteVolume/cellCentred/interpolation/upwind.cpp"
+          "finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp"
           "timeIntegration/timeIntegration.cpp"
           "timeIntegration/rungeKutta.cpp")
 

--- a/src/core/tokenList.cpp
+++ b/src/core/tokenList.cpp
@@ -5,6 +5,18 @@
 
 namespace NeoFOAM
 {
+void logOutRange(
+    const std::out_of_range& e, const std::size_t& key, const std::vector<std::any>& data
+)
+{
+    std::cerr << "Index is out of bounds: " << key << " \n"
+              << "the size is :" << data.size() << " \n"
+              << e.what() << std::endl;
+}
+
+TokenList::TokenList() : data_(), nextIndex_(0) {}
+
+TokenList::TokenList(const TokenList& other) : data_(other.data_), nextIndex_(other.nextIndex_) {}
 
 TokenList::TokenList(const std::vector<std::any>& data, size_t nextIndex)
     : data_(data), nextIndex_(nextIndex)

--- a/src/core/tokenList.cpp
+++ b/src/core/tokenList.cpp
@@ -6,7 +6,13 @@
 namespace NeoFOAM
 {
 
-TokenList::TokenList(const std::initializer_list<std::any>& initList) : data_(initList) {}
+TokenList::TokenList(const std::vector<std::any>& data, size_t nextIndex)
+    : data_(data), nextIndex_(nextIndex)
+{}
+
+TokenList::TokenList(const std::initializer_list<std::any>& initList)
+    : data_(initList), nextIndex_(0)
+{}
 
 void TokenList::insert(const std::any& value) { data_.push_back(value); }
 

--- a/src/dsl/spatialOperator.cpp
+++ b/src/dsl/spatialOperator.cpp
@@ -15,6 +15,12 @@ SpatialOperator::SpatialOperator(SpatialOperator&& eqnOperator)
     : model_ {std::move(eqnOperator.model_)}
 {}
 
+SpatialOperator& SpatialOperator::operator=(const SpatialOperator& eqnOperator)
+{
+    model_ = eqnOperator.model_->clone();
+    return *this;
+}
+
 void SpatialOperator::explicitOperation(Field<scalar>& source)
 {
     model_->explicitOperation(source);

--- a/src/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
+++ b/src/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 NeoFOAM authors
+
+#include <memory>
+
+#include "NeoFOAM/finiteVolume/cellCentred/faceNormalGradient/uncorrected.hpp"
+#include "NeoFOAM/core/parallelAlgorithms.hpp"
+
+namespace NeoFOAM::finiteVolume::cellCentred
+{
+
+void computeFaceNormalGrad(
+    const VolumeField<scalar>& volField,
+    const std::shared_ptr<GeometryScheme> geometryScheme,
+    SurfaceField<scalar>& surfaceField
+)
+{
+    const UnstructuredMesh& mesh = surfaceField.mesh();
+    const auto& exec = surfaceField.exec();
+
+    const auto [owner, neighbour, surfFaceCells] =
+        spans(mesh.faceOwner(), mesh.faceNeighbour(), mesh.boundaryMesh().faceCells());
+
+
+    const auto [phif, phi, phiBCValue, nonOrthDeltaCoeffs] = spans(
+        surfaceField.internalField(),
+        volField.internalField(),
+        volField.boundaryField().value(),
+        geometryScheme->nonOrthDeltaCoeffs().internalField()
+    );
+
+    size_t nInternalFaces = mesh.nInternalFaces();
+
+    NeoFOAM::parallelFor(
+        exec,
+        {0, nInternalFaces},
+        KOKKOS_LAMBDA(const size_t facei) {
+            phif[facei] = nonOrthDeltaCoeffs[facei] * (phi[neighbour[facei]] - phi[owner[facei]]);
+        }
+    );
+
+    NeoFOAM::parallelFor(
+        exec,
+        {nInternalFaces, phif.size()},
+        KOKKOS_LAMBDA(const size_t facei) {
+            auto faceBCI = facei - nInternalFaces;
+            auto own = static_cast<size_t>(surfFaceCells[faceBCI]);
+
+            phif[facei] = nonOrthDeltaCoeffs[facei] * (phi[own] - phiBCValue[faceBCI]);
+        }
+    );
+}
+
+Uncorrected::Uncorrected(
+    const Executor& exec, const UnstructuredMesh& mesh, [[maybe_unused]] Input input
+)
+    : FaceNormalGradientFactory::Register<Uncorrected>(exec, mesh),
+      geometryScheme_(GeometryScheme::readOrCreate(mesh)) {};
+
+Uncorrected::Uncorrected(const Executor& exec, const UnstructuredMesh& mesh)
+    : FaceNormalGradientFactory::Register<Uncorrected>(exec, mesh),
+      geometryScheme_(GeometryScheme::readOrCreate(mesh)) {};
+
+void Uncorrected::faceNormalGrad(
+    const VolumeField<scalar>& volField, SurfaceField<scalar>& surfaceField
+) const
+{
+    computeFaceNormalGrad(volField, geometryScheme_, surfaceField);
+}
+
+
+std::unique_ptr<FaceNormalGradientFactory> Uncorrected::clone() const
+{
+    return std::make_unique<Uncorrected>(*this);
+}
+
+} // namespace NeoFOAM

--- a/src/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
+++ b/src/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
@@ -46,7 +46,7 @@ void computeFaceNormalGrad(
             auto faceBCI = facei - nInternalFaces;
             auto own = static_cast<size_t>(surfFaceCells[faceBCI]);
 
-            phif[facei] = nonOrthDeltaCoeffs[facei] * (phi[own] - phiBCValue[faceBCI]);
+            phif[facei] = nonOrthDeltaCoeffs[facei] * (phiBCValue[faceBCI] - phi[own]);
         }
     );
 }

--- a/src/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
+++ b/src/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
@@ -68,6 +68,11 @@ void Uncorrected::faceNormalGrad(
     computeFaceNormalGrad(volField, geometryScheme_, surfaceField);
 }
 
+const SurfaceField<scalar>& Uncorrected::deltaCoeffs() const
+{
+    return geometryScheme_->nonOrthDeltaCoeffs();
+}
+
 
 std::unique_ptr<FaceNormalGradientFactory> Uncorrected::clone() const
 {

--- a/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
@@ -12,8 +12,10 @@ GaussGreenLaplacian::GaussGreenLaplacian(
     const Executor& exec, const UnstructuredMesh& mesh, const Input& inputs
 )
     : LaplacianOperatorFactory::Register<GaussGreenLaplacian>(exec, mesh),
-      surfaceInterpolation_(exec, mesh, inputs),
-      sparsityPattern_(SparsityPattern::readOrCreate(mesh)) {};
+      surfaceInterpolation_(exec, mesh, inputs), faceNormalGradient_(exec, mesh, inputs),
+      sparsityPattern_(SparsityPattern::readOrCreate(mesh)) {
+
+      };
 
 
 la::LinearSystem<scalar, localIdx> GaussGreenLaplacian::createEmptyLinearSystem() const
@@ -23,6 +25,12 @@ la::LinearSystem<scalar, localIdx> GaussGreenLaplacian::createEmptyLinearSystem(
 
 void GaussGreenLaplacian::laplacian(
     VolumeField<scalar>& lapPhi, const SurfaceField<scalar>& gamma, VolumeField<scalar>& phi
+) {
+    // computeDiv(faceFlux, phi, surfaceInterpolation_, divPhi);
+};
+
+void GaussGreenLaplacian::laplacian(
+    Field<scalar>& lapPhi, const SurfaceField<scalar>& gamma, VolumeField<scalar>& phi
 ) {
     // computeDiv(faceFlux, phi, surfaceInterpolation_, divPhi);
 };

--- a/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 NeoFOAM authors
+
+#include "NeoFOAM/core/parallelAlgorithms.hpp"
+#include "NeoFOAM/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp"
+
+namespace NeoFOAM::finiteVolume::cellCentred
+{
+
+
+GaussGreenLaplacian::GaussGreenLaplacian(
+    const Executor& exec, const UnstructuredMesh& mesh, const Input& inputs
+)
+    : LaplacianOperatorFactory::Register<GaussGreenLaplacian>(exec, mesh),
+      surfaceInterpolation_(exec, mesh, inputs),
+      sparsityPattern_(SparsityPattern::readOrCreate(mesh)) {};
+
+
+la::LinearSystem<scalar, localIdx> GaussGreenLaplacian::createEmptyLinearSystem() const
+{
+    return sparsityPattern_->linearSystem();
+};
+
+void GaussGreenLaplacian::laplacian(
+    VolumeField<scalar>& lapPhi, const SurfaceField<scalar>& gamma, VolumeField<scalar>& phi
+) {
+    // computeDiv(faceFlux, phi, surfaceInterpolation_, divPhi);
+};
+
+
+std::unique_ptr<LaplacianOperatorFactory> GaussGreenLaplacian::clone() const
+{
+    return std::make_unique<GaussGreenLaplacian>(*this);
+}
+
+
+};

--- a/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
@@ -7,6 +7,80 @@
 namespace NeoFOAM::finiteVolume::cellCentred
 {
 
+void computeLaplacian(
+    const FaceNormalGradient& faceNormalGradient,
+    const SurfaceField<scalar>& gamma,
+    VolumeField<scalar>& phi,
+    Field<scalar>& lapPhi
+)
+{
+    const UnstructuredMesh& mesh = phi.mesh();
+    const auto exec = phi.exec();
+
+    SurfaceField<scalar> faceNormalGrad = faceNormalGradient.faceNormalGrad(phi);
+
+    const auto [owner, neighbour, surfFaceCells] =
+        spans(mesh.faceOwner(), mesh.faceNeighbour(), mesh.boundaryMesh().faceCells());
+
+
+    const auto [result, faceArea, fnGrad, vol] =
+        spans(lapPhi, mesh.magFaceAreas(), faceNormalGrad.internalField(), mesh.cellVolumes());
+
+
+    size_t nInternalFaces = mesh.nInternalFaces();
+
+    // check if the executor is GPU
+    if (std::holds_alternative<SerialExecutor>(exec))
+    {
+        for (size_t i = 0; i < nInternalFaces; i++)
+        {
+            scalar flux = faceArea[i] * fnGrad[i];
+            result[static_cast<size_t>(owner[i])] += flux;
+            result[static_cast<size_t>(neighbour[i])] -= flux;
+        }
+
+        for (size_t i = nInternalFaces; i < fnGrad.size(); i++)
+        {
+            auto own = static_cast<size_t>(surfFaceCells[i - nInternalFaces]);
+            scalar valueOwn = faceArea[i] * fnGrad[i];
+            result[own] += valueOwn;
+        }
+
+        for (size_t celli = 0; celli < mesh.nCells(); celli++)
+        {
+            result[celli] *= 1 / vol[celli];
+        }
+    }
+    else
+    {
+        parallelFor(
+            exec,
+            {0, nInternalFaces},
+            KOKKOS_LAMBDA(const size_t i) {
+                scalar flux = faceArea[i] * fnGrad[i];
+                Kokkos::atomic_add(&result[static_cast<size_t>(owner[i])], flux);
+                Kokkos::atomic_sub(&result[static_cast<size_t>(neighbour[i])], flux);
+            }
+        );
+
+        parallelFor(
+            exec,
+            {nInternalFaces, fnGrad.size()},
+            KOKKOS_LAMBDA(const size_t i) {
+                auto own = static_cast<size_t>(surfFaceCells[i - nInternalFaces]);
+                scalar valueOwn = faceArea[i] * fnGrad[i];
+                Kokkos::atomic_add(&result[own], valueOwn);
+            }
+        );
+
+        parallelFor(
+            exec,
+            {0, mesh.nCells()},
+            KOKKOS_LAMBDA(const size_t celli) { result[celli] *= 1 / vol[celli]; }
+        );
+    }
+}
+
 
 GaussGreenLaplacian::GaussGreenLaplacian(
     const Executor& exec, const UnstructuredMesh& mesh, const Input& inputs
@@ -25,14 +99,16 @@ la::LinearSystem<scalar, localIdx> GaussGreenLaplacian::createEmptyLinearSystem(
 
 void GaussGreenLaplacian::laplacian(
     VolumeField<scalar>& lapPhi, const SurfaceField<scalar>& gamma, VolumeField<scalar>& phi
-) {
-    // computeDiv(faceFlux, phi, surfaceInterpolation_, divPhi);
+)
+{
+    computeLaplacian(faceNormalGradient_, gamma, phi, lapPhi.internalField());
 };
 
 void GaussGreenLaplacian::laplacian(
     Field<scalar>& lapPhi, const SurfaceField<scalar>& gamma, VolumeField<scalar>& phi
-) {
-    // computeDiv(faceFlux, phi, surfaceInterpolation_, divPhi);
+)
+{
+    computeLaplacian(faceNormalGradient_, gamma, phi, lapPhi);
 };
 
 

--- a/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
@@ -25,13 +25,10 @@ void BasicGeometryScheme::updateWeights(const Executor& exec, SurfaceField<scala
         exec,
         {0, mesh_.nInternalFaces()},
         KOKKOS_LAMBDA(const size_t facei) {
-            // Note: mag in the dot-product.
-            // For all valid meshes, the non-orthogonality will be less than
-            // 90 deg and the dot-product will be positive.  For invalid
-            // meshes (d & s <= 0), this will stabilise the calculation
-            // but the result will be poor.
-            scalar sfdOwn = mag(sf[facei] & (cf[facei] - c[static_cast<size_t>(owner[facei])]));
-            scalar sfdNei = mag(sf[facei] & (c[static_cast<size_t>(neighbour[facei])] - cf[facei]));
+            scalar sfdOwn =
+                std::abs(sf[facei] & (cf[facei] - c[static_cast<size_t>(owner[facei])]));
+            scalar sfdNei =
+                std::abs(sf[facei] & (c[static_cast<size_t>(neighbour[facei])] - cf[facei]));
 
             if (std::abs(sfdOwn + sfdNei) > ROOTVSMALL)
             {
@@ -55,7 +52,33 @@ void BasicGeometryScheme::updateDeltaCoeffs(
     [[maybe_unused]] const Executor& exec, [[maybe_unused]] SurfaceField<scalar>& deltaCoeffs
 )
 {
-    NF_ERROR_EXIT("Not implemented");
+    const auto [owner, neighbour, surfFaceCells] =
+        spans(mesh_.faceOwner(), mesh_.faceNeighbour(), mesh_.boundaryMesh().faceCells());
+
+
+    const auto [cf, cellCentre] = spans(mesh_.faceCentres(), mesh_.cellCentres());
+
+    auto deltaCoeff = deltaCoeffs.internalField().span();
+
+    parallelFor(
+        exec,
+        {0, mesh_.nInternalFaces()},
+        KOKKOS_LAMBDA(const size_t facei) {
+            Vector cellToCellDist = cellCentre[neighbour[facei]] - cellCentre[owner[facei]];
+            deltaCoeff[facei] = 1.0 / mag(cellToCellDist);
+        }
+    );
+
+    parallelFor(
+        exec,
+        {nInternalFaces, nonOrthDeltaCoeff.size()},
+        KOKKOS_LAMBDA(const size_t facei) {
+            auto own = static_cast<size_t>(surfFaceCells[facei - nInternalFaces]);
+            Vector cellToCellDist = cf[facei] - cellCentre[own];
+
+            deltaCoeff[facei] = 1.0 / mag(cellToCellDist);
+        }
+    );
 }
 
 
@@ -63,7 +86,46 @@ void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
     [[maybe_unused]] const Executor& exec, [[maybe_unused]] SurfaceField<scalar>& nonOrthDeltaCoeffs
 )
 {
-    NF_ERROR_EXIT("Not implemented");
+    const auto [owner, neighbour, surfFaceCells] =
+        spans(mesh_.faceOwner(), mesh_.faceNeighbour(), mesh_.boundaryMesh().faceCells());
+
+
+    const auto [cf, cellCentre, faceAreaVector, faceArea] =
+        spans(mesh_.faceCentres(), mesh_.cellCentres(), mesh_.faceAreas(), mesh_.magFaceAreas());
+
+    auto nonOrthDeltaCoeff = nonOrthDeltaCoeffs.internalField().span();
+    fill(nonOrthDeltaCoeffs.internalField(), 0.0);
+
+    const size_t nInternalFaces = mesh_.nInternalFaces();
+
+    parallelFor(
+        exec,
+        {0, nInternalFaces},
+        KOKKOS_LAMBDA(const size_t facei) {
+            Vector cellToCellDist = cellCentre[neighbour[facei]] - cellCentre[owner[facei]];
+            Vector faceNormal = 1 / faceArea[facei] * faceAreaVector[facei];
+
+            scalar orthoDist = faceNormal & cellToCellDist;
+
+
+            nonOrthDeltaCoeff[facei] = 1.0 / std::max(orthoDist, 0.05 * mag(cellToCellDist));
+        }
+    );
+
+    parallelFor(
+        exec,
+        {nInternalFaces, nonOrthDeltaCoeff.size()},
+        KOKKOS_LAMBDA(const size_t facei) {
+            auto own = static_cast<size_t>(surfFaceCells[facei - nInternalFaces]);
+            Vector cellToCellDist = cf[facei] - cellCentre[own];
+            Vector faceNormal = 1 / faceArea[facei] * faceAreaVector[facei];
+
+            scalar orthoDist = faceNormal & cellToCellDist;
+
+
+            nonOrthDeltaCoeff[facei] = 1.0 / std::max(orthoDist, 0.05 * mag(cellToCellDist));
+        }
+    );
 }
 
 

--- a/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
@@ -69,9 +69,11 @@ void BasicGeometryScheme::updateDeltaCoeffs(
         }
     );
 
+    const size_t nInternalFaces = mesh_.nInternalFaces();
+
     parallelFor(
         exec,
-        {nInternalFaces, nonOrthDeltaCoeff.size()},
+        {nInternalFaces, deltaCoeff.size()},
         KOKKOS_LAMBDA(const size_t facei) {
             auto own = static_cast<size_t>(surfFaceCells[facei - nInternalFaces]);
             Vector cellToCellDist = cf[facei] - cellCentre[own];

--- a/src/finiteVolume/cellCentred/stencil/cellToFaceStencil.cpp
+++ b/src/finiteVolume/cellCentred/stencil/cellToFaceStencil.cpp
@@ -77,17 +77,6 @@ SegmentedField<localIdx, localIdx> CellToFaceStencil::computeStencil() const
         }
     );
 
-    // // print elements per cell
-    // auto stencilView = stencil.view();
-    // for (size_t i = 0; i < nCells; i++)
-    // {
-    //     std::cout << "Cell " << i << " has " << nFacesPerCellSpan[i] << " faces" << std::endl;
-    //     for (auto& values: stencilView.span(i))
-    //     {
-    //         std::cout << "Face " << values << std::endl;
-    //     }
-    // }
-
     return stencil;
 }
 

--- a/src/finiteVolume/cellCentred/stencil/geometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/geometryScheme.cpp
@@ -107,8 +107,8 @@ void GeometryScheme::update()
         [&](const auto& exec)
         {
             kernel_->updateWeights(exec, weights_);
-            // kernel_->updateDeltaCoeffs(exec, deltaCoeffs_);
-            // kernel_->updateNonOrthDeltaCoeffs(exec, nonOrthDeltaCoeffs_);
+            kernel_->updateDeltaCoeffs(exec, deltaCoeffs_);
+            kernel_->updateNonOrthDeltaCoeffs(exec, nonOrthDeltaCoeffs_);
             // kernel_->updateNonOrthCorrectionVectors(exec, nonOrthCorrectionVectors_);
         },
         exec_

--- a/src/mesh/unstructured/unstructuredMesh.cpp
+++ b/src/mesh/unstructured/unstructuredMesh.cpp
@@ -116,7 +116,7 @@ UnstructuredMesh create1DUniformMesh(const Executor exec, const size_t nCells)
     scalar meshSpacing = (rightBoundary[0] - leftBoundary[0]) / static_cast<scalar>(nCells);
     auto hostExec = SerialExecutor {};
     vectorField meshPointsHost(hostExec, nCells + 1, {0.0, 0.0, 0.0});
-    meshPointsHost[0] = leftBoundary;
+    meshPointsHost[nCells - 1] = leftBoundary;
     meshPointsHost[nCells] = rightBoundary;
     auto meshPoints = meshPointsHost.copyToExecutor(exec);
 
@@ -125,9 +125,9 @@ UnstructuredMesh create1DUniformMesh(const Executor exec, const size_t nCells)
     auto leftBoundaryX = leftBoundary[0];
     parallelFor(
         exec,
-        {1, nCells},
+        {0, nCells - 1},
         KOKKOS_LAMBDA(const size_t i) {
-            meshPointsSpan[i][0] = leftBoundaryX + static_cast<scalar>(i) * meshSpacing;
+            meshPointsSpan[i][0] = leftBoundaryX + static_cast<scalar>(i + 1) * meshSpacing;
         }
     );
 
@@ -139,37 +139,34 @@ UnstructuredMesh create1DUniformMesh(const Executor exec, const size_t nCells)
         exec,
         {0, nCells},
         KOKKOS_LAMBDA(const size_t i) {
-            cellCentersSpan[i][0] = 0.5 * (meshPointsSpan[i][0] + meshPointsSpan[i + 1][0]);
+            cellCentersSpan[i][0] = 0.5 * meshSpacing + meshSpacing * static_cast<scalar>(i);
         }
     );
 
 
     vectorField faceAreasHost(hostExec, nCells + 1, {1.0, 0.0, 0.0});
-    faceAreasHost[0] = {-1.0, 0.0, 0.0}; // left boundary face
+    faceAreasHost[nCells - 1] = {-1.0, 0.0, 0.0}; // left boundary face
     auto faceAreas = faceAreasHost.copyToExecutor(exec);
 
     vectorField faceCenters(exec, meshPoints);
     scalarField magFaceAreas(exec, nCells + 1, 1.0);
 
     labelField faceOwnerHost(hostExec, nCells + 1);
-    faceOwnerHost[0] = 0; // left boundary face
+    labelField faceNeighbor(exec, nCells - 1);
+    faceOwnerHost[nCells - 1] = 0;      // left boundary face
+    faceOwnerHost[nCells] = nCells - 1; // right boundary face
     auto faceOwner = faceOwnerHost.copyToExecutor(exec);
 
-    // loop over internal faces and right boundary face
+    // loop over internal faces
     auto faceOwnerSpan = faceOwner.span();
-    parallelFor(
-        exec,
-        {1, nCells + 1},
-        KOKKOS_LAMBDA(const size_t i) { faceOwnerSpan[i] = static_cast<label>(i - 1); }
-    );
-
-    labelField faceNeighbor(exec, nCells + 1);
-
     auto faceNeighborSpan = faceNeighbor.span();
     parallelFor(
         exec,
-        {0, nCells},
-        KOKKOS_LAMBDA(const size_t i) { faceNeighborSpan[i] = static_cast<label>(i); }
+        {0, nCells - 1},
+        KOKKOS_LAMBDA(const size_t i) {
+            faceOwnerSpan[i] = static_cast<label>(i);
+            faceNeighborSpan[i] = static_cast<label>(i + 1);
+        }
     );
 
     vectorField deltaHost(hostExec, 2);

--- a/test/core/tokenList.cpp
+++ b/test/core/tokenList.cpp
@@ -50,6 +50,17 @@ TEST_CASE("tokenList")
         REQUIRE(tokenList.size() == 0);
     }
 
+    SECTION("Next Token")
+    {
+        tokenList =
+            NeoFOAM::TokenList({NeoFOAM::label(1), NeoFOAM::scalar(2.0), std::string("string")});
+        REQUIRE(tokenList.size() == 3);
+        REQUIRE(tokenList.next<NeoFOAM::label>() == 1);
+        REQUIRE(tokenList.next<NeoFOAM::scalar>() == 2.0);
+        REQUIRE(tokenList.next<std::string>() == "string");
+        REQUIRE_THROWS_AS(tokenList.next<NeoFOAM::label>(), std::out_of_range);
+    }
+
     SECTION("Access out of bound index")
     {
         REQUIRE_THROWS_AS(tokenList.get<NeoFOAM::label>(3), std::out_of_range);

--- a/test/dsl/common.hpp
+++ b/test/dsl/common.hpp
@@ -26,9 +26,13 @@ class Dummy : public OperatorMixin
 
 public:
 
-    Dummy(VolumeField& field) : OperatorMixin(field.exec(), field, Operator::Type::Explicit) {}
+    Dummy(VolumeField& field)
+        : OperatorMixin(field.exec(), dsl::Coeff(1.0), field, Operator::Type::Explicit)
+    {}
 
-    Dummy(VolumeField& field, Operator::Type type) : OperatorMixin(field.exec(), field, type) {}
+    Dummy(VolumeField& field, Operator::Type type)
+        : OperatorMixin(field.exec(), dsl::Coeff(1.0), field, type)
+    {}
 
     void explicitOperation(Field& source)
     {
@@ -90,11 +94,12 @@ class TemporalDummy : public OperatorMixin
 
 public:
 
-    TemporalDummy(VolumeField& field) : OperatorMixin(field.exec(), field, Operator::Type::Explicit)
+    TemporalDummy(VolumeField& field)
+        : OperatorMixin(field.exec(), dsl::Coeff(1.0), field, Operator::Type::Explicit)
     {}
 
     TemporalDummy(VolumeField& field, Operator::Type type)
-        : OperatorMixin(field.exec(), field, type)
+        : OperatorMixin(field.exec(), dsl::Coeff(1.0), field, type)
     {}
 
     void explicitOperation(Field& source, NeoFOAM::scalar t, NeoFOAM::scalar dt)

--- a/test/finiteVolume/CMakeLists.txt
+++ b/test/finiteVolume/CMakeLists.txt
@@ -4,4 +4,5 @@
 add_subdirectory(cellCentred/fields)
 add_subdirectory(cellCentred/boundary)
 add_subdirectory(cellCentred/interpolation)
+add_subdirectory(cellCentred/faceNormalGradient)
 add_subdirectory(cellCentred/operator)

--- a/test/finiteVolume/cellCentred/faceNormalGradient/CMakeLists.txt
+++ b/test/finiteVolume/cellCentred/faceNormalGradient/CMakeLists.txt
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Unlicense
+# SPDX-FileCopyrightText: 2024 NeoFOAM authors
+
+neofoam_unit_test(uncorrected)

--- a/test/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
+++ b/test/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2024 NeoFOAM authors
+
+#define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
+                            // a custom main
+#include <catch2/catch_session.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators_all.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include "NeoFOAM/NeoFOAM.hpp"
+
+using NeoFOAM::finiteVolume::cellCentred::SurfaceInterpolation;
+using NeoFOAM::finiteVolume::cellCentred::VolumeField;
+using NeoFOAM::finiteVolume::cellCentred::SurfaceField;
+
+namespace NeoFOAM
+{
+
+template<typename T>
+using I = std::initializer_list<T>;
+
+TEST_CASE("laplacianOperator")
+{
+    NeoFOAM::Executor exec = GENERATE(NeoFOAM::Executor(NeoFOAM::SerialExecutor {})
+                                      // NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
+                                      // NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
+    );
+
+    std::string execName = std::visit([](auto e) { return e.name(); }, exec);
+
+    auto mesh = create1DUniformMesh(exec, 10);
+    auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<NeoFOAM::scalar>>(mesh);
+
+    fvcc::SurfaceField<NeoFOAM::scalar> phif(exec, "phif", mesh, surfaceBCs);
+    fill(phif.internalField(), 0.0);
+
+    auto volumeBCs = fvcc::createCalculatedBCs<fvcc::VolumeBoundary<NeoFOAM::scalar>>(mesh);
+    fvcc::VolumeField<NeoFOAM::scalar> phi(exec, "phi", mesh, volumeBCs);
+    NeoFOAM::parallelFor(
+        phi.internalField(), KOKKOS_LAMBDA(const size_t i) { return scalar(i + 1); }
+    );
+    phi.boundaryField().value() = NeoFOAM::Field<NeoFOAM::scalar>(exec, {0.5, 9.5});
+
+    SECTION("Construct from Token" + execName)
+    {
+        NeoFOAM::Input input = NeoFOAM::TokenList({std::string("uncorrected")});
+        fvcc::FaceNormalGradient uncorrected(exec, mesh, input);
+    }
+
+    SECTION("faceNormalGrad" + execName)
+    {
+        NeoFOAM::Input input = NeoFOAM::TokenList({std::string("uncorrected")});
+        fvcc::FaceNormalGradient uncorrected(exec, mesh, input);
+        uncorrected.faceNormalGrad(phi, phif);
+
+        auto phifHost = phif.internalField().copyToHost();
+        auto sPhif = phifHost.span();
+        for (size_t i = 0; i < 11; i++)
+        {
+            REQUIRE(sPhif[i] == Catch::Approx(10.0).margin(1e-8));
+        }
+    }
+}
+}

--- a/test/finiteVolume/cellCentred/operator/CMakeLists.txt
+++ b/test/finiteVolume/cellCentred/operator/CMakeLists.txt
@@ -2,3 +2,4 @@
 # SPDX-FileCopyrightText: 2024 NeoFOAM authors
 
 neofoam_unit_test(divOperator)
+neofoam_unit_test(laplacianOperator)

--- a/test/finiteVolume/cellCentred/operator/laplacianOperator.cpp
+++ b/test/finiteVolume/cellCentred/operator/laplacianOperator.cpp
@@ -21,7 +21,7 @@ namespace NeoFOAM
 template<typename T>
 using I = std::initializer_list<T>;
 
-TEST_CASE("laplacianOperator")
+TEST_CASE("laplacianOperator fixedValue")
 {
     const size_t nCells = 10;
     NeoFOAM::Executor exec = GENERATE(
@@ -38,69 +38,170 @@ TEST_CASE("laplacianOperator")
     fvcc::SurfaceField<NeoFOAM::scalar> gamma(exec, "gamma", mesh, surfaceBCs);
     fill(gamma.internalField(), 2.0);
 
+    SECTION("fixedValue")
+    {
+        std::vector<fvcc::VolumeBoundary<NeoFOAM::scalar>> bcs;
+        bcs.push_back(fvcc::VolumeBoundary<NeoFOAM::scalar>(
+            mesh,
+            NeoFOAM::Dictionary(
+                {{"type", std::string("fixedValue")}, {"fixedValue", NeoFOAM::scalar(0.5)}}
+            ),
+            0
+        ));
+        bcs.push_back(fvcc::VolumeBoundary<NeoFOAM::scalar>(
+            mesh,
+            NeoFOAM::Dictionary(
+                {{"type", std::string("fixedValue")}, {"fixedValue", NeoFOAM::scalar(10.5)}}
+            ),
+            1
+        ));
 
-    std::vector<fvcc::VolumeBoundary<NeoFOAM::scalar>> bcs;
-    bcs.push_back(fvcc::VolumeBoundary<NeoFOAM::scalar>(
-        mesh,
-        NeoFOAM::Dictionary(
-            {{"type", std::string("fixedValue")}, {"fixedValue", NeoFOAM::scalar(0.5)}}
-        ),
-        0
-    ));
-    bcs.push_back(fvcc::VolumeBoundary<NeoFOAM::scalar>(
-        mesh,
-        NeoFOAM::Dictionary(
-            {{"type", std::string("fixedValue")}, {"fixedValue", NeoFOAM::scalar(10.5)}}
-        ),
-        1
-    ));
+        fvcc::VolumeField<NeoFOAM::scalar> phi(exec, "phi", mesh, bcs);
+        NeoFOAM::parallelFor(
+            phi.internalField(), KOKKOS_LAMBDA(const size_t i) { return scalar(i + 1); }
+        );
+        phi.correctBoundaryConditions();
 
-    fvcc::VolumeField<NeoFOAM::scalar> phi(exec, "phi", mesh, bcs);
-    NeoFOAM::parallelFor(
-        phi.internalField(), KOKKOS_LAMBDA(const size_t i) { return scalar(i + 1); }
+        SECTION("Construct from Token" + execName)
+        {
+            NeoFOAM::Input input = NeoFOAM::TokenList(
+                {std::string("Gauss"), std::string("linear"), std::string("uncorrected")}
+            );
+            fvcc::LaplacianOperator(dsl::Operator::Type::Implicit, gamma, phi, input);
+        }
+
+        SECTION("explicit laplacian operator" + execName)
+        {
+            NeoFOAM::Input input = NeoFOAM::TokenList(
+                {std::string("Gauss"), std::string("linear"), std::string("uncorrected")}
+            );
+            fvcc::LaplacianOperator lapOp(dsl::Operator::Type::Explicit, gamma, phi, input);
+            Field<NeoFOAM::scalar> source(exec, nCells, 0.0);
+            lapOp.explicitOperation(source);
+            auto sourceHost = source.copyToHost();
+            auto sSource = sourceHost.span();
+            for (size_t i = 0; i < nCells; i++)
+            {
+                // the laplacian of a linear function is 0
+                REQUIRE(sourceHost[i] == Catch::Approx(0.0).margin(1e-8));
+            }
+        }
+
+        SECTION("implicit laplacian operator" + execName)
+        {
+            NeoFOAM::Input input = NeoFOAM::TokenList(
+                {std::string("Gauss"), std::string("linear"), std::string("uncorrected")}
+            );
+            fvcc::LaplacianOperator lapOp(dsl::Operator::Type::Explicit, gamma, phi, input);
+            auto ls = lapOp.createEmptyLinearSystem();
+            lapOp.implicitOperation(ls);
+            fvcc::LinearSystem<NeoFOAM::scalar> ls2(
+                phi, ls, fvcc::SparsityPattern::readOrCreate(mesh)
+            );
+
+
+            auto result = ls2 & phi;
+            auto resultHost = result.internalField().copyToHost();
+            auto sResult = resultHost.span();
+            for (size_t celli = 0; celli < sResult.size(); celli++)
+            {
+                // the laplacian of a linear function is 0
+                REQUIRE(sResult[celli] == Catch::Approx(0.0).margin(1e-8));
+            }
+        }
+    }
+}
+
+TEST_CASE("laplacianOperator fixedGradient")
+{
+    const size_t nCells = 10;
+    NeoFOAM::Executor exec = GENERATE(
+        NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );
-    phi.correctBoundaryConditions();
 
-    SECTION("Construct from Token" + execName)
-    {
-        NeoFOAM::Input input = NeoFOAM::TokenList(
-            {std::string("Gauss"), std::string("linear"), std::string("uncorrected")}
-        );
-        fvcc::LaplacianOperator(dsl::Operator::Type::Implicit, gamma, phi, input);
-    }
+    std::string execName = std::visit([](auto e) { return e.name(); }, exec);
 
-    SECTION("explicit laplacian operator" + execName)
+    auto mesh = create1DUniformMesh(exec, nCells);
+    auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<NeoFOAM::scalar>>(mesh);
+
+    fvcc::SurfaceField<NeoFOAM::scalar> gamma(exec, "gamma", mesh, surfaceBCs);
+    fill(gamma.internalField(), 2.0);
+
+    SECTION("fixedGradient")
     {
-        NeoFOAM::Input input = NeoFOAM::TokenList(
-            {std::string("Gauss"), std::string("linear"), std::string("uncorrected")}
+        std::vector<fvcc::VolumeBoundary<NeoFOAM::scalar>> bcs;
+        bcs.push_back(fvcc::VolumeBoundary<NeoFOAM::scalar>(
+            mesh,
+            NeoFOAM::Dictionary(
+                {{"type", std::string("fixedGradient")}, {"fixedGradient", NeoFOAM::scalar(-10.0)}}
+            ),
+            0
+        ));
+        bcs.push_back(fvcc::VolumeBoundary<NeoFOAM::scalar>(
+            mesh,
+            NeoFOAM::Dictionary(
+                {{"type", std::string("fixedGradient")}, {"fixedGradient", NeoFOAM::scalar(10.0)}}
+            ),
+            1
+        ));
+
+        fvcc::VolumeField<NeoFOAM::scalar> phi(exec, "phi", mesh, bcs);
+        NeoFOAM::parallelFor(
+            phi.internalField(), KOKKOS_LAMBDA(const size_t i) { return scalar(i + 1); }
         );
-        fvcc::LaplacianOperator lapOp(dsl::Operator::Type::Explicit, gamma, phi, input);
-        Field<NeoFOAM::scalar> source(exec, nCells, 0.0);
-        lapOp.explicitOperation(source);
-        auto sourceHost = source.copyToHost();
-        auto sSource = sourceHost.span();
-        for (size_t i = 0; i < nCells; i++)
+        phi.correctBoundaryConditions();
+
+        SECTION("Construct from Token" + execName)
         {
-            // the laplacian of a linear function is 0
-            REQUIRE(sourceHost[i] == Catch::Approx(0.0).margin(1e-8));
+            NeoFOAM::Input input = NeoFOAM::TokenList(
+                {std::string("Gauss"), std::string("linear"), std::string("uncorrected")}
+            );
+            fvcc::LaplacianOperator(dsl::Operator::Type::Implicit, gamma, phi, input);
         }
-    }
 
-    SECTION("implicit laplacian operator" + execName)
-    {
-        NeoFOAM::Input input = NeoFOAM::TokenList(
-            {std::string("Gauss"), std::string("linear"), std::string("uncorrected")}
-        );
-        fvcc::LaplacianOperator lapOp(dsl::Operator::Type::Explicit, gamma, phi, input);
-        Field<NeoFOAM::scalar> source(exec, nCells, 0.0);
-        lapOp.explicitOperation(source);
-        auto sourceHost = source.copyToHost();
-        auto sSource = sourceHost.span();
-        for (size_t i = 0; i < nCells; i++)
+        SECTION("explicit laplacian operator" + execName)
         {
-            // the laplacian of a linear function is 0
-            REQUIRE(sourceHost[i] == Catch::Approx(0.0).margin(1e-8));
+            NeoFOAM::Input input = NeoFOAM::TokenList(
+                {std::string("Gauss"), std::string("linear"), std::string("uncorrected")}
+            );
+            fvcc::LaplacianOperator lapOp(dsl::Operator::Type::Explicit, gamma, phi, input);
+            Field<NeoFOAM::scalar> source(exec, nCells, 0.0);
+            lapOp.explicitOperation(source);
+            auto sourceHost = source.copyToHost();
+            auto sSource = sourceHost.span();
+            for (size_t i = 0; i < nCells; i++)
+            {
+                // the laplacian of a linear function is 0
+                REQUIRE(sourceHost[i] == Catch::Approx(0.0).margin(1e-8));
+            }
+        }
+
+        SECTION("implicit laplacian operator" + execName)
+        {
+            NeoFOAM::Input input = NeoFOAM::TokenList(
+                {std::string("Gauss"), std::string("linear"), std::string("uncorrected")}
+            );
+            fvcc::LaplacianOperator lapOp(dsl::Operator::Type::Explicit, gamma, phi, input);
+            auto ls = lapOp.createEmptyLinearSystem();
+            lapOp.implicitOperation(ls);
+            fvcc::LinearSystem<NeoFOAM::scalar> ls2(
+                phi, ls, fvcc::SparsityPattern::readOrCreate(mesh)
+            );
+
+
+            auto result = ls2 & phi;
+            auto resultHost = result.internalField().copyToHost();
+            auto sResult = resultHost.span();
+            for (size_t celli = 0; celli < sResult.size(); celli++)
+            {
+                // the laplacian of a linear function is 0
+                REQUIRE(sResult[celli] == Catch::Approx(0.0).margin(1e-8));
+            }
         }
     }
 }
-}
+
+
+} // namespace NeoFOAM

--- a/test/finiteVolume/cellCentred/operator/laplacianOperator.cpp
+++ b/test/finiteVolume/cellCentred/operator/laplacianOperator.cpp
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2024 NeoFOAM authors
+
+#define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
+                            // a custom main
+#include <catch2/catch_session.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators_all.hpp>
+
+#include "NeoFOAM/NeoFOAM.hpp"
+
+using NeoFOAM::finiteVolume::cellCentred::SurfaceInterpolation;
+using NeoFOAM::finiteVolume::cellCentred::VolumeField;
+using NeoFOAM::finiteVolume::cellCentred::SurfaceField;
+
+namespace NeoFOAM
+{
+
+template<typename T>
+using I = std::initializer_list<T>;
+
+TEST_CASE("laplacianOperator")
+{
+    NeoFOAM::Executor exec = GENERATE(
+        NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
+    );
+
+    std::string execName = std::visit([](auto e) { return e.name(); }, exec);
+
+    auto mesh = create1DUniformMesh(exec, 10);
+    auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<NeoFOAM::scalar>>(mesh);
+
+    fvcc::SurfaceField<NeoFOAM::scalar> gamma(exec, "sf", mesh, surfaceBCs);
+    NeoFOAM::fill(gamma.internalField(), 1.0);
+
+    auto volumeBCs = fvcc::createCalculatedBCs<fvcc::VolumeBoundary<NeoFOAM::scalar>>(mesh);
+    fvcc::VolumeField<NeoFOAM::scalar> phi(exec, "sf", mesh, volumeBCs);
+    NeoFOAM::fill(phi.internalField(), 1.0);
+    // Input input = TokenList({std::string("linear")});
+
+    SECTION("Construct from Token" + execName)
+    {
+        NeoFOAM::Input input = NeoFOAM::TokenList({std::string("Gauss"), std::string("linear")});
+        fvcc::LaplacianOperator(dsl::Operator::Type::Implicit, gamma, phi, input);
+    }
+    // auto linear = SurfaceInterpolation(exec, mesh, input);
+    // std::vector<fvcc::SurfaceBoundary<TestType>> bcs {};
+    // for (auto patchi : I<size_t> {0, 1})
+    // {
+    //     Dictionary dict;
+    //     dict.insert("type", std::string("fixedValue"));
+    //     dict.insert("fixedValue", one<TestType>::value);
+    //     bcs.push_back(fvcc::SurfaceBoundary<TestType>(mesh, dict, patchi));
+    // }
+
+    // auto in = VolumeField<TestType>(exec, "in", mesh, {});
+    // auto out = SurfaceField<TestType>(exec, "out", mesh, bcs);
+
+    // fill(in.internalField(), one<TestType>::value);
+
+    // linear.interpolate(in, out);
+    // out.correctBoundaryConditions();
+
+    // auto outHost = out.internalField().copyToHost();
+    // for (int i = 0; i < out.internalField().size(); i++)
+    // {
+    //     REQUIRE(outHost[i] == one<TestType>::value);
+    // }
+}
+}

--- a/test/timeIntegration/rungeKutta.cpp
+++ b/test/timeIntegration/rungeKutta.cpp
@@ -33,7 +33,9 @@ class YSquared : public OperatorMixin
 
 public:
 
-    YSquared(VolumeField& field) : OperatorMixin(field.exec(), field, Operator::Type::Explicit) {}
+    YSquared(VolumeField& field)
+        : OperatorMixin(field.exec(), dsl::Coeff(1.0), field, Operator::Type::Explicit)
+    {}
 
     void explicitOperation(Field& source) const
     {


### PR DESCRIPTION
# Feature

- [x] Laplacian operator
- [x] faceNormal Gradients
        - [x] uncorrected
- [x] adds BCs contriubtion to implicit BCs
      - all boundary are implmented as mixed BC this way the boundary contribution can be computed with one function dispatch
      - [x] laplacian implicit BCs
      - [] div implicit BCs
- [x] basicGeometric Scheme calculate celltocell distance 
- [x] TokenList are consumed similar to a stream with member function next

# Fixes

- [x] face ordering of 1D mesh
- [x] boundaryFields valueFraction returned refValue_
- [x] fixedGradient accessed out of bounds faceCells
- [x] operators were not scaled within the DSL
