### PR TITLE
Set up a GitLab CI job for benchmarking

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,8 +116,8 @@ benchmark-on-tum-coma:
     - git clone https://oauth2:${API_TOKEN_GITHUB}@${TARGET_REPO}
     - cd ${REPO_NAME}
     - git checkout "${TARGET_BRANCH}" || git checkout -b "${TARGET_BRANCH}"
-    - mkdir "${RUN_IDENTIFIER}"
-    - cp -r ../${RESULTS_DIR}/* "${RUN_IDENTIFIER}"
+    - mkdir -p "${RUN_IDENTIFIER}/${CI_RUNNER_DESCRIPTION}"
+    - cp -r ../${RESULTS_DIR}/* "${RUN_IDENTIFIER}/${CI_RUNNER_DESCRIPTION}"
     - git add .
     - git commit -m "Benchmarks from GitLab pipeline ${RUN_IDENTIFIER}" || echo "No changes to commit"
     - git pull --rebase || true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,45 +4,97 @@
 
 image: greole/neon-cuda
 
-workflow:
-  rules:
-    # Skip pipeline if only doc or Markdown files changed
-    - changes:
-        - doc/**/*
-        - '*.md'
-      when: never
+# workflow:
+#   rules:
+#     # Skip pipeline if only doc or Markdown files changed
+#     - changes:
+#         - doc/**/*
+#         - '*.md'
+#       when: never
 
-    # Run pipeline for everything else
-    - when: always
+#     # Run pipeline for everything else
+#     - when: always
 
 stages:
-  - build-and-test
-  - trigger
+  # - build-and-test
+  # - trigger
+  - benchmark
 
-build-and-test-project:
-  stage: build-and-test
+# build-and-test-project:
+#   stage: build-and-test
+#   tags: ["nvidia-gpus"]
+#   before_script:
+#     # Install pre-commit
+#     - pip3 install --user --break-system-packages pre-commit
+#     - export PATH="$HOME/.local/bin:$PATH"
+
+#     # Optional: show versions of tools
+#     - cmake --version
+#     - clang++ --version || g++ --version
+#     - nvidia-smi
+#     - nvcc --version
+
+#   script:
+#     - cmake --preset develop -DCMAKE_CUDA_ARCHITECTURES=89 -DNeoN_WITH_THREADS=OFF
+#     - cmake --build --preset develop
+#     - ctest --preset develop --output-on-failure
+
+# trigger-foamadapter:
+#   stage: trigger
+#   tags: ["nvidia-gpus"]
+#   needs: ["build-and-test-project"]
+#   script:
+#     - curl --fail --request POST --form token=$FOAMADAPTER_TRIGGER_TOKEN --form ref=main --form variables[NEON_BRANCH]=$CI_COMMIT_REF_NAME --form variables[NEON_COMMIT]=$CI_COMMIT_SHA "${CI_API_V4_URL}/projects/1095/trigger/pipeline"
+#   rules:
+#     - when: on_success
+
+benchmark-on-tum-coma:
+  stage: benchmark
   tags: ["nvidia-gpus"]
-  before_script:
-    # Install pre-commit
-    - pip3 install --user --break-system-packages pre-commit
-    - export PATH="$HOME/.local/bin:$PATH"
-
-    # Optional: show versions of tools
-    - cmake --version
-    - clang++ --version || g++ --version
-    - nvidia-smi
-    - nvcc --version
-
+  # needs: ["build-and-test-project"]
+  variables:
+    RUN_IDENTIFIER: "${CI_PIPELINE_ID}"
+    TARGET_REPO: "github.com/exasim-project/NeoFOAM-BenchmarkData.git"
   script:
-    - cmake --preset develop -DCMAKE_CUDA_ARCHITECTURES=89 -DNeoN_WITH_THREADS=OFF
-    - cmake --build --preset develop
-    - ctest --preset develop --output-on-failure
+    # Install dependencies
+    - pip3 install --user --break-system-packages xmltodict
 
-trigger-foamadapter:
-  stage: trigger
-  tags: ["nvidia-gpus"]
-  needs: ["build-and-test-project"]
-  script:
-    - curl --fail --request POST --form token=$FOAMADAPTER_TRIGGER_TOKEN --form ref=main --form variables[NEON_BRANCH]=$CI_COMMIT_REF_NAME --form variables[NEON_COMMIT]=$CI_COMMIT_SHA "${CI_API_V4_URL}/projects/1095/trigger/pipeline"
-  rules:
-    - when: on_success
+    # Build & benchmark current branch
+    - echo ">>> Build current branch"
+    - cmake --preset profiling
+    - cmake --build --preset profiling
+    - ctest --preset profiling
+    - mkdir -p results
+    - cd build/profiling/bin/benchmarks
+    - python3 ../../../../scripts/catch2json.py
+    - cp *.json ../../../..
+    - cd ../../../..
+    - mv *.json results/
+    - lscpu > results/lscpu.log
+    - rm -rf build
+
+    # Build & benchmark main branch
+    - echo ">>> Build main branch"
+    - git fetch origin main
+    - git checkout main
+    - cmake --preset profiling
+    - cmake --build --preset profiling
+    - ctest --preset profiling
+    - mkdir -p results/main
+    - cd build/profiling/bin/benchmarks
+    - python3 ../../../../scripts/catch2json.py
+    - cp *.json ../../../..
+    - cd ../../../..
+    - mv *.json results/main/
+
+    # Push benchmark results to GitHub
+    - git config --global user.email "gitlab-ci@users.noreply.github.com"
+    - git config --global user.name "GitLab CI"
+    - git clone https://oauth2:${API_TOKEN_GITHUB}@${TARGET_REPO} gh-target
+    - cd gh-target
+    - mkdir -p "${RUN_IDENTIFIER}/${CI_RUNNER_DESCRIPTION}"
+    - cp -r ../results/* "${RUN_IDENTIFIER}/${CI_RUNNER_DESCRIPTION}/"
+    - git add .
+    - git commit -m "Benchmarks from GitLab pipeline ${CI_PIPELINE_ID}" || echo "No changes to commit"
+    - git pull --rebase || true
+    - git push origin main

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,54 +4,54 @@
 
 image: greole/neon-cuda
 
-# workflow:
-#   rules:
-#     # Skip pipeline if only doc or Markdown files changed
-#     - changes:
-#         - doc/**/*
-#         - '*.md'
-#       when: never
+workflow:
+  rules:
+    # Skip pipeline if only doc or Markdown files changed
+    - changes:
+        - doc/**/*
+        - '*.md'
+      when: never
 
-#     # Run pipeline for everything else
-#     - when: always
+    # Run pipeline for everything else
+    - when: always
 
 stages:
-  # - build-and-test
-  # - trigger
+  - build-and-test
+  - trigger
   - benchmark
 
-# build-and-test-project:
-#   stage: build-and-test
-#   tags: ["nvidia-gpus"]
-#   before_script:
-#     # Install pre-commit
-#     - pip3 install --user --break-system-packages pre-commit
-#     - export PATH="$HOME/.local/bin:$PATH"
+build-and-test-project:
+  stage: build-and-test
+  tags: ["nvidia-gpus"]
+  before_script:
+    # Install pre-commit
+    - pip3 install --user --break-system-packages pre-commit
+    - export PATH="$HOME/.local/bin:$PATH"
 
-#     # Optional: show versions of tools
-#     - cmake --version
-#     - clang++ --version || g++ --version
-#     - nvidia-smi
-#     - nvcc --version
+    # Optional: show versions of tools
+    - cmake --version
+    - clang++ --version || g++ --version
+    - nvidia-smi
+    - nvcc --version
 
-#   script:
-#     - cmake --preset develop -DCMAKE_CUDA_ARCHITECTURES=89 -DNeoN_WITH_THREADS=OFF
-#     - cmake --build --preset develop
-#     - ctest --preset develop --output-on-failure
+  script:
+    - cmake --preset develop -DCMAKE_CUDA_ARCHITECTURES=89 -DNeoN_WITH_THREADS=OFF
+    - cmake --build --preset develop
+    - ctest --preset develop --output-on-failure
 
-# trigger-foamadapter:
-#   stage: trigger
-#   tags: ["nvidia-gpus"]
-#   needs: ["build-and-test-project"]
-#   script:
-#     - curl --fail --request POST --form token=$FOAMADAPTER_TRIGGER_TOKEN --form ref=main --form variables[NEON_BRANCH]=$CI_COMMIT_REF_NAME --form variables[NEON_COMMIT]=$CI_COMMIT_SHA "${CI_API_V4_URL}/projects/1095/trigger/pipeline"
-#   rules:
-#     - when: on_success
+trigger-foamadapter:
+  stage: trigger
+  tags: ["nvidia-gpus"]
+  needs: ["build-and-test-project"]
+  script:
+    - curl --fail --request POST --form token=$FOAMADAPTER_TRIGGER_TOKEN --form ref=main --form variables[NEON_BRANCH]=$CI_COMMIT_REF_NAME --form variables[NEON_COMMIT]=$CI_COMMIT_SHA "${CI_API_V4_URL}/projects/1095/trigger/pipeline"
+  rules:
+    - when: on_success
 
 benchmark-on-tum-coma:
   stage: benchmark
   tags: ["nvidia-gpus"]
-  # needs: ["build-and-test-project"]
+  needs: ["trigger-foamadapter"]
   variables:
     RESULTS_DIR: "benchmark-results"
     RUN_IDENTIFIER: "${CI_PIPELINE_ID}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,7 +61,7 @@ benchmark-on-tum-coma:
 
     # Build & benchmark current branch
     - echo ">>> Build current branch"
-    - cmake --preset profiling
+    - cmake --preset profiling -DCMAKE_CUDA_ARCHITECTURES=89 -DNeoN_WITH_THREADS=OFF
     - cmake --build --preset profiling
     - ctest --preset profiling
     - mkdir -p results
@@ -77,7 +77,7 @@ benchmark-on-tum-coma:
     - echo ">>> Build main branch"
     - git fetch origin main
     - git checkout main
-    - cmake --preset profiling
+    - cmake --preset profiling -DCMAKE_CUDA_ARCHITECTURES=89 -DNeoN_WITH_THREADS=OFF
     - cmake --build --preset profiling
     - ctest --preset profiling
     - mkdir -p results/main

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -123,6 +123,9 @@ benchmark-on-tum-coma:
     - git pull --rebase || true
     - git push origin "${TARGET_BRANCH}"
 
-  # Only run benchmarks when manually triggered
-  when: manual
-  allow_failure: true
+  rules:
+    # Run automatically if commit message contains 'run-benchmark'
+    - if: '$CI_COMMIT_MESSAGE =~ /\[run-benchmark\]/i'
+      when: on_success
+    # Otherwise don't create the job at all
+    - when: never

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,8 +116,8 @@ benchmark-on-tum-coma:
     - git clone https://oauth2:${API_TOKEN_GITHUB}@${TARGET_REPO}
     - cd ${REPO_NAME}
     - git checkout "${TARGET_BRANCH}" || git checkout -b "${TARGET_BRANCH}"
-    - mkdir "${RUN_IDENTIFIER}
-    - cp -r ../${RESULTS_DIR}/* "${RUN_IDENTIFIER}
+    - mkdir "${RUN_IDENTIFIER}"
+    - cp -r ../${RESULTS_DIR}/* "${RUN_IDENTIFIER}"
     - git add .
     - git commit -m "Benchmarks from GitLab pipeline ${RUN_IDENTIFIER}" || echo "No changes to commit"
     - git pull --rebase || true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,8 +53,11 @@ benchmark-on-tum-coma:
   tags: ["nvidia-gpus"]
   # needs: ["build-and-test-project"]
   variables:
+    RESULTS_DIR: "benchmark-results"
     RUN_IDENTIFIER: "${CI_PIPELINE_ID}"
-    TARGET_REPO: "github.com/exasim-project/NeoFOAM-BenchmarkData.git"
+    REPO_NAME: "NeoFOAM-BenchmarkData"
+    TARGET_REPO: "github.com/exasim-project/${REPO_NAME}.git"
+    TARGET_BRANCH: "ci-benchmarks"
   script:
     # Install dependencies
     - pip3 install --user --break-system-packages xmltodict
@@ -63,14 +66,14 @@ benchmark-on-tum-coma:
     - echo ">>> Build current branch"
     - cmake --preset profiling -DCMAKE_CUDA_ARCHITECTURES=89 -DNeoN_WITH_THREADS=OFF
     - cmake --build --preset profiling
+    - echo ">>> Running benchmarks...(current branch)"
     - ctest --preset profiling
-    - mkdir -p results
+    - mkdir -p ${RESULTS_DIR}/main
     - cd build/profiling/bin/benchmarks
     - python3 ../../../../scripts/catch2json.py
-    - cp *.json ../../../..
-    - cd ../../../..
-    - mv *.json results/
-    - lscpu > results/lscpu.log
+    - cd ../../../
+    - cp build/profiling/bin/benchmarks/*.json ${RESULTS_DIR}/
+    - lscpu > ${RESULTS_DIR}/lscpu.log
     - rm -rf build
 
     # Build & benchmark main branch
@@ -79,22 +82,23 @@ benchmark-on-tum-coma:
     - git checkout main
     - cmake --preset profiling -DCMAKE_CUDA_ARCHITECTURES=89 -DNeoN_WITH_THREADS=OFF
     - cmake --build --preset profiling
+    - echo ">>> Running benchmarks...(main branch)"
     - ctest --preset profiling
-    - mkdir -p results/main
     - cd build/profiling/bin/benchmarks
     - python3 ../../../../scripts/catch2json.py
-    - cp *.json ../../../..
     - cd ../../../..
-    - mv *.json results/main/
+    - cp build/profiling/bin/benchmarks/*.json ${RESULTS_DIR}/main/
+    - lscpu > ${RESULTS_DIR}/main/lscpu.log
 
     # Push benchmark results to GitHub
     - git config --global user.email "gitlab-ci@users.noreply.github.com"
     - git config --global user.name "GitLab CI"
-    - git clone https://oauth2:${API_TOKEN_GITHUB}@${TARGET_REPO} gh-target
-    - cd gh-target
+    - git clone https://oauth2:${API_TOKEN_GITHUB}@${TARGET_REPO}
+    - cd ${REPO_NAME}
+    - git checkout "${TARGET_BRANCH}" || git checkout -b "${TARGET_BRANCH}"
     - mkdir -p "${RUN_IDENTIFIER}/${CI_RUNNER_DESCRIPTION}"
-    - cp -r ../results/* "${RUN_IDENTIFIER}/${CI_RUNNER_DESCRIPTION}/"
+    - cp -r ../${RESULTS_DIR}/* "${RUN_IDENTIFIER}/${CI_RUNNER_DESCRIPTION}/"
     - git add .
     - git commit -m "Benchmarks from GitLab pipeline ${CI_PIPELINE_ID}" || echo "No changes to commit"
     - git pull --rebase || true
-    - git push origin main
+    - git push origin "${TARGET_BRANCH}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,18 +62,38 @@ benchmark-on-tum-coma:
     # Install dependencies
     - pip3 install --user --break-system-packages xmltodict
 
+    # Collect system info (CPU, GPU, compilers)
+    - mkdir ${RESULTS_DIR}
+    - |
+      {
+        echo "===== CPU INFO ====="
+        lscpu
+        echo ""
+        echo "===== GPU INFO ====="
+        nvidia-smi --query-gpu=gpu_name,memory.total,driver_version --format=csv || echo "No GPU found"
+        echo ""
+        echo "===== COMPILER INFO ====="
+        echo "CMake:"
+        cmake --version
+        echo ""
+        echo "C++ compiler:"
+        clang++ --version || g++ --version || echo "No C++ compiler found"
+        echo ""
+        echo "CUDA compiler:"
+        nvcc --version || echo "nvcc not available"
+      } > ${RESULTS_DIR}/system-info.log
+
     # Build & benchmark current branch
     - echo ">>> Build current branch"
     - cmake --preset profiling -DCMAKE_CUDA_ARCHITECTURES=89 -DNeoN_WITH_THREADS=OFF
     - cmake --build --preset profiling
     - echo ">>> Running benchmarks...(current branch)"
     - ctest --preset profiling
-    - mkdir -p ${RESULTS_DIR}/main
     - cd build/profiling/bin/benchmarks
     - python3 ../../../../scripts/catch2json.py
     - cd ../../../..
     - cp build/profiling/bin/benchmarks/*.json ${RESULTS_DIR}/
-    - lscpu > ${RESULTS_DIR}/lscpu.log
+
     - rm -rf build
 
     # Build & benchmark main branch
@@ -87,8 +107,8 @@ benchmark-on-tum-coma:
     - cd build/profiling/bin/benchmarks
     - python3 ../../../../scripts/catch2json.py
     - cd ../../../..
+    - mkdir -p ${RESULTS_DIR}/main
     - cp build/profiling/bin/benchmarks/*.json ${RESULTS_DIR}/main/
-    - lscpu > ${RESULTS_DIR}/main/lscpu.log
 
     # Push benchmark results to GitHub
     - git config --global user.email "gitlab-ci@users.noreply.github.com"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -122,3 +122,7 @@ benchmark-on-tum-coma:
     - git commit -m "Benchmarks from GitLab pipeline ${RUN_IDENTIFIER}" || echo "No changes to commit"
     - git pull --rebase || true
     - git push origin "${TARGET_BRANCH}"
+
+  # Only run benchmarks when manually triggered
+  when: manual
+  allow_failure: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,9 +116,9 @@ benchmark-on-tum-coma:
     - git clone https://oauth2:${API_TOKEN_GITHUB}@${TARGET_REPO}
     - cd ${REPO_NAME}
     - git checkout "${TARGET_BRANCH}" || git checkout -b "${TARGET_BRANCH}"
-    - mkdir -p "${RUN_IDENTIFIER}/${CI_RUNNER_DESCRIPTION}"
-    - cp -r ../${RESULTS_DIR}/* "${RUN_IDENTIFIER}/${CI_RUNNER_DESCRIPTION}/"
+    - mkdir "${RUN_IDENTIFIER}
+    - cp -r ../${RESULTS_DIR}/* "${RUN_IDENTIFIER}
     - git add .
-    - git commit -m "Benchmarks from GitLab pipeline ${CI_PIPELINE_ID}" || echo "No changes to commit"
+    - git commit -m "Benchmarks from GitLab pipeline ${RUN_IDENTIFIER}" || echo "No changes to commit"
     - git pull --rebase || true
     - git push origin "${TARGET_BRANCH}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -71,7 +71,7 @@ benchmark-on-tum-coma:
     - mkdir -p ${RESULTS_DIR}/main
     - cd build/profiling/bin/benchmarks
     - python3 ../../../../scripts/catch2json.py
-    - cd ../../../
+    - cd ../../../..
     - cp build/profiling/bin/benchmarks/*.json ${RESULTS_DIR}/
     - lscpu > ${RESULTS_DIR}/lscpu.log
     - rm -rf build


### PR DESCRIPTION
# Motivation
Our current GitLab CI pipeline does the following:

1. check if changes in NeoN pass the tests
2. trigger FoamAdapter CI pipeline  to see if changes in NeoN work with FoamAdapter

Besides the correctness, we also want to know the performance of new changes compared to the main branch. Therefore, a GitLab CI job for benchmarking is set up in this PR.

In addition to the performance results, the system information (CPU, GPU and compilers) is also included as part of benchmark dataset.

Fixes #352 
