### PR TITLE
Clean up tests

### DIFF
--- a/include/NeoN/dsl/explicit.hpp
+++ b/include/NeoN/dsl/explicit.hpp
@@ -5,12 +5,15 @@
 #pragma once
 
 #include "NeoN/core/primitives/scalar.hpp"
+#include "NeoN/core/primitives/vec3.hpp"
 #include "NeoN/dsl/spatialOperator.hpp"
+#include "NeoN/dsl/temporalOperator.hpp"
 #include "NeoN/finiteVolume/cellCentred/fields/volumeField.hpp"
 #include "NeoN/finiteVolume/cellCentred/fields/surfaceField.hpp"
 
 // TODO we should get rid of this include since it includes details
 // from a general implementation
+#include "NeoN/finiteVolume/cellCentred/operators/ddtOperator.hpp"
 #include "NeoN/finiteVolume/cellCentred/operators/laplacianOperator.hpp"
 #include "NeoN/finiteVolume/cellCentred/operators/divOperator.hpp"
 #include "NeoN/finiteVolume/cellCentred/operators/surfaceIntegrate.hpp"
@@ -22,6 +25,12 @@ namespace NeoN::dsl::exp
 
 namespace fvcc = NeoN::finiteVolume::cellCentred;
 
+template<typename ValueType>
+TemporalOperator<ValueType> ddt(fvcc::VolumeField<ValueType>& phi)
+{
+    return fvcc::DdtOperator(dsl::Operator::Type::Explicit, phi);
+}
+
 SpatialOperator<scalar>
 div(const fvcc::SurfaceField<scalar>& faceFlux, fvcc::VolumeField<scalar>& phi);
 
@@ -29,6 +38,10 @@ SpatialOperator<scalar> div(const fvcc::SurfaceField<scalar>& flux);
 
 SpatialOperator<scalar>
 laplacian(const fvcc::SurfaceField<scalar>& gamma, fvcc::VolumeField<scalar>& phi);
+
+
+SpatialOperator<Vec3>
+laplacian(const fvcc::SurfaceField<scalar>& gamma, fvcc::VolumeField<Vec3>& phi);
 
 SpatialOperator<scalar> source(fvcc::VolumeField<scalar>& coeff, fvcc::VolumeField<scalar>& phi);
 

--- a/include/NeoN/dsl/solver.hpp
+++ b/include/NeoN/dsl/solver.hpp
@@ -18,7 +18,7 @@
 #include "NeoN/linearAlgebra/linearSystem.hpp"
 #include "NeoN/linearAlgebra/solver.hpp"
 
-// FIXME
+// TODO move sparsity to linearAlgebra from fvcc
 #include "NeoN/finiteVolume/cellCentred/linearAlgebra/sparsityPattern.hpp"
 
 

--- a/include/NeoN/dsl/spatialOperator.hpp
+++ b/include/NeoN/dsl/spatialOperator.hpp
@@ -19,16 +19,14 @@ namespace NeoN::dsl
 {
 
 template<typename T>
-concept HasExplicitOperator = requires(T t) {
-    // using ValueType = typename T::VectorValueType;
+concept HasExplicitOperator = requires(T const t) {
     {
         t.explicitOperation(std::declval<Vector<typename T::VectorValueType>&>())
-    } -> std::same_as<void>; // Adjust return type and arguments as needed
+    } -> std::same_as<void>;
 };
 
 template<typename T>
-concept HasImplicitOperator = requires(T t) {
-    // using ValueType = typename T::VectorValueType;
+concept HasImplicitOperator = requires(T const t) {
     {
         t.implicitOperation(std::declval<la::LinearSystem<typename T::VectorValueType, localIdx>&>()
         )
@@ -57,9 +55,7 @@ public:
 
     using VectorValueType = ValueType;
 
-    // FIXME add again
-    // template<IsSpatialOperator T>
-    template<typename T>
+    template<IsSpatialOperator T>
     SpatialOperator(T cls) : model_(std::make_unique<OperatorModel<T>>(std::move(cls)))
     {}
 

--- a/include/NeoN/dsl/spatialOperator.hpp
+++ b/include/NeoN/dsl/spatialOperator.hpp
@@ -6,6 +6,7 @@
 #include <concepts>
 
 #include "NeoN/core/primitives/scalar.hpp"
+#include "NeoN/core/primitives/vec3.hpp"
 #include "NeoN/core/vector/vector.hpp"
 #include "NeoN/linearAlgebra/linearSystem.hpp"
 #include "NeoN/core/input.hpp"

--- a/include/NeoN/finiteVolume/cellCentred/operators/ddtOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/ddtOperator.hpp
@@ -27,7 +27,7 @@ public:
 
     void explicitOperation(Vector<ValueType>& source, scalar, scalar dt) const;
 
-    void implicitOperation(la::LinearSystem<ValueType, localIdx>& ls, scalar, scalar dt);
+    void implicitOperation(la::LinearSystem<ValueType, localIdx>& ls, scalar, scalar dt) const;
 
     void read(const Input&) {}
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/divOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/divOperator.hpp
@@ -126,7 +126,7 @@ public:
           faceFlux_(faceFlux), divOperatorStrategy_(nullptr) {};
 
 
-    void explicitOperation(Vector<scalar>& source) const
+    void explicitOperation(Vector<ValueType>& source) const
     {
         NF_ASSERT(divOperatorStrategy_, "DivOperatorStrategy not initialized");
         NeoN::Vector<NeoN::scalar> tmpsource(source.exec(), source.size(), 0.0);
@@ -141,7 +141,7 @@ public:
         return divOperatorStrategy_->createEmptyLinearSystem();
     }
 
-    void implicitOperation(la::LinearSystem<ValueType, localIdx>& ls)
+    void implicitOperation(la::LinearSystem<ValueType, localIdx>& ls) const
     {
         NF_ASSERT(divOperatorStrategy_, "DivOperatorStrategy not initialized");
         const auto operatorScaling = this->getCoefficient();

--- a/include/NeoN/finiteVolume/cellCentred/operators/laplacianOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/laplacianOperator.hpp
@@ -137,7 +137,7 @@ public:
         source += tmpsource;
     }
 
-    void implicitOperation(la::LinearSystem<ValueType, localIdx>& ls)
+    void implicitOperation(la::LinearSystem<ValueType, localIdx>& ls) const
     {
         NF_ASSERT(laplacianOperatorStrategy_, "LaplacianOperatorStrategy not initialized");
         const auto operatorScaling = this->getCoefficient();

--- a/include/NeoN/finiteVolume/cellCentred/operators/sourceTerm.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/sourceTerm.hpp
@@ -21,6 +21,8 @@ class SourceTerm : public dsl::OperatorMixin<VolumeField<ValueType>>
 
 public:
 
+    using VectorValueType = ValueType;
+
     SourceTerm(
         dsl::Operator::Type termType,
         VolumeField<scalar>& coefficients,

--- a/include/NeoN/linearAlgebra/ginkgo.hpp
+++ b/include/NeoN/linearAlgebra/ginkgo.hpp
@@ -154,9 +154,10 @@ public:
         return {numIter, initResNorm, finalResNorm};
     }
 
+    // TODO why use a smart pointer here?
     virtual std::unique_ptr<SolverFactory> clone() const final
     {
-        // FIXME
+        NF_ERROR_EXIT("Not implemented");
         return {};
     }
 

--- a/include/NeoN/linearAlgebra/petsc.hpp
+++ b/include/NeoN/linearAlgebra/petsc.hpp
@@ -68,9 +68,10 @@ public:
 
     static std::string schema() { return "none"; }
 
+    // TODO why use a smart pointer here?
     virtual std::unique_ptr<SolverFactory> clone() const final
     {
-        // FIXME
+        NF_ERROR_EXIT("Not implemented");
         return {};
     }
 

--- a/include/NeoN/mesh/unstructured/boundaryMesh.hpp
+++ b/include/NeoN/mesh/unstructured/boundaryMesh.hpp
@@ -204,7 +204,7 @@ public:
      *
      * @return A constant reference to the offset of the boundary faces.
      */
-    // FIXME use Vector here?
+    // TODO consistent use of Vector on CPU
     const std::vector<localIdx>& offset() const;
 
 
@@ -274,7 +274,7 @@ private:
      *
      * The offset is used to access the boundary faces of each boundary.
      */
-    // FIXME use Vector here?
+    // TODO consistent use of Vector on CPU
     std::vector<localIdx> offset_;
 };
 

--- a/src/dsl/explicit.cpp
+++ b/src/dsl/explicit.cpp
@@ -26,6 +26,13 @@ laplacian(const fvcc::SurfaceField<NeoN::scalar>& gamma, fvcc::VolumeField<NeoN:
     );
 }
 
+SpatialOperator<Vec3>
+laplacian(const fvcc::SurfaceField<NeoN::scalar>& gamma, fvcc::VolumeField<NeoN::Vec3>& phi)
+{
+    return SpatialOperator<Vec3>(fvcc::LaplacianOperator(dsl::Operator::Type::Explicit, gamma, phi)
+    );
+}
+
 SpatialOperator<scalar>
 source(fvcc::VolumeField<NeoN::scalar>& coeff, fvcc::VolumeField<NeoN::scalar>& phi)
 {

--- a/src/dsl/spatialOperator.cpp
+++ b/src/dsl/spatialOperator.cpp
@@ -6,9 +6,8 @@
 namespace NeoN::dsl
 {
 
-
 // instantiate the template class
 template class SpatialOperator<scalar>;
-
+template class SpatialOperator<Vec3>;
 
 } // namespace NeoN::dsl

--- a/src/finiteVolume/cellCentred/operators/ddtOperator.cpp
+++ b/src/finiteVolume/cellCentred/operators/ddtOperator.cpp
@@ -35,7 +35,7 @@ void DdtOperator<ValueType>::explicitOperation(Vector<ValueType>& source, scalar
 template<typename ValueType>
 void DdtOperator<ValueType>::implicitOperation(
     la::LinearSystem<ValueType, localIdx>& ls, scalar, scalar dt
-)
+) const
 {
     const scalar dtInver = 1.0 / dt;
     const auto vol = this->getVector().mesh().cellVolumes().view();

--- a/src/mesh/unstructured/boundaryMesh.cpp
+++ b/src/mesh/unstructured/boundaryMesh.cpp
@@ -30,7 +30,7 @@ template<typename ValueType>
 View<const ValueType>
 extractSubView(const Vector<ValueType>& vec, const std::vector<localIdx>& offs, localIdx i)
 {
-    // FIXME make offset a Vector<localIdx> instead of std::vector
+    // TODO make offset a Vector<localIdx> instead of std::vector
     auto j = static_cast<std::size_t>(i);
     return vec.view({offs[j], offs[j + 1]});
 }

--- a/test/dsl/common.hpp
+++ b/test/dsl/common.hpp
@@ -18,9 +18,41 @@ using VolumeField = fvcc::VolumeField<NeoN::scalar>;
 using OperatorMixin = NeoN::dsl::OperatorMixin<VolumeField>;
 using BoundaryData = NeoN::BoundaryData<NeoN::scalar>;
 
+/* helper struct to create a vector in the database
+ */
+struct CreateVector
+{
+    std::string name;
+    const NeoN::UnstructuredMesh& mesh;
+    NeoN::scalar value = 0;
+    std::int64_t timeIndex = 0;
+    std::int64_t iterationIndex = 0;
+    std::int64_t subCycleIndex = 0;
+
+    NeoN::Document operator()(NeoN::Database& db)
+    {
+        std::vector<fvcc::VolumeBoundary<NeoN::scalar>> bcs {};
+        NeoN::Field<NeoN::scalar> domainVector(
+            mesh.exec(),
+            NeoN::Vector<NeoN::scalar>(mesh.exec(), mesh.nCells(), 1.0),
+            mesh.boundaryMesh().offset()
+        );
+        fvcc::VolumeField<NeoN::scalar> vf(mesh.exec(), name, mesh, domainVector, bcs, db, "", "");
+        NeoN::fill(vf.internalVector(), value);
+        return NeoN::Document(
+            {{"name", vf.name},
+             {"timeIndex", timeIndex},
+             {"iterationIndex", iterationIndex},
+             {"subCycleIndex", subCycleIndex},
+             {"field", vf}},
+            fvcc::validateVectorDoc
+        );
+    }
+};
+
+
 /* A dummy implementation of a SpatialOperator
  * following the SpatialOperator interface */
-
 template<typename ValueType>
 class Dummy : public NeoN::dsl::OperatorMixin<fvcc::VolumeField<ValueType>>
 {

--- a/test/dsl/common.hpp
+++ b/test/dsl/common.hpp
@@ -73,7 +73,7 @@ public:
         )
     {}
 
-    void explicitOperation(NeoN::Vector<ValueType>& source)
+    void explicitOperation(NeoN::Vector<ValueType>& source) const
     {
         auto sourceView = source.view();
         auto fieldView = this->field_.internalVector().view();
@@ -85,7 +85,7 @@ public:
         );
     }
 
-    void implicitOperation(la::LinearSystem<ValueType, NeoN::localIdx>& ls)
+    void implicitOperation(la::LinearSystem<ValueType, NeoN::localIdx>& ls) const
     {
         auto values = ls.matrix().values().view();
         auto rhs = ls.rhs().view();

--- a/test/mesh/unstructured/unstructuredMesh.cpp
+++ b/test/mesh/unstructured/unstructuredMesh.cpp
@@ -22,16 +22,6 @@ TEST_CASE("Unstructured Mesh")
         REQUIRE(mesh.nBoundaries() == 4);
     }
 
-    // FIXME this should be a test Field
-    // SECTION("Can create domainVector from mesh " + execName)
-    // {
-
-    //     NeoN::UnstructuredMesh mesh = NeoN::createSingleCellMesh(exec);
-    //     NeoN::Field<NeoN::scalar> domainVector(exec, mesh.);
-
-    //     REQUIRE(domainVector.boundaryData().offset().size() == 5);
-    // }
-
     SECTION("Can create a 1D uniform mesh" + execName)
     {
         NeoN::localIdx nCells = 4;

--- a/test/timeIntegration/implicitTimeIntegration.cpp
+++ b/test/timeIntegration/implicitTimeIntegration.cpp
@@ -13,37 +13,6 @@
 // only needed for msvc
 template class NeoN::timeIntegration::ForwardEuler<VolumeField>;
 
-struct CreateVector
-{
-    std::string name;
-    const NeoN::UnstructuredMesh& mesh;
-    NeoN::scalar value = 0;
-    std::int64_t timeIndex = 0;
-    std::int64_t iterationIndex = 0;
-    std::int64_t subCycleIndex = 0;
-
-    NeoN::Document operator()(NeoN::Database& db)
-    {
-        std::vector<fvcc::VolumeBoundary<NeoN::scalar>> bcs {};
-
-        NeoN::Field<NeoN::scalar> domainVector(
-            mesh.exec(),
-            NeoN::Vector<NeoN::scalar>(mesh.exec(), mesh.nCells(), 1.0),
-            mesh.boundaryMesh().offset()
-        );
-        fvcc::VolumeField<NeoN::scalar> vf(mesh.exec(), name, mesh, domainVector, bcs, db, "", "");
-        NeoN::fill(vf.internalVector(), value);
-        return NeoN::Document(
-            {{"name", vf.name},
-             {"timeIndex", timeIndex},
-             {"iterationIndex", iterationIndex},
-             {"subCycleIndex", subCycleIndex},
-             {"field", vf}},
-            fvcc::validateVectorDoc
-        );
-    }
-};
-
 TEST_CASE("TimeIntegration")
 {
     auto [execName, exec] = GENERATE(allAvailableExecutor());

--- a/test/timeIntegration/rungeKutta.cpp
+++ b/test/timeIntegration/rungeKutta.cpp
@@ -51,34 +51,6 @@ public:
     std::string getName() const { return "YSquared"; }
 };
 
-struct CreateVector
-{
-    std::string name;
-    const NeoN::UnstructuredMesh& mesh;
-    std::int64_t timeIndex = 0;
-    std::int64_t iterationIndex = 0;
-    std::int64_t subCycleIndex = 0;
-
-    NeoN::Document operator()(NeoN::Database& db)
-    {
-        std::vector<fvcc::VolumeBoundary<NeoN::scalar>> bcs {};
-        NeoN::Field<NeoN::scalar> domainVector(
-            mesh.exec(),
-            NeoN::Vector<NeoN::scalar>(mesh.exec(), mesh.nCells(), 1.0),
-            mesh.boundaryMesh().offset()
-        );
-        fvcc::VolumeField<NeoN::scalar> vf(mesh.exec(), name, mesh, domainVector, bcs, db, "", "");
-        return NeoN::Document(
-            {{"name", vf.name},
-             {"timeIndex", timeIndex},
-             {"iterationIndex", iterationIndex},
-             {"subCycleIndex", subCycleIndex},
-             {"field", vf}},
-            fvcc::validateVectorDoc
-        );
-    }
-};
-
 TEST_CASE("TimeIntegration - Runge Kutta")
 {
     auto [execName, exec] = GENERATE(allAvailableExecutor());

--- a/test/timeIntegration/timeIntegration.cpp
+++ b/test/timeIntegration/timeIntegration.cpp
@@ -12,36 +12,6 @@
 // only needed for msvc
 template class NeoN::timeIntegration::ForwardEuler<VolumeField>;
 
-struct CreateVector
-{
-    std::string name;
-    const NeoN::UnstructuredMesh& mesh;
-    NeoN::scalar value = 0;
-    std::int64_t timeIndex = 0;
-    std::int64_t iterationIndex = 0;
-    std::int64_t subCycleIndex = 0;
-
-    NeoN::Document operator()(NeoN::Database& db)
-    {
-        std::vector<fvcc::VolumeBoundary<NeoN::scalar>> bcs {};
-        NeoN::Field<NeoN::scalar> domainVector(
-            mesh.exec(),
-            NeoN::Vector<NeoN::scalar>(mesh.exec(), mesh.nCells(), 1.0),
-            mesh.boundaryMesh().offset()
-        );
-        fvcc::VolumeField<NeoN::scalar> vf(mesh.exec(), name, mesh, domainVector, bcs, db, "", "");
-        NeoN::fill(vf.internalVector(), value);
-        return NeoN::Document(
-            {{"name", vf.name},
-             {"timeIndex", timeIndex},
-             {"iterationIndex", iterationIndex},
-             {"subCycleIndex", subCycleIndex},
-             {"field", vf}},
-            fvcc::validateVectorDoc
-        );
-    }
-};
-
 TEST_CASE("TimeIntegration")
 {
     auto [execName, exec] = GENERATE(allAvailableExecutor());


### PR DESCRIPTION
This PR cleans up our tests by moving commonly used things into the common.hpp header.

- add laplacian operator test again
- Add IsSpatialOperator concept again
- convert FIXMEs to TODOs or adress them
- mark implicitOperation const