### PR TITLE
Add a CI job to trigger FoamAdapter CI pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,11 +41,6 @@ build-and-test-project:
 trigger-foamadapter:
   stage: trigger
   script:
-    - curl --fail --request POST \
-        --form "token=$FOAMADAPTER_TRIGGER_TOKEN" \
-        --form "ref=main" \
-        --form "variables[NEON_BRANCH]=$CI_COMMIT_REF_NAME" \
-        --form "variables[NEON_COMMIT]=$CI_COMMIT_SHA" \
-        "${CI_API_V4_URL}/projects/1095/trigger/pipeline"
+    - curl --fail --request POST --form "token=$FOAMADAPTER_TRIGGER_TOKEN" --form "ref=main" --form "variables[NEON_BRANCH]=$CI_COMMIT_REF_NAME" --form "variables[NEON_COMMIT]=$CI_COMMIT_SHA" "${CI_API_V4_URL}/projects/1095/trigger/pipeline"
   rules:
     - when: always

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,6 +40,7 @@ build-and-test-project:
 
 trigger-foamadapter:
   stage: trigger
+  tags: ["nvidia-gpus"]
   needs: ["build-and-test-project"]
   script:
     - curl --fail --request POST --form token=$FOAMADAPTER_TRIGGER_TOKEN --form ref=main --form variables[NEON_BRANCH]=$CI_COMMIT_REF_NAME --form variables[NEON_COMMIT]=$CI_COMMIT_SHA "${CI_API_V4_URL}/projects/1095/trigger/pipeline"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,8 @@ build-and-test-project:
 
 trigger-foamadapter:
   stage: trigger
+  needs: ["build-and-test-project"]
   script:
-    - curl --fail --request POST --form token=$FOAMADAPTER_TRIGGER_TOKEN --form ref=main --form "variables[NEON_BRANCH]=$CI_COMMIT_REF_NAME" --form "variables[NEON_COMMIT]=$CI_COMMIT_SHA" "${CI_API_V4_URL}/projects/1095/trigger/pipeline"
+    - curl --fail --request POST --form token=$FOAMADAPTER_TRIGGER_TOKEN --form ref=main --form variables[NEON_BRANCH]=$CI_COMMIT_REF_NAME --form variables[NEON_COMMIT]=$CI_COMMIT_SHA "${CI_API_V4_URL}/projects/1095/trigger/pipeline"
   rules:
-    - when: always
+    - when: on_success

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,6 +43,6 @@ trigger-foamadapter:
   tags: ["nvidia-gpus"]
   needs: ["build-and-test-project"]
   script:
-    - curl --fail --request POST --form token=$FOAMADAPTER_TRIGGER_TOKEN --form ref=ci/trigger-from-NeoN-ci --form variables[NEON_BRANCH]=$CI_COMMIT_REF_NAME --form variables[NEON_COMMIT]=$CI_COMMIT_SHA "${CI_API_V4_URL}/projects/1095/trigger/pipeline"
+    - curl --fail --request POST --form token=$FOAMADAPTER_TRIGGER_TOKEN --form ref=main --form variables[NEON_BRANCH]=$CI_COMMIT_REF_NAME --form variables[NEON_COMMIT]=$CI_COMMIT_SHA "${CI_API_V4_URL}/projects/1095/trigger/pipeline"
   rules:
     - when: on_success

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,6 +41,6 @@ build-and-test-project:
 trigger-foamadapter:
   stage: trigger
   script:
-    - curl --fail --request POST --form "token=$FOAMADAPTER_TRIGGER_TOKEN" --form "ref=main" --form "variables[NEON_BRANCH]=$CI_COMMIT_REF_NAME" --form "variables[NEON_COMMIT]=$CI_COMMIT_SHA" "${CI_API_V4_URL}/projects/1095/trigger/pipeline"
+    - curl --fail --request POST --form token=$FOAMADAPTER_TRIGGER_TOKEN --form ref=main --form "variables[NEON_BRANCH]=$CI_COMMIT_REF_NAME" --form "variables[NEON_COMMIT]=$CI_COMMIT_SHA" "${CI_API_V4_URL}/projects/1095/trigger/pipeline"
   rules:
     - when: always

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,7 @@ workflow:
 
 stages:
   - build-and-test
+  - trigger
 
 build-and-test-project:
   stage: build-and-test
@@ -36,3 +37,15 @@ build-and-test-project:
     - cmake --preset develop -DCMAKE_CUDA_ARCHITECTURES=89 -DNeoN_WITH_THREADS=OFF
     - cmake --build --preset develop
     - ctest --preset develop --output-on-failure
+
+trigger-foamadapter:
+  stage: trigger
+  script:
+    - curl --fail --request POST \
+        --form "token=$FOAMADAPTER_TRIGGER_TOKEN" \
+        --form "ref=main" \
+        --form "variables[NEON_BRANCH]=$CI_COMMIT_REF_NAME" \
+        --form "variables[NEON_COMMIT]=$CI_COMMIT_SHA" \
+        "${CI_API_V4_URL}/projects/1095/trigger/pipeline"
+  rules:
+    - when: always

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,6 +43,6 @@ trigger-foamadapter:
   tags: ["nvidia-gpus"]
   needs: ["build-and-test-project"]
   script:
-    - curl --fail --request POST --form token=$FOAMADAPTER_TRIGGER_TOKEN --form ref=main --form variables[NEON_BRANCH]=$CI_COMMIT_REF_NAME --form variables[NEON_COMMIT]=$CI_COMMIT_SHA "${CI_API_V4_URL}/projects/1095/trigger/pipeline"
+    - curl --fail --request POST --form token=$FOAMADAPTER_TRIGGER_TOKEN --form ref=ci/trigger-from-NeoN-ci --form variables[NEON_BRANCH]=$CI_COMMIT_REF_NAME --form variables[NEON_COMMIT]=$CI_COMMIT_SHA "${CI_API_V4_URL}/projects/1095/trigger/pipeline"
   rules:
     - when: on_success


### PR DESCRIPTION
# Motivation
The original CI only runs the NeoN's own tests. However, it is important to ensure that changes in NeoN also works for FoamAdapter. Therefore, we need a mechanism to trigger FoamAdapter CI pipeline to test FoamAdatper against NeoN.
