### PR TITLE
CSR Quality of life

### DIFF
--- a/include/NeoFOAM/fields/field.hpp
+++ b/include/NeoFOAM/fields/field.hpp
@@ -99,7 +99,7 @@ public:
     {
         void* ptr = nullptr;
         std::visit(
-            [&ptr, size](const auto& exec) { ptr = exec.alloc(size * sizeof(ValueType)); }, exec_
+            [&ptr, size](const auto& execu) { ptr = execu.alloc(size * sizeof(ValueType)); }, exec_
         );
         data_ = static_cast<ValueType*>(ptr);
         NeoFOAM::fill(*this, value);

--- a/include/NeoFOAM/linearAlgebra/CSRMatrix.hpp
+++ b/include/NeoFOAM/linearAlgebra/CSRMatrix.hpp
@@ -79,21 +79,21 @@ public:
         Kokkos::abort("Memory not allocated for CSR matrix component.");
     }
 
-    ValueType& entry(const IndexType i, const IndexType j)
+    KOKKOS_INLINE_FUNCTION
+    ValueType& entry(IndexType i, IndexType j)
     {
-        for (IndexType iColumn = 0; iColumn < (colIdxs()[i + 1] - colIdxs()[i]); ++iColumn)
+        for (IndexType ic = 0; ic < (rowPtrs_[i + 1] - rowPtrs_[i]); ++ic)
         {
-            if (colIdxs()[rowPtrs()[i] + iColumn] == j)
+            if (colIdxs_[rowPtrs_[i] + ic] == j)
             {
-                return values()[rowPtrs()[i] + iColumn];
+                return values_[rowPtrs_[i] + ic];
             }
-
-            if (colIdxs()[rowPtrs()[i] + iColumn] > j)
+            if (colIdxs_[rowPtrs_[i] + ic] > j)
             {
-                // Insert
-                NF_ERROR_EXIT("Not implemented must allocate " << i << ", " << j << ".");
-            }
+                Kokkos::abort("WIP.");
+            };
         }
+        Kokkos::abort("Memory not allocated for CSR matrix component.");
     }
 
 private:

--- a/include/NeoFOAM/linearAlgebra/CSRMatrix.hpp
+++ b/include/NeoFOAM/linearAlgebra/CSRMatrix.hpp
@@ -8,6 +8,13 @@
 namespace NeoFOAM::la
 {
 
+enum BlockStructType
+{
+    cell,
+    component
+}
+
+
 template<typename ValueType, typename IndexType>
 class CSRMatrix
 {
@@ -43,9 +50,37 @@ public:
     [[nodiscard]] const std::span<const IndexType> colIdxs() const { return colIdxs_.span(); }
     [[nodiscard]] const std::span<const IndexType> rowPtrs() const { return rowPtrs_.span(); }
 
+    const ValueType& entry(IndexType i, IndexType j)
+    {
+        for (indexType iColumn = 0; iColumn < (colIdxs_[i + 1] - colIdxs_[i]); ++iColumn)
+        {
+            if (colIdxs_[rowPtrs_[i] + iColumn] == j)
+            {
+                return rowPtrs_[rowPtrs_[i] + iColumn];
+            }
+        }
+        NF_ERROR_EXIT("Matrix entry " << i << ", " << j << " has not been allocated, cannot get.");
+    }
+
+    const ValueType& entry(const IndexType i, const IndexType j)
+    {
+        for (indexType iColumn = 0; iColumn < (colIdxs_[i + 1] - colIdxs_[i]); ++iColumn)
+        {
+            if (colIdxs_[rowPtrs_[i] + iColumn] == j)
+            {
+                return rowPtrs_[rowPtrs_[i] + iColumn];
+            }
+
+            if (colIdxs_[rowPtrs_[i] + iColumn] > j)
+            {
+                // Insert
+            }
+        }
+    };
 
 private:
 
+    BlockStructType {cell};
     Field<ValueType> values_;
     Field<IndexType> colIdxs_;
     Field<IndexType> rowPtrs_;

--- a/include/NeoFOAM/linearAlgebra/CSRMatrix.hpp
+++ b/include/NeoFOAM/linearAlgebra/CSRMatrix.hpp
@@ -43,7 +43,6 @@ public:
      * @param i The row index.
      * @param j The column index.
      * @return Reference to the matrix element if it exists.
-     * @note If the element doesn't exist, the function will abort with an error message.
      */
     KOKKOS_INLINE_FUNCTION
     ValueType& entry(const IndexType i, const IndexType j) const
@@ -61,6 +60,14 @@ public:
         Kokkos::abort("Memory not allocated for CSR matrix component.");
         return values_[values_.size()]; // compiler warning suppression.
     }
+
+    /**
+     * @brief Direct access to a value given the offset.
+     * @param offset The offset, from 0, to the value.
+     * @return Reference to the matrix element if it exists.
+     */
+    KOKKOS_INLINE_FUNCTION
+    ValueType& directValue(const IndexType offset) const { values_[offset]; }
 
 private:
 

--- a/include/NeoFOAM/linearAlgebra/CSRMatrix.hpp
+++ b/include/NeoFOAM/linearAlgebra/CSRMatrix.hpp
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: 2023 NeoFOAM authors
 #pragma once
 
+#include <tuple>
+
 #include "NeoFOAM/fields/field.hpp"
 
 
@@ -68,6 +70,15 @@ public:
     KOKKOS_INLINE_FUNCTION
     ValueType& entry(const IndexType offset) const { return values_[offset]; }
 
+    /**
+     * @brief Returns a structured binding of all containers.
+     * @return std::tuple<std::span<ValueType>, std::span<IndexType>, std::span<IndexType>>
+     */
+    std::tuple<std::span<ValueType>, std::span<IndexType>, std::span<IndexType>> span()
+    {
+        return {values_, colIdxs_, rowPtrs_};
+    }
+
 private:
 
     std::span<ValueType> values_;  //!< Span to the values of the CSR matrix.
@@ -119,13 +130,7 @@ public:
      * @brief Get the number of non-zero values in the matrix.
      * @return Number of non-zero values.
      */
-    [[nodiscard]] IndexType nValues() const { return values_.size(); }
-
-    /**
-     * @brief Get the number of column indices in the matrix.
-     * @return Number of column indices.
-     */
-    [[nodiscard]] IndexType nColIdxs() const { return colIdxs_.size(); }
+    [[nodiscard]] IndexType nNonZeros() const { return values_.size(); }
 
     /**
      * @brief Get a span to the values array.

--- a/include/NeoFOAM/linearAlgebra/CSRMatrix.hpp
+++ b/include/NeoFOAM/linearAlgebra/CSRMatrix.hpp
@@ -74,6 +74,7 @@ public:
             if (colIdxs_[rowPtrs_[i] + iColumn] > j)
             {
                 // Insert
+                NF_ERROR_EXIT("Not implemented must allocate " << i << ", " << j << ".");
             }
         }
     };

--- a/include/NeoFOAM/linearAlgebra/CSRMatrix.hpp
+++ b/include/NeoFOAM/linearAlgebra/CSRMatrix.hpp
@@ -66,7 +66,7 @@ public:
      * @return Reference to the matrix element if it exists.
      */
     KOKKOS_INLINE_FUNCTION
-    ValueType& directValue(const IndexType offset) const { return values_[offset]; }
+    ValueType& entry(const IndexType offset) const { return values_[offset]; }
 
 private:
 
@@ -170,7 +170,10 @@ public:
      */
     [[nodiscard]] CSRMatrix<ValueType, IndexType> copyToExecutor(Executor dstExec) const
     {
-        if (dstExec == values_.exec()) return *this;
+        if (dstExec == values_.exec())
+        {
+            return *this;
+        }
         CSRMatrix<ValueType, IndexType> other(
             values_.copyToHost(), colIdxs_.copyToHost(), rowPtrs_.copyToHost()
         );

--- a/include/NeoFOAM/linearAlgebra/CSRMatrix.hpp
+++ b/include/NeoFOAM/linearAlgebra/CSRMatrix.hpp
@@ -124,13 +124,13 @@ public:
      * @brief Get the number of rows in the matrix.
      * @return Number of rows.
      */
-    [[nodiscard]] IndexType nRows() const { return rowPtrs_.size() - 1; }
+    [[nodiscard]] IndexType nRows() const { return static_cast<IndexType>(rowPtrs_.size()) - 1; }
 
     /**
      * @brief Get the number of non-zero values in the matrix.
      * @return Number of non-zero values.
      */
-    [[nodiscard]] IndexType nNonZeros() const { return values_.size(); }
+    [[nodiscard]] IndexType nNonZeros() const { return static_cast<IndexType>(values_.size()); }
 
     /**
      * @brief Get a span to the values array.

--- a/include/NeoFOAM/linearAlgebra/CSRMatrix.hpp
+++ b/include/NeoFOAM/linearAlgebra/CSRMatrix.hpp
@@ -8,18 +8,24 @@
 namespace NeoFOAM::la
 {
 
-enum BlockStructType
-{
-    cell,
-    component
-};
 
+/**
+ * @class CSRMatrixSpan
+ * @brief A helper class to allow easy read/write on all executors.
+ * @tparam ValueType The type of the underlying CSR matrix elements.
+ * @tparam IndexType The type of the indexes.
+ */
 template<typename ValueType, typename IndexType>
 class CSRMatrixSpan
 {
 public:
 
-    // Constructor for non-const spans
+    /**
+     * @brief Constructor for CSRMatrixSpan.
+     * @param values Span of the non-zero values of the matrix.
+     * @param colIdxs Span of the column indices for each non-zero value.
+     * @param rowPtrs Span of the starting index in values/colIdxs for each row.
+     */
     CSRMatrixSpan(
         const std::span<ValueType>& values,
         const std::span<IndexType>& colIdxs,
@@ -27,35 +33,40 @@ public:
     )
         : values_(values), colIdxs_(colIdxs), rowPtrs_(rowPtrs) {};
 
-    // Constructor for const spans - needed for const matrix objects
-    CSRMatrixSpan(
-        const std::span<const ValueType>& values,
-        const std::span<const IndexType>& colIdxs,
-        const std::span<const IndexType>& rowPtrs
-    )
-        : values_(values), colIdxs_(colIdxs), rowPtrs_(rowPtrs) {};
-
+    /**
+     * @brief Default destructor.
+     */
     ~CSRMatrixSpan() = default;
 
+    /**
+     * @brief Retrieve a reference to the matrix element at position (i,j).
+     * @param i The row index.
+     * @param j The column index.
+     * @return Reference to the matrix element if it exists.
+     * @note If the element doesn't exist, the function will abort with an error message.
+     */
     KOKKOS_INLINE_FUNCTION
     ValueType& entry(const IndexType i, const IndexType j) const
     {
-        for (IndexType ic = 0; ic < (rowPtrs_[i + 1] - rowPtrs_[i]); ++ic)
+        const IndexType rowSize = rowPtrs_[i + 1] - rowPtrs_[i];
+        for (std::remove_const_t<IndexType> ic = 0; ic < rowSize; ++ic)
         {
-            if (colIdxs_[rowPtrs_[i] + ic] == j)
+            const IndexType localCol = rowPtrs_[i] + ic;
+            if (colIdxs_[localCol] == j)
             {
-                return values_[rowPtrs_[i] + ic];
+                return values_[localCol];
             }
-            if (colIdxs_[rowPtrs_[i] + ic] > j) break;
+            if (colIdxs_[localCol] > j) break;
         }
         Kokkos::abort("Memory not allocated for CSR matrix component.");
+        return values_[values_.size()]; // compiler warning suppression.
     }
 
 private:
 
-    std::span<ValueType> values_;
-    std::span<IndexType> colIdxs_;
-    std::span<IndexType> rowPtrs_;
+    std::span<ValueType> values_;  //!< Span to the values of the CSR matrix.
+    std::span<IndexType> colIdxs_; //!< Span to the column indices of the CSR matrix.
+    std::span<IndexType> rowPtrs_; //!< Span to the row offsets for the CSR matrix.
 };
 
 template<typename ValueType, typename IndexType>
@@ -64,6 +75,12 @@ class CSRMatrix
 
 public:
 
+    /**
+     * @brief Constructor for CSRMatrix.
+     * @param values The non-zero values of the matrix.
+     * @param colIdxs The column indices for each non-zero value.
+     * @param rowPtrs The starting index in values/colIdxs for each row.
+     */
     CSRMatrix(
         const Field<ValueType>& values,
         const Field<IndexType>& colIdxs,
@@ -75,44 +92,107 @@ public:
         NF_ASSERT(values.exec() == rowPtrs.exec(), "Executors are not the same");
     };
 
+    /**
+     * @brief Default destructor.
+     */
     ~CSRMatrix() = default;
 
+    /**
+     * @brief Get the executor associated with this matrix.
+     * @return Reference to the executor.
+     */
     [[nodiscard]] const Executor& exec() const { return values_.exec(); }
 
+    /**
+     * @brief Get the number of rows in the matrix.
+     * @return Number of rows.
+     */
     [[nodiscard]] IndexType nRows() const { return rowPtrs_.size() - 1; }
 
+    /**
+     * @brief Get the number of non-zero values in the matrix.
+     * @return Number of non-zero values.
+     */
     [[nodiscard]] IndexType nValues() const { return values_.size(); }
 
+    /**
+     * @brief Get the number of column indices in the matrix.
+     * @return Number of column indices.
+     */
     [[nodiscard]] IndexType nColIdxs() const { return colIdxs_.size(); }
 
+    /**
+     * @brief Get a span to the values array.
+     * @return Span containing the matrix values.
+     */
     [[nodiscard]] std::span<ValueType> values() { return values_.span(); }
+
+    /**
+     * @brief Get a span to the column indices array.
+     * @return Span containing the column indices.
+     */
     [[nodiscard]] std::span<IndexType> colIdxs() { return colIdxs_.span(); }
+
+    /**
+     * @brief Get a span to the row pointers array.
+     * @return Span containing the row pointers.
+     */
     [[nodiscard]] std::span<IndexType> rowPtrs() { return rowPtrs_.span(); }
 
+    /**
+     * @brief Get a const span to the values array.
+     * @return Const span containing the matrix values.
+     */
     [[nodiscard]] const std::span<const ValueType> values() const { return values_.span(); }
+
+    /**
+     * @brief Get a const span to the column indices array.
+     * @return Const span containing the column indices.
+     */
     [[nodiscard]] const std::span<const IndexType> colIdxs() const { return colIdxs_.span(); }
+
+    /**
+     * @brief Get a const span to the row pointers array.
+     * @return Const span containing the row pointers.
+     */
     [[nodiscard]] const std::span<const IndexType> rowPtrs() const { return rowPtrs_.span(); }
 
+    /**
+     * @brief Copy the matrix to another executor.
+     * @param dstExec The destination executor.
+     * @return A copy of the matrix on the destination executor.
+     */
     [[nodiscard]] CSRMatrix<ValueType, IndexType> copyToExecutor(Executor dstExec) const
     {
         if (dstExec == values_.exec()) return *this;
-        CSRMatrix<ValueType, IndexType> result(
+        CSRMatrix<ValueType, IndexType> other(
             values_.copyToHost(), colIdxs_.copyToHost(), rowPtrs_.copyToHost()
         );
-        result.type_ = type_;
-        return result;
+        return other;
     }
 
+    /**
+     * @brief Copy the matrix to the host.
+     * @return A copy of the matrix on the host.
+     */
     [[nodiscard]] CSRMatrix<ValueType, IndexType> copyToHost() const
     {
         return copyToExecutor(SerialExecutor());
     }
 
+    /**
+     * @brief Get a span representation of the matrix.
+     * @return CSRMatrixSpan for easy access to matrix elements.
+     */
     [[nodiscard]] CSRMatrixSpan<ValueType, IndexType> span()
     {
         return CSRMatrixSpan(values_.span(), colIdxs_.span(), rowPtrs_.span());
     }
 
+    /**
+     * @brief Get a const span representation of the matrix.
+     * @return Const CSRMatrixSpan for read-only access to matrix elements.
+     */
     [[nodiscard]] const CSRMatrixSpan<const ValueType, const IndexType> span() const
     {
         return CSRMatrixSpan(values_.span(), colIdxs_.span(), rowPtrs_.span());
@@ -120,10 +200,9 @@ public:
 
 private:
 
-    BlockStructType type_ {cell};
-    Field<ValueType> values_;
-    Field<IndexType> colIdxs_;
-    Field<IndexType> rowPtrs_;
+    Field<ValueType> values_;  //!< The (non-zero) values of the CSR matrix.
+    Field<IndexType> colIdxs_; //!< The column indices of the CSR matrix.
+    Field<IndexType> rowPtrs_; //!< The row offsets for the CSR matrix.
 };
 
 } // namespace NeoFOAM

--- a/include/NeoFOAM/linearAlgebra/CSRMatrix.hpp
+++ b/include/NeoFOAM/linearAlgebra/CSRMatrix.hpp
@@ -14,7 +14,6 @@ enum BlockStructType
     component
 };
 
-
 template<typename ValueType, typename IndexType>
 class CSRMatrix
 {
@@ -66,20 +65,18 @@ public:
         return copyToExecutor(SerialExecutor());
     }
 
+    KOKKOS_INLINE_FUNCTION
     const ValueType& entry(const IndexType i, const IndexType j) const
     {
-        const auto& vals = values();
-        const auto& cols = colIdxs();
-        const auto& rows = rowPtrs();
-        for (IndexType ic = 0; ic < (rows[i + 1] - rows[i]); ++ic)
+        for (IndexType ic = 0; ic < (rowPtrs_[i + 1] - rowPtrs_[i]); ++ic)
         {
-            if (cols[rows[i] + ic] == j)
+            if (colIdxs_[rowPtrs_[i] + ic] == j)
             {
-                return vals[rows[i] + ic];
+                return values_[rowPtrs_[i] + ic];
             }
-            if (cols[rows[i] + ic] > j) break;
+            if (colIdxs_[rowPtrs_[i] + ic] > j) break;
         }
-        NF_ERROR_EXIT("Matrix entry " << i << ", " << j << " has not been allocated, cannot get.");
+        Kokkos::abort("Memory not allocated for CSR matrix component.");
     }
 
     ValueType& entry(const IndexType i, const IndexType j)

--- a/include/NeoFOAM/linearAlgebra/CSRMatrix.hpp
+++ b/include/NeoFOAM/linearAlgebra/CSRMatrix.hpp
@@ -8,7 +8,6 @@
 namespace NeoFOAM::la
 {
 
-
 /**
  * @class CSRMatrixSpan
  * @brief A helper class to allow easy read/write on all executors.
@@ -67,7 +66,7 @@ public:
      * @return Reference to the matrix element if it exists.
      */
     KOKKOS_INLINE_FUNCTION
-    ValueType& directValue(const IndexType offset) const { values_[offset]; }
+    ValueType& directValue(const IndexType offset) const { return values_[offset]; }
 
 private:
 

--- a/test/linearAlgebra/CMakeLists.txt
+++ b/test/linearAlgebra/CMakeLists.txt
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Unlicense
 # SPDX-FileCopyrightText: 2024 NeoFOAM authors
 
+neofoam_unit_test(CSRMatrix)
 neofoam_unit_test(linearSystem)

--- a/test/linearAlgebra/CSRMatrix.cpp
+++ b/test/linearAlgebra/CSRMatrix.cpp
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2024 NeoFOAM authors
+
+#define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
+                            // a custom main
+
+#include <string>
+
+#include <catch2/catch_session.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators_all.hpp>
+
+#include "NeoFOAM/linearAlgebra/CSRMatrix.hpp"
+
+TEST_CASE("LinearSystem")
+{
+
+    NeoFOAM::Executor exec = GENERATE(
+        NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
+    );
+    std::string execName = std::visit([](auto e) { return e.name(); }, exec);
+
+    // empty matrix
+    NeoFOAM::Field<NeoFOAM::scalar> valuesEmpty(exec, {});
+    NeoFOAM::Field<NeoFOAM::localIdx> colIdxEmpty(exec, {});
+    NeoFOAM::Field<NeoFOAM::localIdx> rowPtrsEmpty(exec, {});
+    NeoFOAM::la::CSRMatrix<NeoFOAM::scalar, NeoFOAM::localIdx> emptyMatrix(
+        valuesEmpty, colIdxEmpty, rowPtrsEmpty
+    );
+    NeoFOAM::la::CSRMatrix<NeoFOAM::scalar, NeoFOAM::localIdx> emptyMatrixConst(
+        valuesEmpty, colIdxEmpty, rowPtrsEmpty
+    );
+
+    // sparse matrix
+    NeoFOAM::Field<NeoFOAM::scalar> valuesSparse(exec, {1.0, 5.0, 6.0, 8.0});
+    NeoFOAM::Field<NeoFOAM::localIdx> colIdxSparse(exec, {0, 1, 2, 1});
+    NeoFOAM::Field<NeoFOAM::localIdx> rowPtrsSparse(exec, {0, 1, 3, 4});
+    NeoFOAM::la::CSRMatrix<NeoFOAM::scalar, NeoFOAM::localIdx> sparseMatrix(
+        valuesSparse, colIdxSparse, rowPtrsSparse
+    );
+    const NeoFOAM::la::CSRMatrix<NeoFOAM::scalar, NeoFOAM::localIdx> sparseMatrixConst(
+        valuesSparse, colIdxSparse, rowPtrsSparse
+    );
+
+    // dense matrix
+    NeoFOAM::Field<NeoFOAM::scalar> valuesDense(
+        exec, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0}
+    );
+    NeoFOAM::Field<NeoFOAM::localIdx> colIdxDense(exec, {0, 1, 2, 0, 1, 2, 0, 1, 2});
+    NeoFOAM::Field<NeoFOAM::localIdx> rowPtrsDense(exec, {0, 3, 6, 9});
+    NeoFOAM::la::CSRMatrix<NeoFOAM::scalar, NeoFOAM::localIdx> denseMatrix(
+        valuesDense, colIdxDense, rowPtrsDense
+    );
+    const NeoFOAM::la::CSRMatrix<NeoFOAM::scalar, NeoFOAM::localIdx> denseMatrixConst(
+        valuesDense, colIdxDense, rowPtrsDense
+    );
+
+
+    SECTION("Const Entry on " + execName) { sparseMatrixConst.entry() }
+}

--- a/test/linearAlgebra/CSRMatrix.cpp
+++ b/test/linearAlgebra/CSRMatrix.cpp
@@ -59,7 +59,7 @@ TEST_CASE("CSRMatrix")
     );
 
 
-    SECTION("Const Entry on " + execName)
+    SECTION("Read entry on " + execName)
     {
         // Sparse
         NeoFOAM::Field<NeoFOAM::scalar> checkSparse(exec, 4);
@@ -109,5 +109,24 @@ TEST_CASE("CSRMatrix")
         REQUIRE(checkHost.span()[6] == 7.0);
         REQUIRE(checkHost.span()[7] == 8.0);
         REQUIRE(checkHost.span()[8] == 9.0);
+    }
+
+    SECTION("Update existing entry on " + execName)
+    {
+        // Sparse
+        parallelFor(
+            exec,
+            {0, 1},
+            KOKKOS_LAMBDA(const size_t i) {
+                sparseMatrix.entry(0, 0) = -1.0;
+                sparseMatrix.entry(1, 1) = -5.0;
+            }
+        );
+
+        // auto checkHost = checkSparse.copyToHost();
+        // REQUIRE(checkHost.span()[0] == 1.0);
+        // REQUIRE(checkHost.span()[1] == 5.0);
+        // REQUIRE(checkHost.span()[2] == 6.0);
+        // REQUIRE(checkHost.span()[3] == 8.0);
     }
 }

--- a/test/linearAlgebra/CSRMatrix.cpp
+++ b/test/linearAlgebra/CSRMatrix.cpp
@@ -114,17 +114,21 @@ TEST_CASE("CSRMatrix")
     SECTION("Update existing entry on " + execName)
     {
         // Sparse
+        auto csrSpan = denseMatrix.span();
         parallelFor(
             exec,
             {0, 1},
             KOKKOS_LAMBDA(const size_t i) {
-                sparseMatrix.entry(0, 0) = -1.0;
-                sparseMatrix.entry(1, 1) = -5.0;
+                csrSpan.entry(0, 0) = -1.0;
+                // sparseMatrix.entry(1, 1) = -5.0;
             }
         );
 
-        // auto checkHost = checkSparse.copyToHost();
-        // REQUIRE(checkHost.span()[0] == 1.0);
+
+        REQUIRE(denseMatrix.copyToHost().values()[0] == -1.0);
+
+        // auto checkHost = denseMatrixConst.values.copyToHost();
+        // REQUIRE(denseMatrixConst.values()[0] == -1.0);
         // REQUIRE(checkHost.span()[1] == 5.0);
         // REQUIRE(checkHost.span()[2] == 6.0);
         // REQUIRE(checkHost.span()[3] == 8.0);

--- a/test/linearAlgebra/CSRMatrix.cpp
+++ b/test/linearAlgebra/CSRMatrix.cpp
@@ -61,24 +61,53 @@ TEST_CASE("CSRMatrix")
 
     SECTION("Const Entry on " + execName)
     {
-        NeoFOAM::Field<NeoFOAM::scalar> checkValues(exec, 4);
-        auto checkSpan = checkValues.span();
+        // Sparse
+        NeoFOAM::Field<NeoFOAM::scalar> checkSparse(exec, 4);
+        auto checkSparseSpan = checkSparse.span();
         parallelFor(
             exec,
             {0, 1},
             KOKKOS_LAMBDA(const size_t i) {
-                checkSpan[0] = sparseMatrixConst.entry(0, 0);
-                checkSpan[1] = sparseMatrixConst.entry(1, 1);
-                checkSpan[2] = sparseMatrixConst.entry(1, 2);
-                checkSpan[3] = sparseMatrixConst.entry(2, 1);
+                checkSparseSpan[0] = sparseMatrixConst.entry(0, 0);
+                checkSparseSpan[1] = sparseMatrixConst.entry(1, 1);
+                checkSparseSpan[2] = sparseMatrixConst.entry(1, 2);
+                checkSparseSpan[3] = sparseMatrixConst.entry(2, 1);
             }
         );
 
-        auto checkHost = checkValues.copyToHost();
-        auto checkHostSpan = checkHost.span();
-        REQUIRE(checkHostSpan[0] == 1.0);
-        REQUIRE(checkHostSpan[1] == 5.0);
-        REQUIRE(checkHostSpan[2] == 6.0);
-        REQUIRE(checkHostSpan[3] == 8.0);
+        auto checkHost = checkSparse.copyToHost();
+        REQUIRE(checkHost.span()[0] == 1.0);
+        REQUIRE(checkHost.span()[1] == 5.0);
+        REQUIRE(checkHost.span()[2] == 6.0);
+        REQUIRE(checkHost.span()[3] == 8.0);
+
+        // dense
+        NeoFOAM::Field<NeoFOAM::scalar> checkDense(exec, 9);
+        auto checkDenseSpan = checkDense.span();
+        parallelFor(
+            exec,
+            {0, 1},
+            KOKKOS_LAMBDA(const size_t i) {
+                checkDenseSpan[0] = denseMatrixConst.entry(0, 0);
+                checkDenseSpan[1] = denseMatrixConst.entry(0, 1);
+                checkDenseSpan[2] = denseMatrixConst.entry(0, 2);
+                checkDenseSpan[3] = denseMatrixConst.entry(1, 0);
+                checkDenseSpan[4] = denseMatrixConst.entry(1, 1);
+                checkDenseSpan[5] = denseMatrixConst.entry(1, 2);
+                checkDenseSpan[6] = denseMatrixConst.entry(2, 0);
+                checkDenseSpan[7] = denseMatrixConst.entry(2, 1);
+                checkDenseSpan[8] = denseMatrixConst.entry(2, 2);
+            }
+        );
+        checkHost = checkDense.copyToHost();
+        REQUIRE(checkHost.span()[0] == 1.0);
+        REQUIRE(checkHost.span()[1] == 2.0);
+        REQUIRE(checkHost.span()[2] == 3.0);
+        REQUIRE(checkHost.span()[3] == 4.0);
+        REQUIRE(checkHost.span()[4] == 5.0);
+        REQUIRE(checkHost.span()[5] == 6.0);
+        REQUIRE(checkHost.span()[6] == 7.0);
+        REQUIRE(checkHost.span()[7] == 8.0);
+        REQUIRE(checkHost.span()[8] == 9.0);
     }
 }

--- a/test/linearAlgebra/CSRMatrix.cpp
+++ b/test/linearAlgebra/CSRMatrix.cpp
@@ -4,15 +4,13 @@
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main
 
-#include <string>
-
 #include <catch2/catch_session.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators_all.hpp>
 
 #include "NeoFOAM/linearAlgebra/CSRMatrix.hpp"
 
-TEST_CASE("LinearSystem")
+TEST_CASE("CSRMatrix")
 {
 
     NeoFOAM::Executor exec = GENERATE(
@@ -58,5 +56,13 @@ TEST_CASE("LinearSystem")
     );
 
 
-    SECTION("Const Entry on " + execName) { sparseMatrixConst.entry() }
+    SECTION("Const Entry on " + execName)
+    {
+
+        const auto sparseMatrixConstHost = sparseMatrixConst.copyToHost();
+        REQUIRE(sparseMatrixConstHost.entry(0, 0) == 1.0);
+        REQUIRE(sparseMatrixConstHost.entry(1, 1) == 5.0);
+        REQUIRE(sparseMatrixConstHost.entry(1, 2) == 6.0);
+        REQUIRE(sparseMatrixConstHost.entry(2, 1) == 8.0);
+    }
 }

--- a/test/linearAlgebra/CSRMatrix.cpp
+++ b/test/linearAlgebra/CSRMatrix.cpp
@@ -261,4 +261,27 @@ TEST_CASE("CSRMatrix")
         REQUIRE(checkHost[7] == -8.0);
         REQUIRE(checkHost[8] == -9.0);
     }
+
+    SECTION("Span " + execName)
+    {
+        auto hostMatrix = sparseMatrix.copyToHost();
+        auto [value, column, row] = hostMatrix.span().span();
+        auto hostvaluesSparse = valuesSparse.copyToHost();
+        auto hostcolIdxSparse = colIdxSparse.copyToHost();
+        auto hostrowPtrsSparse = rowPtrsSparse.copyToHost();
+
+        REQUIRE(hostvaluesSparse.span().size() == value.size());
+        REQUIRE(hostcolIdxSparse.span().size() == column.size());
+        REQUIRE(hostrowPtrsSparse.span().size() == row.size());
+
+        for (size_t i = 0; i < value.size(); ++i)
+        {
+            REQUIRE(hostvaluesSparse.span()[i] == value[i]);
+            REQUIRE(hostcolIdxSparse.span()[i] == column[i]);
+        }
+        for (size_t i = 0; i < row.size(); ++i)
+        {
+            REQUIRE(hostrowPtrsSparse.span()[i] == row[i]);
+        }
+    }
 }

--- a/test/linearAlgebra/CSRMatrix.cpp
+++ b/test/linearAlgebra/CSRMatrix.cpp
@@ -117,7 +117,8 @@ TEST_CASE("CSRMatrix")
             }
         );
 
-        auto checkHost = sparseMatrix.copyToHost().values();
+        auto hostMatrix = sparseMatrix.copyToHost();
+        auto checkHost = hostMatrix.values();
         REQUIRE(checkHost[0] == -1.0);
         REQUIRE(checkHost[1] == -5.0);
         REQUIRE(checkHost[2] == -6.0);
@@ -141,7 +142,115 @@ TEST_CASE("CSRMatrix")
             }
         );
 
-        checkHost = denseMatrix.copyToHost().values();
+        hostMatrix = denseMatrix.copyToHost();
+        checkHost = hostMatrix.values();
+        REQUIRE(checkHost[0] == -1.0);
+        REQUIRE(checkHost[1] == -2.0);
+        REQUIRE(checkHost[2] == -3.0);
+        REQUIRE(checkHost[3] == -4.0);
+        REQUIRE(checkHost[4] == -5.0);
+        REQUIRE(checkHost[5] == -6.0);
+        REQUIRE(checkHost[6] == -7.0);
+        REQUIRE(checkHost[7] == -8.0);
+        REQUIRE(checkHost[8] == -9.0);
+    }
+
+    SECTION("Read directValue on " + execName)
+    {
+        // Sparse
+        NeoFOAM::Field<NeoFOAM::scalar> checkSparse(exec, 4);
+        auto checkSparseSpan = checkSparse.span();
+        auto csrSparseSpan = sparseMatrixConst.span();
+        parallelFor(
+            exec,
+            {0, 1},
+            KOKKOS_LAMBDA(const size_t) {
+                checkSparseSpan[0] = csrSparseSpan.directValue(0);
+                checkSparseSpan[1] = csrSparseSpan.directValue(1);
+                checkSparseSpan[2] = csrSparseSpan.directValue(2);
+                checkSparseSpan[3] = csrSparseSpan.directValue(3);
+            }
+        );
+        auto checkHost = checkSparse.copyToHost();
+        REQUIRE(checkHost.span()[0] == 1.0);
+        REQUIRE(checkHost.span()[1] == 5.0);
+        REQUIRE(checkHost.span()[2] == 6.0);
+        REQUIRE(checkHost.span()[3] == 8.0);
+
+        // Dense
+        NeoFOAM::Field<NeoFOAM::scalar> checkDense(exec, 9);
+        auto checkDenseSpan = checkDense.span();
+        auto csrDenseSpan = denseMatrixConst.span();
+        parallelFor(
+            exec,
+            {0, 1},
+            KOKKOS_LAMBDA(const size_t) {
+                checkDenseSpan[0] = csrDenseSpan.directValue(0);
+                checkDenseSpan[1] = csrDenseSpan.directValue(1);
+                checkDenseSpan[2] = csrDenseSpan.directValue(2);
+                checkDenseSpan[3] = csrDenseSpan.directValue(3);
+                checkDenseSpan[4] = csrDenseSpan.directValue(4);
+                checkDenseSpan[5] = csrDenseSpan.directValue(5);
+                checkDenseSpan[6] = csrDenseSpan.directValue(6);
+                checkDenseSpan[7] = csrDenseSpan.directValue(7);
+                checkDenseSpan[8] = csrDenseSpan.directValue(8);
+            }
+        );
+        checkHost = checkDense.copyToHost();
+        REQUIRE(checkHost.span()[0] == 1.0);
+        REQUIRE(checkHost.span()[1] == 2.0);
+        REQUIRE(checkHost.span()[2] == 3.0);
+        REQUIRE(checkHost.span()[3] == 4.0);
+        REQUIRE(checkHost.span()[4] == 5.0);
+        REQUIRE(checkHost.span()[5] == 6.0);
+        REQUIRE(checkHost.span()[6] == 7.0);
+        REQUIRE(checkHost.span()[7] == 8.0);
+        REQUIRE(checkHost.span()[8] == 9.0);
+    }
+
+    SECTION("Update existing directValue on " + execName)
+    {
+        // Sparse
+        auto csrSparseSpan = sparseMatrix.span();
+        parallelFor(
+            exec,
+            {0, 1},
+            KOKKOS_LAMBDA(const size_t) {
+                csrSparseSpan.directValue(0) = -1.0;
+                csrSparseSpan.directValue(1) = -5.0;
+                csrSparseSpan.directValue(2) = -6.0;
+                csrSparseSpan.directValue(3) = -8.0;
+            }
+        );
+
+
+        auto hostMatrix = sparseMatrix.copyToHost();
+        auto checkHost = hostMatrix.values();
+        REQUIRE(checkHost[0] == -1.0);
+        REQUIRE(checkHost[1] == -5.0);
+        REQUIRE(checkHost[2] == -6.0);
+        REQUIRE(checkHost[3] == -8.0);
+
+        // Dense
+        auto csrDenseSpan = denseMatrix.span();
+        parallelFor(
+            exec,
+            {0, 1},
+            KOKKOS_LAMBDA(const size_t) {
+                csrDenseSpan.directValue(0) = -1.0;
+                csrDenseSpan.directValue(1) = -2.0;
+                csrDenseSpan.directValue(2) = -3.0;
+                csrDenseSpan.directValue(3) = -4.0;
+                csrDenseSpan.directValue(4) = -5.0;
+                csrDenseSpan.directValue(5) = -6.0;
+                csrDenseSpan.directValue(6) = -7.0;
+                csrDenseSpan.directValue(7) = -8.0;
+                csrDenseSpan.directValue(8) = -9.0;
+            }
+        );
+
+        hostMatrix = denseMatrix.copyToHost();
+        checkHost = hostMatrix.values();
         REQUIRE(checkHost[0] == -1.0);
         REQUIRE(checkHost[1] == -2.0);
         REQUIRE(checkHost[2] == -3.0);

--- a/test/linearAlgebra/CSRMatrix.cpp
+++ b/test/linearAlgebra/CSRMatrix.cpp
@@ -165,10 +165,10 @@ TEST_CASE("CSRMatrix")
             exec,
             {0, 1},
             KOKKOS_LAMBDA(const size_t) {
-                checkSparseSpan[0] = csrSparseSpan.directValue(0);
-                checkSparseSpan[1] = csrSparseSpan.directValue(1);
-                checkSparseSpan[2] = csrSparseSpan.directValue(2);
-                checkSparseSpan[3] = csrSparseSpan.directValue(3);
+                checkSparseSpan[0] = csrSparseSpan.entry(0);
+                checkSparseSpan[1] = csrSparseSpan.entry(1);
+                checkSparseSpan[2] = csrSparseSpan.entry(2);
+                checkSparseSpan[3] = csrSparseSpan.entry(3);
             }
         );
         auto checkHost = checkSparse.copyToHost();
@@ -185,15 +185,15 @@ TEST_CASE("CSRMatrix")
             exec,
             {0, 1},
             KOKKOS_LAMBDA(const size_t) {
-                checkDenseSpan[0] = csrDenseSpan.directValue(0);
-                checkDenseSpan[1] = csrDenseSpan.directValue(1);
-                checkDenseSpan[2] = csrDenseSpan.directValue(2);
-                checkDenseSpan[3] = csrDenseSpan.directValue(3);
-                checkDenseSpan[4] = csrDenseSpan.directValue(4);
-                checkDenseSpan[5] = csrDenseSpan.directValue(5);
-                checkDenseSpan[6] = csrDenseSpan.directValue(6);
-                checkDenseSpan[7] = csrDenseSpan.directValue(7);
-                checkDenseSpan[8] = csrDenseSpan.directValue(8);
+                checkDenseSpan[0] = csrDenseSpan.entry(0);
+                checkDenseSpan[1] = csrDenseSpan.entry(1);
+                checkDenseSpan[2] = csrDenseSpan.entry(2);
+                checkDenseSpan[3] = csrDenseSpan.entry(3);
+                checkDenseSpan[4] = csrDenseSpan.entry(4);
+                checkDenseSpan[5] = csrDenseSpan.entry(5);
+                checkDenseSpan[6] = csrDenseSpan.entry(6);
+                checkDenseSpan[7] = csrDenseSpan.entry(7);
+                checkDenseSpan[8] = csrDenseSpan.entry(8);
             }
         );
         checkHost = checkDense.copyToHost();
@@ -216,10 +216,10 @@ TEST_CASE("CSRMatrix")
             exec,
             {0, 1},
             KOKKOS_LAMBDA(const size_t) {
-                csrSparseSpan.directValue(0) = -1.0;
-                csrSparseSpan.directValue(1) = -5.0;
-                csrSparseSpan.directValue(2) = -6.0;
-                csrSparseSpan.directValue(3) = -8.0;
+                csrSparseSpan.entry(0) = -1.0;
+                csrSparseSpan.entry(1) = -5.0;
+                csrSparseSpan.entry(2) = -6.0;
+                csrSparseSpan.entry(3) = -8.0;
             }
         );
 
@@ -237,15 +237,15 @@ TEST_CASE("CSRMatrix")
             exec,
             {0, 1},
             KOKKOS_LAMBDA(const size_t) {
-                csrDenseSpan.directValue(0) = -1.0;
-                csrDenseSpan.directValue(1) = -2.0;
-                csrDenseSpan.directValue(2) = -3.0;
-                csrDenseSpan.directValue(3) = -4.0;
-                csrDenseSpan.directValue(4) = -5.0;
-                csrDenseSpan.directValue(5) = -6.0;
-                csrDenseSpan.directValue(6) = -7.0;
-                csrDenseSpan.directValue(7) = -8.0;
-                csrDenseSpan.directValue(8) = -9.0;
+                csrDenseSpan.entry(0) = -1.0;
+                csrDenseSpan.entry(1) = -2.0;
+                csrDenseSpan.entry(2) = -3.0;
+                csrDenseSpan.entry(3) = -4.0;
+                csrDenseSpan.entry(4) = -5.0;
+                csrDenseSpan.entry(5) = -6.0;
+                csrDenseSpan.entry(6) = -7.0;
+                csrDenseSpan.entry(7) = -8.0;
+                csrDenseSpan.entry(8) = -9.0;
             }
         );
 

--- a/test/linearAlgebra/CSRMatrix.cpp
+++ b/test/linearAlgebra/CSRMatrix.cpp
@@ -23,17 +23,6 @@ TEST_CASE("CSRMatrix")
     );
     std::string execName = std::visit([](auto e) { return e.name(); }, exec);
 
-    // empty matrix
-    NeoFOAM::Field<NeoFOAM::scalar> valuesEmpty(exec, {});
-    NeoFOAM::Field<NeoFOAM::localIdx> colIdxEmpty(exec, {});
-    NeoFOAM::Field<NeoFOAM::localIdx> rowPtrsEmpty(exec, {});
-    NeoFOAM::la::CSRMatrix<NeoFOAM::scalar, NeoFOAM::localIdx> emptyMatrix(
-        valuesEmpty, colIdxEmpty, rowPtrsEmpty
-    );
-    NeoFOAM::la::CSRMatrix<NeoFOAM::scalar, NeoFOAM::localIdx> emptyMatrixConst(
-        valuesEmpty, colIdxEmpty, rowPtrsEmpty
-    );
-
     // sparse matrix
     NeoFOAM::Field<NeoFOAM::scalar> valuesSparse(exec, {1.0, 5.0, 6.0, 8.0});
     NeoFOAM::Field<NeoFOAM::localIdx> colIdxSparse(exec, {0, 1, 2, 1});
@@ -135,20 +124,20 @@ TEST_CASE("CSRMatrix")
         REQUIRE(checkHost[3] == -8.0);
 
         // Dense
-        auto csrSpan = denseMatrix.span();
+        auto csrDenseSpan = denseMatrix.span();
         parallelFor(
             exec,
             {0, 1},
             KOKKOS_LAMBDA(const size_t) {
-                csrSpan.entry(0, 0) = -1.0;
-                csrSpan.entry(0, 1) = -2.0;
-                csrSpan.entry(0, 2) = -3.0;
-                csrSpan.entry(1, 0) = -4.0;
-                csrSpan.entry(1, 1) = -5.0;
-                csrSpan.entry(1, 2) = -6.0;
-                csrSpan.entry(2, 0) = -7.0;
-                csrSpan.entry(2, 1) = -8.0;
-                csrSpan.entry(2, 2) = -9.0;
+                csrDenseSpan.entry(0, 0) = -1.0;
+                csrDenseSpan.entry(0, 1) = -2.0;
+                csrDenseSpan.entry(0, 2) = -3.0;
+                csrDenseSpan.entry(1, 0) = -4.0;
+                csrDenseSpan.entry(1, 1) = -5.0;
+                csrDenseSpan.entry(1, 2) = -6.0;
+                csrDenseSpan.entry(2, 0) = -7.0;
+                csrDenseSpan.entry(2, 1) = -8.0;
+                csrDenseSpan.entry(2, 2) = -9.0;
             }
         );
 

--- a/test/linearAlgebra/linearSystem.cpp
+++ b/test/linearAlgebra/linearSystem.cpp
@@ -30,10 +30,9 @@ TEST_CASE("LinearSystem")
     NeoFOAM::la::LinearSystem<NeoFOAM::scalar, NeoFOAM::localIdx> linearSystem(csrMatrix, rhs);
 
     REQUIRE(linearSystem.matrix().values().size() == 9);
-    REQUIRE(linearSystem.matrix().nValues() == 9);
     REQUIRE(linearSystem.matrix().colIdxs().size() == 9);
-    REQUIRE(linearSystem.matrix().nColIdxs() == 9);
     REQUIRE(linearSystem.matrix().rowPtrs().size() == 4);
+    REQUIRE(linearSystem.matrix().nNonZeros() == 9);
     REQUIRE(linearSystem.matrix().nRows() == 3);
 
     REQUIRE(linearSystem.rhs().size() == 3);


### PR DESCRIPTION
So in this small quality-of-life PR the CSR matrix in NeoFOAM. The class will be updated so that you can access the elements as if it were a standard dense matrix, it will do the bookkeeping for you. This will make it easier for the end user to focus on the population of the matrix vs. trying to do the bookkeeping. 

In a future update, we can add block matrix strategies. I want to get the 'scalar' version in asap for @HenningScheufler 

TODO:
- [] ~Finish Insert functionality~
- [x] Testing on CPU/GPU etc.  