### PR TITLE
add basic span implementation

### DIFF
--- a/include/NeoFOAM/core.hpp
+++ b/include/NeoFOAM/core.hpp
@@ -9,6 +9,7 @@
 #include "core/parallelAlgorithms.hpp"
 #include "core/runtimeSelectionFactory.hpp"
 #include "core/time.hpp"
+#include "core/span.hpp"
 #include "core/tokenList.hpp"
 #include "core/primitives/label.hpp"
 #include "core/primitives/scalar.hpp"

--- a/include/NeoFOAM/core/span.hpp
+++ b/include/NeoFOAM/core/span.hpp
@@ -30,7 +30,6 @@ public:
     /* a member to store the first out of range data access. This assumes a span has
      * at least a size of 1. A value of zero signals success. This is required we cannot
      * throw from a device function.
-     *
      */
     mutable size_t failureIndex = 0;
 

--- a/include/NeoFOAM/core/span.hpp
+++ b/include/NeoFOAM/core/span.hpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 NeoFOAM authors
+#pragma once
+
+#include <unordered_map>
+#include <any>
+#include <string>
+#include <vector>
+
+#include "NeoFOAM/core/demangle.hpp"
+
+namespace NeoFOAM
+{
+
+template<typename T>
+class Span : public std::span<T>
+{
+public:
+
+    using std::span<T>::span; // Inherit constructors from std::span
+
+    constexpr T& operator[](std::size_t index) const
+    {
+#ifdef DEBUG
+        if (index >= this->size())
+        {
+            Kokkos::abort("Index out of range in DebugSpan.\n");
+        }
+#endif
+        return std::span<T>::operator[](index);
+    }
+};
+
+
+} // namespace NeoFOAM

--- a/include/NeoFOAM/core/span.hpp
+++ b/include/NeoFOAM/core/span.hpp
@@ -36,7 +36,8 @@ public:
 #ifdef NF_DEBUG
         if (index >= this->size())
         {
-            std::string msg("Index is out of range. Index: " + std::to_string(index));
+            std::string msg;
+            msg += "Index is out of range. Index: " + std::to_string(index);
             if (abort)
             {
                 Kokkos::abort(msg.c_str());

--- a/include/NeoFOAM/core/span.hpp
+++ b/include/NeoFOAM/core/span.hpp
@@ -7,22 +7,35 @@
 namespace NeoFOAM
 {
 
-template<typename T>
-class Span : public std::span<T>
+template<typename ValueType>
+class Span : public std::span<ValueType>
 {
 public:
 
-    using std::span<T>::span; // Inherit constructors from std::span
+    bool abort = true;
 
-    constexpr T& operator[](std::size_t index) const
+    using std::span<ValueType>::span; // Inherit constructors from std::span
+
+    Span(std::span<ValueType> in) : Span(in.begin(), in.end()) {}
+
+    constexpr ValueType& operator[](std::size_t index) const
     {
-#ifdef DEBUG
+#ifdef NF_DEBUG
         if (index >= this->size())
         {
-            Kokkos::abort("Index out of range in Span.\n");
+            std::string msg;
+            msg += "Index is out of range. Index: " + std::to_string(index);
+            if (abort)
+            {
+                Kokkos::abort(msg.c_str());
+            }
+            else
+            {
+                throw std::invalid_argument(msg);
+            }
         }
 #endif
-        return std::span<T>::operator[](index);
+        return std::span<ValueType>::operator[](index);
     }
 };
 

--- a/include/NeoFOAM/core/span.hpp
+++ b/include/NeoFOAM/core/span.hpp
@@ -7,15 +7,28 @@
 namespace NeoFOAM
 {
 
+/* @class Span
+ *
+ * @brief A wrapper class for std::span which allows to check whether the index access is in range
+ * The Span can be initialized like a regular std::span or from an existing std::span
+ *
+ * @ingroup core
+ *
+ */
 template<typename ValueType>
 class Span : public std::span<ValueType>
 {
 public:
 
+    /* A flag to control whether the program should terminate on invalid memory access or throw.
+     * Kokkos prefers to terminate, but for testing purpose throwing is preferred
+     */
     bool abort = true;
 
     using std::span<ValueType>::span; // Inherit constructors from std::span
 
+    /* Constructor from existing std::span
+     */
     Span(std::span<ValueType> in) : Span(in.begin(), in.end()) {}
 
     constexpr ValueType& operator[](std::size_t index) const

--- a/include/NeoFOAM/core/span.hpp
+++ b/include/NeoFOAM/core/span.hpp
@@ -36,15 +36,17 @@ public:
 #ifdef NF_DEBUG
         if (index >= this->size())
         {
-            std::string msg;
-            msg += "Index is out of range. Index: " + std::to_string(index);
+            // TODO: currently this is failing on our AWS workflow, once we have clang>16 there
+            // this should work again.
+            // const std::string msg {"Index is out of range. Index: "} + to_string(index);
             if (abort)
             {
-                Kokkos::abort(msg.c_str());
+                Kokkos::abort("Index is out of range");
             }
             else
             {
-                throw std::invalid_argument(msg);
+                // NOTE: throwing from a device function does not work
+                throw std::invalid_argument("Index is out of range");
             }
         }
 #endif

--- a/include/NeoFOAM/core/span.hpp
+++ b/include/NeoFOAM/core/span.hpp
@@ -2,12 +2,7 @@
 // SPDX-FileCopyrightText: 2025 NeoFOAM authors
 #pragma once
 
-#include <unordered_map>
-#include <any>
-#include <string>
-#include <vector>
-
-#include "NeoFOAM/core/demangle.hpp"
+#include <span>
 
 namespace NeoFOAM
 {
@@ -24,7 +19,7 @@ public:
 #ifdef DEBUG
         if (index >= this->size())
         {
-            Kokkos::abort("Index out of range in DebugSpan.\n");
+            Kokkos::abort("Index out of range in Span.\n");
         }
 #endif
         return std::span<T>::operator[](index);

--- a/include/NeoFOAM/core/span.hpp
+++ b/include/NeoFOAM/core/span.hpp
@@ -23,8 +23,7 @@ public:
 #ifdef NF_DEBUG
         if (index >= this->size())
         {
-            std::string msg;
-            msg += "Index is out of range. Index: " + std::to_string(index);
+            std::string msg("Index is out of range. Index: " + std::to_string(index));
             if (abort)
             {
                 Kokkos::abort(msg.c_str());

--- a/include/NeoFOAM/core/span.hpp
+++ b/include/NeoFOAM/core/span.hpp
@@ -23,7 +23,7 @@ class Span : public std::span<ValueType>
 public:
 
     /* A flag to control whether the program should terminate on invalid memory access or throw.
-     * Kokkos prefers to terminate, but for testing purpose throwing is preferred
+     * Kokkos prefers to terminate, but for testing purpose the failureIndex is preferred
      */
     bool abort = true;
 

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -13,6 +13,7 @@ neofoam_unit_test(tokenList)
 neofoam_unit_test(input)
 neofoam_unit_test(executor)
 neofoam_unit_test(parallelAlgorithms)
+neofoam_unit_test(span)
 
 add_executable(runTimeSelectionFactory "runTimeSelectionFactory.cpp")
 target_link_libraries(runTimeSelectionFactory PRIVATE Catch2::Catch2WithMain cpptrace::cpptrace

--- a/test/core/span.cpp
+++ b/test/core/span.cpp
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 NeoFOAM authors
+
+#define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
+                            // a custom main
+#include <catch2/catch_session.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators_all.hpp>
+
+#include <limits>
+#include <Kokkos_Core.hpp>
+
+#include "NeoFOAM/NeoFOAM.hpp"
+
+
+TEST_CASE("parallelFor")
+{
+    NeoFOAM::Executor exec = NeoFOAM::SerialExecutor {};
+    std::string execName = std::visit([](auto e) { return e.name(); }, exec);
+
+    NeoFOAM::Field<NeoFOAM::scalar> fieldA(exec, 5);
+    NeoFOAM::fill(fieldA, 2.0);
+
+    SECTION("parallelFor_") {}
+};

--- a/test/core/span.cpp
+++ b/test/core/span.cpp
@@ -33,8 +33,10 @@ TEST_CASE("parallelFor")
         REQUIRE(fieldANDSpan[4] == 2.0);
     }
 
+#ifdef NF_DEBUG
     fieldANDSpan.abort = false;
     SECTION("detects out of range") { CHECK_THROWS(fieldANDSpan[5]); }
+#endif
 
     SECTION("can be used in parallel for")
     {

--- a/test/core/span.cpp
+++ b/test/core/span.cpp
@@ -30,14 +30,15 @@ TEST_CASE("parallelFor")
     auto fieldANDSpan = NeoFOAM::Span(fieldAStdSpan);
 
     NeoFOAM::parallelFor(
-        exec, {0, 5}, KOKKOS_LAMBDA(const size_t i) { fieldANDSpan[i] *= 2.0; }
+        exec, {0, 4}, KOKKOS_LAMBDA(const size_t i) { fieldANDSpan[i] *= 2.0; }
     );
 
-#ifdef NF_DEBUGC
-    CHECK_THROWS(NeoFOAM::parallelFor(
-                     exec, {5, 6}, KOKKOS_LAMBDA(const size_t i) { fieldANDSpan[i] *= 2.0; }
-    ););
-#endif
+    // NOTE: this does not work since throwing from a device function is not supported
+    // #ifdef NF_DEBUGC
+    //     CHECK_THROWS(NeoFOAM::parallelFor(
+    //                      exec, {5, 6}, KOKKOS_LAMBDA(const size_t i) { fieldANDSpan[i] *= 2.0; }
+    //     ););
+    // #endif
 
     auto fieldAHost = fieldA.copyToHost();
     auto fieldANDSpanHost = NeoFOAM::Span(fieldAHost.span());

--- a/test/core/span.cpp
+++ b/test/core/span.cpp
@@ -45,7 +45,6 @@ TEST_CASE("parallelFor")
     auto fieldHost = field.copyToHost();
     auto fieldNFSpanHost = NeoFOAM::Span(fieldHost.span());
 
-    // to some checking if everything is correct
 #ifdef NF_DEBUG
     fieldNFSpanHost.abort = false;
     SECTION("detects out of range")
@@ -55,6 +54,7 @@ TEST_CASE("parallelFor")
     }
 #endif
 
+    // some checking if everything is correct
     SECTION("can access elements")
     {
         REQUIRE(fieldNFSpanHost[0] == 4.0);

--- a/test/core/span.cpp
+++ b/test/core/span.cpp
@@ -34,24 +34,32 @@ TEST_CASE("parallelFor")
     );
     REQUIRE(fieldNFSpan.failureIndex == 0);
 
-    // #ifdef NF_DEBUGC
-    //     fieldNFSpan.abort = false;
-    //     NeoFOAM::parallelFor(
-    //         exec, {5, 6}, KOKKOS_LAMBDA(const size_t i) { fieldNFSpan[i] *= 2.0; }
-    //     );
-    //     REQUIRE(fieldNFSpan.failureIndex == 5);
-    // #endif
+#ifdef NF_DEBUGC
+// TODO: on MSCV this results in a non terminating loop
+// so for now we deactivate it on MSVC since it a debugging helper
+#ifndef _MSC_VER
+    fieldNFSpan.abort = false;
+    NeoFOAM::parallelFor(
+        exec, {5, 6}, KOKKOS_LAMBDA(const size_t i) { fieldNFSpan[i] *= 2.0; }
+    );
+    REQUIRE(fieldNFSpan.failureIndex == 5);
+#endif
+#endif
 
     auto fieldHost = field.copyToHost();
     auto fieldNFSpanHost = NeoFOAM::Span(fieldHost.span());
 
 #ifdef NF_DEBUG
+// TODO: on MSCV this results in a non terminating loop
+// so for now we deactivate it on MSVC since it a debugging helper
+#ifndef _MSC_VER
     fieldNFSpanHost.abort = false;
     SECTION("detects out of range")
     {
         auto tmp = fieldNFSpanHost[5];
         REQUIRE(fieldNFSpanHost.failureIndex == 5);
     }
+#endif
 #endif
 
     // some checking if everything is correct

--- a/test/core/span.cpp
+++ b/test/core/span.cpp
@@ -34,13 +34,13 @@ TEST_CASE("parallelFor")
     );
     REQUIRE(fieldNFSpan.failureIndex == 0);
 
-#ifdef NF_DEBUGC
-    fieldNFSpan.abort = false;
-    NeoFOAM::parallelFor(
-        exec, {5, 6}, KOKKOS_LAMBDA(const size_t i) { fieldNFSpan[i] *= 2.0; }
-    );
-    REQUIRE(fieldNFSpan.failureIndex == 5);
-#endif
+    // #ifdef NF_DEBUGC
+    //     fieldNFSpan.abort = false;
+    //     NeoFOAM::parallelFor(
+    //         exec, {5, 6}, KOKKOS_LAMBDA(const size_t i) { fieldNFSpan[i] *= 2.0; }
+    //     );
+    //     REQUIRE(fieldNFSpan.failureIndex == 5);
+    // #endif
 
     auto fieldHost = field.copyToHost();
     auto fieldNFSpanHost = NeoFOAM::Span(fieldHost.span());


### PR DESCRIPTION
This PR adds a range checking version of span. The range check gets activated on debug builds. I'll work on a separate PR that switches to `NeoFOAM::Span` over `std::span`, but since we have a backlog of PRs from the Hackathon I wont do it here, since it would probably trigger a lot of merge conflicts.