### PR TITLE
disable copying of field collection

### DIFF
--- a/include/NeoFOAM/core/database/collection.hpp
+++ b/include/NeoFOAM/core/database/collection.hpp
@@ -41,10 +41,24 @@ public:
     {}
 
     /**
-     * @brief Copy constructor.
-     * @param other The Collection instance to copy from.
+     * @brief A Collection is not copyable, only moveable.
      */
-    Collection(const Collection& other);
+    Collection(const Collection& other) = delete;
+
+    /**
+     * @brief A Collection is not copyable, only moveable.
+     */
+    Collection& operator=(const Collection& other) = delete;
+
+    /**
+     * @brief A Collection is moveable, but not copyable
+     */
+    Collection(Collection&& other) = default;
+
+    /**
+     * @brief A Collection is moveable, but not copyable
+     */
+    Collection& operator=(Collection&& other) = default;
 
     /**
      * @brief Retrieves a document by its ID.
@@ -157,7 +171,6 @@ private:
         virtual std::string name() const = 0;
         virtual Database& db() = 0;
         virtual const Database& db() const = 0;
-        virtual std::unique_ptr<CollectionConcept> clone() const = 0;
     };
 
     template<typename CollectionType>
@@ -185,11 +198,6 @@ private:
 
         const Database& db() const override { return collection_.db(); }
 
-        std::unique_ptr<CollectionConcept> clone() const override
-        {
-            return std::make_unique<CollectionModel>(*this);
-        }
-
         CollectionType collection_;
     };
 
@@ -215,6 +223,26 @@ public:
      * @param name The name of the collection.
      */
     CollectionMixin(NeoFOAM::Database& db, std::string name) : docs_(), db_(db), name_(name) {}
+
+    /**
+     * @biref A CollectionMixin is not copyable, only moveable.
+     */
+    CollectionMixin(const CollectionMixin&) = delete;
+
+    /**
+     * @biref A CollectionMixin is not copyable, only moveable.
+     */
+    CollectionMixin& operator=(const CollectionMixin&) = delete;
+
+    /**
+     * @biref A CollectionMixin is moveable, but not copyable.
+     */
+    CollectionMixin(CollectionMixin&&) = default;
+
+    /**
+     * @biref A CollectionMixin is not move-assign-able.
+     */
+    CollectionMixin& operator=(CollectionMixin&&) = delete;
 
     /**
      * @brief Retrieves a document by its ID.

--- a/include/NeoFOAM/core/database/database.hpp
+++ b/include/NeoFOAM/core/database/database.hpp
@@ -24,7 +24,7 @@ public:
      * @param col The collection to be inserted into the database.
      * @return Collection& A reference to the inserted collection.
      */
-    Collection& insert(const std::string& key, const Collection& col);
+    Collection& insert(const std::string& key, Collection&& col);
 
     /**
      * @brief Checks if the database contains an collection with the specified name.

--- a/include/NeoFOAM/core/database/fieldCollection.hpp
+++ b/include/NeoFOAM/core/database/fieldCollection.hpp
@@ -215,6 +215,26 @@ public:
     FieldCollection(NeoFOAM::Database& db, std::string name);
 
     /**
+     * @brief A FieldCollection is not copyable, but moveable
+     */
+    FieldCollection(const FieldCollection&) = delete;
+
+    /**
+     * @brief A FieldCollection is not copyable, but moveable
+     */
+    FieldCollection& operator=(const FieldCollection&) = delete;
+
+    /**
+     * @brief A FieldCollection is move constructable, but not copyable
+     */
+    FieldCollection(FieldCollection&&) = default;
+
+    /**
+     * @brief A FieldCollection is not move-assign-able, but move-construct-able
+     */
+    FieldCollection& operator=(FieldCollection&&) = delete;
+
+    /**
      * @brief Checks if the collection contains a field with the given ID.
      *
      * @param id The ID of the field to check for.

--- a/src/core/database/collection.cpp
+++ b/src/core/database/collection.cpp
@@ -7,8 +7,6 @@
 namespace NeoFOAM
 {
 
-Collection::Collection(const Collection& other) : impl_(other.impl_->clone()) {}
-
 Document& Collection::doc(const std::string& id) { return impl_->doc(id); }
 
 const Document& Collection::doc(const std::string& id) const { return impl_->doc(id); }

--- a/src/core/database/database.cpp
+++ b/src/core/database/database.cpp
@@ -7,9 +7,9 @@
 namespace NeoFOAM
 {
 
-Collection& Database::insert(const std::string& name, const Collection& col)
+Collection& Database::insert(const std::string& name, Collection&& col)
 {
-    return collections_.emplace(name, col).first->second;
+    return collections_.try_emplace(name, std::move(col)).first->second;
 }
 
 bool Database::contains(const std::string& name) const { return collections_.contains(name); }

--- a/test/core/database/fieldCollection.cpp
+++ b/test/core/database/fieldCollection.cpp
@@ -145,7 +145,7 @@ TEST_CASE("FieldCollection")
 
     SECTION("add FieldDocument to FieldCollection" + execName)
     {
-        fvcc::FieldCollection fieldCollection =
+        fvcc::FieldCollection& fieldCollection =
             fvcc::FieldCollection::instance(db, "testFieldCollection");
         REQUIRE(db.size() == 1);
 


### PR DESCRIPTION
# Motivation
This fixes the issue #206.

This PR makes the FieldCollection not copyable, so the return value from `FieldCollection::instance` has to be stored as a reference.
