### PR TITLE
Skip GitLab CI pipeline for commit message containing [skip-gitlab-ci]

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ image: greole/neon-cuda
 workflow:
   rules:
     # Skip pipeline if commit message contains [skip-gitlab-ci]
-    - if: $CI_COMMIT_MESSAGE =~ /\[skip-gitlab-ci\]/i
+    - if: '$CI_COMMIT_MESSAGE =~ /\[skip-gitlab-ci\]/i'
       when: never
 
     # Skip pipeline if only doc or Markdown files changed

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,10 @@ image: greole/neon-cuda
 
 workflow:
   rules:
+    # Skip pipeline if commit message contains [skip-gitlab-ci]
+    - if: $CI_COMMIT_MESSAGE =~ /\[skip-gitlab-ci\]/i
+      when: never
+
     # Skip pipeline if only doc or Markdown files changed
     - changes:
         - doc/**/*


### PR DESCRIPTION
# Motivation
NeoN's GitLab CI pipeline is mainly used for building and running NeoN on GPUs. In some cases, GitLab CI pipeline can be skipped to save GPU resources for other cases which really need GPUs.