### PR TITLE
trigger workflow on pr open

### DIFF
--- a/.github/workflows/build_on_macos.yaml
+++ b/.github/workflows/build_on_macos.yaml
@@ -7,7 +7,9 @@ on:
       - dev
       - main
   pull_request:
-    types: synchronize
+    types:
+      - synchronize
+      - opened
   schedule:
     - cron: "* 0 * * 0"
 

--- a/.github/workflows/build_on_ubuntu.yaml
+++ b/.github/workflows/build_on_ubuntu.yaml
@@ -7,7 +7,9 @@ on:
       - dev
       - main
   pull_request:
-    types: synchronize
+    types:
+      - synchronize
+      - opened
   schedule:
     - cron: "* 0 * * 0"
 

--- a/.github/workflows/build_on_windows.yaml
+++ b/.github/workflows/build_on_windows.yaml
@@ -6,7 +6,9 @@ on:
       - dev
       - main
   pull_request:
-    types: synchronize
+    types:
+      - synchronize
+      - opened
   schedule:
     - cron: "* 0 * * 0"
 


### PR DESCRIPTION
Currently, the build_on_* workflows are only triggered by a pull request synchronize event. That does, however, not include the creation of a PR. In consequence, if you open a PR and don't add any further commits, the full pipeline might have not been executed.