### PR TITLE
Thirdparty configuration for ADIOS2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ option(NEOFOAM_DEVEL_TOOLS "Add development tools to the build system" OFF)
 option(NEOFOAM_BUILD_TESTS "Build the unit tests" OFF)
 option(NEOFOAM_BUILD_BENCHMARKS "Build benchmarks" OFF)
 option(NEOFOAM_BUILD_DOC "Build documentation" OFF)
+option(NEOFOAM_WITH_ADIOS2 "Build NeoFOAM with ADIOS2 support" OFF)
 option(NEOFOAM_WITH_SUNDIALS "Build NeoFOAM with Sundials support [currently required]" ON)
 
 option(NEOFOAM_ENABLE_SANITIZE_ADDRESS "Enable address sanitizer" OFF)

--- a/cmake/CxxThirdParty.cmake
+++ b/cmake/CxxThirdParty.cmake
@@ -53,7 +53,16 @@ cpmaddpackage(
 if(${NEOFOAM_WITH_ADIOS2})
 
   set(ADIOS2_OPTIONS
-      "BUILD_TYPE Release")
+      "BUILD_TYPE Release"
+      "ADIOS2_USE_Kokkos ON"
+      "CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR}/cmake_packages/Kokkos"
+      "ADIOS2_USE_Fortran OFF"
+      "ADIOS2_USE_Python OFF"
+      "ADIOS2_USE_MHS OFF"
+      "ADIOS2_USE_SST OFF"
+      "ADIOS2_BUILD_EXAMPLES OFF"
+      "BUILD_TESTING OFF"
+      "ADIOS2_USE_Profiling OFF")
 
   if(WIN32)
     list(APPEND ADIOS2_OPTIONS "BUILD_STATIC_LIBS ON")
@@ -61,12 +70,6 @@ if(${NEOFOAM_WITH_ADIOS2})
   else()
     list(APPEND ADIOS2_OPTIONS "BUILD_STATIC_LIBS OFF")
     list(APPEND ADIOS2_OPTIONS "BUILD_SHARED_LIBS ON")
-  endif()
-
-  if(Kokkos_ENABLE_CUDA)
-    set(ADIOS2_CUDA_OPTIONS "ENABLE_CUDA ON" "ADIOS2_BUILD_KOKKOS ON")
-  else()
-    set(ADIOS2_CUDA_OPTIONS "ENABLE_CUDA OFF" "ADIOS2_BUILD_KOKKOS ON")
   endif()
 
   cpmaddpackage(

--- a/cmake/CxxThirdParty.cmake
+++ b/cmake/CxxThirdParty.cmake
@@ -55,7 +55,7 @@ if(${NEOFOAM_WITH_ADIOS2})
   set(ADIOS2_KOKKOS_PATCH git apply ${CMAKE_CURRENT_SOURCE_DIR}/cmake/patches/adios2_kokkos.patch)
 
   set(ADIOS2_OPTIONS
-      "BUILD_TYPE Release"
+      "BUILD_TYPE ${CMAKE_BUILD_TYPE}"
       "ADIOS2_USE_Kokkos ON"
       "Kokkos_DIR ${Kokkos_BINARY_DIR}"
       "ADIOS2_USE_Fortran OFF"

--- a/cmake/CxxThirdParty.cmake
+++ b/cmake/CxxThirdParty.cmake
@@ -52,6 +52,8 @@ cpmaddpackage(
 
 if(${NEOFOAM_WITH_ADIOS2})
 
+  set(ADIOS2_KOKKOS_PATCH git apply ${CMAKE_CURRENT_SOURCE_DIR}/cmake/patches/adios2_kokkos.patch)
+
   set(ADIOS2_OPTIONS
       "BUILD_TYPE Release"
       "ADIOS2_USE_Kokkos ON"
@@ -77,6 +79,8 @@ if(${NEOFOAM_WITH_ADIOS2})
     adios2
     GITHUB_REPOSITORY
     ornladios/ADIOS2
+    PATCH_COMMAND
+    ${ADIOS2_KOKKOS_PATCH}
     VERSION
     2.10.2
     OPTIONS

--- a/cmake/CxxThirdParty.cmake
+++ b/cmake/CxxThirdParty.cmake
@@ -50,6 +50,38 @@ cpmaddpackage(
   https://github.com/nlohmann/json/releases/download/v3.11.3/include.zip
   SYSTEM)
 
+if(${NEOFOAM_WITH_ADIOS2})
+
+  set(ADIOS2_OPTIONS
+      "BUILD_TYPE Release")
+
+  if(WIN32)
+    list(APPEND ADIOS2_OPTIONS "BUILD_STATIC_LIBS ON")
+    list(APPEND ADIOS2_OPTIONS "BUILD_SHARED_LIBS OFF")
+  else()
+    list(APPEND ADIOS2_OPTIONS "BUILD_STATIC_LIBS OFF")
+    list(APPEND ADIOS2_OPTIONS "BUILD_SHARED_LIBS ON")
+  endif()
+
+  if(Kokkos_ENABLE_CUDA)
+    set(ADIOS2_CUDA_OPTIONS "ENABLE_CUDA ON" "ADIOS2_BUILD_KOKKOS ON")
+  else()
+    set(ADIOS2_CUDA_OPTIONS "ENABLE_CUDA OFF" "ADIOS2_BUILD_KOKKOS ON")
+  endif()
+
+  cpmaddpackage(
+    NAME
+    adios2
+    GITHUB_REPOSITORY
+    ornladios/ADIOS2
+    VERSION
+    2.10.2
+    OPTIONS
+    ${ADIOS2_OPTIONS}
+    ${ADIOS2_CUDA_OPTIONS}
+    SYSTEM)
+endif()
+
 if(${NEOFOAM_WITH_SUNDIALS})
 
   set(SUNDIALS_OPTIONS

--- a/cmake/CxxThirdParty.cmake
+++ b/cmake/CxxThirdParty.cmake
@@ -55,7 +55,7 @@ if(${NEOFOAM_WITH_ADIOS2})
   set(ADIOS2_OPTIONS
       "BUILD_TYPE Release"
       "ADIOS2_USE_Kokkos ON"
-      "CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR}/cmake_packages/Kokkos"
+      "Kokkos_DIR ${Kokkos_BINARY_DIR}"
       "ADIOS2_USE_Fortran OFF"
       "ADIOS2_USE_Python OFF"
       "ADIOS2_USE_MHS OFF"

--- a/cmake/patches/adios2_kokkos.patch
+++ b/cmake/patches/adios2_kokkos.patch
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Unlicense
+# SPDX-FileCopyrightText: 2025 NeoFOAM authors
 diff --git a/cmake/DetectOptions.cmake b/cmake/DetectOptions.cmake
 index d1348ecdd..421194274 100644
 --- a/cmake/DetectOptions.cmake

--- a/cmake/patches/adios2_kokkos.patch
+++ b/cmake/patches/adios2_kokkos.patch
@@ -1,0 +1,26 @@
+diff --git a/cmake/DetectOptions.cmake b/cmake/DetectOptions.cmake
+index d1348ecdd..421194274 100644
+--- a/cmake/DetectOptions.cmake
++++ b/cmake/DetectOptions.cmake
+@@ -209,9 +209,19 @@ endif()
+ # Kokkos
+ if(ADIOS2_USE_Kokkos)
+   if(ADIOS2_USE_Kokkos STREQUAL AUTO)
+-    find_package(Kokkos 3.7 QUIET)
++    if(TARGET Kokkos::kokkos)
++      set(Kokkos_FOUND True)
++      set(Kokkos_CXX_COMPILER "${CMAKE_CXX_COMPILER}")
++    else()
++      find_package(Kokkos 3.7 QUIET)
++    endif()
+   else()
+-    find_package(Kokkos 3.7 REQUIRED)
++    if(TARGET Kokkos::kokkos)
++      set(Kokkos_FOUND True)
++      set(Kokkos_CXX_COMPILER "${CMAKE_CXX_COMPILER}")
++    else()
++      find_package(Kokkos 3.7 REQUIRED)
++    endif()
+   endif()
+   if(Kokkos_FOUND)
+     set(ADIOS2_HAVE_Kokkos TRUE)


### PR DESCRIPTION
Adds fetching and configuring ADIOS2. Since ADIOS2 detects functioning Kokkos targets, the latter must be readily compiled and installed. Hence, this PR is still in need of a solution for such third-party interdependencies.  Issue #279 
