### PR TITLE
Modify the delta vector direction when creating a single-cell mesh

### DIFF
--- a/src/mesh/unstructured/unstructuredMesh.cpp
+++ b/src/mesh/unstructured/unstructuredMesh.cpp
@@ -86,7 +86,7 @@ UnstructuredMesh createSingleCellMesh(const Executor exec)
         faceAreasVectors,                                                               // sf,
         magFaceAreas,                                                                   // magSf,
         faceAreasVectors,                                                               // nf,
-        {exec, {{0.5, 0.0, 0.0}, {0.0, -0.5, 0.0}, {-0.5, 0.0, 0.0}, {0.0, 0.5, 0.0}}}, // delta
+        {exec, {{-0.5, 0.0, 0.0}, {0.0, 0.5, 0.0}, {0.5, 0.0, 0.0}, {0.0, -0.5, 0.0}}}, // delta
         {exec, {1, 1, 1, 1}},                                                           // weights
         {exec, {2.0, 2.0, 2.0, 2.0}}, // deltaCoeffs --> mag(1 / delta)
         {0, 1, 2, 3, 4}               // offset


### PR DESCRIPTION
# Motivation
Delta vector is defined as the vector from cell center to cell face when there is only a single cell in the mesh.
https://doc.cfd.direct/notes/cfd-general-principles/boundary-mesh

Therefore, each delta vector should have the same direction as the corresponding face area vector. 


