### PR TITLE
create sparsity pattern on host in serial

### DIFF
--- a/src/linearAlgebra/sparsityPattern.cpp
+++ b/src/linearAlgebra/sparsityPattern.cpp
@@ -21,89 +21,126 @@ const SparsityPattern& SparsityPattern::readOrCreate(const UnstructuredMesh& mes
 
 void updateSparsityPattern(const UnstructuredMesh& mesh, SparsityPattern& sp)
 {
-    const auto faceOwner = mesh.faceOwner().view();
-    const auto faceNeiV = mesh.faceNeighbour().view();
+    // const auto faceOwnV = mesh.faceOwner().view();
+    // const auto faceNeiV = mesh.faceNeighbour().view();
     const auto nInternalFaces = mesh.nInternalFaces();
     const auto exec = mesh.exec();
     auto nCells = mesh.nCells();
 
     // start with one to include the diagonal
-    auto nFacesPerCell = Vector<localIdx>(exec, nCells, 1);
-    auto [nFacesPerCellView, neighbourOffsetView, ownerOffsetView, diagOffsetView] =
-        views(nFacesPerCell, sp.neighbourOffset(), sp.ownerOffset(), sp.diagOffset());
+    // TODO: currently the whole algorithm is performed in serial on the host
+    auto nFacesPerCellH = Vector<localIdx>(SerialExecutor {}, nCells, 1);
+    auto [neiOffsetH, ownOffsetH, diagOffsetH, faceOwnH, faceNeiH] = copyToHosts(
+        sp.neighbourOffset(),
+        sp.ownerOffset(),
+        sp.diagOffset(),
+        mesh.faceOwner(),
+        mesh.faceNeighbour()
+    );
+
+    auto [nFacesPerCellHV, neiOffsetHV, ownOffsetHV, diagOffsetHV, faceOwnHV, faceNeiHV] =
+        views(nFacesPerCellH, neiOffsetH, ownOffsetH, diagOffsetH, faceOwnH, faceNeiH);
+
 
     // accumulate number non-zeros per row
     // only the internalfaces define the sparsity pattern
     // get the number of faces per cell to allocate the correct size
     parallelFor(
-        exec,
+        SerialExecutor {},
         {0, nInternalFaces},
         KOKKOS_LAMBDA(const localIdx facei) {
             // hit on performance on serial
-            auto owner = faceOwner[facei];
-            auto neighbour = faceNeiV[facei];
+            auto own = faceOwnHV[facei];
+            auto nei = faceNeiHV[facei];
 
-            Kokkos::atomic_increment(&nFacesPerCellView[owner]);
-            Kokkos::atomic_increment(&nFacesPerCellView[neighbour]);
+            Kokkos::atomic_increment(&nFacesPerCellHV[own]);
+            Kokkos::atomic_increment(&nFacesPerCellHV[nei]);
         }
     );
 
     // get number of total non-zeros
-    auto rowOffs = sp.rowOffs().view();
-    segmentsFromIntervals(nFacesPerCell, sp.rowOffs());
-    auto colIdxV = sp.colIdxs().view();
-    fill(nFacesPerCell, 0); // reset nFacesPerCell
+    auto rowOffsH = sp.rowOffs().copyToHost();
+    auto rowOffsHV = rowOffsH.view();
+    segmentsFromIntervals(nFacesPerCellH, rowOffsH);
+    auto colIdxH = sp.colIdxs().copyToHost();
+    auto colIdxHV = colIdxH.view();
+    fill(nFacesPerCellH, 0); // reset nFacesPerCell
 
     // compute the lower triangular part of the matrix
     parallelFor(
-        exec,
+        SerialExecutor {},
         {0, nInternalFaces},
         KOKKOS_LAMBDA(const localIdx facei) {
-            auto neighbour = faceNeiV[facei];
-            auto owner = faceOwner[facei];
+            auto nei = faceNeiHV[facei];
+            auto own = faceOwnHV[facei];
 
+            // TODO this is probably inherently serial
             // return the oldValues
             // hit on performance on serial
-            auto segIdxNei = Kokkos::atomic_fetch_add(&nFacesPerCellView[neighbour], 1);
-            neighbourOffsetView[facei] = static_cast<uint8_t>(segIdxNei);
+            auto segIdxNei = Kokkos::atomic_fetch_add(&nFacesPerCellHV[nei], 1);
+            neiOffsetHV[facei] = static_cast<uint8_t>(segIdxNei);
 
-            auto startSegNei = rowOffs[neighbour];
+            auto startSegNei = rowOffsHV[nei];
             // neighbour --> current cell
             // colIdx --> needs to be store the owner
-            Kokkos::atomic_assign(&colIdxV[startSegNei + segIdxNei], owner);
+            Kokkos::atomic_assign(&colIdxHV[startSegNei + segIdxNei], own);
         }
     );
 
     map(
-        nFacesPerCell,
+        nFacesPerCellH,
         KOKKOS_LAMBDA(const localIdx celli) {
-            auto nFaces = nFacesPerCellView[celli];
-            diagOffsetView[celli] = static_cast<uint8_t>(nFaces);
-            colIdxV[rowOffs[celli] + nFaces] = celli;
+            auto nFaces = nFacesPerCellHV[celli];
+            diagOffsetHV[celli] = static_cast<uint8_t>(nFaces);
+            colIdxHV[rowOffsHV[celli] + nFaces] = celli;
             return nFaces + 1;
         }
     );
 
     // compute the upper triangular part of the matrix
     parallelFor(
-        exec,
+        SerialExecutor {},
         {0, nInternalFaces},
         KOKKOS_LAMBDA(const localIdx facei) {
-            auto neighbour = faceNeiV[facei];
-            auto owner = faceOwner[facei];
+            auto nei = faceNeiHV[facei];
+            auto own = faceOwnHV[facei];
 
             // return the oldValues
             // hit on performance on serial
             auto segIdxOwn =
-                static_cast<uint8_t>(Kokkos::atomic_fetch_add(&nFacesPerCellView[owner], 1));
-            ownerOffsetView[facei] = segIdxOwn;
+                static_cast<uint8_t>(Kokkos::atomic_fetch_add(&nFacesPerCellHV[own], 1));
+            ownOffsetHV[facei] = segIdxOwn;
 
-            auto startSegOwn = rowOffs[owner];
+            auto startSegOwn = rowOffsHV[own];
             // owner --> current cell
             // colIdx --> needs to be store the neighbour
-            Kokkos::atomic_assign(&colIdxV[startSegOwn + segIdxOwn], neighbour);
+            Kokkos::atomic_assign(&colIdxHV[startSegOwn + segIdxOwn], nei);
         }
     );
+    // NOTE copy back to device
+    sp.ownerOffset() = ownOffsetH.copyToExecutor(exec);
+    sp.neighbourOffset() = neiOffsetH.copyToExecutor(exec);
+    sp.diagOffset() = diagOffsetH.copyToExecutor(exec);
+    sp.colIdxs() = colIdxH.copyToExecutor(exec);
+    sp.rowOffs() = rowOffsH.copyToExecutor(exec);
+
+
+    // sort colIdx
+    // TODO: this implementation could be improved
+    // by actually implementing the parallel sort on device
+    // auto rowOffsH = sp.rowOffs().copyToHost();
+    // auto colIdxH = sp.colIdxs().copyToHost();
+    // auto [rowOffsHV, colIdxHV] = views(rowOffsH, colIdxH);
+    // for (auto celli = 0; celli < rowOffsHV.size() - 1; celli++)
+    // {
+    //     auto start = rowOffsHV[celli];
+    //     auto end = rowOffsHV[celli + 1];
+    //     // detail::parallelSort(exec, {start, end}, &stencilValues[0]);
+    //     auto sub = colIdxHV.subview(start, end - start);
+    //     std::sort(sub.begin(), sub.end());
+    // }
+    // auto sortedValues = Vector(exec, &colIdxHV[0], colIdxHV.size(), SerialExecutor {});
+    // sp.colIdxs() = sortedValues;
 }
 
 SparsityPattern createSparsity(const UnstructuredMesh& mesh)

--- a/src/linearAlgebra/sparsityPattern.cpp
+++ b/src/linearAlgebra/sparsityPattern.cpp
@@ -19,10 +19,9 @@ const SparsityPattern& SparsityPattern::readOrCreate(const UnstructuredMesh& mes
     return stencilDb.get<SparsityPattern>("SparsityPattern");
 }
 
-void updateSparsityPattern(const UnstructuredMesh& mesh, SparsityPattern& sp)
+
+void updateSparsityPatternSerial(const UnstructuredMesh& mesh, SparsityPattern& sp)
 {
-    // const auto faceOwnV = mesh.faceOwner().view();
-    // const auto faceNeiV = mesh.faceNeighbour().view();
     const auto nInternalFaces = mesh.nInternalFaces();
     const auto exec = mesh.exec();
     auto nCells = mesh.nCells();
@@ -123,24 +122,99 @@ void updateSparsityPattern(const UnstructuredMesh& mesh, SparsityPattern& sp)
     sp.diagOffset() = diagOffsetH.copyToExecutor(exec);
     sp.colIdxs() = colIdxH.copyToExecutor(exec);
     sp.rowOffs() = rowOffsH.copyToExecutor(exec);
+}
 
+void updateSparsityPatternParallel(const UnstructuredMesh& mesh, SparsityPattern& sp)
+{
+    const auto faceOwner = mesh.faceOwner().view();
+    const auto faceNeiV = mesh.faceNeighbour().view();
+    const auto nInternalFaces = mesh.nInternalFaces();
+    const auto exec = mesh.exec();
+    auto nCells = mesh.nCells();
 
-    // sort colIdx
-    // TODO: this implementation could be improved
-    // by actually implementing the parallel sort on device
-    // auto rowOffsH = sp.rowOffs().copyToHost();
-    // auto colIdxH = sp.colIdxs().copyToHost();
-    // auto [rowOffsHV, colIdxHV] = views(rowOffsH, colIdxH);
-    // for (auto celli = 0; celli < rowOffsHV.size() - 1; celli++)
-    // {
-    //     auto start = rowOffsHV[celli];
-    //     auto end = rowOffsHV[celli + 1];
-    //     // detail::parallelSort(exec, {start, end}, &stencilValues[0]);
-    //     auto sub = colIdxHV.subview(start, end - start);
-    //     std::sort(sub.begin(), sub.end());
-    // }
-    // auto sortedValues = Vector(exec, &colIdxHV[0], colIdxHV.size(), SerialExecutor {});
-    // sp.colIdxs() = sortedValues;
+    // start with one to include the diagonal
+    auto nFacesPerCell = Vector<localIdx>(exec, nCells, 1);
+    auto [nFacesPerCellView, neighbourOffsetView, ownerOffsetView, diagOffsetView] =
+        views(nFacesPerCell, sp.neighbourOffset(), sp.ownerOffset(), sp.diagOffset());
+
+    // accumulate number non-zeros per row
+    // only the internalfaces define the sparsity pattern
+    // get the number of faces per cell to allocate the correct size
+    parallelFor(
+        exec,
+        {0, nInternalFaces},
+        KOKKOS_LAMBDA(const localIdx facei) {
+            // hit on performance on serial
+            auto owner = faceOwner[facei];
+            auto neighbour = faceNeiV[facei];
+
+            Kokkos::atomic_increment(&nFacesPerCellView[owner]);
+            Kokkos::atomic_increment(&nFacesPerCellView[neighbour]);
+        }
+    );
+
+    // get number of total non-zeros
+    auto rowOffs = sp.rowOffs().view();
+    segmentsFromIntervals(nFacesPerCell, sp.rowOffs());
+    auto colIdxV = sp.colIdxs().view();
+    fill(nFacesPerCell, 0); // reset nFacesPerCell
+
+    // compute the lower triangular part of the matrix
+    parallelFor(
+        exec,
+        {0, nInternalFaces},
+        KOKKOS_LAMBDA(const localIdx facei) {
+            auto neighbour = faceNeiV[facei];
+            auto owner = faceOwner[facei];
+
+            // return the oldValues
+            // hit on performance on serial
+            auto segIdxNei = Kokkos::atomic_fetch_add(&nFacesPerCellView[neighbour], 1);
+            neighbourOffsetView[facei] = static_cast<uint8_t>(segIdxNei);
+
+            auto startSegNei = rowOffs[neighbour];
+            // neighbour --> current cell
+            // colIdx --> needs to be store the owner
+            Kokkos::atomic_assign(&colIdxV[startSegNei + segIdxNei], owner);
+        }
+    );
+
+    map(
+        nFacesPerCell,
+        KOKKOS_LAMBDA(const localIdx celli) {
+            auto nFaces = nFacesPerCellView[celli];
+            diagOffsetView[celli] = static_cast<uint8_t>(nFaces);
+            colIdxV[rowOffs[celli] + nFaces] = celli;
+            return nFaces + 1;
+        }
+    );
+
+    // compute the upper triangular part of the matrix
+    parallelFor(
+        exec,
+        {0, nInternalFaces},
+        KOKKOS_LAMBDA(const localIdx facei) {
+            auto neighbour = faceNeiV[facei];
+            auto owner = faceOwner[facei];
+
+            // return the oldValues
+            // hit on performance on serial
+            auto segIdxOwn =
+                static_cast<uint8_t>(Kokkos::atomic_fetch_add(&nFacesPerCellView[owner], 1));
+            ownerOffsetView[facei] = segIdxOwn;
+
+            auto startSegOwn = rowOffs[owner];
+            // owner --> current cell
+            // colIdx --> needs to be store the neighbour
+            Kokkos::atomic_assign(&colIdxV[startSegOwn + segIdxOwn], neighbour);
+        }
+    );
+}
+
+void updateSparsityPattern(const UnstructuredMesh& mesh, SparsityPattern& sp)
+{
+    // TODO sort pattern after creation and use parallel version
+    updateSparsityPatternSerial(mesh, sp);
 }
 
 SparsityPattern createSparsity(const UnstructuredMesh& mesh)

--- a/src/linearAlgebra/sparsityPattern.cpp
+++ b/src/linearAlgebra/sparsityPattern.cpp
@@ -81,7 +81,7 @@ void updateSparsityPatternSerial(const UnstructuredMesh& mesh, SparsityPattern& 
 
             auto startSegNei = rowOffsHV[nei];
             // neighbour --> current cell
-            // colIdx --> needs to be store the owner
+            // colIdx for row[neighbour] stores owner as a column entry
             Kokkos::atomic_assign(&colIdxHV[startSegNei + segIdxNei], own);
         }
     );


### PR DESCRIPTION
This PR adds an implementation that creates the sparsity in serial. The rational is that

```
    parallelFor(
        exec,
        {0, nInternalFaces},
        KOKKOS_LAMBDA(const localIdx facei) {
        ...
            auto segIdxNei = Kokkos::atomic_fetch_add(&nFacesPerCellView[neighbour], 1);
            neighbourOffsetView[facei] = static_cast<uint8_t>(segIdxNei);
       }
```

In https://github.com/exasim-project/NeoN/tree/fix/serial_sparsity/src/linearAlgebra/sparsityPattern.cpp is not guaranteed to be in order and might produce a sparsity pattern that is not row major ordered. This causes issues with the linear solver on GPUs. 

NB: This is just a fix, the better solution would be use the parallel implementation and sort everything. 