### PR TITLE
Fixed Vect<ValueType> warnings

### DIFF
--- a/src/core/vector/vectorFreeFunctions.cpp
+++ b/src/core/vector/vectorFreeFunctions.cpp
@@ -21,7 +21,19 @@ void scalarMul(Vector<ValueType>& vect, const scalar value)
 {
     auto viewA = vect.view();
     parallelFor(
-        vect, KOKKOS_LAMBDA(const localIdx i)->ValueType { return viewA[i] * value; }
+        vect,
+        KOKKOS_LAMBDA(const localIdx i)->ValueType {
+            return viewA[i] * static_cast<ValueType>(value);
+        }
+    );
+}
+
+template<>
+void scalarMul(Vector<Vec3>& vect, const scalar value)
+{
+    auto viewA = vect.view();
+    parallelFor(
+        vect, KOKKOS_LAMBDA(const localIdx i)->Vec3 { return viewA[i] * value; }
     );
 }
 


### PR DESCRIPTION
Part 2 of #318, where there were some outstanding warnings, just explicitly implemented the vec3 option.