### PR TITLE
Fix/dict propagation

### DIFF
--- a/include/NeoN/dsl/expression.hpp
+++ b/include/NeoN/dsl/expression.hpp
@@ -30,15 +30,16 @@ public:
           spatialOperators_(exp.spatialOperators_)
     {}
 
-    void build(const Dictionary& input)
+    /* @brief dispatch read call to operator */
+    void read(const Dictionary& input)
     {
         for (auto& op : temporalOperators_)
         {
-            op.build(input);
+            op.read(input);
         }
         for (auto& op : spatialOperators_)
         {
-            op.build(input);
+            op.read(input);
         }
     }
 

--- a/include/NeoN/dsl/operator.hpp
+++ b/include/NeoN/dsl/operator.hpp
@@ -50,7 +50,7 @@ public:
     const VectorType& getVector() const { return field_; }
 
     /* @brief Given an input this function reads required coeffs */
-    void build([[maybe_unused]] const Input& input) {}
+    void read([[maybe_unused]] const Input& input) {}
 
 protected:
 

--- a/include/NeoN/dsl/solver.hpp
+++ b/include/NeoN/dsl/solver.hpp
@@ -49,7 +49,7 @@ void solve(
     {
         NF_ERROR_EXIT("No temporal or implicit terms to solve.");
     }
-    exp.build(fvSchemes);
+    exp.read(fvSchemes);
     if (exp.temporalOperators().size() > 0)
     {
         // integrate equations in time

--- a/include/NeoN/dsl/solver.hpp
+++ b/include/NeoN/dsl/solver.hpp
@@ -40,7 +40,7 @@ void solve(
     VectorType& solution,
     scalar t,
     scalar dt,
-    [[maybe_unused]] const Dictionary& fvSchemes,
+    const Dictionary& fvSchemes,
     const Dictionary& fvSolution
 )
 {
@@ -54,7 +54,7 @@ void solve(
     {
         // integrate equations in time
         timeIntegration::TimeIntegration<VectorType> timeIntegrator(
-            fvSchemes.subDict("ddtSchemes"), fvSchemes
+            fvSchemes.subDict("ddtSchemes"), fvSolution
         );
         timeIntegrator.solve(exp, solution, t, dt);
     }

--- a/include/NeoN/dsl/spatialOperator.hpp
+++ b/include/NeoN/dsl/spatialOperator.hpp
@@ -158,7 +158,7 @@ private:
         }
 
         /* @brief Given an input this function reads required coeffs */
-        virtual void read(const Input& input) override { concreteOp_.build(input); }
+        virtual void read(const Input& input) override { concreteOp_.read(input); }
 
         /* returns the fundamental type of an operator, ie explicit, implicit, temporal */
         Operator::Type getType() const override { return concreteOp_.getType(); }

--- a/include/NeoN/dsl/spatialOperator.hpp
+++ b/include/NeoN/dsl/spatialOperator.hpp
@@ -89,8 +89,8 @@ public:
 
     Coeff getCoefficient() const { return model_->getCoefficient(); }
 
-    /* @brief Given an input this function reads required coeffs */
-    void build(const Input& input) { model_->build(input); }
+    /* @brief Given an input this function reads required properties */
+    void read(const Input& input) { model_->read(input); }
 
     /* @brief Get the executor */
     const Executor& exec() const { return model_->exec(); }
@@ -110,7 +110,7 @@ private:
         virtual void implicitOperation(la::LinearSystem<ValueType, localIdx>& ls) = 0;
 
         /* @brief Given an input this function reads required coeffs */
-        virtual void build(const Input& input) = 0;
+        virtual void read(const Input& input) = 0;
 
         /* returns the name of the operator */
         virtual std::string getName() const = 0;
@@ -158,7 +158,7 @@ private:
         }
 
         /* @brief Given an input this function reads required coeffs */
-        virtual void build(const Input& input) override { concreteOp_.build(input); }
+        virtual void read(const Input& input) override { concreteOp_.build(input); }
 
         /* returns the fundamental type of an operator, ie explicit, implicit, temporal */
         Operator::Type getType() const override { return concreteOp_.getType(); }

--- a/include/NeoN/dsl/temporalOperator.hpp
+++ b/include/NeoN/dsl/temporalOperator.hpp
@@ -86,8 +86,8 @@ public:
 
     Coeff getCoefficient() const { return model_->getCoefficient(); }
 
-    /* @brief Given an input this function reads required coeffs */
-    void build(const Input& input) { model_->build(input); }
+    /* @brief Given an input this function reads required properties */
+    void read(const Input& input) { model_->read(input); }
 
     /* @brief Get the executor */
     const Executor& exec() const { return model_->exec(); }
@@ -107,8 +107,8 @@ private:
         virtual void
         implicitOperation(la::LinearSystem<ValueType, localIdx>& ls, scalar t, scalar dt) = 0;
 
-        /* @brief Given an input this function reads required coeffs */
-        virtual void build(const Input& input) = 0;
+        /* @brief Given an input this function reads required properties */
+        virtual void read(const Input& input) = 0;
 
         /* returns the name of the operator */
         virtual std::string getName() const = 0;
@@ -159,7 +159,7 @@ private:
         }
 
         /* @brief Given an input this function reads required coeffs */
-        virtual void build(const Input& input) override { concreteOp_.build(input); }
+        virtual void read(const Input& input) override { concreteOp_.read(input); }
 
         /* returns the fundamental type of an operator, ie explicit, implicit, temporal */
         Operator::Type getType() const override { return concreteOp_.getType(); }

--- a/include/NeoN/finiteVolume/cellCentred/dsl/expression.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/dsl/expression.hpp
@@ -30,8 +30,8 @@ public:
     Expression(
         dsl::Expression<ValueType> expr,
         VolumeField<ValueType>& psi,
-        [[maybe_unused]] const Dictionary& fvSchemes,
-        [[maybe_unused]] const Dictionary& fvSolution
+        const Dictionary& fvSchemes,
+        const Dictionary& fvSolution
     )
         : psi_(psi), expr_(expr), fvSchemes_(fvSchemes), fvSolution_(fvSolution),
           sparsityPattern_(SparsityPattern::readOrCreate(psi.mesh())),
@@ -39,7 +39,7 @@ public:
               *sparsityPattern_.get()
           ))
     {
-        expr_.build(fvSchemes_);
+        expr_.read(fvSchemes_);
         // assemble();
     };
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/ddtOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/ddtOperator.hpp
@@ -29,7 +29,7 @@ public:
 
     void implicitOperation(la::LinearSystem<ValueType, localIdx>& ls, scalar, scalar dt);
 
-    void build(const Input&) {}
+    void read(const Input&) {}
 
     std::string getName() const { return "DdtOperator"; }
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/divOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/divOperator.hpp
@@ -166,7 +166,7 @@ public:
         divOperatorStrategy_->div(divPhi, faceFlux_, this->getVector(), operatorScaling);
     }
 
-    void build(const Input& input)
+    void read(const Input& input)
     {
         const UnstructuredMesh& mesh = this->getVector().mesh();
         if (std::holds_alternative<NeoN::Dictionary>(input))

--- a/include/NeoN/finiteVolume/cellCentred/operators/laplacianOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/laplacianOperator.hpp
@@ -174,7 +174,7 @@ public:
         return lapPhi;
     }
 
-    void build(const Input& input)
+    void read(const Input& input)
     {
         const UnstructuredMesh& mesh = this->field_.mesh();
         if (std::holds_alternative<NeoN::Dictionary>(input))

--- a/include/NeoN/finiteVolume/cellCentred/operators/sourceTerm.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/sourceTerm.hpp
@@ -31,7 +31,7 @@ public:
 
     void implicitOperation(la::LinearSystem<ValueType, localIdx>& ls) const;
 
-    void build(const Input&) {}
+    void read(const Input&) {}
 
     std::string getName() const { return "sourceTerm"; }
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/surfaceIntegrate.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/surfaceIntegrate.hpp
@@ -42,7 +42,7 @@ public:
           coeffs_(surfaceIntegrate.coeffs_) {};
 
 
-    void build(const Input&) {}
+    void read(const Input&) {}
 
     void explicitOperation(Vector<ValueType>& source) const
     {

--- a/include/NeoN/linearAlgebra/solver.hpp
+++ b/include/NeoN/linearAlgebra/solver.hpp
@@ -8,6 +8,18 @@
 
 namespace NeoN::la
 {
+
+
+/* @brief A helper to collect statistics of the solver */
+struct SolverStats
+{
+    int numIter;
+
+    scalar initResNorm;
+
+    scalar finalResNorm;
+};
+
 /* @class SolverFactory
 **
 */

--- a/include/NeoN/timeIntegration/backwardEuler.hpp
+++ b/include/NeoN/timeIntegration/backwardEuler.hpp
@@ -42,10 +42,7 @@ public:
     static std::string schema() { return "none"; }
 
     void solve(
-        dsl::Expression<ValueType>& eqn,
-        SolutionVectorType& solutionVector,
-        [[maybe_unused]] scalar t,
-        scalar dt
+        dsl::Expression<ValueType>& eqn, SolutionVectorType& solutionVector, scalar t, scalar dt
     ) override
     {
         auto source = eqn.explicitOperation(solutionVector.size());

--- a/include/NeoN/timeIntegration/timeIntegration.hpp
+++ b/include/NeoN/timeIntegration/timeIntegration.hpp
@@ -61,7 +61,6 @@ class TimeIntegration
 
 public:
 
-
     using ValueType = typename SolutionVectorType::VectorValueType;
     using Expression = NeoN::dsl::Expression<ValueType>;
 

--- a/test/finiteVolume/cellCentred/operator/laplacianOperator.cpp
+++ b/test/finiteVolume/cellCentred/operator/laplacianOperator.cpp
@@ -111,7 +111,7 @@ TEMPLATE_TEST_CASE("laplacianOperator fixedValue", "[template]", scalar, Vec3)
         {
             ls.reset();
             dsl::SpatialOperator lapOp2 = dsl::imp::laplacian(gamma, phi);
-            lapOp2.build(input);
+            lapOp2.read(input);
             lapOp2 = dsl::Coeff(-0.5) * lapOp2;
 
             lapOp.implicitOperation(ls);


### PR DESCRIPTION
Currently, the solve() method propagates the wrong dictionary to the solver. This PR fixes that. Also, the build method is renamed to `read()`, this seems more appropriate since the operator is already instantiated and now properties are read from an Input.