### PR TITLE
Set up a configuration file for running GitLab CI pipelines on NVIDIA GPUs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,8 @@ build-project:
     # Optional: show versions of tools
     - cmake --version
     - clang++ --version || g++ --version
-    - nvidia-smi || true
+    - nvidia-smi
+    - nvcc --version
 
   script:
     - cmake --preset develop -DCMAKE_CUDA_ARCHITECTURES=89 -DNeoN_WITH_THREADS=OFF

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+#
+# SPDX-License-Identifier: Unlicense
+
+image: greole/neon-cuda
+
+stages:
+  - build-and-test
+
+build-project:
+  stage: build-and-test
+  tags: ["nvidia-gpus"]
+  before_script:
+    # Install pre-commit
+    - pip3 install --user --break-system-packages pre-commit
+    - export PATH="$HOME/.local/bin:$PATH"
+
+    # Optional: show versions of tools
+    - cmake --version
+    - clang++ --version || g++ --version
+    - nvidia-smi || true
+
+  script:
+    - cmake --preset develop -DCMAKE_CUDA_ARCHITECTURES=89 -DNeoN_WITH_THREADS=OFF
+    - cmake --build --preset develop
+    - ctest --preset develop --output-on-failure


### PR DESCRIPTION
# Motivation
The current GitHub CI pipelines only run NeoN on CPUs, but we need to verify NeoN can also work on GPUs. To achieve this, the GitHub repository is copied to GitLab for running GitLab CI pipelines on the GPU compute nodes of TUM COMA cluster. In order to run GitLab CI pipelines, a configuration file .gitlab-ci.yml is added.

After this branch is merged to the main branch, please rebase your branch to the updated main branch so that your branch will have the configuration file for running GitLab CI pipeline.
