### PR TITLE
WIP Singelton database/collection for IO components

### DIFF
--- a/cmake/CxxThirdParty.cmake
+++ b/cmake/CxxThirdParty.cmake
@@ -95,19 +95,38 @@ if(${NeoN_WITH_ADIOS2})
     list(APPEND ADIOS2_OPTIONS "BUILD_SHARED_LIBS ON")
   endif()
 
-  cpmaddpackage(
-    NAME
-    adios2
-    GITHUB_REPOSITORY
-    ornladios/ADIOS2
-    PATCH_COMMAND
-    ${ADIOS2_KOKKOS_PATCH}
-    VERSION
-    2.10.2
-    OPTIONS
-    ${ADIOS2_OPTIONS}
-    ${ADIOS2_CUDA_OPTIONS}
-    SYSTEM)
+  # Checking for patched and cached ADIOS2 will become obsolete after this issue in CPM has been
+  # fixed: https://github.com/cpm-cmake/CPM.cmake/issues/618
+  if(NOT ADIOS2_PATCHED)
+    set(ADIOS2_PATCHED
+        TRUE
+        CACHE INTERNAL "Whether ADIOS2 has been fetched and patched in CPM cache.")
+    cpmaddpackage(
+      NAME
+      adios2
+      GITHUB_REPOSITORY
+      ornladios/ADIOS2
+      PATCH_COMMAND
+      ${ADIOS2_KOKKOS_PATCH}
+      VERSION
+      2.10.2
+      OPTIONS
+      ${ADIOS2_OPTIONS}
+      ${ADIOS2_CUDA_OPTIONS}
+      SYSTEM)
+  else()
+    cpmaddpackage(
+      NAME
+      adios2
+      GITHUB_REPOSITORY
+      ornladios/ADIOS2
+      VERSION
+      2.10.2
+      OPTIONS
+      ${ADIOS2_OPTIONS}
+      ${ADIOS2_CUDA_OPTIONS}
+      SYSTEM)
+  endif()
 endif()
 
 if(${NeoN_WITH_SUNDIALS})

--- a/include/NeoN/core/io/adiosConfig.hpp
+++ b/include/NeoN/core/io/adiosConfig.hpp
@@ -5,6 +5,8 @@
 
 #include <memory>
 
+#include "engine.hpp"
+
 // forward declaration
 namespace adios2
 {
@@ -33,6 +35,8 @@ struct AdiosConfig
      * @param io The rvalue reference of an adios2:IO instance.
      */
     AdiosConfig(adios2::IO&& io) : configPtr_ {std::make_shared<adios2::IO>(io)} {};
+
+    std::shared_ptr<Engine> createEngine(const std::string& path) const;
 
 private:
 

--- a/include/NeoN/core/io/adiosConfig.hpp
+++ b/include/NeoN/core/io/adiosConfig.hpp
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 NeoFOAM authors
+
+#pragma once
+
+#include <memory>
+
+// forward declaration
+namespace adios2
+{
+class ADIOS;
+class IO;
+class Engine;
+}
+
+namespace NeoFOAM::io
+{
+
+/*
+ * @class AdiosConfig
+ * @brief Wrapper for the adios2::IO instance.
+ */
+struct AdiosConfig
+{
+    AdiosConfig() = default;
+    AdiosConfig(adios2::IO& io) : configPtr_ {std::make_unique<adios2::IO>(io)} {};
+
+    std::unique_ptr<adios2::IO> configPtr_;
+};
+
+} // namespace NeoFOAM::io

--- a/include/NeoN/core/io/adiosConfig.hpp
+++ b/include/NeoN/core/io/adiosConfig.hpp
@@ -22,10 +22,21 @@ namespace NeoFOAM::io
  */
 struct AdiosConfig
 {
+    /*
+     * @brief AdiosConfig is default constructable (copyable and moveable).
+     */
     AdiosConfig() = default;
-    AdiosConfig(adios2::IO& io) : configPtr_ {std::make_unique<adios2::IO>(io)} {};
 
-    std::unique_ptr<adios2::IO> configPtr_;
+    /*
+     * @brief Constructor passing the rvalue reference to be stored in configPtr_.
+     *
+     * @param io The rvalue reference of an adios2:IO instance.
+     */
+    AdiosConfig(adios2::IO&& io) : configPtr_ {std::make_shared<adios2::IO>(io)} {};
+
+private:
+
+    std::shared_ptr<adios2::IO> configPtr_;
 };
 
 } // namespace NeoFOAM::io

--- a/include/NeoN/core/io/adiosConfig.hpp
+++ b/include/NeoN/core/io/adiosConfig.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2025 NeoFOAM authors
+// SPDX-FileCopyrightText: 2025 NeoN authors
 
 #pragma once
 
@@ -15,7 +15,7 @@ class IO;
 class Engine;
 }
 
-namespace NeoFOAM::io
+namespace NeoN::io
 {
 
 /*
@@ -43,4 +43,4 @@ private:
     std::shared_ptr<adios2::IO> configPtr_;
 };
 
-} // namespace NeoFOAM::io
+} // namespace NeoN::io

--- a/include/NeoN/core/io/adiosCore.hpp
+++ b/include/NeoN/core/io/adiosCore.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2025 NeoFOAM authors
+// SPDX-FileCopyrightText: 2025 NeoN authors
 
 #pragma once
 
@@ -13,7 +13,7 @@ class IO;
 class Engine;
 }
 
-namespace NeoFOAM::io
+namespace NeoN::io
 {
 
 // forward declare
@@ -38,4 +38,4 @@ private:
     static std::unique_ptr<adios2::ADIOS> adiosPtr_;
 };
 
-} // namespace NeoFOAM::io
+} // namespace NeoN::io

--- a/include/NeoN/core/io/adiosCore.hpp
+++ b/include/NeoN/core/io/adiosCore.hpp
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 NeoFOAM authors
+
+#pragma once
+
+#include <memory>
+
+// forward declaration
+namespace adios2
+{
+class ADIOS;
+class IO;
+class Engine;
+}
+
+namespace NeoFOAM::io
+{
+
+// forward declare
+class AdiosConfig;
+
+/*
+ * @class AdiosCore
+ * @brief Wrapper and storage class for the adios2::ADIOS instance.
+ */
+class AdiosCore
+{
+public:
+
+    AdiosCore() { init(); }
+
+    std::shared_ptr<Config> createConfig();
+    void voidConfig();
+
+private:
+
+    void init();
+
+    static std::unique_ptr<adios2::ADIOS> adiosPtr_;
+};
+
+} // namespace NeoFOAM::io

--- a/include/NeoN/core/io/adiosCore.hpp
+++ b/include/NeoN/core/io/adiosCore.hpp
@@ -29,8 +29,7 @@ public:
 
     AdiosCore() { init(); }
 
-    std::shared_ptr<Config> createConfig();
-    void voidConfig();
+    std::shared_ptr<Config> createConfig(const std::string& key) const;
 
 private:
 

--- a/include/NeoN/core/io/adiosEngine.hpp
+++ b/include/NeoN/core/io/adiosEngine.hpp
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 NeoFOAM authors
+
+#pragma once
+
+#include <memory>
+
+// forward declaration
+namespace adios2
+{
+class ADIOS;
+class IO;
+class Engine;
+}
+
+namespace NeoFOAM::io
+{
+
+/*
+ * @class AdiosEngine
+ * @brief Wrapper for the adios2::Engine instance.
+ */
+struct AdiosEngine
+{
+    /*
+     * @brief AdiosEngine is default constructable (copyable and moveable).
+     */
+    AdiosEngine() = default;
+
+    /*
+     * @brief Constructor passing the rvalue reference to be stored in enginePtr_.
+     *
+     * @param io The rvalue reference of an adios2:Engine instance.
+     */
+    AdiosEngine(adios2::Engine&& engine) : enginePtr_ {std::make_shared<adios2::Engine>(engine)} {};
+
+private:
+
+    std::shared_ptr<adios2::Engine> enginePtr_;
+};
+
+} // namespace NeoFOAM::io

--- a/include/NeoN/core/io/adiosEngine.hpp
+++ b/include/NeoN/core/io/adiosEngine.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2025 NeoFOAM authors
+// SPDX-FileCopyrightText: 2025 NeoN authors
 
 #pragma once
 
@@ -13,7 +13,7 @@ class IO;
 class Engine;
 }
 
-namespace NeoFOAM::io
+namespace NeoN::io
 {
 
 /*
@@ -39,4 +39,4 @@ private:
     std::shared_ptr<adios2::Engine> enginePtr_;
 };
 
-} // namespace NeoFOAM::io
+} // namespace NeoN::io

--- a/include/NeoN/core/io/buffer.hpp
+++ b/include/NeoN/core/io/buffer.hpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 NeoN authors
+
+#pragma once
+
+#include <memory>
+
+namespace NeoN::io
+{
+
+/*
+ * @class Buffer
+ * @brief Type-erased interface to store the IO buffer like adios2::Variable.
+ *
+ * The Buffer class is a type-erased interface to store buffer components from IO
+ * libraries wrapped into classes that cohere with the Buffer's interface.
+ */
+class Buffer
+{
+public:
+
+    /*
+     * @brief Constructs an Buffer component for IO from a specific BufferType.
+     *
+     * @tparam BufferType The buffer type that wraps a specific IO library.
+     * @param buffer The buffer instance to be wrapped.
+     */
+    template<typename BufferType>
+    Buffer(BufferType buffer) : pimpl_(std::make_unique<BufferModel<BufferType>>(std::move(buffer)))
+    {}
+
+private:
+
+    /*
+     * @brief Base concept declaring the type-erased interface
+     */
+    struct BufferConcept
+    {
+        virtual ~BufferConcept() = default;
+    };
+
+    /*
+     * @brief Derived model delegating the implementation to the type-erased PIMPL
+     */
+    template<typename BufferType>
+    struct BufferModel : BufferConcept
+    {
+        BufferModel(BufferType buffer) : buffer_(std::move(buffer_)) {}
+        BufferType buffer_;
+    };
+
+    /*
+     * @brief Type-erased PIMPL
+     */
+    std::unique_ptr<BufferConcept> pimpl_;
+};
+
+} // namespace NeoN::io

--- a/include/NeoN/core/io/config.hpp
+++ b/include/NeoN/core/io/config.hpp
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2025 NeoFOAM authors
+// SPDX-FileCopyrightText: 2025 NeoN authors
 
 #pragma once
 
 #include <memory>
 
-namespace NeoFOAM::io
+namespace NeoN::io
 {
 
 /*
@@ -55,4 +55,4 @@ private:
     std::unique_ptr<ConfigConcept> pimpl_;
 };
 
-} // namespace NeoFOAM::io
+} // namespace NeoN::io

--- a/include/NeoN/core/io/config.hpp
+++ b/include/NeoN/core/io/config.hpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 NeoFOAM authors
+
+#pragma once
+
+#include <memory>
+
+namespace NeoFOAM::io
+{
+
+/*
+ * @class Config
+ * @brief Type-erased interface to store the IO configuration like adios2::IO.
+ *
+ * The Config class is a type-erased interface to store configurational components
+ * from IO libraries wrapped into classes that cohere with the Config's interface.
+ */
+class Config
+{
+public:
+
+    /*
+     * @brief Constructs a Config component for IO from a specific ConfigType.
+     *
+     * @tparam ConfigType The configuration type that wraps a specific IO library configuration.
+     * @param config The configuration instance to be wrapped.
+     */
+    template<typename ConfigType>
+    Config(ConfigType config) : pimpl_(std::make_unique<ConfigModel<ConfigType>>(std::move(config)))
+    {}
+
+private:
+
+    /*
+     * @brief Base concept declaring the type-erased interface
+     */
+    struct ConfigConcept
+    {
+        virtual ~ConfigConcept() = default;
+    };
+
+    /*
+     * @brief Derived model delegating the implementation to the type-erased PIMPL
+     */
+    template<typename ConfigType>
+    struct ConfigModel : ConfigConcept
+    {
+        ConfigModel(ConfigType config) : config_(std::move(config)) {}
+        ConfigType config_;
+    };
+
+    /*
+     * @brief Type-erased PIMPL
+     */
+    std::unique_ptr<ConfigConcept> pimpl_;
+};
+
+} // namespace NeoFOAM::io

--- a/include/NeoN/core/io/core.hpp
+++ b/include/NeoN/core/io/core.hpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 NeoFOAM authors
+
+#pragma once
+
+#include <memory>
+
+namespace NeoFOAM::io
+{
+
+/*
+ * @class Core
+ * @brief Type-erased interface to store the IO core like adios2::ADIOS.
+ *
+ * The Core class is a type-erased interface to store core components from IO
+ * libraries wrapped into classes that cohere with the Core's interface.
+ */
+class Core
+{
+public:
+
+    /*
+     * @brief Constructs a Core component for IO from a specific CoreType.
+     *
+     * @tparam CoreType The core type that wraps a specific IO library base.
+     * @param core The core instance to be wrapped.
+     */
+    template<typename CoreType>
+    Core(CoreType core) : pimpl_(std::make_unique<CoreModel<CoreType>>(std::move(core)))
+    {}
+
+private:
+
+    /*
+     * @brief Base concept declaring the type-erased interface
+     */
+    struct CoreConcept
+    {
+        virtual ~CoreConcept() = default;
+    };
+
+    /*
+     * @brief Derived model delegating the implementation to the type-erased PIMPL
+     */
+    template<typename CoreType>
+    struct CoreModel : CoreConcept
+    {
+        CoreModel(CoreType core) : core_(std::move(core)) {}
+        CoreType core_;
+    };
+
+    /*
+     * @brief Type-erased PIMPL
+     */
+    std::unique_ptr<CoreConcept> pimpl_;
+};
+
+} // namespace NeoFOAM::io

--- a/include/NeoN/core/io/core.hpp
+++ b/include/NeoN/core/io/core.hpp
@@ -32,9 +32,10 @@ public:
     Core(CoreType core) : pimpl_(std::make_unique<CoreModel<CoreType>>(std::move(core)))
     {}
 
-    std::shared_ptr<Config> createConfig() { return pimpl_->createConfig(); }
-
-    void voidConfig() { pimpl_->voidConfig(); }
+    std::shared_ptr<Config> createConfig(const std::string& name) const
+    {
+        return pimpl_->createConfig(name);
+    }
 
 private:
 
@@ -44,8 +45,7 @@ private:
     struct CoreConcept
     {
         virtual ~CoreConcept() = default;
-        virtual std::shared_ptr<Config> createConfig() = 0;
-        virtual void voidConfig() = 0;
+        virtual std::shared_ptr<Config> createConfig(const std::string& name) const = 0;
     };
 
     /*
@@ -56,8 +56,10 @@ private:
     {
         CoreModel(CoreType core) : core_(std::move(core)) {}
 
-        std::shared_ptr<Config> createConfig() { return core_->createConfig(); }
-        void voidConfig() { core_->voidConfig(); }
+        std::shared_ptr<Config> createConfig(const std::string& name) const
+        {
+            return core_->createConfig(name);
+        }
 
         CoreType core_;
     };

--- a/include/NeoN/core/io/core.hpp
+++ b/include/NeoN/core/io/core.hpp
@@ -8,6 +8,9 @@
 namespace NeoFOAM::io
 {
 
+// forward declare
+class Config;
+
 /*
  * @class Core
  * @brief Type-erased interface to store the IO core like adios2::ADIOS.
@@ -29,6 +32,10 @@ public:
     Core(CoreType core) : pimpl_(std::make_unique<CoreModel<CoreType>>(std::move(core)))
     {}
 
+    std::shared_ptr<Config> createConfig() { return pimpl_->createConfig(); }
+
+    void voidConfig() { pimpl_->voidConfig(); }
+
 private:
 
     /*
@@ -37,6 +44,8 @@ private:
     struct CoreConcept
     {
         virtual ~CoreConcept() = default;
+        virtual std::shared_ptr<Config> createConfig() = 0;
+        virtual void voidConfig() = 0;
     };
 
     /*
@@ -46,6 +55,10 @@ private:
     struct CoreModel : CoreConcept
     {
         CoreModel(CoreType core) : core_(std::move(core)) {}
+
+        std::shared_ptr<Config> createConfig() { return core_->createConfig(); }
+        void voidConfig() { core_->voidConfig(); }
+
         CoreType core_;
     };
 

--- a/include/NeoN/core/io/core.hpp
+++ b/include/NeoN/core/io/core.hpp
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2025 NeoFOAM authors
+// SPDX-FileCopyrightText: 2025 NeoN authors
 
 #pragma once
 
 #include <memory>
 
-namespace NeoFOAM::io
+namespace NeoN::io
 {
 
 // forward declare
@@ -70,4 +70,4 @@ private:
     std::unique_ptr<CoreConcept> pimpl_;
 };
 
-} // namespace NeoFOAM::io
+} // namespace NeoN::io

--- a/include/NeoN/core/io/dataOutput.hpp
+++ b/include/NeoN/core/io/dataOutput.hpp
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 NeoFOAM authors
+#pragma once
+
+#include <adios2.h>
+
+
+namespace NeoFOAM::io
+{
+
+struct DataOutput
+{
+    void put();
+};
+
+} // namespace NeoFOAM::io

--- a/include/NeoN/core/io/dataOutput.hpp
+++ b/include/NeoN/core/io/dataOutput.hpp
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2025 NeoFOAM authors
+// SPDX-FileCopyrightText: 2025 NeoN authors
 #pragma once
 
 #include <adios2.h>
 
 
-namespace NeoFOAM::io
+namespace NeoN::io
 {
 
 struct DataOutput
@@ -13,4 +13,4 @@ struct DataOutput
     void put();
 };
 
-} // namespace NeoFOAM::io
+} // namespace NeoN::io

--- a/include/NeoN/core/io/engine.hpp
+++ b/include/NeoN/core/io/engine.hpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 NeoFOAM authors
+
+#pragma once
+
+#include <memory>
+
+namespace NeoFOAM::io
+{
+
+/*
+ * @class Engine
+ * @brief Type-erased interface to store the IO engine/stream like adios2::Engine.
+ *
+ * The Engine class is a type-erased interface to store engine/streaming components from IO
+ * libraries wrapped into classes that cohere with the Engine's interface.
+ */
+class Engine
+{
+public:
+
+    /*
+     * @brief Constructs an Engine component for IO from a specific EngineType.
+     *
+     * @tparam EngineType The engine type that wraps a specific IO library engine/stream.
+     * @param engine The engine instance to be wrapped.
+     */
+    template<typename EngineType>
+    Engine(EngineType core) : pimpl_(std::make_unique<EngineModel<EngineType>>(std::move(core)))
+    {}
+
+private:
+
+    /*
+     * @brief Base concept declaring the type-erased interface
+     */
+    struct EngineConcept
+    {
+        virtual ~EngineConcept() = default;
+    };
+
+    /*
+     * @brief Derived model delegating the implementation to the type-erased PIMPL
+     */
+    template<typename EngineType>
+    struct EngineModel : EngineConcept
+    {
+        EngineModel(EngineType core) : core_(std::move(core)) {}
+        EngineType core_;
+    };
+
+    /*
+     * @brief Type-erased PIMPL
+     */
+    std::unique_ptr<EngineConcept> pimpl_;
+};
+
+} // namespace NeoFOAM::io

--- a/include/NeoN/core/io/engine.hpp
+++ b/include/NeoN/core/io/engine.hpp
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2025 NeoFOAM authors
+// SPDX-FileCopyrightText: 2025 NeoN authors
 
 #pragma once
 
 #include <memory>
 
-namespace NeoFOAM::io
+namespace NeoN::io
 {
 
 /*
@@ -55,4 +55,4 @@ private:
     std::unique_ptr<EngineConcept> pimpl_;
 };
 
-} // namespace NeoFOAM::io
+} // namespace NeoN::io

--- a/include/NeoN/core/io/staticIOComponents.hpp
+++ b/include/NeoN/core/io/staticIOComponents.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2025 NeoFOAM authors
+// SPDX-FileCopyrightText: 2025 NeoN authors
 
 #pragma once
 
@@ -12,7 +12,7 @@
 #include "config.hpp"
 #include "engine.hpp"
 
-namespace NeoFOAM::io
+namespace NeoN::io
 {
 
 /**
@@ -108,4 +108,4 @@ public:
     }
 };
 
-} // namespace NeoFOAM::io
+} // namespace NeoN::io

--- a/include/NeoN/core/io/staticIOComponents.hpp
+++ b/include/NeoN/core/io/staticIOComponents.hpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 NeoFOAM authors
+
+#pragma once
+
+#include <unordered_map>
+#include <string>
+#include <memory>
+
+namespace NeoFOAM::io
+{
+
+/**
+ * @class StaticIOComponents
+ * @brief A collection of IO components that must be initialized only once during program life time.
+ *
+ * The StaticIOComponents class renders a database for IO components that must not be
+ * recreated/reinitialized during program life time like adios2::ADIOS. Plus the class allows
+ * storing IO resources for asynchronous IO.
+ */
+class StaticIOComponents
+{
+    static std::unique_ptr<StaticIOComponents> ioComponents_;
+
+    /**
+     * @brief Private constructor of the singleton instance ioComponents_
+     */
+    StaticIOComponents();
+
+public:
+
+    /**
+     * @brief Retrieves the singleton instance of StaticIOComponents
+     */
+    StaticIOComponents* instance();
+
+    /**
+     * @brief Deletes the singleton instance of StaticIOComponents
+     */
+    void deleteInstance();
+
+    /**
+     * @brief StaticIOComponent is not copyable
+     */
+    StaticIOComponents(StaticIOComponents&) = delete;
+
+    /**
+     * @brief StaticIOComponent is not copyable
+     */
+    StaticIOComponents& operator=(const StaticIOComponents&) = delete;
+
+    /*
+     * @brief Destructor to finalize all remaining components
+     */
+    ~StaticIOComponents() = default;
+};
+
+} // namespace NeoFOAM::io

--- a/include/NeoN/core/io/staticIOComponents.hpp
+++ b/include/NeoN/core/io/staticIOComponents.hpp
@@ -44,7 +44,7 @@ public:
     /**
      * @brief Retrieves the singleton instance of StaticIOComponents
      */
-    StaticIOComponents* instance();
+    static StaticIOComponents* instance();
 
     /**
      * @brief Deletes the singleton instance of StaticIOComponents

--- a/include/NeoN/core/io/staticIOComponents.hpp
+++ b/include/NeoN/core/io/staticIOComponents.hpp
@@ -7,6 +7,10 @@
 #include <string>
 #include <memory>
 
+#include "core.hpp"
+#include "config.hpp"
+#include "engine.hpp"
+
 namespace NeoFOAM::io
 {
 
@@ -21,6 +25,14 @@ namespace NeoFOAM::io
 class StaticIOComponents
 {
     static std::unique_ptr<StaticIOComponents> ioComponents_;
+
+    using core_component = Core;
+    using config_map = std::unordered_map<std::string, std::shared_ptr<Config>>;
+    using engine_map = std::unordered_map<std::string, std::shared_ptr<Engine>>;
+
+    std::unique_ptr<core_component> core_;
+    std::unique_ptr<config_map> configMap_;
+    std::unique_ptr<engine_map> engineMap_;
 
     /**
      * @brief Private constructor of the singleton instance ioComponents_

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(
           "core/dictionary.cpp"
           "core/demangle.cpp"
           "core/io/dataOutput.cpp"
+          "core/io/staticIOComponents.cpp"
           "core/tokenList.cpp"
           "dsl/coeff.cpp"
           "dsl/explicit.cpp"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(
           "core/database/oldTimeCollection.cpp"
           "core/dictionary.cpp"
           "core/demangle.cpp"
+          "core/io/dataOutput.cpp"
           "core/tokenList.cpp"
           "dsl/coeff.cpp"
           "dsl/explicit.cpp"
@@ -67,6 +68,9 @@ target_link_libraries(NeoN PRIVATE NeoN_warnings NeoN_options)
 target_link_libraries(NeoN PUBLIC NeoN_public_api Kokkos::kokkos sundials_core sundials_arkode
                                   sundials_nvecserial cpptrace::cpptrace)
 
+if(NeoN_WITH_ADIOS2)
+  target_link_libraries(NeoN PUBLIC adios2)
+endif()
 if(NeoN_ENABLE_MPI_SUPPORT)
   target_link_libraries(NeoN PUBLIC MPI::MPI_CXX)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(
           "core/dictionary.cpp"
           "core/demangle.cpp"
           "core/io/adiosCore.cpp"
+          "core/io/adiosConfig.cpp"
           "core/io/dataOutput.cpp"
           "core/io/staticIOComponents.cpp"
           "core/tokenList.cpp"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(
           "core/database/oldTimeCollection.cpp"
           "core/dictionary.cpp"
           "core/demangle.cpp"
+          "core/io/adiosCore.cpp"
           "core/io/dataOutput.cpp"
           "core/io/staticIOComponents.cpp"
           "core/tokenList.cpp"

--- a/src/core/io/adiosConfig.cpp
+++ b/src/core/io/adiosConfig.cpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 NeoFOAM authors
+
+#include <adios2.h>
+
+#include "NeoFOAM/core/io/staticIOComponents.hpp"
+#include "NeoFOAM/core/io/adiosCore.hpp"
+#include "NeoFOAM/core/io/adiosConfig.hpp"
+#include "NeoFOAM/core/io/config.hpp"
+
+namespace NeoFOAM::io
+{
+
+std::shared_ptr<Engine> AdiosConfig::createEngine(const std::string& path) const
+{
+    StaticIOComponents* components = StaticIOComponents::instance();
+    auto key = configPtr_->Name() + path;
+    std::shared_ptr<Engine> adiosEngine;
+    adiosEngine = components->at(key, adiosEngine);
+    if (!adiosEngine)
+    {
+        // TODO Where to BeginStep?
+        adiosEngine =
+            std::make_shared<Engine>(new Engine(configPtr_->Open(path, adios2::Mode::Append)));
+        components->insert(key, adiosEngine);
+    }
+    return adiosEngine;
+}
+
+} // namespace NeoFOAM

--- a/src/core/io/adiosConfig.cpp
+++ b/src/core/io/adiosConfig.cpp
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2025 NeoFOAM authors
+// SPDX-FileCopyrightText: 2025 NeoN authors
 
 #include <adios2.h>
 
-#include "NeoFOAM/core/io/staticIOComponents.hpp"
-#include "NeoFOAM/core/io/adiosCore.hpp"
-#include "NeoFOAM/core/io/adiosConfig.hpp"
-#include "NeoFOAM/core/io/config.hpp"
+#include "NeoN/core/io/staticIOComponents.hpp"
+#include "NeoN/core/io/adiosCore.hpp"
+#include "NeoN/core/io/adiosConfig.hpp"
+#include "NeoN/core/io/config.hpp"
 
-namespace NeoFOAM::io
+namespace NeoN::io
 {
 
 std::shared_ptr<Engine> AdiosConfig::createEngine(const std::string& path) const
@@ -27,4 +27,4 @@ std::shared_ptr<Engine> AdiosConfig::createEngine(const std::string& path) const
     return adiosEngine;
 }
 
-} // namespace NeoFOAM
+} // namespace NeoN

--- a/src/core/io/adiosCore.cpp
+++ b/src/core/io/adiosCore.cpp
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 NeoFOAM authors
+
+#include <adios2.h>
+
+#include "NeoFOAM/core/io/staticIOComponents.hpp"
+#include "NeoFOAM/core/io/adiosCore.hpp"
+#include "NeoFOAM/core/io/adiosConfig.hpp"
+#include "NeoFOAM/core/io/config.hpp"
+
+namespace NeoFOAM::io
+{
+
+std::unique_ptr<adios2::ADIOS> AdiosCore::adiosPtr_;
+
+std::shared_ptr<Config> AdiosCore::createConfig()
+{
+    StaticIOComponents* components = StaticIOComponents::instance();
+    std::shared_ptr<Config> adiosConfig;
+
+    // TODO implement AdiosConfig, its construction and declaration
+    // std::shared_ptr<AdiosConfig> adiosConfig;
+
+    return adiosConfig;
+}
+
+void AdiosCore::init()
+{
+    if (!adiosPtr_)
+    {
+        // Constructor for non-MPI (serial) application
+        adiosPtr_.reset(new adios2::ADIOS());
+        // TODO Add construction for MPI application
+        //      once NeoFOAM supports MPI runs.
+        // TODO Add configuration file.
+    }
+}
+
+} // namespace NeoFOAM

--- a/src/core/io/adiosCore.cpp
+++ b/src/core/io/adiosCore.cpp
@@ -13,13 +13,18 @@ namespace NeoFOAM::io
 
 std::unique_ptr<adios2::ADIOS> AdiosCore::adiosPtr_;
 
-std::shared_ptr<Config> AdiosCore::createConfig()
+std::shared_ptr<Config> AdiosCore::createConfig(const std::string& name) const
 {
     StaticIOComponents* components = StaticIOComponents::instance();
     std::shared_ptr<Config> adiosConfig;
 
-    // TODO implement AdiosConfig, its construction and declaration
-    // std::shared_ptr<AdiosConfig> adiosConfig;
+    adiosConfig = components->at(name, adiosConfig);
+
+    if (!adiosConfig)
+    {
+        adiosConfig = std::make_shared<Config>(new Config(AdiosConfig(adiosPtr_->DeclareIO(name))));
+        components->insert(name, adiosConfig);
+    }
 
     return adiosConfig;
 }

--- a/src/core/io/adiosCore.cpp
+++ b/src/core/io/adiosCore.cpp
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2025 NeoFOAM authors
+// SPDX-FileCopyrightText: 2025 NeoN authors
 
 #include <adios2.h>
 
-#include "NeoFOAM/core/io/staticIOComponents.hpp"
-#include "NeoFOAM/core/io/adiosCore.hpp"
-#include "NeoFOAM/core/io/adiosConfig.hpp"
-#include "NeoFOAM/core/io/config.hpp"
+#include "NeoN/core/io/staticIOComponents.hpp"
+#include "NeoN/core/io/adiosCore.hpp"
+#include "NeoN/core/io/adiosConfig.hpp"
+#include "NeoN/core/io/config.hpp"
 
-namespace NeoFOAM::io
+namespace NeoN::io
 {
 
 std::unique_ptr<adios2::ADIOS> AdiosCore::adiosPtr_;
@@ -36,9 +36,9 @@ void AdiosCore::init()
         // Constructor for non-MPI (serial) application
         adiosPtr_.reset(new adios2::ADIOS());
         // TODO Add construction for MPI application
-        //      once NeoFOAM supports MPI runs.
+        //      once NeoN supports MPI runs.
         // TODO Add configuration file.
     }
 }
 
-} // namespace NeoFOAM
+} // namespace NeoN

--- a/src/core/io/dataOutput.cpp
+++ b/src/core/io/dataOutput.cpp
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2025 NeoFOAM authors
+// SPDX-FileCopyrightText: 2025 NeoN authors
 
 #include <numeric>
 #include <iostream> // for operator<<, basic_ostream, endl, cerr, ostream
 
-#include "NeoFOAM/core/io/dataOutput.hpp"
+#include "NeoN/core/io/dataOutput.hpp"
 
-namespace NeoFOAM::io
+namespace NeoN::io
 {
 
 void DataOutput::put() {}
 
-} // namespace NeoFOAM
+} // namespace NeoN

--- a/src/core/io/dataOutput.cpp
+++ b/src/core/io/dataOutput.cpp
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 NeoFOAM authors
+
+#include <numeric>
+#include <iostream> // for operator<<, basic_ostream, endl, cerr, ostream
+
+#include "NeoFOAM/core/io/dataOutput.hpp"
+
+namespace NeoFOAM::io
+{
+
+void DataOutput::put() {}
+
+} // namespace NeoFOAM

--- a/src/core/io/staticIOComponents.cpp
+++ b/src/core/io/staticIOComponents.cpp
@@ -3,6 +3,9 @@
 
 #include "NeoFOAM/core/io/staticIOComponents.hpp"
 
+// FIXME This is only for compile tests at the moment.
+#include "NeoFOAM/core/io/adiosCore.hpp"
+
 namespace NeoFOAM::io
 {
 
@@ -13,6 +16,9 @@ StaticIOComponents* StaticIOComponents::instance()
     if (!ioComponents_)
     {
         ioComponents_.reset(new StaticIOComponents());
+
+        // FIXME This is only for compile tests at the moment.
+        ioComponents_->core_ = std::make_unique<Core>(new Core(new AdiosCore()));
     }
     return ioComponents_.get();
 }

--- a/src/core/io/staticIOComponents.cpp
+++ b/src/core/io/staticIOComponents.cpp
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 NeoFOAM authors
+
+#include "NeoFOAM/core/io/staticIOComponents.hpp"
+
+namespace NeoFOAM::io
+{
+
+std::unique_ptr<StaticIOComponents> StaticIOComponents::ioComponents_;
+
+StaticIOComponents* StaticIOComponents::instance()
+{
+    if (!ioComponents_)
+    {
+        ioComponents_.reset(new StaticIOComponents());
+    }
+    return ioComponents_.get();
+}
+
+}

--- a/src/core/io/staticIOComponents.cpp
+++ b/src/core/io/staticIOComponents.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2025 NeoFOAM authors
+// SPDX-FileCopyrightText: 2025 NeoN authors
 
-#include "NeoFOAM/core/io/staticIOComponents.hpp"
+#include "NeoN/core/io/staticIOComponents.hpp"
 
 // FIXME This is only for compile tests at the moment.
-#include "NeoFOAM/core/io/adiosCore.hpp"
+#include "NeoN/core/io/adiosCore.hpp"
 
-namespace NeoFOAM::io
+namespace NeoN::io
 {
 
 std::unique_ptr<StaticIOComponents> StaticIOComponents::ioComponents_;


### PR DESCRIPTION
Adds a database for IO components. Idea behind it is that, for instance, ADIOS2 requires a global adios2::ADIOS instance that must not be destroyed and recreated. The singleton also stores configurational and streaming components/resources so that streams can stay open for asynchronous IO.

But everything ADIOS2-related is abstracted away through type-erased Core, Config, and Engine classes so that other IO libraries can be patched. 
