### PR TITLE
add auto reuse annotate

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Unlicense
 # SPDX-FileCopyrightText: 2023 NeoN authors
+
 # ----------------------------------
 # Options affecting listfile parsing
 # ----------------------------------

--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2023 NeoN authors
 
 # ----------------------------------
 # Options affecting listfile parsing

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2023 NeoN authors
 
 # git-ls-files --others --exclude-from=.git/info/exclude
 # Lines that start with '#' are comments.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,8 @@ repos:
         language: python
         additional_dependencies: [reuse==2.1.0]
         types_or: [c, c++, inc, python]
-        # .cmake-format.py use Unlicense
+        # .cmake-format.py, doc/conf.py use Unlicense
+        # don't have NeoN license for script/package.py
         exclude: |
           (?x)^(
             .cmake-format.py|
@@ -47,14 +48,18 @@ repos:
         name: reuse-annotate-unlicense
         entry: reuse annotate --license Unlicense --copyright 'NeoN authors' --merge-copyright
         language: python
-        require_serial: true
         additional_dependencies: [reuse==2.1.0]
-        types_or: [cmake, python, gitignore, toml]
+        types_or: [cmake, gitignore, toml]
         # CPM.cmake from others. note: the current CPM.cmake can not be parsed by reuse annotate
         exclude: |
           (?x)^(
             REUSE.toml|
-            scripts/package.py|
-            scripts/catch2json.py|
             cmake/CPM.cmake
           )$
+      # Some specific files for Unlicense
+      - id: reuse-annotate-unlicense-files
+        name: reuse-annotate-unlicense-files
+        entry: reuse annotate --license Unlicense --copyright 'NeoN authors' --merge-copyright
+        language: python
+        additional_dependencies: [reuse==2.1.0]
+        files: .cmake-format.py|doc/conf.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,6 @@ repos:
             .cmake-format.py|
             doc/conf.py|
             scripts/package.py|
-            test/mesh/unstructured/communicator.cpp
           )$
       # For Unlicense
       - id: reuse-annotate-unlicense
@@ -57,21 +56,5 @@ repos:
             REUSE.toml|
             scripts/package.py|
             scripts/catch2json.py|
-            cmake/CPM.cmake|
-            test/CMakeLists.txt|
-            test/core/mpi/CMakeLists.txt
+            cmake/CPM.cmake
           )$
-      # exception for unlicense rule -> MIT instead
-      - id: reuse-annotate-mit-file
-        name: reuse-annotate-mit-file
-        entry: reuse annotate --license MIT --copyright 'NeoN authors' --merge-copyright
-        language: python
-        additional_dependencies: [reuse==2.1.0]
-        files: test/CMakeLists.txt|test/core/mpi/CMakeLists.txt
-      # exception for MIT rule -> Unlicense instead
-      - id: reuse-annotate-unlicense-file
-        name: reuse-annotate-unlicense-file
-        entry: reuse annotate --license Unlicense --copyright 'NeoN authors' --merge-copyright
-        language: python
-        additional_dependencies: [reuse==2.1.0]
-        files: test/mesh/unstructured/communicator.cpp

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,53 @@ repos:
     rev: v1.23.1
     hooks:
       - id: typos
+  - repo: local
+    hooks:
+      # The official reuse hook only supports calling lint, so we need our own hook
+      # For MIT License
+      - id: reuse-annotate-mit
+        name: reuse-annotate-mit
+        entry: reuse annotate --license MIT --copyright 'NeoN authors' --merge-copyright
+        language: python
+        additional_dependencies: [reuse==2.1.0]
+        types_or: [c, c++, inc, python]
+        # .cmake-format.py use Unlicense
+        exclude: |
+          (?x)^(
+            .cmake-format.py|
+            doc/conf.py|
+            scripts/package.py|
+            test/mesh/unstructured/communicator.cpp
+          )$
+      # For Unlicense
+      - id: reuse-annotate-unlicense
+        name: reuse-annotate-unlicense
+        entry: reuse annotate --license Unlicense --copyright 'NeoN authors' --merge-copyright
+        language: python
+        require_serial: true
+        additional_dependencies: [reuse==2.1.0]
+        types_or: [cmake, python, gitignore, toml]
+        # CPM.cmake from others. note: the current CPM.cmake can not be parsed by reuse annotate
+        exclude: |
+          (?x)^(
+            REUSE.toml|
+            scripts/package.py|
+            scripts/catch2json.py|
+            cmake/CPM.cmake|
+            test/CMakeLists.txt|
+            test/core/mpi/CMakeLists.txt
+          )$
+      # exception for unlicense rule -> MIT instead
+      - id: reuse-annotate-mit-file
+        name: reuse-annotate-mit-file
+        entry: reuse annotate --license MIT --copyright 'NeoN authors' --merge-copyright
+        language: python
+        additional_dependencies: [reuse==2.1.0]
+        files: test/CMakeLists.txt|test/core/mpi/CMakeLists.txt
+      # exception for MIT rule -> Unlicense instead
+      - id: reuse-annotate-unlicense-file
+        name: reuse-annotate-unlicense-file
+        entry: reuse annotate --license Unlicense --copyright 'NeoN authors' --merge-copyright
+        language: python
+        additional_dependencies: [reuse==2.1.0]
+        files: test/mesh/unstructured/communicator.cpp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add temporal operators inside expressions and the ability to solve linear system [#259 ](https://github.com/exasim-project/NeoN/pull/259)
 - Add segmentedField to represent vector of vectors [#202](https://github.com/exasim-project/NeoN/pull/202)
 - Add courant number calculation based on parallelFor [#224](https://github.com/exasim-project/NeoN/pull/224)
+- Add license automation [#343](https://github.com/exasim-project/NeoN/pull/343)
 ## Fixes
 # Version 0.1.0
 - improve build with MSVC and Clang on Windows [#163](https://github.com/exasim-project/NeoN/pull/163)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2023 NeoN authors
 
 cmake_minimum_required(VERSION 3.22.0)
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2023 NeoN authors
 
 [files]
 extend-exclude = ["third_party/*", "doc/Doxyfile.in"]

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2023-25 NeoN authors
+# SPDX-FileCopyrightText: 2023-2025 NeoN authors
 
 function(NeoN_benchmark BENCH)
 

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2023-2025 NeoN authors
 
 function(NeoN_benchmark BENCH)
 

--- a/benchmarks/catch_main.hpp
+++ b/benchmarks/catch_main.hpp
@@ -1,5 +1,7 @@
-// SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
 #pragma once
 
 #include <Kokkos_Core.hpp>

--- a/benchmarks/fields/CMakeLists.txt
+++ b/benchmarks/fields/CMakeLists.txt
@@ -1,4 +1,5 @@
+# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2023 NeoN authors
 
 neon_benchmark(field)

--- a/benchmarks/fields/field.cpp
+++ b/benchmarks/fields/field.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/benchmarks/finiteVolume/cellCentred/interpolation/CMakeLists.txt
+++ b/benchmarks/finiteVolume/cellCentred/interpolation/CMakeLists.txt
@@ -1,5 +1,6 @@
-# SPDX-License-Identifier: Unlicense
 # SPDX-FileCopyrightText: 2025 NeoN authors
+#
+# SPDX-License-Identifier: Unlicense
 
 neon_benchmark(linear)
 neon_benchmark(upwind)

--- a/benchmarks/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/benchmarks/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025 NeoN authors
+//
+// SPDX-License-Identifier: MIT
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/benchmarks/finiteVolume/cellCentred/interpolation/upwind.cpp
+++ b/benchmarks/finiteVolume/cellCentred/interpolation/upwind.cpp
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025 NeoN authors
+//
+// SPDX-License-Identifier: MIT
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/benchmarks/finiteVolume/cellCentred/operator/CMakeLists.txt
+++ b/benchmarks/finiteVolume/cellCentred/operator/CMakeLists.txt
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Unlicense
 # SPDX-FileCopyrightText: 2025 NeoN authors
+#
+# SPDX-License-Identifier: Unlicense
 
 neon_benchmark(divOperator)

--- a/benchmarks/finiteVolume/cellCentred/operator/divOperator.cpp
+++ b/benchmarks/finiteVolume/cellCentred/operator/divOperator.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/benchmarks/finiteVolume/cellCentred/operator/gaussGreenGrad.cpp
+++ b/benchmarks/finiteVolume/cellCentred/operator/gaussGreenGrad.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/benchmarks/finiteVolume/cellCentred/operator/gradOperator.cpp
+++ b/benchmarks/finiteVolume/cellCentred/operator/gradOperator.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024-2025 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/cmake/AutoEnableDevice.cmake
+++ b/cmake/AutoEnableDevice.cmake
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2023 NeoN authors
 
 message(STATUS "Auto detecting accelerator devices")
 include(CheckLanguage)

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -1,6 +1,7 @@
-# SPDX-License-Identifier: Unlicense
+# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
 # SPDX-FileCopyrightText: 2023 Jason Turner
-# SPDX-FileCopyrightText: 2023 NeoN authors
+#
+# SPDX-License-Identifier: Unlicense
 
 # cmake-format: off
 ##############################################################################

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -1,11 +1,14 @@
 # SPDX-License-Identifier: Unlicense
 # SPDX-FileCopyrightText: 2023 Jason Turner
 # SPDX-FileCopyrightText: 2023 NeoN authors
+
+# cmake-format: off
 ##############################################################################
 # This function will prevent in-source builds                                #
 # from here                                                                  #
 # https://github.com/cpp-best-practices/cmake_template                       #
 ##############################################################################
+# cmake-format: on
 
 function(NeoN_set_project_warnings project_name WARNINGS_AS_ERRORS CLANG_WARNINGS GCC_WARNINGS
          CUDA_WARNINGS)

--- a/cmake/CxxThirdParty.cmake
+++ b/cmake/CxxThirdParty.cmake
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2023 NeoN authors
 
 # set(FETCHCONTENT_BASE_DIR ${CMAKE_BINARY_DIR}/cmake_packages)
 

--- a/cmake/Docs.cmake
+++ b/cmake/Docs.cmake
@@ -1,5 +1,7 @@
+# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2023 NeoN authors
+
 find_package(Doxygen REQUIRED)
 find_package(Sphinx REQUIRED)
 

--- a/cmake/FindSphinx.cmake
+++ b/cmake/FindSphinx.cmake
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2023 NeoN authors
 
 # Look for an executable called sphinx-build
 find_program(

--- a/cmake/PreventInSourceBuilds.cmake
+++ b/cmake/PreventInSourceBuilds.cmake
@@ -1,6 +1,7 @@
-# SPDX-License-Identifier: Unlicense
+# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
 # SPDX-FileCopyrightText: 2023 Jason Turner
-# SPDX-FileCopyrightText: 2023 NeoN authors
+#
+# SPDX-License-Identifier: Unlicense
 
 # cmake-format: off
 ##############################################################################

--- a/cmake/PreventInSourceBuilds.cmake
+++ b/cmake/PreventInSourceBuilds.cmake
@@ -1,11 +1,14 @@
 # SPDX-License-Identifier: Unlicense
 # SPDX-FileCopyrightText: 2023 Jason Turner
 # SPDX-FileCopyrightText: 2023 NeoN authors
+
+# cmake-format: off
 ##############################################################################
 # This function will prevent in-source builds                                #
 # from here                                                                  #
 # https://github.com/cpp-best-practices/cmake_template                       #
 ##############################################################################
+# cmake-format: on
 
 function(myproject_assure_out_of_source_builds)
   # make sure the user doesn't play dirty with symlinks

--- a/cmake/Sanitizer.cmake
+++ b/cmake/Sanitizer.cmake
@@ -1,6 +1,7 @@
-# SPDX-License-Identifier: Unlicense
+# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
 # SPDX-FileCopyrightText: 2023 Jason Turner
-# SPDX-FileCopyrightText: 2023 NeoN authors
+#
+# SPDX-License-Identifier: Unlicense
 
 # cmake-format: off
 ##############################################################################

--- a/cmake/Sanitizer.cmake
+++ b/cmake/Sanitizer.cmake
@@ -1,11 +1,14 @@
 # SPDX-License-Identifier: Unlicense
 # SPDX-FileCopyrightText: 2023 Jason Turner
 # SPDX-FileCopyrightText: 2023 NeoN authors
+
+# cmake-format: off
 ##############################################################################
 # This function will enable sanitizers                                       #
 # from here                                                                  #
 # https://github.com/cpp-best-practices/cmake_template                       #
 ##############################################################################
+# cmake-format: on
 
 function(
   enable_sanitizers

--- a/cmake/StandardProjectSettings.cmake
+++ b/cmake/StandardProjectSettings.cmake
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Unlicense
 # SPDX-FileCopyrightText: 2023 Jason Turner
 # SPDX-FileCopyrightText: 2023 NeoN authors
+
 # Set a default build type if none was specified
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)

--- a/cmake/StandardProjectSettings.cmake
+++ b/cmake/StandardProjectSettings.cmake
@@ -1,6 +1,7 @@
-# SPDX-License-Identifier: Unlicense
+# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
 # SPDX-FileCopyrightText: 2023 Jason Turner
-# SPDX-FileCopyrightText: 2023 NeoN authors
+#
+# SPDX-License-Identifier: Unlicense
 
 # Set a default build type if none was specified
 

--- a/cmake/StaticAnalyzers.cmake
+++ b/cmake/StaticAnalyzers.cmake
@@ -1,6 +1,7 @@
-# SPDX-License-Identifier: Unlicense
+# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
 # SPDX-FileCopyrightText: 2023 Jason Turner
-# SPDX-FileCopyrightText: 2023 NeoN authors
+#
+# SPDX-License-Identifier: Unlicense
 
 # cmake-format: off
 ##############################################################################

--- a/cmake/StaticAnalyzers.cmake
+++ b/cmake/StaticAnalyzers.cmake
@@ -1,11 +1,14 @@
 # SPDX-License-Identifier: Unlicense
 # SPDX-FileCopyrightText: 2023 Jason Turner
 # SPDX-FileCopyrightText: 2023 NeoN authors
+
+# cmake-format: off
 ##############################################################################
 # This function will enable static analyzers                                 #
 # from here                                                                  #
 # https://github.com/cpp-best-practices/cmake_template                       #
 ##############################################################################
+# cmake-format: on
 macro(NeoN_enable_cppcheck WARNINGS_AS_ERRORS CPPCHECK_OPTIONS)
   find_program(CPPCHECK cppcheck)
   if(CPPCHECK)

--- a/cmake/banner.cmake
+++ b/cmake/banner.cmake
@@ -1,5 +1,6 @@
-# SPDX-License-Identifier: Unlicense
 # SPDX-FileCopyrightText: 2025 NeoN authors
+#
+# SPDX-License-Identifier: Unlicense
 
 # Get the latest abbreviated commit hash of the working branch
 execute_process(

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Unlicense
 # SPDX-FileCopyrightText: 2024 NeoN authors
+
 # Configuration file for the Sphinx documentation builder.
 #
 # For the full list of built-in configuration values, see the documentation:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2024 NeoN authors
 
 # Configuration file for the Sphinx documentation builder.
 #

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2023 NeoN authors
 
 add_library(NeoN_public_api INTERFACE) # dummy target
 add_library(NeoN::NeoN_public_api ALIAS NeoN_public_api) # dummy target

--- a/include/NeoN/core/array.hpp
+++ b/include/NeoN/core/array.hpp
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025 NeoN authors
+//
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/include/NeoN/core/containerFreeFunctions.hpp
+++ b/include/NeoN/core/containerFreeFunctions.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #pragma once
 
 #include <type_traits>

--- a/include/NeoN/core/database/collection.hpp
+++ b/include/NeoN/core/database/collection.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/core/database/database.hpp
+++ b/include/NeoN/core/database/database.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/core/database/document.hpp
+++ b/include/NeoN/core/database/document.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/core/database/fieldCollection.hpp
+++ b/include/NeoN/core/database/fieldCollection.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
+
 #pragma once
 
 #include <limits>

--- a/include/NeoN/core/database/oldTimeCollection.hpp
+++ b/include/NeoN/core/database/oldTimeCollection.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
+
 #pragma once
 
 #include <string>

--- a/include/NeoN/core/demangle.hpp
+++ b/include/NeoN/core/demangle.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #pragma once
 // TODO For WIN builds, needs to be ifdef'ed out.

--- a/include/NeoN/core/dictionary.hpp
+++ b/include/NeoN/core/dictionary.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #pragma once
 
 #include <unordered_map>

--- a/include/NeoN/core/error.hpp
+++ b/include/NeoN/core/error.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023-2024 NeoN authors
+
 #pragma once
 
 #include <cstdlib>

--- a/include/NeoN/core/executor/CPUExecutor.hpp
+++ b/include/NeoN/core/executor/CPUExecutor.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #pragma once
 
 #include <Kokkos_Core.hpp> // IWYU pragma: keep

--- a/include/NeoN/core/executor/GPUExecutor.hpp
+++ b/include/NeoN/core/executor/GPUExecutor.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #pragma once
 
 #include <Kokkos_Core.hpp>

--- a/include/NeoN/core/executor/executor.hpp
+++ b/include/NeoN/core/executor/executor.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #pragma once
 
 #include <string>

--- a/include/NeoN/core/executor/serialExecutor.hpp
+++ b/include/NeoN/core/executor/serialExecutor.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #pragma once
 
 #include <Kokkos_Core.hpp>

--- a/include/NeoN/core/info.hpp
+++ b/include/NeoN/core/info.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/core/input.hpp
+++ b/include/NeoN/core/input.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #pragma once
 
 #include <variant>

--- a/include/NeoN/core/macros.hpp
+++ b/include/NeoN/core/macros.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/core/mpi/environment.hpp
+++ b/include/NeoN/core/mpi/environment.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #pragma once
 
 #ifdef NF_WITH_MPI_SUPPORT

--- a/include/NeoN/core/mpi/fullDuplexCommBuffer.hpp
+++ b/include/NeoN/core/mpi/fullDuplexCommBuffer.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #pragma once
 
 #include <vector>

--- a/include/NeoN/core/mpi/halfDuplexCommBuffer.hpp
+++ b/include/NeoN/core/mpi/halfDuplexCommBuffer.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #pragma once
 
 #include <string>

--- a/include/NeoN/core/mpi/operators.hpp
+++ b/include/NeoN/core/mpi/operators.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #pragma once
 
 #include <complex>

--- a/include/NeoN/core/parallelAlgorithms.hpp
+++ b/include/NeoN/core/parallelAlgorithms.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #pragma once
 
 #include <Kokkos_Core.hpp>

--- a/include/NeoN/core/primitives/label.hpp
+++ b/include/NeoN/core/primitives/label.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #pragma once
 
 #include <cstdint>

--- a/include/NeoN/core/primitives/scalar.hpp
+++ b/include/NeoN/core/primitives/scalar.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #pragma once
 
 #include <Kokkos_Core.hpp> // IWYU pragma: keep

--- a/include/NeoN/core/primitives/tensor.hpp
+++ b/include/NeoN/core/primitives/tensor.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #pragma once
 
 #include "scalar.hpp"

--- a/include/NeoN/core/primitives/traits.hpp
+++ b/include/NeoN/core/primitives/traits.hpp
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025 NeoN authors
+//
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/include/NeoN/core/primitives/vec3.hpp
+++ b/include/NeoN/core/primitives/vec3.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/core/runtimeSelectionFactory.hpp
+++ b/include/NeoN/core/runtimeSelectionFactory.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2023 AMR Wind Authors
 // SPDX-FileCopyrightText: 2023-2024 NeoN authors
+
 // ##############################################################################
 // # Original design taken from amr wind                                        #
 // # from here                                                                  #
@@ -314,9 +315,11 @@ public:
          */
         static bool addSubType()
         {
-            CreatorFunc func = [](Args... args) -> std::unique_ptr<Base> {
-                return static_cast<std::unique_ptr<Base>>(new derivedClass(std::forward<Args>(args
-                )...));
+            CreatorFunc func = [](Args... args) -> std::unique_ptr<Base>
+            {
+                return static_cast<std::unique_ptr<Base>>(
+                    new derivedClass(std::forward<Args>(args)...)
+                );
             };
             RuntimeSelectionFactory::table()[derivedClass::name()] = func;
 
@@ -407,7 +410,7 @@ private:
 template<class Base, class... Args>
 template<class derivedClass>
 bool RuntimeSelectionFactory<Base, Parameters<Args...>>::Register<derivedClass>::REGISTERED =
-    RuntimeSelectionFactory<Base, Parameters<Args...>>::template Register<derivedClass>::addSubType(
-    );
+    RuntimeSelectionFactory<Base, Parameters<Args...>>::template Register<
+        derivedClass>::addSubType();
 
 }; // namespace NeoN

--- a/include/NeoN/core/runtimeSelectionFactory.hpp
+++ b/include/NeoN/core/runtimeSelectionFactory.hpp
@@ -1,6 +1,7 @@
-// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
 // SPDX-FileCopyrightText: 2023 AMR Wind Authors
-// SPDX-FileCopyrightText: 2023-2024 NeoN authors
+//
+// SPDX-License-Identifier: MIT
 
 // ##############################################################################
 // # Original design taken from amr wind                                        #
@@ -315,11 +316,9 @@ public:
          */
         static bool addSubType()
         {
-            CreatorFunc func = [](Args... args) -> std::unique_ptr<Base>
-            {
-                return static_cast<std::unique_ptr<Base>>(
-                    new derivedClass(std::forward<Args>(args)...)
-                );
+            CreatorFunc func = [](Args... args) -> std::unique_ptr<Base> {
+                return static_cast<std::unique_ptr<Base>>(new derivedClass(std::forward<Args>(args
+                )...));
             };
             RuntimeSelectionFactory::table()[derivedClass::name()] = func;
 
@@ -410,7 +409,7 @@ private:
 template<class Base, class... Args>
 template<class derivedClass>
 bool RuntimeSelectionFactory<Base, Parameters<Args...>>::Register<derivedClass>::REGISTERED =
-    RuntimeSelectionFactory<Base, Parameters<Args...>>::template Register<
-        derivedClass>::addSubType();
+    RuntimeSelectionFactory<Base, Parameters<Args...>>::template Register<derivedClass>::addSubType(
+    );
 
 }; // namespace NeoN

--- a/include/NeoN/core/segmentedVector.hpp
+++ b/include/NeoN/core/segmentedVector.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #pragma once
 
 #include "NeoN/core/view.hpp"

--- a/include/NeoN/core/time.hpp
+++ b/include/NeoN/core/time.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #pragma once
 
 #include <iostream>

--- a/include/NeoN/core/tokenList.hpp
+++ b/include/NeoN/core/tokenList.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #pragma once
 
 #include <vector>

--- a/include/NeoN/core/vector/vector.hpp
+++ b/include/NeoN/core/vector/vector.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #pragma once
 
 #include <Kokkos_Core.hpp>

--- a/include/NeoN/core/vector/vectorFreeFunctions.hpp
+++ b/include/NeoN/core/vector/vectorFreeFunctions.hpp
@@ -1,5 +1,7 @@
-// SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
 #pragma once
 
 #include "NeoN/core/primitives/scalar.hpp"

--- a/include/NeoN/core/vector/vectorTypeDefs.hpp
+++ b/include/NeoN/core/vector/vectorTypeDefs.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023-2024 NeoN authors
+
 #pragma once
 
 #include "NeoN/core/primitives/scalar.hpp"

--- a/include/NeoN/core/view.hpp
+++ b/include/NeoN/core/view.hpp
@@ -1,5 +1,7 @@
-// SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
 #pragma once
 
 #include <Kokkos_Core.hpp>

--- a/include/NeoN/dsl/coeff.hpp
+++ b/include/NeoN/dsl/coeff.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #pragma once
 
 #include "NeoN/core/primitives/scalar.hpp"

--- a/include/NeoN/dsl/ddt.hpp
+++ b/include/NeoN/dsl/ddt.hpp
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
 //
-// SPDX-FileCopyrightText: 2023 NeoN authors
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/include/NeoN/dsl/explicit.hpp
+++ b/include/NeoN/dsl/explicit.hpp
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
 //
-// SPDX-FileCopyrightText: 2023 NeoN authors
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/include/NeoN/dsl/expression.hpp
+++ b/include/NeoN/dsl/expression.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023-2024 NeoN authors
+
 #pragma once
 
 #include <vector>

--- a/include/NeoN/dsl/implicit.hpp
+++ b/include/NeoN/dsl/implicit.hpp
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
 //
-// SPDX-FileCopyrightText: 2023 NeoN authors
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/include/NeoN/dsl/operator.hpp
+++ b/include/NeoN/dsl/operator.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023-2024 NeoN authors
+
 #pragma once
 
 #include "NeoN/linearAlgebra/sparsityPattern.hpp"

--- a/include/NeoN/dsl/solver.hpp
+++ b/include/NeoN/dsl/solver.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023-2024 NeoN authors
+
 #pragma once
 
 #include <iostream>

--- a/include/NeoN/dsl/spatialOperator.hpp
+++ b/include/NeoN/dsl/spatialOperator.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023-2025 NeoN authors
+
 #pragma once
 
 #include <memory>

--- a/include/NeoN/dsl/temporalOperator.hpp
+++ b/include/NeoN/dsl/temporalOperator.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023-2025 NeoN authors
+
 #pragma once
 
 #include <memory>

--- a/include/NeoN/fields/boundaryData.hpp
+++ b/include/NeoN/fields/boundaryData.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
+
 #pragma once
 
 #include <Kokkos_Core.hpp>

--- a/include/NeoN/fields/field.hpp
+++ b/include/NeoN/fields/field.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
+
 #pragma once
 
 #include <Kokkos_Core.hpp>

--- a/include/NeoN/finiteVolume/cellCentred/auxiliary/coNum.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/auxiliary/coNum.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary/boundaryPatchMixin.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/boundaryPatchMixin.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #pragma once
 
 #include "NeoN/mesh/unstructured/unstructuredMesh.hpp"

--- a/include/NeoN/finiteVolume/cellCentred/boundary/surface/calculated.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/surface/calculated.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary/surface/empty.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/surface/empty.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary/surface/fixedValue.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/surface/fixedValue.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary/surfaceBoundaryFactory.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/surfaceBoundaryFactory.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/calculated.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/calculated.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/empty.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/empty.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/extrapolated.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/extrapolated.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedGradient.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedGradient.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedValue.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedValue.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/faceNormalGradient.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/faceNormalGradient.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/uncorrected.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/uncorrected.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/fields/domain.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/fields/domain.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/fields/surfaceField.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/fields/surfaceField.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/fields/volumeField.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/fields/volumeField.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/interpolation/linear.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/interpolation/linear.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/interpolation/upwind.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/interpolation/upwind.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/ddtOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/ddtOperator.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/divOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/divOperator.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023-2025 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/laplacianOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/laplacianOperator.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/sourceTerm.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/sourceTerm.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/surfaceIntegrate.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/surfaceIntegrate.hpp
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025 NeoN authors
+//
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/stencil/basicGeometryScheme.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/stencil/basicGeometryScheme.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/stencil/cellToFaceStencil.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/stencil/cellToFaceStencil.hpp
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025 NeoN authors
+//
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/include/NeoN/finiteVolume/cellCentred/stencil/geometryScheme.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/stencil/geometryScheme.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #pragma once
 
 

--- a/include/NeoN/finiteVolume/cellCentred/stencil/stencilDataBase.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/stencil/stencilDataBase.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #pragma once
 
 #include <unordered_map>

--- a/include/NeoN/helpers/exceptions.hpp
+++ b/include/NeoN/helpers/exceptions.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #pragma once
 
 #include "NeoN/core/primitives/label.hpp"

--- a/include/NeoN/linearAlgebra/CSRMatrix.hpp
+++ b/include/NeoN/linearAlgebra/CSRMatrix.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #pragma once
 
 #include "NeoN/core/vector/vector.hpp"

--- a/include/NeoN/linearAlgebra/ginkgo.hpp
+++ b/include/NeoN/linearAlgebra/ginkgo.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/linearAlgebra/linearSystem.hpp
+++ b/include/NeoN/linearAlgebra/linearSystem.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #pragma once
 
 #include "NeoN/core/vector/vector.hpp"

--- a/include/NeoN/linearAlgebra/petsc.hpp
+++ b/include/NeoN/linearAlgebra/petsc.hpp
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025 NeoN authors
+//
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/include/NeoN/linearAlgebra/petscSolverContext.hpp
+++ b/include/NeoN/linearAlgebra/petscSolverContext.hpp
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025 NeoN authors
+//
+// SPDX-License-Identifier: MIT
 
 // inspired by
 // https://develop.openfoam.com/modules/external-solver/-/blob/develop/src/petsc4Foam/utils/petscLinearSolverContext.H

--- a/include/NeoN/linearAlgebra/petscSolverContext.hpp
+++ b/include/NeoN/linearAlgebra/petscSolverContext.hpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025 NeoN authors
+
 // inspired by
 // https://develop.openfoam.com/modules/external-solver/-/blob/develop/src/petsc4Foam/utils/petscLinearSolverContext.H
 

--- a/include/NeoN/linearAlgebra/solver.hpp
+++ b/include/NeoN/linearAlgebra/solver.hpp
@@ -1,5 +1,7 @@
-// SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
 #pragma once
 
 #include "NeoN/core/input.hpp"

--- a/include/NeoN/linearAlgebra/sparsityPattern.hpp
+++ b/include/NeoN/linearAlgebra/sparsityPattern.hpp
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025 NeoN authors
+//
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/include/NeoN/linearAlgebra/utilities.hpp
+++ b/include/NeoN/linearAlgebra/utilities.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024-2025 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/mesh/unstructured/boundaryMesh.hpp
+++ b/include/NeoN/mesh/unstructured/boundaryMesh.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #pragma once
 
 #include <vector>

--- a/include/NeoN/mesh/unstructured/communicator.hpp
+++ b/include/NeoN/mesh/unstructured/communicator.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #pragma once
 
 #include <vector>

--- a/include/NeoN/mesh/unstructured/unstructuredMesh.hpp
+++ b/include/NeoN/mesh/unstructured/unstructuredMesh.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/timeIntegration/backwardEuler.hpp
+++ b/include/NeoN/timeIntegration/backwardEuler.hpp
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
 //
-// SPDX-FileCopyrightText: 2023 NeoN authors
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/include/NeoN/timeIntegration/forwardEuler.hpp
+++ b/include/NeoN/timeIntegration/forwardEuler.hpp
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
 //
-// SPDX-FileCopyrightText: 2023 NeoN authors
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/include/NeoN/timeIntegration/rungeKutta.hpp
+++ b/include/NeoN/timeIntegration/rungeKutta.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/timeIntegration/sundials.hpp
+++ b/include/NeoN/timeIntegration/sundials.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #pragma once
 

--- a/include/NeoN/timeIntegration/timeIntegration.hpp
+++ b/include/NeoN/timeIntegration/timeIntegration.hpp
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
 //
-// SPDX-FileCopyrightText: 2023 NeoN authors
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/scripts/catch2json.py
+++ b/scripts/catch2json.py
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: MIT
-# SPDX-FileCopyrightText: 2023-2025 NeoN authors
 
 import xmltodict
 import json

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2023 NeoN authors
 
 add_library(NeoN ${NeoN_LIB_TYPE})
 add_library(NeoN::NeoN ALIAS NeoN) # dummy target

--- a/src/core/database/collection.cpp
+++ b/src/core/database/collection.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #include "NeoN/core/database/collection.hpp"
 

--- a/src/core/database/database.cpp
+++ b/src/core/database/database.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #include "NeoN/core/database/database.hpp"
 #include "NeoN/core/database/collection.hpp"

--- a/src/core/database/document.cpp
+++ b/src/core/database/document.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #include "NeoN/core/database/document.hpp"
 

--- a/src/core/database/fieldCollection.cpp
+++ b/src/core/database/fieldCollection.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #include "NeoN/core/database/fieldCollection.hpp"
 

--- a/src/core/database/oldTimeCollection.cpp
+++ b/src/core/database/oldTimeCollection.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #include "NeoN/core/database/oldTimeCollection.hpp"
 

--- a/src/core/demangle.cpp
+++ b/src/core/demangle.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #ifdef __GNUC__
 #include <cxxabi.h> // for __cxa_demangle

--- a/src/core/dictionary.cpp
+++ b/src/core/dictionary.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include <numeric>
 #include <iostream> // for operator<<, basic_ostream, endl, cerr, ostream

--- a/src/core/mpi/halfDuplexCommBuffer.cpp
+++ b/src/core/mpi/halfDuplexCommBuffer.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include "NeoN/core/mpi/halfDuplexCommBuffer.hpp"
 

--- a/src/core/primitives/vec3.cpp
+++ b/src/core/primitives/vec3.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include "NeoN/core/primitives/vec3.hpp"
 

--- a/src/core/time.cpp
+++ b/src/core/time.cpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #include "NeoN/core/time.hpp"
 
 namespace NeoN

--- a/src/core/tokenList.cpp
+++ b/src/core/tokenList.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include "NeoN/core/tokenList.hpp"
 

--- a/src/core/vector/vector.cpp
+++ b/src/core/vector/vector.cpp
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025 NeoN authors
+//
+// SPDX-License-Identifier: MIT
 
 #include "NeoN/core/primitives/scalar.hpp"
 #include "NeoN/core/primitives/vec3.hpp"

--- a/src/core/vector/vectorFreeFunctions.cpp
+++ b/src/core/vector/vectorFreeFunctions.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include <Kokkos_Core.hpp>
 

--- a/src/dsl/coeff.cpp
+++ b/src/dsl/coeff.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include "NeoN/core/containerFreeFunctions.hpp"
 #include "NeoN/dsl/coeff.hpp"

--- a/src/dsl/explicit.cpp
+++ b/src/dsl/explicit.cpp
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025 NeoN authors
+//
+// SPDX-License-Identifier: MIT
 
 #include "NeoN/dsl/explicit.hpp"
 

--- a/src/dsl/spatialOperator.cpp
+++ b/src/dsl/spatialOperator.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023-2025 NeoN authors
 
 #include "NeoN/dsl/spatialOperator.hpp"
 

--- a/src/dsl/temporalOperator.cpp
+++ b/src/dsl/temporalOperator.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023-2025 NeoN authors
 
 #include "NeoN/dsl/temporalOperator.hpp"
 

--- a/src/executor/CPUExecutor.cpp
+++ b/src/executor/CPUExecutor.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include "NeoN/core/executor/CPUExecutor.hpp"
 

--- a/src/executor/GPUExecutor.cpp
+++ b/src/executor/GPUExecutor.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include "NeoN/core/executor/GPUExecutor.hpp"
 

--- a/src/executor/serialExecutor.cpp
+++ b/src/executor/serialExecutor.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include "NeoN/core/executor/serialExecutor.hpp"
 

--- a/src/finiteVolume/cellCentred/auxiliary/coNum.cpp
+++ b/src/finiteVolume/cellCentred/auxiliary/coNum.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include <limits>
 

--- a/src/finiteVolume/cellCentred/boundary/boundary.cpp
+++ b/src/finiteVolume/cellCentred/boundary/boundary.cpp
@@ -1,4 +1,5 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #include "NeoN/finiteVolume/cellCentred/boundary.hpp"

--- a/src/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
+++ b/src/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include <memory>
 

--- a/src/finiteVolume/cellCentred/fields/volumeField.cpp
+++ b/src/finiteVolume/cellCentred/fields/volumeField.cpp
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025 NeoN authors
+//
+// SPDX-License-Identifier: MIT
 
 #include "NeoN/core/vector/vectorFreeFunctions.hpp"
 #include "NeoN/core/macros.hpp"

--- a/src/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include <memory>
 

--- a/src/finiteVolume/cellCentred/interpolation/upwind.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/upwind.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include <memory>
 

--- a/src/finiteVolume/cellCentred/operators/ddtOperator.cpp
+++ b/src/finiteVolume/cellCentred/operators/ddtOperator.cpp
@@ -1,6 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
-
 
 #include "NeoN/core/parallelAlgorithms.hpp"
 #include "NeoN/core/database/oldTimeCollection.hpp"

--- a/src/finiteVolume/cellCentred/operators/expression.cpp
+++ b/src/finiteVolume/cellCentred/operators/expression.cpp
@@ -1,6 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
-
 
 #include "NeoN/core/parallelAlgorithms.hpp"
 #include "NeoN/finiteVolume/cellCentred/expression.hpp"

--- a/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include "NeoN/core/containerFreeFunctions.hpp"
 #include "NeoN/core/parallelAlgorithms.hpp"

--- a/src/finiteVolume/cellCentred/operators/gaussGreenGrad.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenGrad.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include "NeoN/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp"
 #include "NeoN/finiteVolume/cellCentred/interpolation/linear.hpp"

--- a/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
@@ -1,6 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
-
 
 #include "NeoN/core/parallelAlgorithms.hpp"
 #include "NeoN/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp"

--- a/src/finiteVolume/cellCentred/operators/sourceTerm.cpp
+++ b/src/finiteVolume/cellCentred/operators/sourceTerm.cpp
@@ -1,6 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
-
 
 #include "NeoN/core/parallelAlgorithms.hpp"
 #include "NeoN/finiteVolume/cellCentred/operators/sourceTerm.hpp"

--- a/src/finiteVolume/cellCentred/operators/surfaceIntegrate.cpp
+++ b/src/finiteVolume/cellCentred/operators/surfaceIntegrate.cpp
@@ -1,6 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
-
 
 #include "NeoN/core/parallelAlgorithms.hpp"
 #include "NeoN/finiteVolume/cellCentred/operators/surfaceIntegrate.hpp"

--- a/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include "NeoN/core/containerFreeFunctions.hpp"
 #include "NeoN/core/parallelAlgorithms.hpp"

--- a/src/finiteVolume/cellCentred/stencil/cellToFaceStencil.cpp
+++ b/src/finiteVolume/cellCentred/stencil/cellToFaceStencil.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include "NeoN/core/containerFreeFunctions.hpp"
 #include "NeoN/finiteVolume/cellCentred/stencil/cellToFaceStencil.hpp"

--- a/src/finiteVolume/cellCentred/stencil/geometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/geometryScheme.cpp
@@ -1,6 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
-
 
 #include "NeoN/finiteVolume/cellCentred/stencil/geometryScheme.hpp"
 #include "NeoN/finiteVolume/cellCentred/stencil/basicGeometryScheme.hpp"

--- a/src/finiteVolume/cellCentred/stencil/stencilDataBase.cpp
+++ b/src/finiteVolume/cellCentred/stencil/stencilDataBase.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include "NeoN/finiteVolume/cellCentred/stencil/stencilDataBase.hpp"
 

--- a/src/linearAlgebra/sparsityPattern.cpp
+++ b/src/linearAlgebra/sparsityPattern.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include "NeoN/core/containerFreeFunctions.hpp"
 #include "NeoN/core/segmentedVector.hpp"

--- a/src/linearAlgebra/utilities.cpp
+++ b/src/linearAlgebra/utilities.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024-2025 NeoN authors
 
 #include "NeoN/core/parallelAlgorithms.hpp"
 #include "NeoN/linearAlgebra/utilities.hpp"

--- a/src/mesh/unstructured/boundaryMesh.cpp
+++ b/src/mesh/unstructured/boundaryMesh.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include "NeoN/mesh/unstructured/boundaryMesh.hpp"
 

--- a/src/mesh/unstructured/communicator.cpp
+++ b/src/mesh/unstructured/communicator.cpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
+
 #include "NeoN/mesh/unstructured/communicator.hpp"
 
 namespace NeoN

--- a/src/mesh/unstructured/unstructuredMesh.cpp
+++ b/src/mesh/unstructured/unstructuredMesh.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
 

--- a/src/timeIntegration/rungeKutta.cpp
+++ b/src/timeIntegration/rungeKutta.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include "NeoN/timeIntegration/rungeKutta.hpp"
 

--- a/src/timeIntegration/timeIntegration.cpp
+++ b/src/timeIntegration/timeIntegration.cpp
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
 //
-// SPDX-FileCopyrightText: 2023 NeoN authors
+// SPDX-License-Identifier: MIT
 
 #include "NeoN/timeIntegration/timeIntegration.hpp"
 #include "NeoN/timeIntegration/forwardEuler.hpp"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: MIT
-# SPDX-FileCopyrightText: 2023-2024 NeoN authors
 
 list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
 #
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Unlicense
 
 list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)
 

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2023-2024 NeoN authors
 
 if(NeoN_ENABLE_MPI_SUPPORT)
   add_library(NeoN_catch_main_mpi test_main_mpi.cpp mpiReporter.cpp mpiGlobals.cpp

--- a/test/catch2/catch2_common.hpp
+++ b/test/catch2/catch2_common.hpp
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025 NeoN authors
+//
+// SPDX-License-Identifier: MIT
 
 #include <catch2/catch_session.hpp>
 #include <catch2/catch_test_macros.hpp>

--- a/test/catch2/executorGenerator.hpp
+++ b/test/catch2/executorGenerator.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #pragma once
 

--- a/test/catch2/mpiGlobals.cpp
+++ b/test/catch2/mpiGlobals.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #include "mpiGlobals.hpp"
 

--- a/test/catch2/mpiGlobals.hpp
+++ b/test/catch2/mpiGlobals.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #pragma once
 

--- a/test/catch2/mpiReporter.cpp
+++ b/test/catch2/mpiReporter.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #include "mpiReporter.hpp"
 

--- a/test/catch2/mpiReporter.hpp
+++ b/test/catch2/mpiReporter.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #pragma once
 

--- a/test/catch2/mpiSerialization.cpp
+++ b/test/catch2/mpiSerialization.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #include "mpiSerialization.hpp"
 

--- a/test/catch2/mpiSerialization.hpp
+++ b/test/catch2/mpiSerialization.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #pragma once
 

--- a/test/catch2/test_main.cpp
+++ b/test/catch2/test_main.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include <iostream>
 

--- a/test/catch2/test_main_mpi.cpp
+++ b/test/catch2/test_main_mpi.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include "catch2/catch_session.hpp"
 #include "catch2/catch_test_macros.hpp"

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2024 NeoN authors
 
 if(NeoN_ENABLE_MPI_SUPPORT)
   add_subdirectory(mpi)

--- a/test/core/array.cpp
+++ b/test/core/array.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023-2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/core/database/CMakeLists.txt
+++ b/test/core/database/CMakeLists.txt
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2024 NeoN authors
 
 neon_unit_test(collection)
 neon_unit_test(database)

--- a/test/core/database/collection.cpp
+++ b/test/core/database/collection.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/core/database/customTestCollection.hpp
+++ b/test/core/database/customTestCollection.hpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #pragma once
 

--- a/test/core/database/database.cpp
+++ b/test/core/database/database.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/core/database/document.cpp
+++ b/test/core/database/document.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/core/database/fieldCollection.cpp
+++ b/test/core/database/fieldCollection.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/core/database/oldTimeCollection.cpp
+++ b/test/core/database/oldTimeCollection.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/core/dictionary.cpp
+++ b/test/core/dictionary.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include "catch2_common.hpp"
 

--- a/test/core/executor.cpp
+++ b/test/core/executor.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/core/input.cpp
+++ b/test/core/input.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/core/mpi/CMakeLists.txt
+++ b/test/core/mpi/CMakeLists.txt
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: MIT
-# SPDX-FileCopyrightText: 2023 NeoN authors
 
 if(NeoN_ENABLE_MPI_SUPPORT)
   neon_unit_test(fullDuplexCommBuffer MPI_SIZE 3)

--- a/test/core/mpi/CMakeLists.txt
+++ b/test/core/mpi/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
 #
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Unlicense
 
 if(NeoN_ENABLE_MPI_SUPPORT)
   neon_unit_test(fullDuplexCommBuffer MPI_SIZE 3)

--- a/test/core/mpi/fullDuplexCommBuffer.cpp
+++ b/test/core/mpi/fullDuplexCommBuffer.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include <catch2/catch_session.hpp>
 #include <catch2/catch_test_macros.hpp>

--- a/test/core/mpi/halfDuplexCommBuffer.cpp
+++ b/test/core/mpi/halfDuplexCommBuffer.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include <catch2/catch_session.hpp>
 #include <catch2/catch_test_macros.hpp>

--- a/test/core/mpi/operators.cpp
+++ b/test/core/mpi/operators.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include <catch2/catch_session.hpp>
 #include <catch2/catch_test_macros.hpp>

--- a/test/core/parallelAlgorithms.cpp
+++ b/test/core/parallelAlgorithms.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/core/primitives/CMakeLists.txt
+++ b/test/core/primitives/CMakeLists.txt
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2024 NeoN authors
 
 neon_unit_test(scalar)
 neon_unit_test(vec3)

--- a/test/core/primitives/scalar.cpp
+++ b/test/core/primitives/scalar.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023-2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/core/primitives/vec3.cpp
+++ b/test/core/primitives/vec3.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023-2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/core/runTimeSelectionFactory.cpp
+++ b/test/core/runTimeSelectionFactory.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/core/segmentedVector.cpp
+++ b/test/core/segmentedVector.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023-2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/core/tokenList.cpp
+++ b/test/core/tokenList.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #include "catch2_common.hpp"
 

--- a/test/core/vector/CMakeLists.txt
+++ b/test/core/vector/CMakeLists.txt
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: Unlicense
 # SPDX-FileCopyrightText: 2025 NeoN authors
+#
+# SPDX-License-Identifier: Unlicense
 
 neon_unit_test(vector)

--- a/test/core/vector/vector.cpp
+++ b/test/core/vector/vector.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023-2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/core/view.cpp
+++ b/test/core/view.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/dsl/CMakeLists.txt
+++ b/test/dsl/CMakeLists.txt
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2024 NeoN authors
 
 neon_unit_test(coeff)
 neon_unit_test(expression)

--- a/test/dsl/coeff.cpp
+++ b/test/dsl/coeff.cpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023-2024 NeoN authors
+
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main
 #include "catch2_common.hpp"

--- a/test/dsl/common.hpp
+++ b/test/dsl/common.hpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023-2024 NeoN authors
+
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main
 #include "catch2_common.hpp"

--- a/test/dsl/expression.cpp
+++ b/test/dsl/expression.cpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023-2024 NeoN authors
+
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main
 

--- a/test/dsl/spatialOperator.cpp
+++ b/test/dsl/spatialOperator.cpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023-2024 NeoN authors
+
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main
 

--- a/test/dsl/temporalOperator.cpp
+++ b/test/dsl/temporalOperator.cpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023-2024 NeoN authors
+
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main
 

--- a/test/fields/CMakeLists.txt
+++ b/test/fields/CMakeLists.txt
@@ -1,4 +1,5 @@
+# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2024 NeoN authors
 
 neon_unit_test(field)

--- a/test/fields/field.cpp
+++ b/test/fields/field.cpp
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023-2024 NeoN authors
+
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main
 #include "catch2_common.hpp"

--- a/test/finiteVolume/CMakeLists.txt
+++ b/test/finiteVolume/CMakeLists.txt
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2024 NeoN authors
 
 add_subdirectory(cellCentred/fields)
 add_subdirectory(cellCentred/boundary)

--- a/test/finiteVolume/cellCentred/auxiliary/CMakeLists.txt
+++ b/test/finiteVolume/cellCentred/auxiliary/CMakeLists.txt
@@ -1,4 +1,5 @@
+# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2024 NeoN authors
 
 neon_unit_test(coNum)

--- a/test/finiteVolume/cellCentred/auxiliary/coNum.cpp
+++ b/test/finiteVolume/cellCentred/auxiliary/coNum.cpp
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025 NeoN authors
+//
+// SPDX-License-Identifier: MIT
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/finiteVolume/cellCentred/boundary/CMakeLists.txt
+++ b/test/finiteVolume/cellCentred/boundary/CMakeLists.txt
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2024 NeoN authors
 
 add_subdirectory(volume)
 add_subdirectory(surface)

--- a/test/finiteVolume/cellCentred/boundary/surface/CMakeLists.txt
+++ b/test/finiteVolume/cellCentred/boundary/surface/CMakeLists.txt
@@ -1,4 +1,5 @@
+# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2024 NeoN authors
 
 neon_unit_test(surfFixedValue)

--- a/test/finiteVolume/cellCentred/boundary/surface/surfFixedValue.cpp
+++ b/test/finiteVolume/cellCentred/boundary/surface/surfFixedValue.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/finiteVolume/cellCentred/boundary/volume/CMakeLists.txt
+++ b/test/finiteVolume/cellCentred/boundary/volume/CMakeLists.txt
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2024 NeoN authors
 
 neon_unit_test(volFixedValue)
 neon_unit_test(volFixedGradient)

--- a/test/finiteVolume/cellCentred/boundary/volume/volFixedGradient.cpp
+++ b/test/finiteVolume/cellCentred/boundary/volume/volFixedGradient.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/finiteVolume/cellCentred/boundary/volume/volFixedValue.cpp
+++ b/test/finiteVolume/cellCentred/boundary/volume/volFixedValue.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/finiteVolume/cellCentred/faceNormalGradient/CMakeLists.txt
+++ b/test/finiteVolume/cellCentred/faceNormalGradient/CMakeLists.txt
@@ -1,4 +1,5 @@
+# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2024 NeoN authors
 
 neon_unit_test(uncorrected)

--- a/test/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
+++ b/test/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/finiteVolume/cellCentred/fields/CMakeLists.txt
+++ b/test/finiteVolume/cellCentred/fields/CMakeLists.txt
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2024 NeoN authors
 
 neon_unit_test(surfaceField)
 neon_unit_test(volumeField)

--- a/test/finiteVolume/cellCentred/fields/surfaceField.cpp
+++ b/test/finiteVolume/cellCentred/fields/surfaceField.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/finiteVolume/cellCentred/fields/volumeField.cpp
+++ b/test/finiteVolume/cellCentred/fields/volumeField.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/finiteVolume/cellCentred/interpolation/CMakeLists.txt
+++ b/test/finiteVolume/cellCentred/interpolation/CMakeLists.txt
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2024 NeoN authors
 
 neon_unit_test(linear)
 neon_unit_test(upwind)

--- a/test/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/test/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/finiteVolume/cellCentred/interpolation/surfaceInterpolation.cpp
+++ b/test/finiteVolume/cellCentred/interpolation/surfaceInterpolation.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/finiteVolume/cellCentred/interpolation/upwind.cpp
+++ b/test/finiteVolume/cellCentred/interpolation/upwind.cpp
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025 NeoN authors
+//
+// SPDX-License-Identifier: MIT
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/finiteVolume/cellCentred/operator/CMakeLists.txt
+++ b/test/finiteVolume/cellCentred/operator/CMakeLists.txt
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2024 NeoN authors
 
 neon_unit_test(ddtOperator)
 neon_unit_test(laplacianOperator)

--- a/test/finiteVolume/cellCentred/operator/common_operator.hpp
+++ b/test/finiteVolume/cellCentred/operator/common_operator.hpp
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025 NeoN authors
+//
+// SPDX-License-Identifier: MIT
 
 #include "NeoN/NeoN.hpp"
 

--- a/test/finiteVolume/cellCentred/operator/ddtOperator.cpp
+++ b/test/finiteVolume/cellCentred/operator/ddtOperator.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/finiteVolume/cellCentred/operator/gaussGreenDiv.cpp
+++ b/test/finiteVolume/cellCentred/operator/gaussGreenDiv.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/finiteVolume/cellCentred/operator/laplacianOperator.cpp
+++ b/test/finiteVolume/cellCentred/operator/laplacianOperator.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/finiteVolume/cellCentred/operator/sourceTerm.cpp
+++ b/test/finiteVolume/cellCentred/operator/sourceTerm.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/linearAlgebra/CMakeLists.txt
+++ b/test/linearAlgebra/CMakeLists.txt
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2024 NeoN authors
 
 neon_unit_test(CSRMatrix)
 neon_unit_test(linearSystem)

--- a/test/linearAlgebra/CSRMatrix.cpp
+++ b/test/linearAlgebra/CSRMatrix.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/linearAlgebra/ginkgo.cpp
+++ b/test/linearAlgebra/ginkgo.cpp
@@ -1,5 +1,7 @@
-// SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2025 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
 #include "catch2_common.hpp"
 
 #include "NeoN/NeoN.hpp"

--- a/test/linearAlgebra/linearAlgebra.cpp
+++ b/test/linearAlgebra/linearAlgebra.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #include "catch2_common.hpp"
 

--- a/test/linearAlgebra/linearSystem.cpp
+++ b/test/linearAlgebra/linearSystem.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/linearAlgebra/petsc.cpp
+++ b/test/linearAlgebra/petsc.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #include "catch2/catch_session.hpp"
 #include "catch2/catch_test_macros.hpp"

--- a/test/linearAlgebra/sparsityPattern.cpp
+++ b/test/linearAlgebra/sparsityPattern.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/linearAlgebra/utilities.cpp
+++ b/test/linearAlgebra/utilities.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/mesh/CMakeLists.txt
+++ b/test/mesh/CMakeLists.txt
@@ -1,4 +1,5 @@
+# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2023-2024 NeoN authors
 
 add_subdirectory(unstructured)

--- a/test/mesh/unstructured/CMakeLists.txt
+++ b/test/mesh/unstructured/CMakeLists.txt
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2023-2024 NeoN authors
 
 if(NeoN_ENABLE_MPI_SUPPORT)
   neon_unit_test(communicator MPI_SIZE 3)

--- a/test/mesh/unstructured/communicator.cpp
+++ b/test/mesh/unstructured/communicator.cpp
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
 //
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 
 // #include <source_location>
 

--- a/test/mesh/unstructured/communicator.cpp
+++ b/test/mesh/unstructured/communicator.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: Unlicense
-// SPDX-FileCopyrightText: 2023-2024 NeoN authors
 
 // #include <source_location>
 

--- a/test/mesh/unstructured/unstructuredMesh.cpp
+++ b/test/mesh/unstructured/unstructuredMesh.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023-2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/timeIntegration/CMakeLists.txt
+++ b/test/timeIntegration/CMakeLists.txt
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+#
 # SPDX-License-Identifier: Unlicense
-# SPDX-FileCopyrightText: 2024 NeoN authors
 
 neon_unit_test(timeIntegration)
 neon_unit_test(implicitTimeIntegration)

--- a/test/timeIntegration/implicitTimeIntegration.cpp
+++ b/test/timeIntegration/implicitTimeIntegration.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/timeIntegration/rungeKutta.cpp
+++ b/test/timeIntegration/rungeKutta.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main

--- a/test/timeIntegration/timeIntegration.cpp
+++ b/test/timeIntegration/timeIntegration.cpp
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+//
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2024 NeoN authors
 
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main


### PR DESCRIPTION
# Motivation
This adds reuse annotate in pre-commit. It helps to automatically add license.

in annotate, if there are some comments right after the license, annotate tends to delete them.
Thus, in the second commit, I insert a new line between license and the comments.

Because this project contains two kinds of license: MIT and Unlicense, reviewer maybe need to go through the changes more carefully.