### PR TITLE
Extended AWS CI to use different instances.

### DIFF
--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -61,6 +61,8 @@ jobs:
           pre-runner-script: |
                  #!/bin/bash
                  . /root/spack/share/spack/setup-env.sh
+                 sudo rm /usr/local/cuda
+                 sudo ln -s /usr/local/cuda-12.2 /usr/local/cuda
 
   build-on-aws:
     name: Build on aws

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         instance:
           - TYPE: g4dn.xlarge
-            AMI: ami-0ecaa2016453bc16b
+            AMI: ami-06615d18bfde0a1e7
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -60,10 +60,7 @@ jobs:
             ]
           pre-runner-script: |
                  #!/bin/bash
-                 #. /root/spack/share/spack/setup-env.sh
-                 #spack install node-js
-                 #echo 'module use /usr/share/lmod/lmod/modulefiles/Compilers' >> /root/.bashrc
-                 #echo 'module use /usr/share/lmod/lmod/modulefiles/Compilers' >> /ec2-user/.bashrc
+                 . /root/spack/share/spack/setup-env.sh
 
   build-on-aws:
     name: Build on aws
@@ -91,25 +88,24 @@ jobs:
         shell: bash -i {0}
         run: |
           . /root/spack/share/spack/setup-env.sh
-          spack load cmake
+          spack load cmake@3.30.5
           spack load hip
-          spack load kokkos
+          spack load kokkos@4.3.00
           module load clang/17
           cmake --version
-          CC=clang \
-          CXX=clang++ \
+          #CC=clang \
+          #CXX=clang++ \
           cmake --preset ${{matrix.preset}} \
             -DNEOFOAM_BUILD_TESTS=ON \
             -DNEOFOAM_DEVEL_TOOLS=OFF \
-            -DNEOFOAM_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF \
-            -DKokkos_ENABLE_HIP=ON
+            -DNEOFOAM_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF
           cmake --build --preset ${{matrix.preset}}
       - name: Test NeoFOAM
         shell: bash -i {0}
         run: |
           . /root/spack/share/spack/setup-env.sh
           module load gnu/11
-          spack load cmake
+          spack load cmake@3.30.5
           ctest --preset ${{matrix.preset}}
   benchmark-on-aws:
     name: Benchmark on aws
@@ -121,14 +117,15 @@ jobs:
         shell: bash -i {0}
         run: |
           . /root/spack/share/spack/setup-env.sh
-          module load gnu/11
-          spack load cmake
+          module load clang/17
+          spack load cmake@3.30.5
           cmake --version
           python3 -m pip install xmltodict
-          CC=clang \
-          CXX=clang++ \
+          #CC=clang \
+          #CXX=clang++ \
           cmake --preset profiling
           cmake --build --preset profiling
+          module load gnu/11
           ctest --preset profiling
           mkdir -p ${{github.event.number}}/main
           cd build/profiling/bin/benchmarks
@@ -139,10 +136,12 @@ jobs:
           rm -rf build
           git fetch origin
           git checkout main
-          CC=clang \
-          CXX=clang++ \
+          #CC=clang \
+          #CXX=clang++ \
+          module load clang/17
           cmake --preset profiling
           cmake --build --preset profiling
+          module load gnu/11
           ctest --preset profiling
           cd build/profiling/bin/benchmarks
           python3 ../../../../scripts/catch2json.py

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -36,9 +36,9 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    outputs:
-      label_${{ matrix.instance.index }}: ${{ steps.start-ec2-runner.outputs.label }}  # Outputs JSON array of runner labels
-      ec2-instance-id_${{ matrix.instance.index }}: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    #outputs:
+    #  label_${{ matrix.instance.index }}: ${{ steps.start-ec2-runner.outputs.label }}  # Outputs JSON array of runner labels
+    #  ec2-instance-id_${{ matrix.instance.index }}: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
@@ -68,6 +68,11 @@ jobs:
                  sudo rm /usr/local/cuda
                  sudo rm /usr/local/cuda-12.1
                  sudo ln -s /usr/local/cuda-12.2 /usr/local/cuda
+      - name: Store Runner Label
+        id: set-label
+        run: |
+          echo "label_${{ matrix.instance.index }}=${{ steps.start-ec2-runner.outputs.label }}" >> $GITHUB_OUTPUT
+          echo "ec2-instance-id_${{ matrix.instance.index }}=${{ steps.start-ec2-runner.outputs.ec2-instance-id }}" >> $GITHUB_OUTPUT
         
   build-on-aws:
     name: Build on aws

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -26,9 +26,12 @@ jobs:
       fail-fast: false
       matrix:
         instance:
-          - TYPE: g4ad.xlarge
+          - TYPE: p3.2xlarge
             AMI: ami-0f8c4824f9f2e449e
             index: 0
+          #- TYPE: g4ad.xlarge AMD GPU V520 currently not supported by cmake
+          #  AMI: ami-0f8c4824f9f2e449e
+          #  index: 0
           - TYPE: g4dn.xlarge
             AMI: ami-06615d18bfde0a1e7
             index: 1
@@ -152,7 +155,7 @@ jobs:
         run: |
           . /root/spack/share/spack/setup-env.sh
           spack load cmake@3.30.5
-          spack load hip
+          #spack load hip
           #spack load kokkos@4.3.00
           module load clang/17
           cmake --version

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -58,7 +58,7 @@ jobs:
           ec2-image-id: ${{matrix.instance.AMI}}
           ec2-instance-type: ${{matrix.instance.TYPE}}
           iam-role-name: Role4Github
-          subnet-id: subnet-87eb68a6
+          subnet-id: subnet-c128ae9e
           security-group-id: sg-559f8967
           aws-resource-tags: > # optional, requires additional permissions
             [

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -131,7 +131,7 @@ jobs:
     name: Benchmark on aws
     needs: [start-runner, build-on-aws] # required to start the main job when the runner is ready
     runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
-    if: env.DEBUG != 'true'
+    if: github.event.inputs.debug != 'true'
     steps:
       - name: Build NeoFOAM
         shell: bash -i {0}

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -56,6 +56,8 @@ jobs:
                  #!/bin/bash
                  . /root/spack/share/spack/setup-env.sh
                  spack install node-js
+                 echo 'module use /usr/share/lmod/lmod/modulefiles/Compilers' >> /root/.bashrc
+                 echo 'module use /usr/share/lmod/lmod/modulefiles/Compilers' >> /ec2-user/.bashrc
 
   build-on-aws:
     name: Build on aws
@@ -71,9 +73,8 @@ jobs:
         run: |
           sudo rm /actions-runner/externals/node20/bin/node
           sudo ln -s /root/spack/opt/spack/linux-centos7-x86_64_v3/gcc-10.5.0/node-js-22.11.0-mrucyknlrjtbai4kihv5widviflhliip/bin/node /actions-runner/externals/node20/bin/node
-          module use /usr/share/lmod/lmod/modulefiles/Compilers
       - name: Checkout NeoFOAM
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up cache
         uses: actions/cache@v3
         if: ${{!contains(github.event.pull_request.labels.*.name, 'Skip-cache')}}
@@ -101,7 +102,7 @@ jobs:
         shell: bash -i {0}
         run: |
           . /root/spack/share/spack/setup-env.sh
-          module load clang/17
+          module load gnu/11
           spack load cmake
           ctest --preset ${{matrix.preset}}
   benchmark-on-aws:
@@ -114,7 +115,7 @@ jobs:
         shell: bash -i {0}
         run: |
           . /root/spack/share/spack/setup-env.sh
-          module load clang/17
+          module load gnu/11
           spack load cmake
           cmake --version
           python3 -m pip install xmltodict

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -37,8 +37,8 @@ jobs:
       id-token: write
       contents: read
     outputs:
-      label_${{ matrix.index }}: ${{ steps.start-ec2-runner.outputs.label }}  # Outputs JSON array of runner labels
-      ec2-instance-id_${{ matrix.index }}: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+      label_${{ matrix.instance.index }}: ${{ steps.start-ec2-runner.outputs.label }}  # Outputs JSON array of runner labels
+      ec2-instance-id_${{ matrix.instance.index }}: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -92,6 +92,11 @@ jobs:
         run: |
           echo "LABELS_JSON=[]" >> $GITHUB_ENV
           echo "EC2_IDS_JSON=[]" >> $GITHUB_ENV
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: aggregated-data
+          path: downloaded_data
 
       - name: Loop Through Matrix Indices and Download Artifacts
         id: aggregate
@@ -101,18 +106,22 @@ jobs:
 
           for index in {0..10}; do  # Adjust max index if needed
             artifact_name="labels_${index}"
-            mkdir -p downloaded_artifacts/$artifact_name
+            echo "Attempting to download artifact: $artifact_name"
 
-            echo "Trying to download: $artifact_name"
-            # Attempt to download artifact (fails silently if not found)
-            echo "Downloading: $artifact_name"
-            curl -fsSLO --retry 3 https://github.com/${{ github.repository }}/actions/artifacts/$artifact_name || continue
-
-            LABEL=$(cat downloaded_artifacts/$artifact_name/label_${index}.txt)
-            EC2_ID=$(cat downloaded_artifacts/$artifact_name/ec2-instance-id_${index}.txt)
+            # Attempt to download artifact, ignore errors if not found
+            if gh run download --name "$artifact_name" --dir "downloaded_artifacts/$artifact_name"; then
+              echo "Downloaded: $artifact_name"
               
-            LABELS+=("\"$LABEL\"")
-            EC2_IDS+=("\"$EC2_ID\"")
+              # Read values from downloaded files
+              LABEL=$(cat downloaded_artifacts/$artifact_name/label_${index}.txt)
+              EC2_ID=$(cat downloaded_artifacts/$artifact_name/ec2-instance-id_${index}.txt)
+
+              # Append to arrays
+              LABELS+=("\"$LABEL\"")
+              EC2_IDS+=("\"$EC2_ID\"")
+            else
+              echo "Artifact $artifact_name not found, skipping."
+            fi
           done
 
           # Convert arrays to JSON
@@ -121,6 +130,8 @@ jobs:
 
           echo "labels=$LABELS_JSON" >> $GITHUB_OUTPUT
           echo "ec2_ids=$EC2_IDS_JSON" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
 
       - name: Show Aggregated Data
         run: |

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -139,7 +139,7 @@ jobs:
         preset: ["develop", "production"]
     steps:
       - name: Prepare environment
-        shell: bash -i {0}
+        shell: bash {0}
         run: |
           sudo rm /actions-runner/externals/node20/bin/node
           sudo ln -s /root/spack/opt/spack/linux-centos7-x86_64_v3/gcc-10.5.0/node-js*/bin/node /actions-runner/externals/node20/bin/node
@@ -152,7 +152,7 @@ jobs:
           path: build
           key: aws_PR_${{ github.event.pull_request.number }}_${{matrix.preset}}_${{matrix.instance.ec2-type}}
       - name: Build NeoFOAM
-        shell: bash -i {0}
+        shell: bash {0}
         run: |
           . /root/spack/share/spack/setup-env.sh
           spack load cmake@3.30.5
@@ -168,7 +168,7 @@ jobs:
             -DNEOFOAM_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF
           cmake --build --preset ${{matrix.preset}}
       - name: Test NeoFOAM
-        shell: bash -i {0}
+        shell: bash {0}
         run: |
           . /root/spack/share/spack/setup-env.sh
           module load gnu/11
@@ -185,7 +185,7 @@ jobs:
         instance: ${{ fromJson(needs.aggregate-labels.outputs.matrix) }}
     steps:
       - name: Build NeoFOAM
-        shell: bash -i {0}
+        shell: bash {0}
         run: |
           . /root/spack/share/spack/setup-env.sh
           module load clang/17

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         instance:
           - TYPE: g5.2xlarge
-            AMI: ami-0f8c4824f9f2e449e
+            AMI: ami-06615d18bfde0a1e7
             index: 0
           #- TYPE: g4ad.xlarge AMD GPU V520 currently not supported by cmake
           #  AMI: ami-0f8c4824f9f2e449e

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -69,19 +69,56 @@ jobs:
                  sudo rm /usr/local/cuda-12.1
                  sudo ln -s /usr/local/cuda-12.2 /usr/local/cuda
       - name: Store Runner Label
-        id: set-label
         run: |
-          echo "label_${{ matrix.instance.index }}=${{ steps.start-ec2-runner.outputs.label }}" >> $GITHUB_OUTPUT
-          echo "ec2-instance-id_${{ matrix.instance.index }}=${{ steps.start-ec2-runner.outputs.ec2-instance-id }}" >> $GITHUB_OUTPUT
-          echo "label_${{ matrix.instance.index }}=${{ steps.start-ec2-runner.outputs.label }}" >> $GITHUB_ENV
-          echo "ec2-instance-id_${{ matrix.instance.index }}=${{ steps.start-ec2-runner.outputs.ec2-instance-id }}" >> $GITHUB_ENV
-  aggregate:
-      needs: start-runner
-      runs-on: ubuntu-latest
-      steps:
-        - name: Aggregate Outputs
-          run: |
-            echo "Aggregated Labels: ${{ toJson(needs.start-runner.outputs) }}"
+          echo "${{ steps.start-ec2-runner.outputs.label }}" > label_${{ matrix.instance.index }}.txt
+          echo "${{ steps.start-ec2-runner.outputs.ec2-instance-id }}" >> ec2-instance-id_${{ matrix.instance.index }}.txt
+      - name: Upload Label Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: labels
+          path: label_${{ matrix.instance.index }}.txt
+          retention-days: 1
+      - name: Upload EC2 Instance ID Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ec2-instance-ids
+          path: ec2-instance-id_${{ matrix.instance.index }}.txt
+          retention-days: 1
+  aggregate-labels:
+    needs: start-runner
+    runs-on: ubuntu-latest
+    outputs:
+      all_labels: ${{ steps.aggregate.outputs.labels }}
+      all_ec2_ids: ${{ steps.aggregate.outputs.ec2_ids }}
+
+    steps:
+      - name: Download Label Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: labels
+          path: labels
+
+      - name: Download EC2 ID Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ec2-instance-ids
+          path: ec2-instance-ids
+
+      - name: Aggregate Labels and EC2 IDs
+        id: aggregate
+        run: |
+          # Join all labels into a single space-separated string
+          LABELS=$(cat labels/*.txt | tr '\n' ' ')
+          echo "labels=$LABELS" >> $GITHUB_OUTPUT
+
+          # Join all EC2 instance IDs into a single space-separated string
+          EC2_IDS=$(cat ec2-instance-ids/*.txt | tr '\n' ' ')
+          echo "ec2_ids=$EC2_IDS" >> $GITHUB_OUTPUT
+
+      - name: Show Aggregated Data
+        run: |
+          echo "Aggregated Labels: ${{ steps.aggregate.outputs.labels }}"
+          echo "Aggregated EC2 Instance IDs: ${{ steps.aggregate.outputs.ec2_ids }}"
         
   build-on-aws:
     name: Build on aws
@@ -90,7 +127,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ "${{ needs.start-runner.outputs.label_0 }}" , "${{ needs.start-runner.outputs.label_1 }}" ]
+        runner: ${{ steps.aggregate.outputs.labels }}
         preset: ["develop", "production"]
     steps:
       - name: Prepare environment

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -73,6 +73,7 @@ jobs:
         with:
           name: runner-labels
           path: /tmp/labels.txt
+          
   collect-runner-labels:
     name: Collect Runner Labels
     needs: start-runner

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -37,6 +37,7 @@ jobs:
     outputs:
       labels: ${{ steps.start-ec2-runner.outputs.label }}  # Outputs JSON array of runner labels
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+      runner-labels: ${{ steps.set-label.outputs.label }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
@@ -67,20 +68,20 @@ jobs:
                  sudo rm /usr/local/cuda-12.1
                  sudo ln -s /usr/local/cuda-12.2 /usr/local/cuda
       - name: Store Label in File
-        run: echo "${{ steps.start-ec2-runner.outputs.label }}" >> /tmp/labels.txt
+        id: set-label
+        run: echo "label=${{ steps.start-ec2-runner.outputs.label }}" >> $GITHUB_OUTPUT
           
   collect-runner-labels:
     name: Collect Runner Labels
     needs: start-runner
     runs-on: ubuntu-latest
     outputs:
-      labels: ${{ steps.aggregate-labels.outputs.labels_json }}
+      labels: ${{ steps.aggregate-labels.outputs.labels }}
     steps:
       - name: Aggregate All Labels into JSON
         id: aggregate-labels
         run: |
-          LABELS=$(jq -R -s -c 'split("\n")[:-1]' /tmp/labels.txt)
-          echo "labels_json=$LABELS" >> $GITHUB_OUTPUT
+          echo "labels=$(jq -c -n '[${{ join(',', needs.start-runner.outputs.runner-labels) }}]')" >> $GITHUB_OUTPUT
         
   build-on-aws:
     name: Build on aws

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Show Aggregated Data
         run: |
-          run: echo "Matrix: ${{ steps.aggregate.outputs.matrix }}"
+          echo "Matrix: ${{ steps.aggregate.outputs.matrix }}"
         
   build-on-aws:
     name: Build on aws

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -92,12 +92,7 @@ jobs:
         run: |
           echo "LABELS_JSON=[]" >> $GITHUB_ENV
           echo "EC2_IDS_JSON=[]" >> $GITHUB_ENV
-      - name: Download Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: aggregated-data
-          path: downloaded_data
-
+          
       - name: Loop Through Matrix Indices and Download Artifacts
         id: aggregate
         run: |

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -44,7 +44,7 @@ jobs:
           ec2-image-id: ami-03af087024bfdbbee
           ec2-instance-type: g4ad.xlarge
           iam-role-name: Role4Github
-          subnet-id: subnet-b5d2adbb
+          subnet-id: subnet-87eb68a6
           security-group-id: sg-559f8967
           aws-resource-tags: > # optional, requires additional permissions
             [

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -56,6 +56,8 @@ jobs:
                  #!/bin/bash
                  . /root/spack/share/spack/setup-env.sh
                  spack install node-js
+                 rm /actions-runner/externals/node20/bin/node
+                 ln -s /root/spack/opt/spack/linux-centos7-x86_64_v3/gcc-10.5.0/node-js-22.11.0-mrucyknlrjtbai4kihv5widviflhliip/bin/node /actions-runner/externals/node20/bin/node
                  #sudo yum update -y && \
                  #sudo yum install docker git libicu ninja-build libasan10 -y
                  #sudo amazon-linux-extras install epel -y

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -27,9 +27,9 @@ jobs:
       fail-fast: false
       matrix:
         instance:
-          - TYPE: g5.2xlarge
-            AMI: ami-053248e1ad04b8278
-            index: 0
+          #- TYPE: g5.2xlarge
+          #  AMI: ami-053248e1ad04b8278
+          #  index: 0
           #- TYPE: g4ad.xlarge AMD GPU V520 currently not supported by cmake
           #  AMI: ami-0f8c4824f9f2e449e
           #  index: 0

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -122,6 +122,8 @@ jobs:
           LABELS_JSON=$(echo "${LABELS[@]}" | jq -s .)
           EC2_IDS_JSON=$(echo "${EC2_IDS[@]}" | jq -s .)
 
+          echo $LABELS_JSON
+
           echo "labels=$LABELS_JSON" >> $GITHUB_OUTPUT
           echo "ec2_ids=$EC2_IDS_JSON" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -96,7 +96,8 @@ jobs:
             -DNEOFOAM_BUILD_TESTS=ON \
             -DNEOFOAM_DEVEL_TOOLS=OFF \
             -DNEOFOAM_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF \
-            -DKokkos_ENABLE_HIP=ON
+            -DKokkos_ENABLE_HIP=ON \
+            -DNEOFOAM_WITH_SUNDIALS=OFF
           cmake --build --preset ${{matrix.preset}}
       - name: Test NeoFOAM
         shell: bash -i {0}

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -22,6 +22,12 @@ jobs:
   start-runner:
     if: ${{contains(github.event.pull_request.labels.*.name, 'full-ci') || github.event_name == 'workflow_dispatch'}}
     name: Start self-hosted EC2 runner
+    strategy:
+      fail-fast: false
+      matrix:
+        instance:
+          - TYPE: g4dn.xlarge
+            AMI: ami-03af087024bfdbbee
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -41,8 +47,8 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          ec2-image-id: ami-016cbffe7e42b2547
-          ec2-instance-type: g4ad.xlarge
+          ec2-image-id: ${{matrix.instance.AMI}}
+          ec2-instance-type: ${{matrix.instance.TYPE}}
           iam-role-name: Role4Github
           subnet-id: subnet-87eb68a6
           security-group-id: sg-559f8967
@@ -54,10 +60,10 @@ jobs:
             ]
           pre-runner-script: |
                  #!/bin/bash
-                 . /root/spack/share/spack/setup-env.sh
-                 spack install node-js
-                 echo 'module use /usr/share/lmod/lmod/modulefiles/Compilers' >> /root/.bashrc
-                 echo 'module use /usr/share/lmod/lmod/modulefiles/Compilers' >> /ec2-user/.bashrc
+                 #. /root/spack/share/spack/setup-env.sh
+                 #spack install node-js
+                 #echo 'module use /usr/share/lmod/lmod/modulefiles/Compilers' >> /root/.bashrc
+                 #echo 'module use /usr/share/lmod/lmod/modulefiles/Compilers' >> /ec2-user/.bashrc
 
   build-on-aws:
     name: Build on aws

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -66,12 +66,13 @@ jobs:
                  sudo rm /usr/local/cuda
                  sudo rm /usr/local/cuda-12.1
                  sudo ln -s /usr/local/cuda-12.2 /usr/local/cuda
-      - name: Store Label in GitHub Variable
-        run: echo "RUNNER_LABEL=${{ steps.start-ec2-runner.outputs.label }}" >> $GITHUB_ENV
+      - name: Store Label in File
+        run: echo "${{ steps.start-ec2-runner.outputs.label }}" >> /tmp/labels.txt
       - name: Collect runner labels
         id: collect-labels
         run: |
-          echo "labels_json=${{ steps.collect-labels.outputs.labels_json }} [\"${RUNNER_LABEL}\"]" >> $GITHUB_ENV
+          LABELS=$(jq -R -s -c 'split("\n")[:-1]' /tmp/labels.txt)
+          echo "labels_json=$LABELS" >> $GITHUB_OUTPUT
       - name: Debug output
         run: |
           echo "LABELS_JSON=${{ steps.collect-labels.outputs.labels_json }}"

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -56,6 +56,7 @@ jobs:
                  #!/bin/bash
                  . /root/spack/share/spack/setup-env.sh
                  spack install node-js
+                 spack install kokkos@4.3.0
                  echo 'module use /usr/share/lmod/lmod/modulefiles/Compilers' >> /root/.bashrc
                  echo 'module use /usr/share/lmod/lmod/modulefiles/Compilers' >> /ec2-user/.bashrc
 
@@ -87,7 +88,7 @@ jobs:
           . /root/spack/share/spack/setup-env.sh
           spack load cmake
           spack load hip
-          spack load kokkos
+          spack load kokkos@4.3.0
           module load clang/17
           cmake --version
           CC=clang \

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -64,15 +64,17 @@ jobs:
                  #!/bin/bash
                  . /root/spack/share/spack/setup-env.sh
                  sudo rm /usr/local/cuda
+                 sudo rm /usr/local/cuda-12.1
                  sudo ln -s /usr/local/cuda-12.2 /usr/local/cuda
 
   build-on-aws:
     name: Build on aws
     needs: start-runner # required to start the main job when the runner is ready
-    runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
+    runs-on: ${{ matrix.runner }} # run the job on the newly created runner
     strategy:
       fail-fast: false
       matrix:
+        runner: ${{ fromJson(needs.start-runner.outputs.labels) }}
         preset: ["develop", "production"]
     steps:
       - name: Prepare environment

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -168,7 +168,7 @@ jobs:
             -DNEOFOAM_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF
           cmake --build --preset ${{matrix.preset}}
       - name: Test NeoFOAM
-        shell: bash {0}
+        shell: bash -i {0}
         run: |
           . /root/spack/share/spack/setup-env.sh
           module load gnu/11

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -109,6 +109,8 @@ jobs:
           EC2_IDS=()
           for index in {0..1}; do  # Adjust max index if needed
             # Read values from downloaded files
+            ls downloaded_data
+            unzip "downloaded_data/labels_${index}.zip" -d "downloaded_data"
             LABEL=$(cat downloaded_data/labels_${index}/label_${index}.txt)
             EC2_ID=$(cat downloaded_data/labels_${index}/ec2-instance-id_${index}.txt)
 

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -154,7 +154,7 @@ jobs:
         if: ${{!contains(github.event.pull_request.labels.*.name, 'Skip-cache')}}
         with:
           path: build
-          key: aws_PR_${{ github.event.pull_request.number }}_${{matrix.preset}}
+          key: aws_PR_${{ github.event.pull_request.number }}_${{matrix.preset}}_${{matrix.runner}}
       - name: Build NeoFOAM
         shell: bash -i {0}
         run: |

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -7,6 +7,7 @@ env:
   OMPI_MCA_rmaps_base_oversubscribe: true
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
   DEBUG: ${{ github.event.inputs.debug }}
+  RUN_IDENTIFIER: ${{ github.event.number || format('manual-{0}', github.run_number) }}
 on:
   pull_request:
     types: [opened, synchronize]
@@ -197,11 +198,11 @@ jobs:
           cmake --build --preset profiling
           module load gnu/11
           ctest --preset profiling
-          mkdir -p ${{github.event.number}}/main
+          mkdir -p ${{ env.RUN_IDENTIFIER }}/main
           cd build/profiling/bin/benchmarks
           python3 ../../../../scripts/catch2json.py
           cd ../../../..
-          cp build/profiling/bin/benchmarks/*.json ${{github.event.number}}/
+          cp build/profiling/bin/benchmarks/*.json ${{ env.RUN_IDENTIFIER }}/
           lscpu > ${{github.event.number}}/lscpu.log
           rm -rf build
           git fetch origin
@@ -216,17 +217,17 @@ jobs:
           cd build/profiling/bin/benchmarks
           python3 ../../../../scripts/catch2json.py
           cd ../../../..
-          cp build/profiling/bin/benchmarks/*.json ${{github.event.number}}/main/
+          cp build/profiling/bin/benchmarks/*.json ${{ env.RUN_IDENTIFIER }}/main/
 
       - name: Push Benchmark Data
         uses: cpina/github-action-push-to-another-repository@main
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:
-          source-directory: ${{github.event.number}}
+          source-directory: ${{ env.RUN_IDENTIFIER }}
           destination-github-username: 'exasim-project'
           destination-repository-name: 'NeoFOAM-BenchmarkData'
-          target-directory: ${{github.event.number}}/${{matrix.instance.ec2-type}}
+          target-directory: ${{ env.RUN_IDENTIFIER }}/${{matrix.instance.ec2-type}}
           user-email: github-actions@github.com
           target-branch: main
   stop-runner:

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: ${{ fromJson(needs.start-runner.outputs.labels) }}
+        runner: ${{ fromJson(needs.start-runner.outputs.label) }}
         preset: ["develop", "production"]
     steps:
       - name: Prepare environment
@@ -121,7 +121,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: ${{ fromJson(needs.start-runner.outputs.labels) }}
+        runner: ${{ fromJson(needs.start-runner.outputs.label) }}
     steps:
       - name: Build NeoFOAM
         shell: bash -i {0}

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -28,16 +28,17 @@ jobs:
         instance:
           - TYPE: g4ad.xlarge
             AMI: ami-0f8c4824f9f2e449e
+            index: 0
           - TYPE: g4dn.xlarge
             AMI: ami-06615d18bfde0a1e7
+            index: 1
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
     outputs:
-      labels: ${{ steps.start-ec2-runner.outputs.label }}  # Outputs JSON array of runner labels
-      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
-      runner-labels: ${{ steps.set-label.outputs.label }}
+      label_${{ matrix.index }}: ${{ steps.start-ec2-runner.outputs.label }}  # Outputs JSON array of runner labels
+      ec2-instance-id_${{ matrix.index }}: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
@@ -70,6 +71,11 @@ jobs:
       - name: Store Label in File
         id: set-label
         run: echo "label=${{ steps.start-ec2-runner.outputs.label }}" >> $GITHUB_OUTPUT
+      - name: Store Label in File
+        id: append-label
+        run: |
+          OLD_LABEL="${{ steps.set-label.outputs.label }}"
+          echo "label=$OLD_LABEL:${{ steps.start-ec2-runner.outputs.label }}" >> $GITHUB_OUTPUT
           
   collect-runner-labels:
     name: Collect Runner Labels
@@ -86,12 +92,12 @@ jobs:
         
   build-on-aws:
     name: Build on aws
-    needs: [start-runner,collect-runner-labels] # required to start the main job when the runner is ready
+    needs: start-runner # required to start the main job when the runner is ready
     runs-on: ${{ matrix.runner }} # run the job on the newly created runner
     strategy:
       fail-fast: false
       matrix:
-        runner: ${{ fromJson(needs.collect-runner-labels.outputs.labels) }}
+        runner: [ "${{ needs.start-runner.outputs.label_0 }}" , "${{ needs.start-runner.outputs.label_1 }}" ]
         preset: ["develop", "production"]
     steps:
       - name: Prepare environment
@@ -138,7 +144,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: ${{ fromJson(needs.start-runner.outputs.labels) }}
+        runner: [ "${{ needs.start-runner.outputs.label_0 }}" , "${{ needs.start-runner.outputs.label_1 }}" ]
     steps:
       - name: Build NeoFOAM
         shell: bash -i {0}

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -35,7 +35,7 @@ jobs:
       id-token: write
       contents: read
     outputs:
-      labels: ${{ steps.collect-labels.outputs.json_labels }}  # Outputs JSON array of runner labels
+      labels: ${{ steps.collect-labels.outputs.labels_json }}  # Outputs JSON array of runner labels
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
@@ -69,8 +69,8 @@ jobs:
       - name: Collect runner labels
         id: collect-labels
         run: |
-          echo 'json_labels=["${{ steps.start-ec2-runner.outputs.label }}"]' >> $GITHUB_ENV
-        shell: bash
+          echo "labels_json=[\"${{ steps.start-ec2-runner.outputs.label }}\"]" >> $GITHUB_ENV
+          echo "Show label: ${{ steps.start-ec2-runner.outputs.label }}"
 
   build-on-aws:
     name: Build on aws

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -56,8 +56,6 @@ jobs:
                  #!/bin/bash
                  . /root/spack/share/spack/setup-env.sh
                  spack install node-js
-                 sudo rm /actions-runner/externals/node20/bin/node
-                 sudo ln -s /root/spack/opt/spack/linux-centos7-x86_64_v3/gcc-10.5.0/node-js-22.11.0-mrucyknlrjtbai4kihv5widviflhliip/bin/node /actions-runner/externals/node20/bin/node
                  #sudo yum update -y && \
                  #sudo yum install docker git libicu ninja-build libasan10 -y
                  #sudo amazon-linux-extras install epel -y
@@ -94,6 +92,11 @@ jobs:
       matrix:
         preset: ["develop", "production"]
     steps:
+      - name: Prepare environment
+        shell: bash -i {0}
+        run: |
+          sudo rm /actions-runner/externals/node20/bin/node
+          sudo ln -s /root/spack/opt/spack/linux-centos7-x86_64_v3/gcc-10.5.0/node-js-22.11.0-mrucyknlrjtbai4kihv5widviflhliip/bin/node /actions-runner/externals/node20/bin/node
       - name: Checkout NeoFOAM
         uses: actions/checkout@v2
       - name: Set up cache

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -119,8 +119,8 @@ jobs:
           done
 
           # Convert arrays to JSON
-          LABELS_JSON=$(echo "[${LABELS[*]}]" | jq -c .)
-          EC2_IDS_JSON=$(echo "[${EC2_IDS[*]}]" | jq -c .)
+          LABELS_JSON=$(echo "${LABELS[@]}" | jq -s .)
+          EC2_IDS_JSON=$(echo "${EC2_IDS[@]}" | jq -s .)
 
           echo "labels=$LABELS_JSON" >> $GITHUB_OUTPUT
           echo "ec2_ids=$EC2_IDS_JSON" >> $GITHUB_OUTPUT

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -188,7 +188,7 @@ jobs:
       id-token: write
       contents: read
     # only try to run the stop job if the start runner hasn't been skipped
-    if: ${{ always() && needs.start-runner.result != 'skipped' && env.DEBUG != 'true'}}
+    if: always() && needs.start-runner.result != 'skipped' && env.DEBUG != 'true'
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -73,6 +73,15 @@ jobs:
         run: |
           echo "label_${{ matrix.instance.index }}=${{ steps.start-ec2-runner.outputs.label }}" >> $GITHUB_OUTPUT
           echo "ec2-instance-id_${{ matrix.instance.index }}=${{ steps.start-ec2-runner.outputs.ec2-instance-id }}" >> $GITHUB_OUTPUT
+          echo "label_${{ matrix.instance.index }}=${{ steps.start-ec2-runner.outputs.label }}" >> $GITHUB_ENV
+          echo "ec2-instance-id_${{ matrix.instance.index }}=${{ steps.start-ec2-runner.outputs.ec2-instance-id }}" >> $GITHUB_ENV
+  aggregate:
+      needs: start-runner
+      runs-on: ubuntu-latest
+      steps:
+        - name: Aggregate Outputs
+          run: |
+            echo "Aggregated Labels: ${{ toJson(needs.start-runner.outputs) }}"
         
   build-on-aws:
     name: Build on aws

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Store Label in File
         run: echo "${{ steps.start-ec2-runner.outputs.label }}" >> /tmp/labels.txt
       - name: Store Labels as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: runner-labels
           path: /tmp/labels.txt
@@ -82,7 +82,7 @@ jobs:
       labels: ${{ steps.set-labels.outputs.labels_json }}
     steps:
       - name: Download Runner Labels
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: runner-labels
           

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -72,7 +72,7 @@ jobs:
         shell: bash -i {0}
         run: |
           sudo rm /actions-runner/externals/node20/bin/node
-          sudo ln -s /root/spack/opt/spack/linux-centos7-x86_64_v3/gcc-10.5.0/node-js-22.11.0-mrucyknlrjtbai4kihv5widviflhliip/bin/node /actions-runner/externals/node20/bin/node
+          sudo ln -s /root/spack/opt/spack/linux-centos7-x86_64_v3/gcc-10.5.0/node-js*/bin/node /actions-runner/externals/node20/bin/node
       - name: Checkout NeoFOAM
         uses: actions/checkout@v2
       - name: Set up cache

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -28,13 +28,13 @@ jobs:
       matrix:
         instance:
           - TYPE: g5.2xlarge
-            AMI: ami-06615d18bfde0a1e7
+            AMI: ami-0f8c4824f9f2e449e
             index: 0
           #- TYPE: g4ad.xlarge AMD GPU V520 currently not supported by cmake
           #  AMI: ami-0f8c4824f9f2e449e
           #  index: 0
           - TYPE: g4dn.xlarge
-            AMI: ami-06615d18bfde0a1e7
+            AMI: ami-0f8c4824f9f2e449e
             index: 1
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -91,9 +91,6 @@ jobs:
           LABELS=$(jq -R -s -c 'split("\n")[:-1]' labels.txt)
           echo "labels_json=$LABELS" >> $GITHUB_ENV
           echo "::set-output name=labels_json::$LABELS"
-
-      - name: Debug Output
-        run: echo "Final JSON Labels: ${{ steps.set-labels.outputs.labels_json }}"
         
   build-on-aws:
     name: Build on aws

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -223,7 +223,7 @@ jobs:
           source-directory: ${{github.event.number}}
           destination-github-username: 'exasim-project'
           destination-repository-name: 'NeoFOAM-BenchmarkData'
-          target-directory: ${{github.event.number}}/gdnxlarge
+          target-directory: ${{github.event.number}}/${{matrix.instance.ec2-type}}
           user-email: github-actions@github.com
           target-branch: main
   stop-runner:

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -122,7 +122,7 @@ jobs:
         
   build-on-aws:
     name: Build on aws
-    needs: start-runner # required to start the main job when the runner is ready
+    needs: aggregate-labels # required to start the main job when the runner is ready
     runs-on: ${{ matrix.runner }} # run the job on the newly created runner
     strategy:
       fail-fast: false
@@ -168,13 +168,13 @@ jobs:
           ctest --preset ${{matrix.preset}}
   benchmark-on-aws:
     name: Benchmark on aws
-    needs: [start-runner, build-on-aws] # required to start the main job when the runner is ready
+    needs: [start-runner,aggregate-labels, build-on-aws] # required to start the main job when the runner is ready
     runs-on: ${{ matrix.runner }} # run the job on the newly created runner
     if: github.event.inputs.debug != 'true'
     strategy:
       fail-fast: false
       matrix:
-        runner: [ "${{ needs.start-runner.outputs.label_0 }}" , "${{ needs.start-runner.outputs.label_1 }}" ]
+        runner: ${{ fromJson(needs.aggregate-labels.outputs.all_labels) }}
     steps:
       - name: Build NeoFOAM
         shell: bash -i {0}

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -37,11 +37,11 @@ jobs:
           aws-region: us-east-1
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: HendriceH/ec2-github-runner@v1.10  # Starts 60GB Root + 30 GB Share volume
+        uses: machulav/ec2-github-runner@v2.3.8
         with:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          ec2-image-id: ami-09850873fdddbce78
+          ec2-image-id: ami-016cbffe7e42b2547
           ec2-instance-type: g4ad.xlarge
           iam-role-name: Role4Github
           subnet-id: subnet-87eb68a6
@@ -54,29 +54,30 @@ jobs:
             ]
           pre-runner-script: |
                  #!/bin/bash
-                 sudo yum update -y && \
-                 sudo yum install docker git libicu ninja-build libasan10 -y
-                 sudo amazon-linux-extras install epel -y
-                 sudo yum install Lmod -y
-                 sudo systemctl enable docker
-                 sudo mkfs -t xfs /dev/sda1
-                 sudo mkdir -p /share
-                 sudo mount /dev/sda1 /share
-                 aws s3 cp s3://ucfd-share/pcluster/3.x/alinux2/x86_64/postinstall_github .
-                 chmod +x postinstall_github
-                 sudo ./postinstall_github > ~/install.log
-                 mkdir -p /share/ec2-user
-                 export USER=ec2-user
-                 cd /share/ec2-user
-                 mkdir .nvm
-                 export NVM_DIR=/share/ec2-user/.nvm
-                 sudo curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
-                 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
-                 nvm install v16.20.2
-                 echo "NVM_DIR=/share/ec2-user/.nvm" >> $GITHUB_ENV
-                 echo "NVM_BIN=/share/ec2-user/.nvm/versions/node/v16.20.2/bin" >> $GITHUB_ENV
+                 . /root/spack/share/spack/setup-env.sh 
+                 #sudo yum update -y && \
+                 #sudo yum install docker git libicu ninja-build libasan10 -y
+                 #sudo amazon-linux-extras install epel -y
+                 #sudo yum install Lmod -y
+                 #sudo systemctl enable docker
+                 #sudo mkfs -t xfs /dev/sda1
+                 #sudo mkdir -p /share
+                 #sudo mount /dev/sda1 /share
+                 #aws s3 cp s3://ucfd-share/pcluster/3.x/alinux2/x86_64/postinstall_github .
+                 #chmod +x postinstall_github
+                 #sudo ./postinstall_github > ~/install.log
+                 #mkdir -p /share/ec2-user
+                 #export USER=ec2-user
+                 #cd /share/ec2-user
+                 #mkdir .nvm
+                 #export NVM_DIR=/share/ec2-user/.nvm
+                 #sudo curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+                 #[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+                 #nvm install v16.20.2
+                 #echo "NVM_DIR=/share/ec2-user/.nvm" >> $GITHUB_ENV
+                 #echo "NVM_BIN=/share/ec2-user/.nvm/versions/node/v16.20.2/bin" >> $GITHUB_ENV
                  # load rocm
-                 echo -e "[ROCm]\nname=ROCm\nbaseurl=https://repo.radeon.com/rocm/yum/6.2.4/main/\nenabled=1\ngpgcheck=1\ngpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" | sudo tee /etc/yum.repos.d/rocm.repo > /dev/null
+                 #echo -e "[ROCm]\nname=ROCm\nbaseurl=https://repo.radeon.com/rocm/yum/6.2.4/main/\nenabled=1\ngpgcheck=1\ngpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" | sudo tee /etc/yum.repos.d/rocm.repo > /dev/null
                  #sudo yum install amdgpu -y
                  #sudo yum install rocm-libs -y
                  #cp /opt/rocm/lib/rocmmod /share/lmod/modulefiles/Compilers/rocm-6.2.4
@@ -90,15 +91,6 @@ jobs:
       matrix:
         preset: ["develop", "production"]
     steps:
-      - name: Prepare environment
-        shell: bash -i {0}
-        run: |
-          . /share/ec2-user/.nvm/nvm.sh
-          nvm -v
-          nvm install v16.20.2
-          node -v
-          sudo rm /share/software/actions-runner/externals/node20/bin/node
-          ln -s /share/ec2-user/.nvm/versions/node/v16.20.2/bin/node /share/software/actions-runner/externals/node20/bin/node
       - name: Checkout NeoFOAM
         uses: actions/checkout@v2
       - name: Set up cache
@@ -110,11 +102,12 @@ jobs:
       - name: Build NeoFOAM
         shell: bash -i {0}
         run: |
-          export HOME=/share/ec2-user
-          module load clang/16
-          module load libfabric-aws
-          module spider libfabric-aws
-          module load cmake
+          . /root/spack/share/spack/setup-env.sh
+          spack load cmake
+          spack load rocthrust
+          spack load hip
+          spack load kokkos
+          module load clang/17
           cmake --version
           CC=clang \
           CXX=clang++ \
@@ -122,15 +115,14 @@ jobs:
             -DNEOFOAM_BUILD_TESTS=ON \
             -DNEOFOAM_DEVEL_TOOLS=OFF \
             -DNEOFOAM_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF \
-            -DKokkos_ENABLE_CUDA=ON
+            -DKokkos_ENABLE_HIP=ON
           cmake --build --preset ${{matrix.preset}}
       - name: Test NeoFOAM
         shell: bash -i {0}
         run: |
-          export HOME=/share/ec2-user
-          module load clang/16
-          module load libfabric-aws
-          module load cmake
+          . /root/spack/share/spack/setup-env.sh
+          module load clang/17
+          spack load cmake
           ctest --preset ${{matrix.preset}}
   benchmark-on-aws:
     name: Benchmark on aws
@@ -141,11 +133,9 @@ jobs:
       - name: Build NeoFOAM
         shell: bash -i {0}
         run: |
-          export HOME=/share/ec2-user
-          module load clang/16
-          module load libfabric-aws
-          module spider libfabric-aws
-          module load cmake
+          . /root/spack/share/spack/setup-env.sh
+          module load clang/17
+          spack load cmake
           cmake --version
           python3 -m pip install xmltodict
           CC=clang \
@@ -201,7 +191,7 @@ jobs:
           role-to-assume: arn:aws:iam::308634587211:role/Github-OIDC-Role-29bocUD8VBZr
           aws-region: us-east-1
       - name: Stop EC2 runner
-        uses: HendriceH/ec2-github-runner@v1.10
+        uses: machulav/ec2-github-runner@v2.3.8
         with:
           mode: stop
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -56,7 +56,6 @@ jobs:
                  #!/bin/bash
                  . /root/spack/share/spack/setup-env.sh
                  spack install node-js
-                 spack install kokkos@4.3.0
                  echo 'module use /usr/share/lmod/lmod/modulefiles/Compilers' >> /root/.bashrc
                  echo 'module use /usr/share/lmod/lmod/modulefiles/Compilers' >> /ec2-user/.bashrc
 
@@ -88,7 +87,7 @@ jobs:
           . /root/spack/share/spack/setup-env.sh
           spack load cmake
           spack load hip
-          spack load kokkos@4.3.0
+          spack load kokkos
           module load clang/17
           cmake --version
           CC=clang \

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -71,6 +71,9 @@ jobs:
         run: |
           echo "labels_json=[\"${{ steps.start-ec2-runner.outputs.label }}\"]" >> $GITHUB_ENV
           echo "Show label: ${{ steps.start-ec2-runner.outputs.label }}"
+      - name: Debug output
+        run: |
+          echo "LABELS_JSON=${{ steps.collect-labels.outputs.labels_json }}"
 
   build-on-aws:
     name: Build on aws

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -66,11 +66,12 @@ jobs:
                  sudo rm /usr/local/cuda
                  sudo rm /usr/local/cuda-12.1
                  sudo ln -s /usr/local/cuda-12.2 /usr/local/cuda
+      - name: Store Label in GitHub Variable
+        run: echo "RUNNER_LABEL=${{ steps.start-ec2-runner.outputs.label }}" >> $GITHUB_ENV
       - name: Collect runner labels
         id: collect-labels
         run: |
-          echo "labels_json=[\"${{ steps.start-ec2-runner.outputs.label }}\"]" >> $GITHUB_ENV
-          echo "Show label: ${{ steps.start-ec2-runner.outputs.label }}"
+          run: echo "labels_json=${{ steps.collect-labels.outputs.labels_json }} [\"${RUNNER_LABEL}\"]" >> $GITHUB_ENV
       - name: Debug output
         run: |
           echo "LABELS_JSON=${{ steps.collect-labels.outputs.labels_json }}"

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -81,6 +81,7 @@ jobs:
       - name: Aggregate All Labels into JSON
         id: aggregate-labels
         run: |
+          echo "${{ needs.start-runner.outputs.labels }}"
           echo "labels=$(jq -c -n '[${{ join(',', needs.start-runner.outputs.runner-labels) }}]')" >> $GITHUB_OUTPUT
         
   build-on-aws:

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -75,14 +75,10 @@ jobs:
       - name: Upload Label Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: labels
-          path: label_${{ matrix.instance.index }}.txt
-          retention-days: 1
-      - name: Upload EC2 Instance ID Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ec2-instance-ids
-          path: ec2-instance-id_${{ matrix.instance.index }}.txt
+          name: labels_${{ matrix.instance.index }}
+          path: |
+            label_${{ matrix.instance.index }}.txt
+            ec2-instance-id_${{ matrix.instance.index }}.txt
           retention-days: 1
   aggregate-labels:
     needs: start-runner
@@ -92,27 +88,36 @@ jobs:
       all_ec2_ids: ${{ steps.aggregate.outputs.ec2_ids }}
 
     steps:
-      - name: Download Label Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: labels
-          path: labels
+      - name: Initialize Empty JSON Arrays
+        run: |
+          echo "LABELS_JSON=[]" >> $GITHUB_ENV
+          echo "EC2_IDS_JSON=[]" >> $GITHUB_ENV
 
-      - name: Download EC2 ID Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: ec2-instance-ids
-          path: ec2-instance-ids
-
-      - name: Aggregate Labels and EC2 IDs as JSON
+      - name: Loop Through Matrix Indices and Download Artifacts
         id: aggregate
         run: |
-          # Read labels and convert them into a JSON array
-          LABELS_JSON=$(jq -R . < labels/*.txt | jq -s .)
-          echo "labels=$LABELS_JSON" >> $GITHUB_OUTPUT
+          LABELS=()
+          EC2_IDS=()
 
-          # Read EC2 instance IDs and convert them into a JSON array
-          EC2_IDS_JSON=$(jq -R . < ec2-instance-ids/*.txt | jq -s .)
+          for index in {0..10}; do  # Adjust max index if needed
+            artifact_name="labels_${index}"
+            mkdir -p downloaded_artifacts/$artifact_name
+
+            echo "Trying to download: $artifact_name"
+            if gh run download --name "$artifact_name" --dir "downloaded_artifacts/$artifact_name"; then
+              LABEL=$(cat downloaded_artifacts/$artifact_name/label_${index}.txt)
+              EC2_ID=$(cat downloaded_artifacts/$artifact_name/ec2-instance-id_${index}.txt)
+              
+              LABELS+=("\"$LABEL\"")
+              EC2_IDS+=("\"$EC2_ID\"")
+            fi
+          done
+
+          # Convert arrays to JSON
+          LABELS_JSON=$(echo "[${LABELS[*]}]" | jq -c .)
+          EC2_IDS_JSON=$(echo "[${EC2_IDS[*]}]" | jq -c .)
+
+          echo "labels=$LABELS_JSON" >> $GITHUB_OUTPUT
           echo "ec2_ids=$EC2_IDS_JSON" >> $GITHUB_OUTPUT
 
       - name: Show Aggregated Data

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -68,27 +68,6 @@ jobs:
                  sudo rm /usr/local/cuda
                  sudo rm /usr/local/cuda-12.1
                  sudo ln -s /usr/local/cuda-12.2 /usr/local/cuda
-      - name: Store Label in File
-        id: set-label
-        run: echo "label=${{ steps.start-ec2-runner.outputs.label }}" >> $GITHUB_OUTPUT
-      - name: Store Label in File
-        id: append-label
-        run: |
-          OLD_LABEL="${{ steps.set-label.outputs.label }}"
-          echo "label=$OLD_LABEL:${{ steps.start-ec2-runner.outputs.label }}" >> $GITHUB_OUTPUT
-          
-  collect-runner-labels:
-    name: Collect Runner Labels
-    needs: start-runner
-    runs-on: ubuntu-latest
-    outputs:
-      labels: ${{ steps.aggregate-labels.outputs.labels }}
-    steps:
-      - name: Aggregate All Labels into JSON
-        id: aggregate-labels
-        run: |
-          echo "${{ needs.start-runner.outputs.labels }}"
-          echo "labels=$(jq -c -n '[${{ join(',', needs.start-runner.outputs.runner-labels) }}]')" >> $GITHUB_OUTPUT
         
   build-on-aws:
     name: Build on aws

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -96,8 +96,7 @@ jobs:
             -DNEOFOAM_BUILD_TESTS=ON \
             -DNEOFOAM_DEVEL_TOOLS=OFF \
             -DNEOFOAM_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF \
-            -DKokkos_ENABLE_HIP=ON \
-            -DNEOFOAM_WITH_SUNDIALS=OFF
+            -DKokkos_ENABLE_HIP=ON
           cmake --build --preset ${{matrix.preset}}
       - name: Test NeoFOAM
         shell: bash -i {0}

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -41,7 +41,7 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          ec2-image-id: ami-09850873fdddbce78
+          ec2-image-id: ami-03af087024bfdbbee
           ec2-instance-type: g4ad.xlarge
           iam-role-name: Role4Github
           subnet-id: subnet-87eb68a6
@@ -75,6 +75,18 @@ jobs:
                  nvm install v16.20.2
                  echo "NVM_DIR=/share/ec2-user/.nvm" >> $GITHUB_ENV
                  echo "NVM_BIN=/share/ec2-user/.nvm/versions/node/v16.20.2/bin" >> $GITHUB_ENV
+                 # load rocm
+                 sudo cat > /etc/yum.repos.d/rocm.repo << EOF
+                 [ROCm]
+                 name=ROCm
+                 baseurl=https://repo.radeon.com/rocm/yum/6.2.4/main/
+                 enabled=1
+                 gpgcheck=1
+                 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
+                 EOF
+                 sudo yum install amdgpu -y
+                 sudo yum install rocm-libs -y
+                 cp /opt/rocm/lib/rocmmod /share/lmod/modulefiles/Compilers/rocm-6.2.4
 
   build-on-aws:
     name: Build on aws

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -188,7 +188,7 @@ jobs:
       id-token: write
       contents: read
     # only try to run the stop job if the start runner hasn't been skipped
-    if: always() && needs.start-runner.result != 'skipped' && env.DEBUG != 'true'
+    if: always() && needs.start-runner.result != 'skipped' && github.event.inputs.debug != 'true'
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -153,7 +153,7 @@ jobs:
           . /root/spack/share/spack/setup-env.sh
           spack load cmake@3.30.5
           spack load hip
-          spack load kokkos@4.3.00
+          #spack load kokkos@4.3.00
           module load clang/17
           cmake --version
           #CC=clang \

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -35,7 +35,7 @@ jobs:
       id-token: write
       contents: read
     outputs:
-      label: ${{ steps.start-ec2-runner.outputs.label }}
+      labels: ${{ steps.collect-labels.outputs.json_labels }}  # Outputs JSON array of runner labels
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
@@ -66,6 +66,11 @@ jobs:
                  sudo rm /usr/local/cuda
                  sudo rm /usr/local/cuda-12.1
                  sudo ln -s /usr/local/cuda-12.2 /usr/local/cuda
+      - name: Collect runner labels
+        id: collect-labels
+        run: |
+          echo 'json_labels=["${{ steps.start-ec2-runner.outputs.label }}"]' >> $GITHUB_ENV
+        shell: bash
 
   build-on-aws:
     name: Build on aws
@@ -74,7 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: ${{ fromJson(needs.start-runner.outputs.label) }}
+        runner: ${{ fromJson(needs.start-runner.outputs.labels) }}
         preset: ["develop", "production"]
     steps:
       - name: Prepare environment
@@ -121,7 +126,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: ${{ fromJson(needs.start-runner.outputs.label) }}
+        runner: ${{ fromJson(needs.start-runner.outputs.labels) }}
     steps:
       - name: Build NeoFOAM
         shell: bash -i {0}

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -41,7 +41,7 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          ec2-image-id: ami-03af087024bfdbbee
+          ec2-image-id: ami-09850873fdddbce78
           ec2-instance-type: g4ad.xlarge
           iam-role-name: Role4Github
           subnet-id: subnet-87eb68a6
@@ -76,17 +76,10 @@ jobs:
                  echo "NVM_DIR=/share/ec2-user/.nvm" >> $GITHUB_ENV
                  echo "NVM_BIN=/share/ec2-user/.nvm/versions/node/v16.20.2/bin" >> $GITHUB_ENV
                  # load rocm
-                 sudo cat > /etc/yum.repos.d/rocm.repo << EOF
-                 [ROCm]
-                 name=ROCm
-                 baseurl=https://repo.radeon.com/rocm/yum/6.2.4/main/
-                 enabled=1
-                 gpgcheck=1
-                 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
-                 EOF
-                 sudo yum install amdgpu -y
-                 sudo yum install rocm-libs -y
-                 cp /opt/rocm/lib/rocmmod /share/lmod/modulefiles/Compilers/rocm-6.2.4
+                 echo -e "[ROCm]\nname=ROCm\nbaseurl=https://repo.radeon.com/rocm/yum/6.2.4/main/\nenabled=1\ngpgcheck=1\ngpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" | sudo tee /etc/yum.repos.d/rocm.repo > /dev/null
+                 #sudo yum install amdgpu -y
+                 #sudo yum install rocm-libs -y
+                 #cp /opt/rocm/lib/rocmmod /share/lmod/modulefiles/Compilers/rocm-6.2.4
 
   build-on-aws:
     name: Build on aws

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -71,7 +71,7 @@ jobs:
       - name: Collect runner labels
         id: collect-labels
         run: |
-          run: echo "labels_json=${{ steps.collect-labels.outputs.labels_json }} [\"${RUNNER_LABEL}\"]" >> $GITHUB_ENV
+          echo "labels_json=${{ steps.collect-labels.outputs.labels_json }} [\"${RUNNER_LABEL}\"]" >> $GITHUB_ENV
       - name: Debug output
         run: |
           echo "LABELS_JSON=${{ steps.collect-labels.outputs.labels_json }}"

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -35,7 +35,7 @@ jobs:
       id-token: write
       contents: read
     outputs:
-      labels: ${{ steps.collect-labels.outputs.labels_json }}  # Outputs JSON array of runner labels
+      labels: ${{ steps.start-ec2-runner.outputs.label }}  # Outputs JSON array of runner labels
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
@@ -68,23 +68,41 @@ jobs:
                  sudo ln -s /usr/local/cuda-12.2 /usr/local/cuda
       - name: Store Label in File
         run: echo "${{ steps.start-ec2-runner.outputs.label }}" >> /tmp/labels.txt
-      - name: Collect runner labels
-        id: collect-labels
+      - name: Store Labels as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: runner-labels
+          path: /tmp/labels.txt
+  collect-runner-labels:
+    name: Collect Runner Labels
+    needs: start-runner
+    runs-on: ubuntu-latest
+    outputs:
+      labels: ${{ steps.set-labels.outputs.labels_json }}
+    steps:
+      - name: Download Runner Labels
+        uses: actions/download-artifact@v3
+        with:
+          name: runner-labels
+          
+      - name: Convert Labels to JSON
+        id: set-labels
         run: |
-          LABELS=$(jq -R -s -c 'split("\n")[:-1]' /tmp/labels.txt)
-          echo "labels_json=$LABELS" >> $GITHUB_OUTPUT
-      - name: Debug output
-        run: |
-          echo "LABELS_JSON=${{ steps.collect-labels.outputs.labels_json }}"
+          LABELS=$(jq -R -s -c 'split("\n")[:-1]' labels.txt)
+          echo "labels_json=$LABELS" >> $GITHUB_ENV
+          echo "::set-output name=labels_json::$LABELS"
 
+      - name: Debug Output
+        run: echo "Final JSON Labels: ${{ steps.set-labels.outputs.labels_json }}"
+        
   build-on-aws:
     name: Build on aws
-    needs: start-runner # required to start the main job when the runner is ready
+    needs: [start-runner,collect-runner-labels] # required to start the main job when the runner is ready
     runs-on: ${{ matrix.runner }} # run the job on the newly created runner
     strategy:
       fail-fast: false
       matrix:
-        runner: ${{ fromJson(needs.start-runner.outputs.labels) }}
+        runner: ${{ fromJson(needs.collect-runner-labels.outputs.labels) }}
         preset: ["develop", "production"]
     steps:
       - name: Prepare environment

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -116,7 +116,7 @@ jobs:
           done
 
           # Convert arrays to JSON
-          MATRIX_JSON=$(echo "${LABELS[@]}" | jq -s . | jq -c .)
+          MATRIX_JSON=$(echo "${INSTANCES[@]}" | jq -s . | jq -c .)
           echo $MATRIX_JSON
           echo "matrix=$MATRIX_JSON" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         instance:
           - TYPE: g4dn.xlarge
-            AMI: ami-03af087024bfdbbee
+            AMI: ami-0ecaa2016453bc16b
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -71,7 +71,8 @@ jobs:
       - name: Store Runner Label
         run: |
           echo "${{ steps.start-ec2-runner.outputs.label }}" > label_${{ matrix.instance.index }}.txt
-          echo "${{ steps.start-ec2-runner.outputs.ec2-instance-id }}" >> ec2-instance-id_${{ matrix.instance.index }}.txt
+          echo "${{ steps.start-ec2-runner.outputs.ec2-instance-id }}" > ec2-instance-id_${{ matrix.instance.index }}.txt
+          echo "${{ steps.start-ec2-runner.ec2-instance-type }}" > type_${{ matrix.instance.index }}.txt
       - name: Upload Label Artifact
         uses: actions/upload-artifact@v4
         with:
@@ -79,6 +80,7 @@ jobs:
           path: |
             label_${{ matrix.instance.index }}.txt
             ec2-instance-id_${{ matrix.instance.index }}.txt
+            type_${{ matrix.instance.index }}.txt
           retention-days: 1
   aggregate-labels:
     needs: start-runner
@@ -86,12 +88,14 @@ jobs:
     outputs:
       all_labels: ${{ steps.aggregate.outputs.labels }}
       all_ec2_ids: ${{ steps.aggregate.outputs.ec2_ids }}
+      all_ec2_types: ${{ steps.aggregate.outputs.ec2_types }}
 
     steps:
       - name: Initialize Empty JSON Arrays
         run: |
           echo "LABELS_JSON=[]" >> $GITHUB_ENV
           echo "EC2_IDS_JSON=[]" >> $GITHUB_ENV
+          echo "EC2_TYPES_JSON=[]" >> $GITHUB_ENV
       - name: Download Artifact 1
         uses: actions/download-artifact@v4
         with:
@@ -107,30 +111,34 @@ jobs:
         run: |
           LABELS=()
           EC2_IDS=()
+          EC2_TYPES=()
           for index in {0..1}; do  # Adjust max index if needed
             # Read values from downloaded files
             ls downloaded_data
             LABEL=$(cat downloaded_data/label_${index}.txt)
             EC2_ID=$(cat downloaded_data/ec2-instance-id_${index}.txt)
+            EC2_TYPE=$(cat downloaded_data/type_${index}.txt)
 
             # Append to arrays
             LABELS+=("\"$LABEL\"")
             EC2_IDS+=("\"$EC2_ID\"")
+            EC2_TYPES+=("\"$EC2_TYPE\"")
           done
 
           # Convert arrays to JSON
           LABELS_JSON=$(echo "${LABELS[@]}" | jq -s . | jq -c .)
           EC2_IDS_JSON=$(echo "${EC2_IDS[@]}" | jq -s . | jq -c .)
-
-          echo $LABELS_JSON
+          EC2_TYPES_JSON=$(echo "${EC2_TYPES[@]}" | jq -s . | jq -c .)
 
           echo "labels=$LABELS_JSON" >> $GITHUB_OUTPUT
           echo "ec2_ids=$EC2_IDS_JSON" >> $GITHUB_OUTPUT
+          echo "ec2_types=$EC2_TYPES_JSON" >> $GITHUB_OUTPUT
 
       - name: Show Aggregated Data
         run: |
           echo "Aggregated Labels: ${{ steps.aggregate.outputs.labels }}"
           echo "Aggregated EC2 Instance IDs: ${{ steps.aggregate.outputs.ec2_ids }}"
+          echo "Aggregated EC2 Instance Types: ${{ steps.aggregate.outputs.ec2_types }}"
         
   build-on-aws:
     name: Build on aws
@@ -140,6 +148,7 @@ jobs:
       fail-fast: false
       matrix:
         runner: ${{ fromJson(needs.aggregate-labels.outputs.all_labels) }}
+        ec2-type: ${{ fromJson(needs.aggregate-labels.outputs.all_ec2_types) }}
         preset: ["develop", "production"]
     steps:
       - name: Prepare environment
@@ -154,7 +163,7 @@ jobs:
         if: ${{!contains(github.event.pull_request.labels.*.name, 'Skip-cache')}}
         with:
           path: build
-          key: aws_PR_${{ github.event.pull_request.number }}_${{matrix.preset}}_${{matrix.runner}}
+          key: aws_PR_${{ github.event.pull_request.number }}_${{matrix.preset}}_${{matrix.ec2-type}}
       - name: Build NeoFOAM
         shell: bash -i {0}
         run: |
@@ -236,9 +245,15 @@ jobs:
           target-branch: main
   stop-runner:
     name: Stop self-hosted EC2 runner
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ${{ fromJson(needs.aggregate-labels.outputs.all_labels) }}
+        ec2-ids: ${{ fromJson(needs.aggregate-labels.outputs.all_ec2_ids) }}
     needs:
       - start-runner # required to get output from the start-runner job
       - benchmark-on-aws # required to wait when the main job is done
+      - aggregate-labels
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -256,5 +271,5 @@ jobs:
         with:
           mode: stop
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          label: ${{ needs.start-runner.outputs.label }}
-          ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}
+          label: ${{ matrix.runner }}
+          ec2-instance-id: ${{ matrix.ec2-ids }}

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -28,13 +28,13 @@ jobs:
       matrix:
         instance:
           - TYPE: g5.2xlarge
-            AMI: ami-0f8c4824f9f2e449e
+            AMI: ami-053248e1ad04b8278
             index: 0
           #- TYPE: g4ad.xlarge AMD GPU V520 currently not supported by cmake
           #  AMI: ami-0f8c4824f9f2e449e
           #  index: 0
           - TYPE: g4dn.xlarge
-            AMI: ami-0f8c4824f9f2e449e
+            AMI: ami-053248e1ad04b8278
             index: 1
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         instance:
-          - TYPE: p3.2xlarge
+          - TYPE: g5.2xlarge
             AMI: ami-0f8c4824f9f2e449e
             index: 0
           #- TYPE: g4ad.xlarge AMD GPU V520 currently not supported by cmake

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -92,31 +92,29 @@ jobs:
         run: |
           echo "LABELS_JSON=[]" >> $GITHUB_ENV
           echo "EC2_IDS_JSON=[]" >> $GITHUB_ENV
-          
+      - name: Download Artifact 1
+        uses: actions/download-artifact@v4
+        with:
+          name: labels_0
+          path: downloaded_data
+      - name: Download Artifact 2
+        uses: actions/download-artifact@v4
+        with:
+          name: labels_1
+          path: downloaded_data
       - name: Loop Through Matrix Indices and Download Artifacts
         id: aggregate
         run: |
           LABELS=()
           EC2_IDS=()
+          for index in {0..1}; do  # Adjust max index if needed
+            # Read values from downloaded files
+            LABEL=$(cat downloaded_data/labels_${index}/label_${index}.txt)
+            EC2_ID=$(cat downloaded_data/labels_${index}/ec2-instance-id_${index}.txt)
 
-          for index in {0..10}; do  # Adjust max index if needed
-            artifact_name="labels_${index}"
-            echo "Attempting to download artifact: $artifact_name"
-
-            # Attempt to download artifact, ignore errors if not found
-            if gh run download --name "$artifact_name" --dir "downloaded_artifacts/$artifact_name"; then
-              echo "Downloaded: $artifact_name"
-              
-              # Read values from downloaded files
-              LABEL=$(cat downloaded_artifacts/$artifact_name/label_${index}.txt)
-              EC2_ID=$(cat downloaded_artifacts/$artifact_name/ec2-instance-id_${index}.txt)
-
-              # Append to arrays
-              LABELS+=("\"$LABEL\"")
-              EC2_IDS+=("\"$EC2_ID\"")
-            else
-              echo "Artifact $artifact_name not found, skipping."
-            fi
+            # Append to arrays
+            LABELS+=("\"$LABEL\"")
+            EC2_IDS+=("\"$EC2_ID\"")
           done
 
           # Convert arrays to JSON
@@ -125,8 +123,6 @@ jobs:
 
           echo "labels=$LABELS_JSON" >> $GITHUB_OUTPUT
           echo "ec2_ids=$EC2_IDS_JSON" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
 
       - name: Show Aggregated Data
         run: |

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -74,7 +74,7 @@ jobs:
           sudo rm /actions-runner/externals/node20/bin/node
           sudo ln -s /root/spack/opt/spack/linux-centos7-x86_64_v3/gcc-10.5.0/node-js-22.11.0-mrucyknlrjtbai4kihv5widviflhliip/bin/node /actions-runner/externals/node20/bin/node
       - name: Checkout NeoFOAM
-        uses: actions/checkout@v4
+        uses: actions/checkout@v2
       - name: Set up cache
         uses: actions/cache@v3
         if: ${{!contains(github.event.pull_request.labels.*.name, 'Skip-cache')}}

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -54,7 +54,8 @@ jobs:
             ]
           pre-runner-script: |
                  #!/bin/bash
-                 . /root/spack/share/spack/setup-env.sh 
+                 . /root/spack/share/spack/setup-env.sh
+                 spack install node-js
                  #sudo yum update -y && \
                  #sudo yum install docker git libicu ninja-build libasan10 -y
                  #sudo amazon-linux-extras install epel -y

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -69,9 +69,9 @@ jobs:
           pre-runner-script: |
                  #!/bin/bash
                  . /root/spack/share/spack/setup-env.sh
-                 sudo rm /usr/local/cuda
-                 sudo rm /usr/local/cuda-12.1
-                 sudo ln -s /usr/local/cuda-12.2 /usr/local/cuda
+                 #sudo rm /usr/local/cuda
+                 #sudo rm /usr/local/cuda-12.1
+                 #sudo ln -s /usr/local/cuda-12.2 /usr/local/cuda
       - name: Store Runner Label
         run: |
           echo "${{ steps.start-ec2-runner.outputs.label }}" > label_${{ matrix.instance.index }}.txt
@@ -152,7 +152,7 @@ jobs:
           path: build
           key: aws_PR_${{ github.event.pull_request.number }}_${{matrix.preset}}_${{matrix.instance.ec2-type}}
       - name: Build NeoFOAM
-        shell: bash {0}
+        shell: bash -i {0}
         run: |
           . /root/spack/share/spack/setup-env.sh
           spack load cmake@3.30.5
@@ -185,7 +185,7 @@ jobs:
         instance: ${{ fromJson(needs.aggregate-labels.outputs.matrix) }}
     steps:
       - name: Build NeoFOAM
-        shell: bash {0}
+        shell: bash -i {0}
         run: |
           . /root/spack/share/spack/setup-env.sh
           module load clang/17

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -26,6 +26,8 @@ jobs:
       fail-fast: false
       matrix:
         instance:
+          - TYPE: g4ad.xlarge
+            AMI: ami-0f8c4824f9f2e449e
           - TYPE: g4dn.xlarge
             AMI: ami-06615d18bfde0a1e7
     runs-on: ubuntu-latest

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -56,8 +56,8 @@ jobs:
                  #!/bin/bash
                  . /root/spack/share/spack/setup-env.sh
                  spack install node-js
-                 rm /actions-runner/externals/node20/bin/node
-                 ln -s /root/spack/opt/spack/linux-centos7-x86_64_v3/gcc-10.5.0/node-js-22.11.0-mrucyknlrjtbai4kihv5widviflhliip/bin/node /actions-runner/externals/node20/bin/node
+                 sudo rm /actions-runner/externals/node20/bin/node
+                 sudo ln -s /root/spack/opt/spack/linux-centos7-x86_64_v3/gcc-10.5.0/node-js-22.11.0-mrucyknlrjtbai4kihv5widviflhliip/bin/node /actions-runner/externals/node20/bin/node
                  #sudo yum update -y && \
                  #sudo yum install docker git libicu ninja-build libasan10 -y
                  #sudo amazon-linux-extras install epel -y

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -72,7 +72,7 @@ jobs:
         run: |
           echo "${{ steps.start-ec2-runner.outputs.label }}" > label_${{ matrix.instance.index }}.txt
           echo "${{ steps.start-ec2-runner.outputs.ec2-instance-id }}" > ec2-instance-id_${{ matrix.instance.index }}.txt
-          echo "${{ steps.start-ec2-runner.ec2-instance-type }}" > type_${{ matrix.instance.index }}.txt
+          echo "${{ matrix.instance.TYPE }}" > type_${{ matrix.instance.index }}.txt
       - name: Upload Label Artifact
         uses: actions/upload-artifact@v4
         with:
@@ -143,12 +143,13 @@ jobs:
   build-on-aws:
     name: Build on aws
     needs: aggregate-labels # required to start the main job when the runner is ready
-    runs-on: ${{ matrix.runner }} # run the job on the newly created runner
+    runs-on: ${{ matrix.instance.runner }} # run the job on the newly created runner
     strategy:
       fail-fast: false
       matrix:
-        runner: ${{ fromJson(needs.aggregate-labels.outputs.all_labels) }}
-        ec2-type: ${{ fromJson(needs.aggregate-labels.outputs.all_ec2_types) }}
+        instance:
+          - runner: ${{ fromJson(needs.aggregate-labels.outputs.all_labels) }}
+            ec2-type: ${{ fromJson(needs.aggregate-labels.outputs.all_ec2_types) }}
         preset: ["develop", "production"]
     steps:
       - name: Prepare environment
@@ -163,7 +164,7 @@ jobs:
         if: ${{!contains(github.event.pull_request.labels.*.name, 'Skip-cache')}}
         with:
           path: build
-          key: aws_PR_${{ github.event.pull_request.number }}_${{matrix.preset}}_${{matrix.ec2-type}}
+          key: aws_PR_${{ github.event.pull_request.number }}_${{matrix.preset}}_${{matrix.instance.ec2-type}}
       - name: Build NeoFOAM
         shell: bash -i {0}
         run: |

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -56,32 +56,6 @@ jobs:
                  #!/bin/bash
                  . /root/spack/share/spack/setup-env.sh
                  spack install node-js
-                 #sudo yum update -y && \
-                 #sudo yum install docker git libicu ninja-build libasan10 -y
-                 #sudo amazon-linux-extras install epel -y
-                 #sudo yum install Lmod -y
-                 #sudo systemctl enable docker
-                 #sudo mkfs -t xfs /dev/sda1
-                 #sudo mkdir -p /share
-                 #sudo mount /dev/sda1 /share
-                 #aws s3 cp s3://ucfd-share/pcluster/3.x/alinux2/x86_64/postinstall_github .
-                 #chmod +x postinstall_github
-                 #sudo ./postinstall_github > ~/install.log
-                 #mkdir -p /share/ec2-user
-                 #export USER=ec2-user
-                 #cd /share/ec2-user
-                 #mkdir .nvm
-                 #export NVM_DIR=/share/ec2-user/.nvm
-                 #sudo curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
-                 #[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
-                 #nvm install v16.20.2
-                 #echo "NVM_DIR=/share/ec2-user/.nvm" >> $GITHUB_ENV
-                 #echo "NVM_BIN=/share/ec2-user/.nvm/versions/node/v16.20.2/bin" >> $GITHUB_ENV
-                 # load rocm
-                 #echo -e "[ROCm]\nname=ROCm\nbaseurl=https://repo.radeon.com/rocm/yum/6.2.4/main/\nenabled=1\ngpgcheck=1\ngpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" | sudo tee /etc/yum.repos.d/rocm.repo > /dev/null
-                 #sudo yum install amdgpu -y
-                 #sudo yum install rocm-libs -y
-                 #cp /opt/rocm/lib/rocmmod /share/lmod/modulefiles/Compilers/rocm-6.2.4
 
   build-on-aws:
     name: Build on aws
@@ -97,6 +71,7 @@ jobs:
         run: |
           sudo rm /actions-runner/externals/node20/bin/node
           sudo ln -s /root/spack/opt/spack/linux-centos7-x86_64_v3/gcc-10.5.0/node-js-22.11.0-mrucyknlrjtbai4kihv5widviflhliip/bin/node /actions-runner/externals/node20/bin/node
+          module use /usr/share/lmod/lmod/modulefiles/Compilers
       - name: Checkout NeoFOAM
         uses: actions/checkout@v2
       - name: Set up cache
@@ -110,7 +85,6 @@ jobs:
         run: |
           . /root/spack/share/spack/setup-env.sh
           spack load cmake
-          spack load rocthrust
           spack load hip
           spack load kokkos
           module load clang/17

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -104,13 +104,15 @@ jobs:
             mkdir -p downloaded_artifacts/$artifact_name
 
             echo "Trying to download: $artifact_name"
-            if gh run download --name "$artifact_name" --dir "downloaded_artifacts/$artifact_name"; then
-              LABEL=$(cat downloaded_artifacts/$artifact_name/label_${index}.txt)
-              EC2_ID=$(cat downloaded_artifacts/$artifact_name/ec2-instance-id_${index}.txt)
+            # Attempt to download artifact (fails silently if not found)
+            echo "Downloading: $artifact_name"
+            curl -fsSLO --retry 3 https://github.com/${{ github.repository }}/actions/artifacts/$artifact_name || continue
+
+            LABEL=$(cat downloaded_artifacts/$artifact_name/label_${index}.txt)
+            EC2_ID=$(cat downloaded_artifacts/$artifact_name/ec2-instance-id_${index}.txt)
               
-              LABELS+=("\"$LABEL\"")
-              EC2_IDS+=("\"$EC2_ID\"")
-            fi
+            LABELS+=("\"$LABEL\"")
+            EC2_IDS+=("\"$EC2_ID\"")
           done
 
           # Convert arrays to JSON

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -42,7 +42,7 @@ jobs:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ami-03af087024bfdbbee
-          ec2-instance-type: g4dn.xlarge
+          ec2-instance-type: g4ad.xlarge
           iam-role-name: Role4Github
           subnet-id: subnet-b5d2adbb
           security-group-id: sg-559f8967

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -68,30 +68,19 @@ jobs:
                  sudo ln -s /usr/local/cuda-12.2 /usr/local/cuda
       - name: Store Label in File
         run: echo "${{ steps.start-ec2-runner.outputs.label }}" >> /tmp/labels.txt
-      - name: Store Labels as Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: runner-labels
-          path: /tmp/labels.txt
           
   collect-runner-labels:
     name: Collect Runner Labels
     needs: start-runner
     runs-on: ubuntu-latest
     outputs:
-      labels: ${{ steps.set-labels.outputs.labels_json }}
+      labels: ${{ steps.aggregate-labels.outputs.labels_json }}
     steps:
-      - name: Download Runner Labels
-        uses: actions/download-artifact@v4
-        with:
-          name: runner-labels
-          
-      - name: Convert Labels to JSON
-        id: set-labels
+      - name: Aggregate All Labels into JSON
+        id: aggregate-labels
         run: |
-          LABELS=$(jq -R -s -c 'split("\n")[:-1]' labels.txt)
-          echo "labels_json=$LABELS" >> $GITHUB_ENV
-          echo "::set-output name=labels_json::$LABELS"
+          LABELS=$(jq -R -s -c 'split("\n")[:-1]' /tmp/labels.txt)
+          echo "labels_json=$LABELS" >> $GITHUB_OUTPUT
         
   build-on-aws:
     name: Build on aws

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -34,7 +34,7 @@ jobs:
           #  AMI: ami-0f8c4824f9f2e449e
           #  index: 0
           - TYPE: g4dn.xlarge
-            AMI: ami-053248e1ad04b8278
+            AMI: ami-055b8a94dc5225395
             index: 0
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -86,16 +86,11 @@ jobs:
     needs: start-runner
     runs-on: ubuntu-latest
     outputs:
-      all_labels: ${{ steps.aggregate.outputs.labels }}
-      all_ec2_ids: ${{ steps.aggregate.outputs.ec2_ids }}
-      all_ec2_types: ${{ steps.aggregate.outputs.ec2_types }}
-
+      matrix: ${{ steps.aggregate.outputs.matrix }}
     steps:
       - name: Initialize Empty JSON Arrays
         run: |
-          echo "LABELS_JSON=[]" >> $GITHUB_ENV
-          echo "EC2_IDS_JSON=[]" >> $GITHUB_ENV
-          echo "EC2_TYPES_JSON=[]" >> $GITHUB_ENV
+          echo "MATRIX_JSON=[]" >> $GITHUB_ENV
       - name: Download Artifact 1
         uses: actions/download-artifact@v4
         with:
@@ -109,36 +104,25 @@ jobs:
       - name: Loop Through Matrix Indices and Download Artifacts
         id: aggregate
         run: |
-          LABELS=()
-          EC2_IDS=()
-          EC2_TYPES=()
+          INSTANCES=()
           for index in {0..1}; do  # Adjust max index if needed
             # Read values from downloaded files
-            ls downloaded_data
             LABEL=$(cat downloaded_data/label_${index}.txt)
             EC2_ID=$(cat downloaded_data/ec2-instance-id_${index}.txt)
             EC2_TYPE=$(cat downloaded_data/type_${index}.txt)
 
-            # Append to arrays
-            LABELS+=("\"$LABEL\"")
-            EC2_IDS+=("\"$EC2_ID\"")
-            EC2_TYPES+=("\"$EC2_TYPE\"")
+            # Create JSON object for this instance
+            INSTANCES+=("{\"runner\":\"$LABEL\", \"ec2-id\":\"$EC2_ID\", \"ec2-type\":\"$EC2_TYPE\"}")
           done
 
           # Convert arrays to JSON
-          LABELS_JSON=$(echo "${LABELS[@]}" | jq -s . | jq -c .)
-          EC2_IDS_JSON=$(echo "${EC2_IDS[@]}" | jq -s . | jq -c .)
-          EC2_TYPES_JSON=$(echo "${EC2_TYPES[@]}" | jq -s . | jq -c .)
-
-          echo "labels=$LABELS_JSON" >> $GITHUB_OUTPUT
-          echo "ec2_ids=$EC2_IDS_JSON" >> $GITHUB_OUTPUT
-          echo "ec2_types=$EC2_TYPES_JSON" >> $GITHUB_OUTPUT
+          MATRIX_JSON=$(echo "${LABELS[@]}" | jq -s . | jq -c .)
+          echo $MATRIX_JSON
+          echo "matrix=$MATRIX_JSON" >> $GITHUB_OUTPUT
 
       - name: Show Aggregated Data
         run: |
-          echo "Aggregated Labels: ${{ steps.aggregate.outputs.labels }}"
-          echo "Aggregated EC2 Instance IDs: ${{ steps.aggregate.outputs.ec2_ids }}"
-          echo "Aggregated EC2 Instance Types: ${{ steps.aggregate.outputs.ec2_types }}"
+          run: echo "Matrix: ${{ steps.aggregate.outputs.matrix }}"
         
   build-on-aws:
     name: Build on aws
@@ -147,9 +131,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        instance:
-          - runner: ${{ fromJson(needs.aggregate-labels.outputs.all_labels) }}
-            ec2-type: ${{ fromJson(needs.aggregate-labels.outputs.all_ec2_types) }}
+        instance: ${{ fromJson(needs.aggregate-labels.outputs.matrix) }}
         preset: ["develop", "production"]
     steps:
       - name: Prepare environment
@@ -191,12 +173,12 @@ jobs:
   benchmark-on-aws:
     name: Benchmark on aws
     needs: [start-runner,aggregate-labels, build-on-aws] # required to start the main job when the runner is ready
-    runs-on: ${{ matrix.runner }} # run the job on the newly created runner
+    runs-on: ${{ matrix.instance.runner }} # run the job on the newly created runner
     if: github.event.inputs.debug != 'true'
     strategy:
       fail-fast: false
       matrix:
-        runner: ${{ fromJson(needs.aggregate-labels.outputs.all_labels) }}
+        instance: ${{ fromJson(needs.aggregate-labels.outputs.matrix) }}
     steps:
       - name: Build NeoFOAM
         shell: bash -i {0}
@@ -249,8 +231,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: ${{ fromJson(needs.aggregate-labels.outputs.all_labels) }}
-        ec2-ids: ${{ fromJson(needs.aggregate-labels.outputs.all_ec2_ids) }}
+        instance: ${{ fromJson(needs.aggregate-labels.outputs.matrix) }}
     needs:
       - start-runner # required to get output from the start-runner job
       - benchmark-on-aws # required to wait when the main job is done
@@ -272,5 +253,5 @@ jobs:
         with:
           mode: stop
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          label: ${{ matrix.runner }}
-          ec2-instance-id: ${{ matrix.ec2-ids }}
+          label: ${{ matrix.instance.runner }}
+          ec2-instance-id: ${{ matrix.instance.ec2-id }}

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -6,12 +6,18 @@ env:
   OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
   OMPI_MCA_rmaps_base_oversubscribe: true
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+  DEBUG: ${{ github.event.inputs.debug }}
 on:
   pull_request:
     types: [opened, synchronize]
 
   # enable to manually trigger the tests
   workflow_dispatch:
+    inputs:
+        debug:
+          description: 'Enable debug mode (true/false)'
+          required: false
+          default: 'false'
 jobs:
   start-runner:
     if: ${{contains(github.event.pull_request.labels.*.name, 'full-ci') || github.event_name == 'workflow_dispatch'}}
@@ -125,6 +131,7 @@ jobs:
     name: Benchmark on aws
     needs: [start-runner, build-on-aws] # required to start the main job when the runner is ready
     runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
+    if: env.DEBUG != 'true'
     steps:
       - name: Build NeoFOAM
         shell: bash -i {0}
@@ -181,7 +188,7 @@ jobs:
       id-token: write
       contents: read
     # only try to run the stop job if the start runner hasn't been skipped
-    if: ${{ always() && needs.start-runner.result != 'skipped' }}
+    if: ${{ always() && needs.start-runner.result != 'skipped' && env.DEBUG != 'true'}}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -35,7 +35,7 @@ jobs:
           #  index: 0
           - TYPE: g4dn.xlarge
             AMI: ami-053248e1ad04b8278
-            index: 1
+            index: 0
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -100,16 +100,16 @@ jobs:
         with:
           name: labels_0
           path: downloaded_data
-      - name: Download Artifact 2
-        uses: actions/download-artifact@v4
-        with:
-          name: labels_1
-          path: downloaded_data
+      #- name: Download Artifact 2
+      #  uses: actions/download-artifact@v4
+      #  with:
+      #    name: labels_1
+      #    path: downloaded_data
       - name: Loop Through Matrix Indices and Download Artifacts
         id: aggregate
         run: |
           INSTANCES=()
-          for index in {0..1}; do  # Adjust max index if needed
+          for index in {0..0}; do  # Adjust max index if needed
             # Read values from downloaded files
             LABEL=$(cat downloaded_data/label_${index}.txt)
             EC2_ID=$(cat downloaded_data/ec2-instance-id_${index}.txt)

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -110,9 +110,8 @@ jobs:
           for index in {0..1}; do  # Adjust max index if needed
             # Read values from downloaded files
             ls downloaded_data
-            unzip "downloaded_data/labels_${index}.zip" -d "downloaded_data"
-            LABEL=$(cat downloaded_data/labels_${index}/label_${index}.txt)
-            EC2_ID=$(cat downloaded_data/labels_${index}/ec2-instance-id_${index}.txt)
+            LABEL=$(cat downloaded_data/label_${index}.txt)
+            EC2_ID=$(cat downloaded_data/ec2-instance-id_${index}.txt)
 
             # Append to arrays
             LABELS+=("\"$LABEL\"")

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -41,7 +41,7 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          ec2-image-id: ami-03af087024bfdbbee
+          ec2-image-id: ami-09850873fdddbce78
           ec2-instance-type: g4ad.xlarge
           iam-role-name: Role4Github
           subnet-id: subnet-87eb68a6

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -116,8 +116,12 @@ jobs:
   benchmark-on-aws:
     name: Benchmark on aws
     needs: [start-runner, build-on-aws] # required to start the main job when the runner is ready
-    runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
+    runs-on: ${{ matrix.runner }} # run the job on the newly created runner
     if: github.event.inputs.debug != 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ${{ fromJson(needs.start-runner.outputs.labels) }}
     steps:
       - name: Build NeoFOAM
         shell: bash -i {0}

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -104,16 +104,16 @@ jobs:
           name: ec2-instance-ids
           path: ec2-instance-ids
 
-      - name: Aggregate Labels and EC2 IDs
+      - name: Aggregate Labels and EC2 IDs as JSON
         id: aggregate
         run: |
-          # Join all labels into a single space-separated string
-          LABELS=$(cat labels/*.txt | tr '\n' ' ')
-          echo "labels=$LABELS" >> $GITHUB_OUTPUT
+          # Read labels and convert them into a JSON array
+          LABELS_JSON=$(jq -R . < labels/*.txt | jq -s .)
+          echo "labels=$LABELS_JSON" >> $GITHUB_OUTPUT
 
-          # Join all EC2 instance IDs into a single space-separated string
-          EC2_IDS=$(cat ec2-instance-ids/*.txt | tr '\n' ' ')
-          echo "ec2_ids=$EC2_IDS" >> $GITHUB_OUTPUT
+          # Read EC2 instance IDs and convert them into a JSON array
+          EC2_IDS_JSON=$(jq -R . < ec2-instance-ids/*.txt | jq -s .)
+          echo "ec2_ids=$EC2_IDS_JSON" >> $GITHUB_OUTPUT
 
       - name: Show Aggregated Data
         run: |
@@ -127,7 +127,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: ${{ steps.aggregate.outputs.labels }}
+        runner: ${{ fromJson(needs.aggregate-labels.outputs.all_labels) }}
         preset: ["develop", "production"]
     steps:
       - name: Prepare environment

--- a/.github/workflows/build_on_aws.yaml
+++ b/.github/workflows/build_on_aws.yaml
@@ -119,8 +119,8 @@ jobs:
           done
 
           # Convert arrays to JSON
-          LABELS_JSON=$(echo "${LABELS[@]}" | jq -s .)
-          EC2_IDS_JSON=$(echo "${EC2_IDS[@]}" | jq -s .)
+          LABELS_JSON=$(echo "${LABELS[@]}" | jq -s . | jq -c .)
+          EC2_IDS_JSON=$(echo "${EC2_IDS[@]}" | jq -s . | jq -c .)
 
           echo $LABELS_JSON
 


### PR DESCRIPTION
Additional AMI and loop to run on g4ad instances using AMD Radeon v520pro GPUs. Can be extened in the future to use additional scientific instances like p4. There are currently 2 AMIs ready to use. The one for g4dn instances is NVIDIA and should in theory work for any instance with nvidia gpu. 
A debug flag can be set now, which will keep the AWS instance running after the compilation attempt for debugging (and skip benchmark).
The benchmark logic currently doesn't work if the workflow is run manually (missing PR number).
While NeoFOAM compiles for the AMD instance, I think it is not correctly detecting the GPU. This might be due to the v520pro not correctly being detected by CMAKE the arch number is GFX1011 which doesn't seem to be known by cmake. One can try to force GFX1030 but there might be errors.