### PR TITLE
 Add destructor to ddtOperator, SourceTerm, and SparsityPattern

### DIFF
--- a/include/NeoN/finiteVolume/cellCentred/operators/ddtOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/ddtOperator.hpp
@@ -25,6 +25,8 @@ public:
 
     DdtOperator(dsl::Operator::Type termType, VolumeField<ValueType>& field);
 
+    ~DdtOperator();
+
     void explicitOperation(Vector<ValueType>& source, scalar, scalar dt) const;
 
     void implicitOperation(la::LinearSystem<ValueType, localIdx>& ls, scalar, scalar dt) const;

--- a/include/NeoN/finiteVolume/cellCentred/operators/sourceTerm.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/sourceTerm.hpp
@@ -30,6 +30,8 @@ public:
         VolumeField<ValueType>& field
     );
 
+    ~SourceTerm();
+
     void explicitOperation(Vector<ValueType>& source) const;
 
     void implicitOperation(la::LinearSystem<ValueType, localIdx>& ls) const;

--- a/include/NeoN/linearAlgebra/sparsityPattern.hpp
+++ b/include/NeoN/linearAlgebra/sparsityPattern.hpp
@@ -36,6 +36,8 @@ public:
         Vector<localIdx>&& diagOffset
     );
 
+    ~SparsityPattern() = default;
+
     /*@brief getter for ownerOffset */
     const Array<uint8_t>& ownerOffset() const;
 

--- a/src/finiteVolume/cellCentred/operators/ddtOperator.cpp
+++ b/src/finiteVolume/cellCentred/operators/ddtOperator.cpp
@@ -11,7 +11,8 @@ namespace NeoN::finiteVolume::cellCentred
 {
 
 template<typename ValueType>
-DdtOperator<ValueType>::~DdtOperator(){}
+DdtOperator<ValueType>::~DdtOperator()
+{}
 
 template<typename ValueType>
 DdtOperator<ValueType>::DdtOperator(dsl::Operator::Type termType, VolumeField<ValueType>& field)

--- a/src/finiteVolume/cellCentred/operators/ddtOperator.cpp
+++ b/src/finiteVolume/cellCentred/operators/ddtOperator.cpp
@@ -11,6 +11,9 @@ namespace NeoN::finiteVolume::cellCentred
 {
 
 template<typename ValueType>
+DdtOperator<ValueType>::~DdtOperator(){}
+
+template<typename ValueType>
 DdtOperator<ValueType>::DdtOperator(dsl::Operator::Type termType, VolumeField<ValueType>& field)
     : dsl::OperatorMixin<VolumeField<ValueType>>(field.exec(), dsl::Coeff(1.0), field, termType),
       sparsityPattern_(la::SparsityPattern::readOrCreate(field.mesh())) {};

--- a/src/finiteVolume/cellCentred/operators/sourceTerm.cpp
+++ b/src/finiteVolume/cellCentred/operators/sourceTerm.cpp
@@ -9,6 +9,9 @@ namespace NeoN::finiteVolume::cellCentred
 {
 
 template<typename ValueType>
+SourceTerm<ValueType>::~SourceTerm() {}
+
+template<typename ValueType>
 SourceTerm<ValueType>::SourceTerm(
     dsl::Operator::Type termType, VolumeField<scalar>& coefficients, VolumeField<ValueType>& field
 )

--- a/src/finiteVolume/cellCentred/operators/sourceTerm.cpp
+++ b/src/finiteVolume/cellCentred/operators/sourceTerm.cpp
@@ -9,7 +9,8 @@ namespace NeoN::finiteVolume::cellCentred
 {
 
 template<typename ValueType>
-SourceTerm<ValueType>::~SourceTerm() {}
+SourceTerm<ValueType>::~SourceTerm()
+{}
 
 template<typename ValueType>
 SourceTerm<ValueType>::SourceTerm(


### PR DESCRIPTION
# Motivation


used in combination with FoamAdapter

Feat/caseInputs

* fix compiler bug in clang 18 by adding destructor to ddtOperator and SourceTerm