### PR TITLE
views free function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Version 0.2.0 (unreleased)
 ## Features
 ### Refactoring
-- Free function views added, allows for multiple views from multiple class's view methods to be returned in a structured binding.  [#311](https://github.com/exasim-project/NeoN/pull/311)
+- General refactor of span and spans to view and views.  [#311](https://github.com/exasim-project/NeoN/pull/311)
 - View replaces std::span and Field uses view() rather than span() and returns a view [#298](https://github.com/exasim-project/NeoN/pull/298)
 ### Implicit Capabilities
 - Implicit BCs and Laplacian operator [#262](https://github.com/exasim-project/NeoN/pull/262)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Version 0.2.0 (unreleased)
 ## Features
 ### Refactoring
+- Free function views added, allows for multiple views from multiple class's view methods to be returned in a structured binding.  [#311](https://github.com/exasim-project/NeoN/pull/311)
 - View replaces std::span and Field uses view() rather than span() and returns a view [#298](https://github.com/exasim-project/NeoN/pull/298)
 ### Implicit Capabilities
 - Implicit BCs and Laplacian operator [#262](https://github.com/exasim-project/NeoN/pull/262)

--- a/doc/basics/algorithms.rst
+++ b/doc/basics/algorithms.rst
@@ -47,7 +47,7 @@ The executor type determines the ``Kokkos::RangePolicy<runOn>`` and thus dispatc
 Additionally, we name the kernel as ``"parallelFor"`` to improve visibility in profiling tools like nsys.
 Finally, a ``KOKKOS_LAMBDA`` is dispatched assigning the result of the given kernel function to the view of the field.
 Here the view holds data pointers to the device data and defines the begin and end pointer of the data.
-Several overloads of the ``parallelFor`` functions exists to simplify running parallelFor on fields and spans with and without an explicitly defined data range.
+Several overloads of the ``parallelFor`` functions exists to simplify running parallelFor on fields and views with and without an explicitly defined data range.
 
 
 To learn more on how to use the algorithms it is recommended to check the corresponding `unit test <https://github.com/exasim-project/NeoN/blob/main/test/core/parallelAlgorithms.cpp>`_.

--- a/doc/basics/segmentedField.rst
+++ b/doc/basics/segmentedField.rst
@@ -13,12 +13,12 @@ It can be used to represent cell to cell stencil.
     NeoN::Vector<NeoN::localIdx> segments(exec, {0, 2, 4, 6, 8, 10});
 
     NeoN::SegmentedVector<NeoN::label, NeoN::localIdx> segVector(values, segments);
-    auto [valueSpan, segment] = segVector.spans();
+    auto [valueView, segment] = segVector.views();
     auto segView = segVector.view();
     NeoN::Vector<NeoN::label> result(exec, 5);
 
     NeoN::fill(result, 0);
-    auto resultSpan = result.view();
+    auto resultView = result.view();
 
     parallelFor(
         exec,
@@ -26,25 +26,25 @@ It can be used to represent cell to cell stencil.
         KOKKOS_LAMBDA(const localIdx segI) {
             // check if it works with bounds
             auto [bStart, bEnd] = segView.bounds(segI);
-            auto bVals = valueSpan.subspan(bStart, bEnd - bStart);
+            auto bVals = valueView.subview(bStart, bEnd - bStart);
             for (auto& val : bVals)
             {
-                resultSpan[segI] += val;
+                resultView[segI] += val;
             }
 
             // check if it works with range
             auto [rStart, rLength] = segView.range(segI);
-            auto rVals = valueSpan.subspan(rStart, rLength);
+            auto rVals = valueView.subview(rStart, rLength);
             for (auto& val : rVals)
             {
-                resultSpan[segI] += val;
+                resultView[segI] += val;
             }
 
-            // check with subspan
-            auto vals = segView.span(segI);
+            // check with subview
+            auto vals = segView.view(segI);
             for (auto& val : vals)
             {
-                resultSpan[segI] += val;
+                resultView[segI] += val;
             }
         }
     );
@@ -52,4 +52,4 @@ It can be used to represent cell to cell stencil.
 In this example, each of the five segments would have a size of two.
 This data allows the representation of stencils in a continuous memory layout, which can be beneficial for performance optimization in numerical simulations especially on GPUs.
 
-The spans method return the value and segment span and it is also possible to return a view that can also be called on a device
+The views method return the value and segment view and it is also possible to return a view that can also be called on a device

--- a/doc/mpi_architecture.rst
+++ b/doc/mpi_architecture.rst
@@ -131,7 +131,7 @@ The full communication between two ranks is thus given below:
 
         // load the send buffer
         const int commRank = mpiEnv.Rank() ? 1 : 0;
-        auto sendBuffer = buffer.getSendBuffer<double>(commRank); // span returned.
+        auto sendBuffer = buffer.getSendBuffer<double>(commRank); // View returned.
         sendBuffer[0] = allData[sendMap[0]];
 
         // start the non-blocking communication
@@ -145,7 +145,7 @@ The full communication between two ranks is thus given below:
         buffer.waitComplete();
 
         // unload the receive buffer
-        auto receiveBuffer = buffer.getReceiveBuffer<double>(commRank); // span returned.
+        auto receiveBuffer = buffer.getReceiveBuffer<double>(commRank); // View returned.
         allData[receiveMap[0]] = receiveBuffer[0];
 
         // finalize the communication, releasing the buffer

--- a/include/NeoN/core/mpi/fullDuplexCommBuffer.hpp
+++ b/include/NeoN/core/mpi/fullDuplexCommBuffer.hpp
@@ -4,10 +4,10 @@
 
 #include <vector>
 #include <string>
-#include <span>
 
 #include "NeoN/core/mpi/environment.hpp"
 #include "NeoN/core/mpi/halfDuplexCommBuffer.hpp"
+#include "NeoN/core/view.hpp"
 
 namespace NeoN
 {
@@ -66,49 +66,49 @@ public:
     }
 
     /**
-     * @brief Gets a span of data for the send buffer for a specific rank.
+     * @brief Gets a View of data for the send buffer for a specific rank.
      * @tparam valueType The type of the data.
      * @param rank The rank of the send buffer to get.
-     * @return A span of data for the send buffer.
+     * @return A view of data for the send buffer.
      */
     template<typename valueType>
-    std::span<valueType> getSend(const size_t rank)
+    View<valueType> getSend(const size_t rank)
     {
         return send_.get<valueType>(rank);
     }
 
     /**
-     * @brief Gets a span of data for the send buffer for a specific rank.
+     * @brief Gets a view of data for the send buffer for a specific rank.
      * @tparam valueType The type of the data.
      * @param rank The rank of the send buffer to get.
-     * @return A span of data for the send buffer.
+     * @return A view of data for the send buffer.
      */
     template<typename valueType>
-    std::span<const valueType> getSend(const size_t rank) const
+    View<const valueType> getSend(const size_t rank) const
     {
         return send_.get<valueType>(rank);
     }
 
     /**
-     * @brief Gets a span of data for the receive buffer for a specific rank.
+     * @brief Gets a view of data for the receive buffer for a specific rank.
      * @tparam valueType The type of the data.
      * @param rank The rank of the receive buffer to get.
-     * @return A span of data for the receive buffer.
+     * @return A view of data for the receive buffer.
      */
     template<typename valueType>
-    std::span<valueType> getReceive(const size_t rank)
+    View<valueType> getReceive(const size_t rank)
     {
         return receive_.get<valueType>(rank);
     }
 
     /**
-     * @brief Gets a span of data for the receive buffer for a specific rank.
+     * @brief Gets a view of data for the receive buffer for a specific rank.
      * @tparam valueType The type of the data.
      * @param rank The rank of the receive buffer to get.
-     * @return A span of data for the receive buffer.
+     * @return A view of data for the receive buffer.
      */
     template<typename valueType>
-    std::span<const valueType> getReceive(const size_t rank) const
+    View<const valueType> getReceive(const size_t rank) const
     {
         return receive_.get<valueType>(rank);
     }

--- a/include/NeoN/core/mpi/halfDuplexCommBuffer.hpp
+++ b/include/NeoN/core/mpi/halfDuplexCommBuffer.hpp
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2023 NeoN authors
 #pragma once
 
-#include <span>
 #include <string>
 #include <typeindex>
 #include <vector>
@@ -10,6 +9,7 @@
 #include "NeoN/core/error.hpp"
 #include "NeoN/core/mpi/environment.hpp"
 #include "NeoN/core/mpi/operators.hpp"
+#include "NeoN/core/view.hpp"
 
 namespace NeoN
 {
@@ -160,36 +160,36 @@ public:
     void finaliseComm();
 
     /**
-     * @brief Get a span of the buffer data for a given rank.
+     * @brief Get a View of the buffer data for a given rank.
      *
      * @tparam valueType The type of the data to be stored in the buffer.
      * @param rank The rank of the data to be retrieved.
-     * @return std::span<valueType> A span of the data for the given rank.
+     * @return View<valueType> A View of the data for the given rank.
      */
     template<typename valueType>
-    std::span<valueType> get(const size_t rank)
+    View<valueType> get(const size_t rank)
     {
         NF_DEBUG_ASSERT(isCommInit(), "Communication buffer is not initialised.");
         NF_DEBUG_ASSERT(typeSize_ == sizeof(valueType), "Data type (size) mismatch.");
-        return std::span<valueType>(
+        return View<valueType>(
             reinterpret_cast<valueType*>(rankBuffer_.data() + rankOffset_[rank]),
             (rankOffset_[rank + 1] - rankOffset_[rank]) / sizeof(valueType)
         );
     }
 
     /**
-     * @brief Get a span of the buffer data for a given rank.
+     * @brief Get a view of the buffer data for a given rank.
      *
      * @tparam valueType The type of the data to be stored in the buffer.
      * @param rank The rank of the data to be retrieved.
-     * @return std::span<const valueType> A span of the data for the given rank.
+     * @return View<const valueType> A View of the data for the given rank.
      */
     template<typename valueType>
-    std::span<const valueType> get(const size_t rank) const
+    View<const valueType> get(const size_t rank) const
     {
         NF_DEBUG_ASSERT(isCommInit(), "Communication buffer is not initialised.");
         NF_DEBUG_ASSERT(typeSize_ == sizeof(valueType), "Data type (size) mismatch.");
-        return std::span<const valueType>(
+        return View<const valueType>(
             reinterpret_cast<const valueType*>(rankBuffer_.data() + rankOffset_[rank]),
             (rankOffset_[rank + 1] - rankOffset_[rank]) / sizeof(valueType)
         );

--- a/include/NeoN/core/view.hpp
+++ b/include/NeoN/core/view.hpp
@@ -11,10 +11,10 @@
 namespace NeoN
 {
 
-/* @class Span
+/* @class View
  *
  * @brief A wrapper class for std::span which allows to check whether the index access is in range
- * The Span can be initialized like a regular std::span or from an existing std::span
+ * The View can be initialized like a regular std::span or from an existing std::span
  *
  * @ingroup core
  *
@@ -72,12 +72,12 @@ public:
 
     localIdx size() const { return static_cast<localIdx>(base::size()); }
 
-    View<ValueType> subspan(localIdx start, localIdx length) const
+    View<ValueType> subview(localIdx start, localIdx length) const
     {
         return base::subspan(static_cast<size_t>(start), static_cast<size_t>(length));
     }
 
-    View<ValueType> subspan(localIdx start) const
+    View<ValueType> subview(localIdx start) const
     {
         return base::subspan(static_cast<size_t>(start));
     }

--- a/include/NeoN/core/view.hpp
+++ b/include/NeoN/core/view.hpp
@@ -4,6 +4,7 @@
 
 #include <limits>
 #include <span>
+#include <type_traits>
 
 #include "NeoN/core/primitives/label.hpp"
 
@@ -82,5 +83,24 @@ public:
     }
 };
 
+/**
+ * @brief Concept, for any type which has the 'view' method.
+ * @tparam Types Class type with potential 'view' method.
+ */
+template<class Type>
+concept hasView =
+    requires(Type& inst) { inst.view(); } || requires(const Type& inst) { inst.view(); };
+
+/**
+ * @brief Unpacks all views of the passed classes.
+ * @tparam Types Types of the classes with views
+ * @return Tuple containing the unpacked views (use structured bindings).
+ */
+template<typename... Types>
+    requires(hasView<std::remove_reference_t<Types>> && ...)
+auto views(Types&... args)
+{
+    return std::tuple(args.view()...);
+}
 
 } // namespace NeoN

--- a/include/NeoN/dsl/coeff.hpp
+++ b/include/NeoN/dsl/coeff.hpp
@@ -34,7 +34,7 @@ public:
     KOKKOS_INLINE_FUNCTION
     scalar operator[](const localIdx i) const { return (hasView_) ? view_[i] * coeff_ : coeff_; }
 
-    bool hasSpan();
+    bool hasView();
 
     View<const scalar> view();
 

--- a/include/NeoN/dsl/solver.hpp
+++ b/include/NeoN/dsl/solver.hpp
@@ -72,7 +72,7 @@ void solve(
         exp.implicitOperation(ls);
         auto expTmp = exp.explicitOperation(solution.mesh().nCells());
 
-        auto [vol, expSource, rhs] = spans(solution.mesh().cellVolumes(), expTmp, ls.rhs());
+        auto [vol, expSource, rhs] = views(solution.mesh().cellVolumes(), expTmp, ls.rhs());
 
         // subtract the explicit source term from the rhs
         parallelFor(

--- a/include/NeoN/dsl/spatialOperator.hpp
+++ b/include/NeoN/dsl/spatialOperator.hpp
@@ -217,7 +217,7 @@ SpatialOperator<ValueType> operator*(const Coeff& coeff, SpatialOperator<ValueTy
 //     // TODO implement
 //     NF_ERROR_EXIT("Not implemented");
 //     SpatialOperator result = lhs;
-//     // if (!result.getCoefficient().useSpan)
+//     // if (!result.getCoefficient().useView)
 //     // {
 //     //     result.setVector(std::make_shared<Vector<scalar>>(result.exec(),
 //     result.nCells(), 1.0));

--- a/include/NeoN/fields/fieldFreeFunctions.hpp
+++ b/include/NeoN/fields/fieldFreeFunctions.hpp
@@ -141,12 +141,6 @@ void mul(Vector<ValueType>& a, const Vector<std::type_identity_t<ValueType>>& b)
 }
 
 template<typename... Args>
-auto spans(Args&... fields)
-{
-    return std::make_tuple(fields.view()...);
-}
-
-template<typename... Args>
 auto copyToHosts(Args&... fields)
 {
     return std::make_tuple(fields.copyToHost()...);
@@ -171,16 +165,16 @@ template<typename T>
 bool equal(const Vector<T>& field, const Vector<T>& field2)
 {
     auto [hostVector, hostVector2] = copyToHosts(field, field2);
-    auto [hostSpan, hostSpan2] = spans(hostVector, hostVector2);
+    auto [hostView, hostView2] = views(hostVector, hostVector2);
 
-    if (hostSpan.size() != hostSpan2.size())
+    if (hostView.size() != hostView2.size())
     {
         return false;
     }
 
-    for (localIdx i = 0; i < hostSpan.size(); i++)
+    for (localIdx i = 0; i < hostView.size(); i++)
     {
-        if (hostSpan[i] != hostSpan2[i])
+        if (hostView[i] != hostView2[i])
         {
             return false;
         }
@@ -190,18 +184,18 @@ bool equal(const Vector<T>& field, const Vector<T>& field2)
 };
 
 template<typename T>
-bool equal(const Vector<T>& field, View<T> span2)
+bool equal(const Vector<T>& field, View<T> view2)
 {
     auto hostView = field.copyToHost().view();
 
-    if (hostView.size() != span2.size())
+    if (hostView.size() != view2.size())
     {
         return false;
     }
 
     for (localIdx i = 0; i < hostView.size(); i++)
     {
-        if (hostView[i] != span2[i])
+        if (hostView[i] != view2[i])
         {
             return false;
         }

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/extrapolated.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/extrapolated.hpp
@@ -27,7 +27,7 @@ void extrapolateValue(
 {
     const auto iVector = domainVector.internalVector().view();
 
-    auto [refGradient, value, valueFraction, refValue, faceCells] = spans(
+    auto [refGradient, value, valueFraction, refValue, faceCells] = views(
         domainVector.boundaryData().refGrad(),
         domainVector.boundaryData().value(),
         domainVector.boundaryData().valueFraction(),

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedGradient.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedGradient.hpp
@@ -29,7 +29,7 @@ void setGradientValue(
 {
     const auto iVector = domainVector.internalVector().view();
 
-    auto [refGradient, value, valueFraction, refValue, faceCells, deltaCoeffs] = spans(
+    auto [refGradient, value, valueFraction, refValue, faceCells, deltaCoeffs] = views(
         domainVector.boundaryData().refGrad(),
         domainVector.boundaryData().value(),
         domainVector.boundaryData().valueFraction(),

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedValue.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedValue.hpp
@@ -23,7 +23,7 @@ void setFixedValue(
     Field<ValueType>& domainVector, std::pair<size_t, size_t> range, ValueType fixedValue
 )
 {
-    auto [refGradient, value, valueFraction, refValue] = spans(
+    auto [refGradient, value, valueFraction, refValue] = views(
         domainVector.boundaryData().refGrad(),
         domainVector.boundaryData().value(),
         domainVector.boundaryData().valueFraction(),

--- a/include/NeoN/finiteVolume/cellCentred/dsl/expression.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/dsl/expression.hpp
@@ -116,7 +116,7 @@ public:
             // solve sparse matrix system
             auto vol = psi_.mesh().cellVolumes().view();
             auto expSource = expr_.explicitOperation(psi_.mesh().nCells());
-            auto expSourceSpan = expSource.view();
+            auto expSourceView = expSource.view();
 
             ls_ = expr_.implicitOperation();
             auto rhs = ls_.rhs().view();
@@ -124,7 +124,7 @@ public:
             NeoN::parallelFor(
                 exec(),
                 {0, rhs.size()},
-                KOKKOS_LAMBDA(const localIdx i) { rhs[i] -= expSourceSpan[i] * vol[i]; }
+                KOKKOS_LAMBDA(const localIdx i) { rhs[i] -= expSourceView[i] * vol[i]; }
             );
         }
     }
@@ -159,14 +159,14 @@ public:
     {
         // TODO currently assumes that matrix is already assembled
         const auto diagOffset = sparsityPattern_->diagOffset().view();
-        const auto rowPtrs = ls_.matrix().rowPtrs().view();
+        const auto rowOffs = ls_.matrix().rowOffs().view();
         auto rhs = ls_.rhs().view();
         auto values = ls_.matrix().values().view();
         NeoN::parallelFor(
             ls_.exec(),
             {refCell, refCell + 1},
             KOKKOS_LAMBDA(const std::size_t refCelli) {
-                auto diagIdx = rowPtrs[refCelli] + diagOffset[refCelli];
+                auto diagIdx = rowOffs[refCelli] + diagOffset[refCelli];
                 auto diagValue = values[diagIdx];
                 rhs[refCelli] += diagValue * refValue;
                 values[diagIdx] += diagValue;
@@ -198,15 +198,15 @@ operator&(const Expression<ValueType, IndexType> expr, const VolumeField<ValueTy
     );
 
     auto [result, b, x] =
-        spans(resultVector.internalVector(), expr.linearSystem().rhs(), psi.internalVector());
-    const auto [values, colIdxs, rowPtrs] = expr.linearSystem().view();
+        views(resultVector.internalVector(), expr.linearSystem().rhs(), psi.internalVector());
+    const auto [values, colIdxs, rowOffs] = expr.linearSystem().view();
 
     NeoN::parallelFor(
         resultVector.exec(),
         {0, result.size()},
         KOKKOS_LAMBDA(const std::size_t rowi) {
-            IndexType rowStart = rowPtrs[rowi];
-            IndexType rowEnd = rowPtrs[rowi + 1];
+            IndexType rowStart = rowOffs[rowi];
+            IndexType rowEnd = rowOffs[rowi + 1];
             ValueType sum = 0.0;
             for (IndexType coli = rowStart; coli < rowEnd; coli++)
             {

--- a/include/NeoN/finiteVolume/cellCentred/linearAlgebra/sparsityPattern.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/linearAlgebra/sparsityPattern.hpp
@@ -37,7 +37,7 @@ public:
 
     [[nodiscard]] const Vector<localIdx>& colIdxs() const { return colIdxs_; };
 
-    [[nodiscard]] const Vector<localIdx>& rowPtrs() const { return rowPtrs_; };
+    [[nodiscard]] const Vector<localIdx>& rowOffs() const { return rowOffs_; };
 
     [[nodiscard]] localIdx rows() const { return diagOffset_.size(); };
 
@@ -50,7 +50,7 @@ private:
 
     const UnstructuredMesh& mesh_;
 
-    Vector<localIdx> rowPtrs_; //! rowPtrs map from row to start index in values
+    Vector<localIdx> rowOffs_; //! rowOffs map from row to start index in values
 
     Vector<localIdx> colIdxs_; //!
 

--- a/include/NeoN/linearAlgebra/CSRMatrix.hpp
+++ b/include/NeoN/linearAlgebra/CSRMatrix.hpp
@@ -132,40 +132,40 @@ public:
     [[nodiscard]] IndexType nNonZeros() const { return static_cast<IndexType>(values_.size()); }
 
     /**
-     * @brief Get a span to the values array.
-     * @return Span containing the matrix values.
+     * @brief Get a reference to values vector.
+     * @return Vector containing the matrix values.
      */
     [[nodiscard]] Vector<ValueType>& values() { return values_; }
 
     /**
-     * @brief Get a span to the column indices array.
-     * @return Span containing the column indices.
+     * @brief Get a reference to column indices vector.
+     * @return Vector containing the column indices.
      */
     [[nodiscard]] Vector<IndexType>& colIdxs() { return colIdxs_; }
 
     /**
-     * @brief Get a span to the row pointers array.
-     * @return Span containing the row pointers.
+     * @brief Get a reference to row offset vector.
+     * @return Vi containing the row pointers.
      */
-    [[nodiscard]] Vector<IndexType>& rowPtrs() { return rowOffs_; }
+    [[nodiscard]] Vector<IndexType>& rowOffs() { return rowOffs_; }
 
     /**
-     * @brief Get a const span to the values array.
-     * @return Const span containing the matrix values.
+     * @brief Get a const reference to values vector.
+     * @return Const vector containing the matrix values.
      */
     [[nodiscard]] const Vector<ValueType>& values() const { return values_; }
 
     /**
-     * @brief Get a const span to the column indices array.
-     * @return Const span containing the column indices.
+     * @brief Get a const reference to column indices vector.
+     * @return Const vector containing the column indices.
      */
     [[nodiscard]] const Vector<IndexType>& colIdxs() const { return colIdxs_; }
 
     /**
-     * @brief Get a const span to the row pointers array.
-     * @return Const span containing the row pointers.
+     * @brief Get a const reference to row offset vector.
+     * @return Const vector containing the row pointers.
      */
-    [[nodiscard]] const Vector<IndexType>& rowPtrs() const { return rowOffs_; }
+    [[nodiscard]] const Vector<IndexType>& rowOffs() const { return rowOffs_; }
 
     /**
      * @brief Copy the matrix to another executor.
@@ -227,20 +227,20 @@ private:
 // la::CSRMatrixView<const ValueTypeIn, const IndexTypeIn> in)
 // {
 //     Vector<IndexTypeOut> colIdxsTmp(exec, in.colIdxs.size());
-//     Vector<IndexTypeOut> rowPtrsTmp(exec, in.rowOffs.size());
+//     Vector<IndexTypeOut> rowOffsTmp(exec, in.rowOffs.size());
 //     Vector<ValueTypeOut> valuesTmp(exec, in.values.data(), in.values.size());
 
 //     parallelFor(
 //         colIdxsTmp, KOKKOS_LAMBDA(const localIdx i) { return IndexTypeOut {in.colIdxs[i]}; }
 //     );
 //     parallelFor(
-//         rowPtrsTmp, KOKKOS_LAMBDA(const localIdx i) { return IndexTypeOut {in.rowOffs[i]}; }
+//         rowOffsTmp, KOKKOS_LAMBDA(const localIdx i) { return IndexTypeOut {in.rowOffs[i]}; }
 //     );
 //     parallelFor(
 //         valuesTmp, KOKKOS_LAMBDA(const localIdx i) { return ValueTypeOut {in.values[i]}; }
 //     );
 
-//     return la::CSRMatrix<ValueTypeOut, IndexTypeOut> {valuesTmp, colIdxsTmp, rowPtrsTmp};
+//     return la::CSRMatrix<ValueTypeOut, IndexTypeOut> {valuesTmp, colIdxsTmp, rowOffsTmp};
 // }
 
 

--- a/include/NeoN/linearAlgebra/petscSolverContext.hpp
+++ b/include/NeoN/linearAlgebra/petscSolverContext.hpp
@@ -80,7 +80,7 @@ public:
 
         // auto fieldS = field.view();
 
-        auto rowPtrHost = hostLS.matrix().rowPtrs().view();
+        auto rowPtrHost = hostLS.matrix().rowOffs().view();
         auto colIdxHost = hostLS.matrix().colIdxs().view();
         auto rhsHost = sys.rhs().copyToHost();
 

--- a/src/dsl/coeff.cpp
+++ b/src/dsl/coeff.cpp
@@ -16,7 +16,7 @@ Coeff::Coeff(scalar coeff, const Vector<scalar>& field)
 
 Coeff::Coeff(const Vector<scalar>& field) : coeff_(1.0), view_(field.view()), hasView_(true) {}
 
-bool Coeff::hasSpan() { return hasView_; }
+bool Coeff::hasView() { return hasView_; }
 
 View<const scalar> Coeff::view() { return view_; }
 
@@ -35,7 +35,7 @@ Coeff& Coeff::operator*=(const Coeff& rhs)
 
     if (!hasView_ && rhs.hasView_)
     {
-        // Take over the span
+        // Take over the view
         view_ = rhs.view_;
         hasView_ = true;
     }
@@ -47,7 +47,7 @@ namespace detail
 {
 void toVector(Coeff& coeff, Vector<scalar>& rhs)
 {
-    if (coeff.hasSpan())
+    if (coeff.hasView())
     {
         rhs.resize(coeff.view().size());
         fill(rhs, 1.0);

--- a/src/finiteVolume/cellCentred/auxiliary/coNum.cpp
+++ b/src/finiteVolume/cellCentred/auxiliary/coNum.cpp
@@ -21,7 +21,7 @@ scalar computeCoNum(const SurfaceField<scalar>& faceFlux, const scalar dt)
     VolumeField<scalar> phi(exec, "phi", mesh, createCalculatedBCs<VolumeBoundary<scalar>>(mesh));
     fill(phi.internalVector(), 0.0);
 
-    const auto [surfFaceCells, volPhi, surfOwner, surfNeighbour, surfFaceFlux, surfV] = spans(
+    const auto [surfFaceCells, volPhi, surfOwner, surfNeighbour, surfFaceFlux, surfV] = views(
         mesh.boundaryMesh().faceCells(),
         phi.internalVector(),
         mesh.faceOwner(),

--- a/src/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
+++ b/src/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
@@ -19,10 +19,10 @@ void computeFaceNormalGrad(
     const auto& exec = surfaceVector.exec();
 
     const auto [owner, neighbour, surfFaceCells] =
-        spans(mesh.faceOwner(), mesh.faceNeighbour(), mesh.boundaryMesh().faceCells());
+        views(mesh.faceOwner(), mesh.faceNeighbour(), mesh.boundaryMesh().faceCells());
 
 
-    const auto [phif, phi, phiBCValue, nonOrthDeltaCoeffs] = spans(
+    const auto [phif, phi, phiBCValue, nonOrthDeltaCoeffs] = views(
         surfaceVector.internalVector(),
         volVector.internalVector(),
         volVector.boundaryData().value(),

--- a/src/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -18,7 +18,7 @@ void computeLinearInterpolation(
 {
     const auto exec = dst.exec();
     auto dstS = dst.internalVector().view();
-    const auto [srcS, weightS, ownerS, neighS, boundS] = spans(
+    const auto [srcS, weightS, ownerS, neighS, boundS] = views(
         src.internalVector(),
         weights.internalVector(),
         dst.mesh().faceOwner(),

--- a/src/finiteVolume/cellCentred/interpolation/upwind.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/upwind.cpp
@@ -19,7 +19,7 @@ void computeUpwindInterpolation(
 {
     const auto exec = dst.exec();
     auto dstS = dst.internalVector().view();
-    const auto [srcS, weightS, ownerS, neighS, boundS, fluxS] = spans(
+    const auto [srcS, weightS, ownerS, neighS, boundS, fluxS] = views(
         src.internalVector(),
         weights.internalVector(),
         dst.mesh().faceOwner(),

--- a/src/finiteVolume/cellCentred/linearAlgebra/sparsityPattern.cpp
+++ b/src/finiteVolume/cellCentred/linearAlgebra/sparsityPattern.cpp
@@ -8,7 +8,7 @@ namespace NeoN::finiteVolume::cellCentred
 {
 
 SparsityPattern::SparsityPattern(const UnstructuredMesh& mesh)
-    : mesh_(mesh), rowPtrs_(mesh_.exec(), mesh.nCells() + 1, 0),
+    : mesh_(mesh), rowOffs_(mesh_.exec(), mesh.nCells() + 1, 0),
       colIdxs_(mesh_.exec(), mesh.nCells() + 2 * mesh.nInternalFaces(), 0),
       ownerOffset_(mesh_.exec(), mesh_.nInternalFaces(), 0),
       neighbourOffset_(mesh_.exec(), mesh_.nInternalFaces(), 0),
@@ -38,8 +38,8 @@ void SparsityPattern::update()
 
     // start with one to include the diagonal
     Vector<localIdx> nFacesPerCell(exec, nCells, 1);
-    auto [nFacesPerCellSpan, neighbourOffsetSpan, ownerOffsetSpan, diagOffsetSpan] =
-        spans(nFacesPerCell, neighbourOffset_, ownerOffset_, diagOffset_);
+    auto [nFacesPerCellView, neighbourOffsetView, ownerOffsetView, diagOffsetView] =
+        views(nFacesPerCell, neighbourOffset_, ownerOffset_, diagOffset_);
 
     // accumulate number non-zeros per row
     // only the internalfaces define the sparsity pattern
@@ -52,14 +52,14 @@ void SparsityPattern::update()
             auto owner = faceOwner[facei];
             auto neighbour = faceNeighbour[facei];
 
-            Kokkos::atomic_increment(&nFacesPerCellSpan[owner]);
-            Kokkos::atomic_increment(&nFacesPerCellSpan[neighbour]);
+            Kokkos::atomic_increment(&nFacesPerCellView[owner]);
+            Kokkos::atomic_increment(&nFacesPerCellView[neighbour]);
         }
     );
 
     // get number of total non-zeros
-    segmentsFromIntervals(nFacesPerCell, rowPtrs_);
-    auto rowPtrs = rowPtrs_.view();
+    segmentsFromIntervals(nFacesPerCell, rowOffs_);
+    auto rowOffs = rowOffs_.view();
     View<localIdx> sColIdx = colIdxs_.view();
     fill(nFacesPerCell, 0); // reset nFacesPerCell
 
@@ -73,10 +73,10 @@ void SparsityPattern::update()
 
             // return the oldValues
             // hit on performance on serial
-            auto segIdxNei = Kokkos::atomic_fetch_add(&nFacesPerCellSpan[neighbour], 1);
-            neighbourOffsetSpan[facei] = static_cast<uint8_t>(segIdxNei);
+            auto segIdxNei = Kokkos::atomic_fetch_add(&nFacesPerCellView[neighbour], 1);
+            neighbourOffsetView[facei] = static_cast<uint8_t>(segIdxNei);
 
-            auto startSegNei = rowPtrs[neighbour];
+            auto startSegNei = rowOffs[neighbour];
             // neighbour --> current cell
             // colIdx --> needs to be store the owner
             Kokkos::atomic_assign(&sColIdx[startSegNei + segIdxNei], owner);
@@ -86,9 +86,9 @@ void SparsityPattern::update()
     map(
         nFacesPerCell,
         KOKKOS_LAMBDA(const localIdx celli) {
-            auto nFaces = nFacesPerCellSpan[celli];
-            diagOffsetSpan[celli] = static_cast<uint8_t>(nFaces);
-            sColIdx[rowPtrs[celli] + nFaces] = celli;
+            auto nFaces = nFacesPerCellView[celli];
+            diagOffsetView[celli] = static_cast<uint8_t>(nFaces);
+            sColIdx[rowOffs[celli] + nFaces] = celli;
             return nFaces + 1;
         }
     );
@@ -104,10 +104,10 @@ void SparsityPattern::update()
             // return the oldValues
             // hit on performance on serial
             auto segIdxOwn =
-                static_cast<uint8_t>(Kokkos::atomic_fetch_add(&nFacesPerCellSpan[owner], 1));
-            ownerOffsetSpan[facei] = segIdxOwn;
+                static_cast<uint8_t>(Kokkos::atomic_fetch_add(&nFacesPerCellView[owner], 1));
+            ownerOffsetView[facei] = segIdxOwn;
 
-            auto startSegOwn = rowPtrs[owner];
+            auto startSegOwn = rowOffs[owner];
             // owner --> current cell
             // colIdx --> needs to be store the neighbour
             Kokkos::atomic_assign(&sColIdx[startSegOwn + segIdxOwn], neighbour);

--- a/src/finiteVolume/cellCentred/operators/ddtOperator.cpp
+++ b/src/finiteVolume/cellCentred/operators/ddtOperator.cpp
@@ -20,14 +20,14 @@ void DdtOperator<ValueType>::explicitOperation(Vector<ValueType>& source, scalar
 {
     const scalar dtInver = 1.0 / dt;
     const auto vol = this->getVector().mesh().cellVolumes().view();
-    auto [sourceSpan, field, oldVector] =
-        spans(source, this->field_.internalVector(), oldTime(this->field_).internalVector());
+    auto [sourceView, field, oldVector] =
+        views(source, this->field_.internalVector(), oldTime(this->field_).internalVector());
 
     NeoN::parallelFor(
         source.exec(),
         source.range(),
         KOKKOS_LAMBDA(const localIdx celli) {
-            sourceSpan[celli] += dtInver * (field[celli] - oldVector[celli]) * vol[celli];
+            sourceView[celli] += dtInver * (field[celli] - oldVector[celli]) * vol[celli];
         }
     );
 }
@@ -41,7 +41,7 @@ void DdtOperator<ValueType>::implicitOperation(
     const auto vol = this->getVector().mesh().cellVolumes().view();
     const auto operatorScaling = this->getCoefficient();
     const auto [diagOffs, oldVector] =
-        spans(sparsityPattern_->diagOffset(), oldTime(this->field_).internalVector());
+        views(sparsityPattern_->diagOffset(), oldTime(this->field_).internalVector());
     auto [matrix, rhs] = ls.view();
 
     NeoN::parallelFor(

--- a/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
@@ -157,7 +157,7 @@ void computeDivImp(
     const auto nInternalFaces = mesh.nInternalFaces();
     const auto exec = phi.exec();
 
-    const auto [sFaceFlux, owner, neighbour, surfFaceCells, diagOffs, ownOffs, neiOffs] = spans(
+    const auto [sFaceFlux, owner, neighbour, surfFaceCells, diagOffs, ownOffs, neiOffs] = views(
         faceFlux.internalVector(),
         mesh.faceOwner(),
         mesh.faceNeighbour(),
@@ -203,7 +203,7 @@ void computeDivImp(
         }
     );
 
-    auto [refGradient, value, valueFraction, refValue] = spans(
+    auto [refGradient, value, valueFraction, refValue] = views(
         phi.boundaryData().refGrad(),
         phi.boundaryData().value(),
         phi.boundaryData().valueFraction(),

--- a/src/finiteVolume/cellCentred/operators/gaussGreenGrad.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenGrad.cpp
@@ -29,7 +29,7 @@ void computeGrad(
 
     auto surfGradPhi = out.internalVector().view();
 
-    const auto [surfFaceCells, sBSf, surfPhif, surfOwner, surfNeighbour, faceAreaS, surfV] = spans(
+    const auto [surfFaceCells, sBSf, surfPhif, surfOwner, surfNeighbour, faceAreaS, surfV] = views(
         mesh.boundaryMesh().faceCells(),
         mesh.boundaryMesh().sf(),
         phif.internalVector(),

--- a/src/finiteVolume/cellCentred/operators/sourceTerm.cpp
+++ b/src/finiteVolume/cellCentred/operators/sourceTerm.cpp
@@ -19,13 +19,13 @@ template<typename ValueType>
 void SourceTerm<ValueType>::explicitOperation(Vector<ValueType>& source) const
 {
     auto operatorScaling = this->getCoefficient();
-    auto [sourceSpan, fieldSpan, coeff] =
-        spans(source, this->field_.internalVector(), coefficients_.internalVector());
+    auto [sourceView, fieldView, coeff] =
+        views(source, this->field_.internalVector(), coefficients_.internalVector());
     NeoN::parallelFor(
         source.exec(),
         source.range(),
         KOKKOS_LAMBDA(const localIdx celli) {
-            sourceSpan[celli] += operatorScaling[celli] * coeff[celli] * fieldSpan[celli];
+            sourceView[celli] += operatorScaling[celli] * coeff[celli] * fieldView[celli];
         }
     );
 }
@@ -36,7 +36,7 @@ void SourceTerm<ValueType>::implicitOperation(la::LinearSystem<ValueType, localI
     const auto operatorScaling = this->getCoefficient();
     const auto vol = coefficients_.mesh().cellVolumes().view();
     const auto [diagOffs, coeff] =
-        spans(sparsityPattern_->diagOffset(), coefficients_.internalVector());
+        views(sparsityPattern_->diagOffset(), coefficients_.internalVector());
     auto [matrix, rhs] = ls.view();
 
     NeoN::parallelFor(

--- a/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
@@ -51,10 +51,10 @@ void BasicGeometryScheme::updateDeltaCoeffs(
 )
 {
     const auto [owner, neighbour, surfFaceCells] =
-        spans(mesh_.faceOwner(), mesh_.faceNeighbour(), mesh_.boundaryMesh().faceCells());
+        views(mesh_.faceOwner(), mesh_.faceNeighbour(), mesh_.boundaryMesh().faceCells());
 
 
-    const auto [cf, cellCentre] = spans(mesh_.faceCentres(), mesh_.cellCentres());
+    const auto [cf, cellCentre] = views(mesh_.faceCentres(), mesh_.cellCentres());
 
     auto deltaCoeff = deltaCoeffs.internalVector().view();
 
@@ -87,11 +87,11 @@ void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
 )
 {
     const auto [owner, neighbour, surfFaceCells] =
-        spans(mesh_.faceOwner(), mesh_.faceNeighbour(), mesh_.boundaryMesh().faceCells());
+        views(mesh_.faceOwner(), mesh_.faceNeighbour(), mesh_.boundaryMesh().faceCells());
 
 
     const auto [cf, cellCentre, faceAreaVec3, faceArea] =
-        spans(mesh_.faceCentres(), mesh_.cellCentres(), mesh_.faceAreas(), mesh_.magFaceAreas());
+        views(mesh_.faceCentres(), mesh_.cellCentres(), mesh_.faceAreas(), mesh_.magFaceAreas());
 
     auto nonOrthDeltaCoeff = nonOrthDeltaCoeffs.internalVector().view();
     fill(nonOrthDeltaCoeffs.internalVector(), 0.0);

--- a/src/finiteVolume/cellCentred/stencil/cellToFaceStencil.cpp
+++ b/src/finiteVolume/cellCentred/stencil/cellToFaceStencil.cpp
@@ -13,20 +13,20 @@ SegmentedVector<localIdx, localIdx> CellToFaceStencil::computeStencil() const
     const auto exec = mesh_.exec();
     const auto nCells = mesh_.nCells();
     const auto [faceOwner, faceNeighbour, faceFaceCells] =
-        spans(mesh_.faceOwner(), mesh_.faceNeighbour(), mesh_.boundaryMesh().faceCells());
+        views(mesh_.faceOwner(), mesh_.faceNeighbour(), mesh_.boundaryMesh().faceCells());
 
     const auto nInternalFaces = mesh_.nInternalFaces();
 
     Vector<localIdx> nFacesPerCell(exec, nCells, 0);
-    View<localIdx> nFacesPerCellSpan = nFacesPerCell.view();
+    View<localIdx> nFacesPerCellView = nFacesPerCell.view();
 
     parallelFor(
         exec,
         {0, nInternalFaces},
         KOKKOS_LAMBDA(const localIdx i) {
-            Kokkos::atomic_increment(&nFacesPerCellSpan[static_cast<size_t>(faceOwner[i])]
+            Kokkos::atomic_increment(&nFacesPerCellView[static_cast<size_t>(faceOwner[i])]
             ); // hit on performance on serial
-            Kokkos::atomic_increment(&nFacesPerCellSpan[static_cast<size_t>(faceNeighbour[i])]);
+            Kokkos::atomic_increment(&nFacesPerCellView[static_cast<size_t>(faceNeighbour[i])]);
         }
     );
 
@@ -34,12 +34,12 @@ SegmentedVector<localIdx, localIdx> CellToFaceStencil::computeStencil() const
         exec,
         {0, faceFaceCells.size()},
         KOKKOS_LAMBDA(const localIdx i) {
-            Kokkos::atomic_increment(&nFacesPerCellSpan[faceFaceCells[i]]);
+            Kokkos::atomic_increment(&nFacesPerCellView[faceFaceCells[i]]);
         }
     );
 
     SegmentedVector<localIdx, localIdx> stencil(nFacesPerCell); // guessed
-    auto [stencilValues, segment] = stencil.spans();
+    auto [stencilValues, segment] = stencil.views();
 
     fill(nFacesPerCell, 0); // reset nFacesPerCell
 
@@ -52,9 +52,9 @@ SegmentedVector<localIdx, localIdx> CellToFaceStencil::computeStencil() const
 
             // return the oldValues
             localIdx segIdxOwn = Kokkos::atomic_fetch_add(
-                &nFacesPerCellSpan[owner], 1
+                &nFacesPerCellView[owner], 1
             ); // hit on performance on serial
-            localIdx segIdxNei = Kokkos::atomic_fetch_add(&nFacesPerCellSpan[neighbour], 1);
+            localIdx segIdxNei = Kokkos::atomic_fetch_add(&nFacesPerCellView[neighbour], 1);
 
             auto startSegOwn = segment[owner];
             auto startSegNei = segment[neighbour];
@@ -70,7 +70,7 @@ SegmentedVector<localIdx, localIdx> CellToFaceStencil::computeStencil() const
             localIdx owner = faceFaceCells[facei - nInternalFaces];
             // return the oldValues
             localIdx segIdxOwn = Kokkos::atomic_fetch_add(
-                &nFacesPerCellSpan[owner], 1
+                &nFacesPerCellView[owner], 1
             ); // hit on performance on serial
             localIdx startSegOwn = segment[owner];
             Kokkos::atomic_assign(&stencilValues[startSegOwn + segIdxOwn], facei);

--- a/src/mesh/unstructured/boundaryMesh.cpp
+++ b/src/mesh/unstructured/boundaryMesh.cpp
@@ -28,7 +28,7 @@ const labelVector& BoundaryMesh::faceCells() const { return faceCells_; }
 
 template<typename ValueType>
 View<const ValueType>
-extractSubSpan(const Vector<ValueType>& vec, const std::vector<localIdx>& offs, localIdx i)
+extractSubView(const Vector<ValueType>& vec, const std::vector<localIdx>& offs, localIdx i)
 {
     // FIXME make offset a Vector<localIdx> instead of std::vector
     auto j = static_cast<std::size_t>(i);
@@ -38,63 +38,63 @@ extractSubSpan(const Vector<ValueType>& vec, const std::vector<localIdx>& offs, 
 
 View<const label> BoundaryMesh::faceCells(const localIdx i) const
 {
-    return extractSubSpan(faceCells_, offset_, i);
+    return extractSubView(faceCells_, offset_, i);
 }
 
 const vectorVector& BoundaryMesh::cf() const { return Cf_; }
 
 View<const Vec3> BoundaryMesh::cf(const localIdx i) const
 {
-    return extractSubSpan(Cf_, offset_, i);
+    return extractSubView(Cf_, offset_, i);
 }
 
 const vectorVector& BoundaryMesh::cn() const { return Cn_; }
 
 View<const Vec3> BoundaryMesh::cn(const localIdx i) const
 {
-    return extractSubSpan(Cn_, offset_, i);
+    return extractSubView(Cn_, offset_, i);
 }
 
 const vectorVector& BoundaryMesh::sf() const { return Sf_; }
 
 View<const Vec3> BoundaryMesh::sf(const localIdx i) const
 {
-    return extractSubSpan(Sf_, offset_, i);
+    return extractSubView(Sf_, offset_, i);
 }
 
 const scalarVector& BoundaryMesh::magSf() const { return magSf_; }
 
 View<const scalar> BoundaryMesh::magSf(const localIdx i) const
 {
-    return extractSubSpan(magSf_, offset_, i);
+    return extractSubView(magSf_, offset_, i);
 }
 
 const vectorVector& BoundaryMesh::nf() const { return nf_; }
 
 View<const Vec3> BoundaryMesh::nf(const localIdx i) const
 {
-    return extractSubSpan(nf_, offset_, i);
+    return extractSubView(nf_, offset_, i);
 }
 
 const vectorVector& BoundaryMesh::delta() const { return delta_; }
 
 View<const Vec3> BoundaryMesh::delta(const localIdx i) const
 {
-    return extractSubSpan(delta_, offset_, i);
+    return extractSubView(delta_, offset_, i);
 }
 
 const scalarVector& BoundaryMesh::weights() const { return weights_; }
 
 View<const scalar> BoundaryMesh::weights(const localIdx i) const
 {
-    return extractSubSpan(weights_, offset_, i);
+    return extractSubView(weights_, offset_, i);
 }
 
 const scalarVector& BoundaryMesh::deltaCoeffs() const { return deltaCoeffs_; }
 
 View<const scalar> BoundaryMesh::deltaCoeffs(const localIdx i) const
 {
-    return extractSubSpan(deltaCoeffs_, offset_, i);
+    return extractSubView(deltaCoeffs_, offset_, i);
 }
 
 const std::vector<localIdx>& BoundaryMesh::offset() const { return offset_; }

--- a/src/mesh/unstructured/unstructuredMesh.cpp
+++ b/src/mesh/unstructured/unstructuredMesh.cpp
@@ -116,31 +116,31 @@ UnstructuredMesh create1DUniformMesh(const Executor exec, const localIdx nCells)
     scalar meshSpacing = (rightBoundary[0] - leftBoundary[0]) / static_cast<scalar>(nCells);
     auto hostExec = SerialExecutor {};
     vectorVector meshPointsHost(hostExec, nCells + 1, {0.0, 0.0, 0.0});
-    auto meshPointsHostSpan = meshPointsHost.view();
-    meshPointsHostSpan[nCells - 1] = leftBoundary;
-    meshPointsHostSpan[nCells] = rightBoundary;
+    auto meshPointsHostView = meshPointsHost.view();
+    meshPointsHostView[nCells - 1] = leftBoundary;
+    meshPointsHostView[nCells] = rightBoundary;
     auto meshPoints = meshPointsHost.copyToExecutor(exec);
 
     // loop over internal mesh points
-    auto meshPointsSpan = meshPoints.view();
+    auto meshPointsView = meshPoints.view();
     auto leftBoundaryX = leftBoundary[0];
     parallelFor(
         exec,
         {0, nCells - 1},
         KOKKOS_LAMBDA(const localIdx i) {
-            meshPointsSpan[i][0] = leftBoundaryX + static_cast<scalar>(i + 1) * meshSpacing;
+            meshPointsView[i][0] = leftBoundaryX + static_cast<scalar>(i + 1) * meshSpacing;
         }
     );
 
     scalarVector cellVolumes(exec, nCells, meshSpacing);
 
     vectorVector cellCenters(exec, nCells, {0.0, 0.0, 0.0});
-    auto cellCentersSpan = cellCenters.view();
+    auto cellCentersView = cellCenters.view();
     parallelFor(
         exec,
         {0, nCells},
         KOKKOS_LAMBDA(const localIdx i) {
-            cellCentersSpan[i][0] = 0.5 * meshSpacing + meshSpacing * static_cast<scalar>(i);
+            cellCentersView[i][0] = 0.5 * meshSpacing + meshSpacing * static_cast<scalar>(i);
         }
     );
 
@@ -155,42 +155,42 @@ UnstructuredMesh create1DUniformMesh(const Executor exec, const localIdx nCells)
 
     labelVector faceOwnerHost(hostExec, nCells + 1);
     labelVector faceNeighbor(exec, nCells - 1);
-    auto faceOwnerHostSpan = faceOwnerHost.view();
-    faceOwnerHostSpan[nCells - 1] = 0;                          // left boundary face
-    faceOwnerHostSpan[nCells] = static_cast<label>(nCells) - 1; // right boundary face
+    auto faceOwnerHostView = faceOwnerHost.view();
+    faceOwnerHostView[nCells - 1] = 0;                          // left boundary face
+    faceOwnerHostView[nCells] = static_cast<label>(nCells) - 1; // right boundary face
     auto faceOwner = faceOwnerHost.copyToExecutor(exec);
 
     // loop over internal faces
-    auto faceOwnerSpan = faceOwner.view();
-    auto faceNeighborSpan = faceNeighbor.view();
+    auto faceOwnerView = faceOwner.view();
+    auto faceNeighborView = faceNeighbor.view();
     parallelFor(
         exec,
         {0, nCells - 1},
         KOKKOS_LAMBDA(const localIdx i) {
-            faceOwnerSpan[i] = i;
-            faceNeighborSpan[i] = i + 1;
+            faceOwnerView[i] = i;
+            faceNeighborView[i] = i + 1;
         }
     );
 
     vectorVector deltaHost(hostExec, 2);
-    auto deltaHostSpan = deltaHost.view();
+    auto deltaHostView = deltaHost.view();
     auto cellCentersHost = cellCenters.copyToHost();
-    auto cellCentersHostSpan = cellCentersHost.view();
-    deltaHostSpan[0] = {leftBoundary[0] - cellCentersHostSpan[0][0], 0.0, 0.0};
-    deltaHostSpan[1] = {rightBoundary[0] - cellCentersHostSpan[nCells - 1][0], 0.0, 0.0};
+    auto cellCentersHostView = cellCentersHost.view();
+    deltaHostView[0] = {leftBoundary[0] - cellCentersHostView[0][0], 0.0, 0.0};
+    deltaHostView[1] = {rightBoundary[0] - cellCentersHostView[nCells - 1][0], 0.0, 0.0};
     auto delta = deltaHost.copyToExecutor(exec);
 
     scalarVector deltaCoeffsHost(hostExec, 2);
-    auto deltaCoeffsHostSpan = deltaCoeffsHost.view();
-    deltaCoeffsHostSpan[0] = 1 / mag(deltaHostSpan[0]);
-    deltaCoeffsHostSpan[1] = 1 / mag(deltaHostSpan[1]);
+    auto deltaCoeffsHostView = deltaCoeffsHost.view();
+    deltaCoeffsHostView[0] = 1 / mag(deltaHostView[0]);
+    deltaCoeffsHostView[1] = 1 / mag(deltaHostView[1]);
     auto deltaCoeffs = deltaCoeffsHost.copyToExecutor(exec);
 
     BoundaryMesh boundaryMesh(
         exec,
         {exec, {0, nCells - 1}},
         {exec, {leftBoundary, rightBoundary}},
-        {exec, {cellCentersHostSpan[0], cellCentersHostSpan[nCells - 1]}},
+        {exec, {cellCentersHostView[0], cellCentersHostView[nCells - 1]}},
         {exec, {{-1.0, 0.0, 0.0}, {1.0, 0.0, 0.0}}},
         {exec, {1.0, 1.0}},
         {exec, {{-1.0, 0.0, 0.0}, {1.0, 0.0, 0.0}}},

--- a/test/core/view.cpp
+++ b/test/core/view.cpp
@@ -15,8 +15,8 @@ TEST_CASE("parallelFor")
     auto [execName, exec] = GENERATE(allAvailableExecutor());
 
     NeoN::Vector<NeoN::scalar> field(exec, 5);
+    const NeoN::Vector<NeoN::scalar> field1(exec, 4, 3.0);
     NeoN::fill(field, 2.0);
-
 
     auto fieldStdView = field.view();
     auto fieldNFView = NeoN::View(fieldStdView);
@@ -62,5 +62,27 @@ TEST_CASE("parallelFor")
         REQUIRE(fieldNFViewHost[2] == 4.0);
         REQUIRE(fieldNFViewHost[3] == 4.0);
         REQUIRE(fieldNFViewHost[4] == 4.0);
+    }
+
+    // unpack multiple views, and check correctness.
+    SECTION("views")
+    {
+        auto fieldHost = field.copyToHost();
+        auto field1Host = field1.copyToHost();
+
+        auto [viewHost, view1Host] = views(fieldHost, field1Host);
+
+        REQUIRE(viewHost.size() == 5);
+        REQUIRE(viewHost[0] == 4.0);
+        REQUIRE(viewHost[1] == 4.0);
+        REQUIRE(viewHost[2] == 4.0);
+        REQUIRE(viewHost[3] == 4.0);
+        REQUIRE(viewHost[4] == 4.0);
+
+        REQUIRE(view1Host.size() == 4);
+        REQUIRE(view1Host[0] == 3.0);
+        REQUIRE(view1Host[1] == 3.0);
+        REQUIRE(view1Host[2] == 3.0);
+        REQUIRE(view1Host[3] == 3.0);
     }
 };

--- a/test/dsl/coeff.cpp
+++ b/test/dsl/coeff.cpp
@@ -63,7 +63,7 @@ TEST_CASE("Coeff")
                 );
             };
             auto hostVectorA = fieldA.copyToHost();
-            REQUIRE(coeff.hasSpan() == true);
+            REQUIRE(coeff.hasView() == true);
             REQUIRE(hostVectorA.view()[0] == 3.0);
             REQUIRE(hostVectorA.view()[1] == 3.0);
             REQUIRE(hostVectorA.view()[2] == 3.0);
@@ -78,7 +78,7 @@ TEST_CASE("Coeff")
                 );
             };
             auto hostVectorA = fieldA.copyToHost();
-            REQUIRE(coeff.hasSpan() == false);
+            REQUIRE(coeff.hasView() == false);
             REQUIRE(hostVectorA.view()[0] == 4.0);
             REQUIRE(hostVectorA.view()[1] == 4.0);
             REQUIRE(hostVectorA.view()[2] == 4.0);
@@ -93,7 +93,7 @@ TEST_CASE("Coeff")
                 );
             };
             auto hostVectorA = fieldA.copyToHost();
-            REQUIRE(coeff.hasSpan() == true);
+            REQUIRE(coeff.hasView() == true);
             REQUIRE(hostVectorA.view()[0] == -3.0);
             REQUIRE(hostVectorA.view()[1] == -3.0);
             REQUIRE(hostVectorA.view()[2] == -3.0);

--- a/test/dsl/common.hpp
+++ b/test/dsl/common.hpp
@@ -138,8 +138,8 @@ public:
     {
         NeoN::Vector<ValueType> values(this->exec(), 1, NeoN::zero<ValueType>());
         NeoN::Vector<NeoN::localIdx> colIdx(this->exec(), 1, 0.0);
-        NeoN::Vector<NeoN::localIdx> rowPtrs(this->exec(), {0, 1});
-        NeoN::la::CSRMatrix<ValueType, NeoN::localIdx> csrMatrix(values, colIdx, rowPtrs);
+        NeoN::Vector<NeoN::localIdx> rowOffs(this->exec(), {0, 1});
+        NeoN::la::CSRMatrix<ValueType, NeoN::localIdx> csrMatrix(values, colIdx, rowOffs);
 
         NeoN::Vector<ValueType> rhs(this->exec(), 1, NeoN::zero<ValueType>());
         NeoN::la::LinearSystem<ValueType, NeoN::localIdx> linearSystem(csrMatrix, rhs);

--- a/test/fields/segmentedVector.cpp
+++ b/test/fields/segmentedVector.cpp
@@ -16,7 +16,7 @@ TEST_CASE("segmentedVector")
     SECTION("Constructor from sizes " + execName)
     {
         NeoN::SegmentedVector<NeoN::label, NeoN::localIdx> segVector(exec, 10, 5);
-        auto [values, segments] = segVector.spans();
+        auto [values, segments] = segVector.views();
 
         REQUIRE(values.size() == 10);
         REQUIRE(segments.size() == 6);
@@ -46,7 +46,7 @@ TEST_CASE("segmentedVector")
 
         SECTION("loop over segments")
         {
-            auto [valueSpan, segment] = segVector.spans();
+            auto [valueView, segment] = segVector.views();
             auto segView = segVector.view();
             NeoN::Vector<NeoN::label> result(exec, 5);
 
@@ -59,7 +59,7 @@ TEST_CASE("segmentedVector")
                 KOKKOS_LAMBDA(const NeoN::localIdx segI) {
                     // check if it works with bounds
                     auto [bStart, bEnd] = segView.bounds(segI);
-                    auto bVals = valueSpan.subspan(bStart, bEnd - bStart);
+                    auto bVals = valueView.subview(bStart, bEnd - bStart);
                     for (auto& val : bVals)
                     {
                         resultView[segI] += val;
@@ -67,14 +67,14 @@ TEST_CASE("segmentedVector")
 
                     // check if it works with range
                     auto [rStart, rLength] = segView.range(segI);
-                    auto rVals = valueSpan.subspan(rStart, rLength);
+                    auto rVals = valueView.subview(rStart, rLength);
                     for (auto& val : rVals)
                     {
                         resultView[segI] += val;
                     }
 
-                    // check with subspan
-                    auto vals = segView.span(segI);
+                    // check with subview
+                    auto vals = segView.view(segI);
                     for (auto& val : vals)
                     {
                         resultView[segI] += val;
@@ -127,7 +127,7 @@ TEST_CASE("segmentedVector")
                 {0, segVector.numSegments()},
                 KOKKOS_LAMBDA(const NeoN::localIdx segI) {
                     // fill values
-                    auto vals = segView.span(segI);
+                    auto vals = segView.view(segI);
                     for (auto& val : vals)
                     {
                         val = segI;

--- a/test/fields/vector.cpp
+++ b/test/fields/vector.cpp
@@ -176,9 +176,9 @@ TEST_CASE("Vector Container Operations")
         REQUIRE(view[1] == 2);
         REQUIRE(view[2] == 3);
 
-        auto subView = hostA.view({1, 3});
-        REQUIRE(subView[0] == 2);
-        REQUIRE(subView[1] == 3);
+        auto subview = hostA.view({1, 3});
+        REQUIRE(subview[0] == 2);
+        REQUIRE(subview[1] == 3);
     }
 
     SECTION("viewVec3" + execName)
@@ -191,9 +191,9 @@ TEST_CASE("Vector Container Operations")
         REQUIRE(view[1] == NeoN::Vec3(2, 2, 2));
         REQUIRE(view[2] == NeoN::Vec3(3, 3, 3));
 
-        auto subView = hostA.view({1, 3});
-        REQUIRE(subView[0] == NeoN::Vec3(2, 2, 2));
-        REQUIRE(subView[1] == NeoN::Vec3(3, 3, 3));
+        auto subview = hostA.view({1, 3});
+        REQUIRE(subview[0] == NeoN::Vec3(2, 2, 2));
+        REQUIRE(subview[1] == NeoN::Vec3(3, 3, 3));
     }
 
     SECTION("copyToHost " + execName)
@@ -256,7 +256,7 @@ TEST_CASE("Vector Operations")
     }
 }
 
-TEST_CASE("getSpans")
+TEST_CASE("getViews")
 {
     NeoN::Executor exec = GENERATE(
         NeoN::Executor(NeoN::SerialExecutor {}),
@@ -269,7 +269,7 @@ TEST_CASE("getSpans")
     NeoN::Vector<NeoN::scalar> c(exec, 3, 3.0);
 
     auto [hostA, hostB, hostC] = NeoN::copyToHosts(a, b, c);
-    auto [viewB, viewC] = NeoN::spans(b, c);
+    auto [viewB, viewC] = NeoN::views(b, c);
 
     REQUIRE(hostA.view()[0] == 1.0);
     REQUIRE(hostB.view()[0] == 2.0);

--- a/test/finiteVolume/cellCentred/linearAlgebra/sparsityPattern.cpp
+++ b/test/finiteVolume/cellCentred/linearAlgebra/sparsityPattern.cpp
@@ -50,9 +50,9 @@ TEST_CASE("SparsityPattern")
         REQUIRE(diagOffsS[9] == 1);
     }
 
-    SECTION("Can produce rowPtrs " + execName)
+    SECTION("Can produce rowOffs " + execName)
     {
-        auto rowPtr = sp.rowPtrs().copyToHost();
+        auto rowPtr = sp.rowOffs().copyToHost();
         auto rowPtrH = rowPtr.view();
 
         REQUIRE(rowPtrH[0] == 0);

--- a/test/linearAlgebra/CSRMatrix.cpp
+++ b/test/linearAlgebra/CSRMatrix.cpp
@@ -17,23 +17,23 @@ TEST_CASE("CSRMatrix")
     // sparse matrix
     NeoN::Vector<NeoN::scalar> valuesSparse(exec, {1.0, 5.0, 6.0, 8.0});
     NeoN::Vector<NeoN::localIdx> colIdxSparse(exec, {0, 1, 2, 1});
-    NeoN::Vector<NeoN::localIdx> rowPtrsSparse(exec, {0, 1, 3, 4});
+    NeoN::Vector<NeoN::localIdx> rowOffsSparse(exec, {0, 1, 3, 4});
     NeoN::la::CSRMatrix<NeoN::scalar, NeoN::localIdx> sparseMatrix(
-        valuesSparse, colIdxSparse, rowPtrsSparse
+        valuesSparse, colIdxSparse, rowOffsSparse
     );
     const NeoN::la::CSRMatrix<NeoN::scalar, NeoN::localIdx> sparseMatrixConst(
-        valuesSparse, colIdxSparse, rowPtrsSparse
+        valuesSparse, colIdxSparse, rowOffsSparse
     );
 
     // dense matrix
     NeoN::Vector<NeoN::scalar> valuesDense(exec, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0});
     NeoN::Vector<NeoN::localIdx> colIdxDense(exec, {0, 1, 2, 0, 1, 2, 0, 1, 2});
-    NeoN::Vector<NeoN::localIdx> rowPtrsDense(exec, {0, 3, 6, 9});
+    NeoN::Vector<NeoN::localIdx> rowOffsDense(exec, {0, 3, 6, 9});
     NeoN::la::CSRMatrix<NeoN::scalar, NeoN::localIdx> denseMatrix(
-        valuesDense, colIdxDense, rowPtrsDense
+        valuesDense, colIdxDense, rowOffsDense
     );
     const NeoN::la::CSRMatrix<NeoN::scalar, NeoN::localIdx> denseMatrixConst(
-        valuesDense, colIdxDense, rowPtrsDense
+        valuesDense, colIdxDense, rowOffsDense
     );
 
     // NOTE: The purpose of this test is to detect changes in the order
@@ -46,17 +46,17 @@ TEST_CASE("CSRMatrix")
         auto valuesDenseHostView = valuesDenseHost.view();
         auto colIdxDenseHost = colIdxDense.copyToHost();
         auto colIdxDenseHostView = colIdxDenseHost.view();
-        auto rowPtrsDenseHost = rowPtrsDense.copyToHost();
-        auto rowPtrsDenseHostView = rowPtrsDenseHost.view();
+        auto rowOffsDenseHost = rowOffsDense.copyToHost();
+        auto rowOffsDenseHostView = rowOffsDenseHost.view();
 
         for (int i = 0; i < valuesDenseHostView.size(); ++i)
         {
             REQUIRE(valuesDenseHostView[i] == values[i]);
             REQUIRE(colIdxDenseHostView[i] == colIdxs[i]);
         }
-        for (int i = 0; i < rowPtrsDenseHostView.size(); ++i)
+        for (int i = 0; i < rowOffsDenseHostView.size(); ++i)
         {
-            REQUIRE(rowPtrsDenseHostView[i] == rowOffs[i]);
+            REQUIRE(rowOffsDenseHostView[i] == rowOffs[i]);
         }
     }
 
@@ -280,11 +280,11 @@ TEST_CASE("CSRMatrix")
         auto [value, column, row] = hostMatrix.view();
         auto hostvaluesSparse = valuesSparse.copyToHost();
         auto hostcolIdxSparse = colIdxSparse.copyToHost();
-        auto hostrowPtrsSparse = rowPtrsSparse.copyToHost();
+        auto hostrowOffsSparse = rowOffsSparse.copyToHost();
 
         REQUIRE(hostvaluesSparse.size() == value.size());
         REQUIRE(hostcolIdxSparse.size() == column.size());
-        REQUIRE(hostrowPtrsSparse.size() == row.size());
+        REQUIRE(hostrowOffsSparse.size() == row.size());
 
         for (NeoN::localIdx i = 0; i < value.size(); ++i)
         {
@@ -293,7 +293,7 @@ TEST_CASE("CSRMatrix")
         }
         for (NeoN::localIdx i = 0; i < row.size(); ++i)
         {
-            REQUIRE(hostrowPtrsSparse.view()[i] == row[i]);
+            REQUIRE(hostrowOffsSparse.view()[i] == row[i]);
         }
     }
 }

--- a/test/linearAlgebra/ginkgo.cpp
+++ b/test/linearAlgebra/ginkgo.cpp
@@ -94,8 +94,8 @@ TEST_CASE("MatrixAssembly - Ginkgo")
 
         Vector<scalar> values(exec, {1.0, -0.1, -0.1, 1.0, -0.1, -0.1, 1.0});
         Vector<localIdx> colIdx(exec, {0, 1, 0, 1, 2, 1, 2});
-        Vector<localIdx> rowPtrs(exec, {0, 2, 5, 7});
-        CSRMatrix<scalar, localIdx> csrMatrix(values, colIdx, rowPtrs);
+        Vector<localIdx> rowOffs(exec, {0, 2, 5, 7});
+        CSRMatrix<scalar, localIdx> csrMatrix(values, colIdx, rowOffs);
 
         Vector<scalar> rhs(exec, {1.0, 2.0, 3.0});
         LinearSystem<scalar, localIdx> linearSystem(csrMatrix, rhs);

--- a/test/linearAlgebra/linearSystem.cpp
+++ b/test/linearAlgebra/linearSystem.cpp
@@ -22,8 +22,8 @@ TEST_CASE("LinearSystem")
 
     Vector<scalar> values(exec, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0});
     Vector<localIdx> colIdx(exec, {0, 1, 2, 0, 1, 2, 0, 1, 2});
-    Vector<localIdx> rowPtrs(exec, {0, 3, 6, 9});
-    CSRMatrix<scalar, localIdx> csrMatrix(values, colIdx, rowPtrs);
+    Vector<localIdx> rowOffs(exec, {0, 3, 6, 9});
+    CSRMatrix<scalar, localIdx> csrMatrix(values, colIdx, rowOffs);
 
     SECTION("construct " + execName)
     {
@@ -33,7 +33,7 @@ TEST_CASE("LinearSystem")
 
         REQUIRE(linearSystem.matrix().values().size() == 9);
         REQUIRE(linearSystem.matrix().colIdxs().size() == 9);
-        REQUIRE(linearSystem.matrix().rowPtrs().size() == 4);
+        REQUIRE(linearSystem.matrix().rowOffs().size() == 4);
         REQUIRE(linearSystem.matrix().nRows() == 3);
         REQUIRE(linearSystem.rhs().size() == 3);
     }
@@ -54,7 +54,7 @@ TEST_CASE("LinearSystem")
 
         REQUIRE(linearSystem.matrix().values().size() == nnz);
         REQUIRE(linearSystem.matrix().colIdxs().size() == nnz);
-        REQUIRE(linearSystem.matrix().rowPtrs().size() == nCells + 1);
+        REQUIRE(linearSystem.matrix().rowOffs().size() == nCells + 1);
         REQUIRE(linearSystem.matrix().nRows() == nCells);
         REQUIRE(linearSystem.rhs().size() == nCells);
     }

--- a/test/linearAlgebra/petsc.cpp
+++ b/test/linearAlgebra/petsc.cpp
@@ -45,8 +45,8 @@ TEST_CASE("MatrixAssembly - Petsc")
         Vector<NeoN::scalar> values(exec, {10.0, 4.0, 7.0, 2.0, 10.0, 8.0, 3.0, 6.0, 10.0});
         // TODO work on support for unsingned types
         Vector<localIdx> colIdx(exec, {0, 1, 2, 0, 1, 2, 0, 1, 2});
-        Vector<localIdx> rowPtrs(exec, {0, 3, 6, 9});
-        CSRMatrix<scalar, localIdx> csrMatrix(values, colIdx, rowPtrs);
+        Vector<localIdx> rowOffs(exec, {0, 3, 6, 9});
+        CSRMatrix<scalar, localIdx> csrMatrix(values, colIdx, rowOffs);
 
         Vector<NeoN::scalar> rhs(exec, {1.0, 2.0, 3.0});
         LinearSystem<scalar, localIdx> linearSystem(csrMatrix, rhs);
@@ -77,8 +77,8 @@ TEST_CASE("MatrixAssembly - Petsc")
             );
 
             Vector<localIdx> colIdx(exec, {0, 1, 2, 0, 1, 2, 0, 1, 2});
-            Vector<localIdx> rowPtrs(exec, {0, 3, 6, 9});
-            CSRMatrix<scalar, localIdx> csrMatrix(values, colIdx, rowPtrs);
+            Vector<localIdx> rowOffs(exec, {0, 3, 6, 9});
+            CSRMatrix<scalar, localIdx> csrMatrix(values, colIdx, rowOffs);
 
             Vector<NeoN::scalar> rhs(exec, {1.0, 2.0, 3.0});
             LinearSystem<scalar, localIdx> linearSystem(csrMatrix, rhs);


### PR DESCRIPTION
Presently, when we want to get multiple views at the start of a function, we need 'lines' of:

```cpp
auto viewA = A.view();
auto viewB = B.view();
```
Is some old code we have a class method 'spans', while this does not replace that, it is a similar concept but applied over classes: Multiple `view`s from multiple classes can be returned in a structured binding.

```cpp
auto [viewA, viewB] = views(A, B);
```
