### PR TITLE
Split build and test into separate jobs and stages 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,23 +5,36 @@
 image: greole/neon-cuda
 
 stages:
-  - build-and-test
+  - build
+  - test
+
+variables:
+  GIT_STRATEGY: clone
+  GIT_DEPTH: 1
 
 build-project:
-  stage: build-and-test
+  stage: build
   tags: ["nvidia-gpus"]
   before_script:
-    # Install pre-commit
     - pip3 install --user --break-system-packages pre-commit
     - export PATH="$HOME/.local/bin:$PATH"
-
-    # Optional: show versions of tools
     - cmake --version
     - clang++ --version || g++ --version
     - nvidia-smi
     - nvcc --version
-
   script:
     - cmake --preset develop -DCMAKE_CUDA_ARCHITECTURES=89 -DNeoN_WITH_THREADS=OFF
     - cmake --build --preset develop
+  artifacts:
+    paths:
+      - build/          
+    expire_in: 1h
+
+test-project:
+  stage: test
+  tags: ["nvidia-gpus"]
+  needs: ["build-project"]  
+  script:
     - ctest --preset develop --output-on-failure
+  dependencies:
+    - build-project         

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,14 +27,14 @@ build-project:
     - cmake --build --preset develop
   artifacts:
     paths:
-      - build/          
+      - build/
     expire_in: 1h
 
 test-project:
   stage: test
   tags: ["nvidia-gpus"]
-  needs: ["build-project"]  
+  needs: ["build-project"]
   script:
     - ctest --preset develop --output-on-failure
   dependencies:
-    - build-project         
+    - build-project


### PR DESCRIPTION
# Motivation
Originally, only a single job is used for building and testing. However, it would be better to split it to separate jobs and stages for faster feedback and easier debugging.
