### PR TITLE
Skip the build job on a PR with label "Skip-build"

### DIFF
--- a/.github/workflows/build_on_ubuntu.yaml
+++ b/.github/workflows/build_on_ubuntu.yaml
@@ -7,9 +7,7 @@ on:
       - dev
       - main
   pull_request:
-    types:
-      - synchronize
-      - opened
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   schedule:
     - cron: "0 9 * * *"
 
@@ -23,8 +21,9 @@ concurrency:
 
 jobs:
   build:
-    if: ${{!contains(github.event.pull_request.labels.*.name, 'Skip-build')}}
     name: Build NeoN on ubuntu
+    runs-on: ubuntu-latest
+    if: "!contains(toJson(github.event.pull_request.labels.*.name), 'Skip-build')"
     strategy:
       fail-fast: false
       matrix:
@@ -43,7 +42,6 @@ jobs:
               CC: clang
               CXX: clang++
             preset: "profiling"
-    runs-on: ubuntu-latest
     steps:
      - name: Checkout to repository
        uses: actions/checkout@v4

--- a/.github/workflows/build_on_windows.yaml
+++ b/.github/workflows/build_on_windows.yaml
@@ -6,9 +6,7 @@ on:
       - dev
       - main
   pull_request:
-    types:
-      - synchronize
-      - opened
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   schedule:
     - cron: "0 9 * * *"
 
@@ -21,7 +19,7 @@ env:
 
 jobs:
   windows_msvc:
-    if: ${{!contains(github.event.pull_request.labels.*.name, 'Skip-build')}}
+    if: "!contains(toJson(github.event.pull_request.labels.*.name), 'Skip-build')"
     name: msvc
     runs-on: [windows-latest]
     steps:


### PR DESCRIPTION
# Motivation
The current build workflows do not always work as expected: Some build jobs are still running on a PR labeled with "Skip-build".

This PR tries to fix this issue. A PR labeled with "Skip-build" should not trigger any build job.
