### PR TITLE
Trigger FoamAdapter CI pipelilne on the same branch name as NeoN

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,4 +49,3 @@ trigger-foamadapter:
       curl --fail --request POST --form token=$FOAMADAPTER_TRIGGER_TOKEN --form ref=$CI_COMMIT_REF_NAME --form variables[NEON_BRANCH]=$CI_COMMIT_REF_NAME --form variables[NEON_COMMIT]=$CI_COMMIT_SHA "${CI_API_V4_URL}/projects/1095/trigger/pipeline"
   rules:
     - when: on_success
-

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,6 +43,10 @@ trigger-foamadapter:
   tags: ["nvidia-gpus"]
   needs: ["build-and-test-project"]
   script:
-    - curl --fail --request POST --form token=$FOAMADAPTER_TRIGGER_TOKEN --form ref=main --form variables[NEON_BRANCH]=$CI_COMMIT_REF_NAME --form variables[NEON_COMMIT]=$CI_COMMIT_SHA "${CI_API_V4_URL}/projects/1095/trigger/pipeline"
+    - |
+      echo "Triggering FoamAdapter CI..."
+      echo "NeoN branch=$CI_COMMIT_REF_NAME commit=$CI_COMMIT_SHA"
+      curl --fail --request POST --form token=$FOAMADAPTER_TRIGGER_TOKEN --form ref=$CI_COMMIT_REF_NAME --form variables[NEON_BRANCH]=$CI_COMMIT_REF_NAME --form variables[NEON_COMMIT]=$CI_COMMIT_SHA "${CI_API_V4_URL}/projects/1095/trigger/pipeline"
   rules:
     - when: on_success
+


### PR DESCRIPTION
# Motivation
Currently, the CI pipeline triggers the FoamAdapter CI always on the main branch of FoamAdapter. However, sometimes we may need changes in FoamAdapter to work with changes in NeoN. In practice, we use the same branch name in both FoamAdapter and NeoN. Therefore, we need a CI pipeline to trigger the FoamAdapter CI on the same branch of FoamAdapter. That is what this PR tries to achieve.

