### PR TITLE
Set up CI on a AMD GPU

### DIFF
--- a/.github/scripts/cancel_triggered_pipelines.sh
+++ b/.github/scripts/cancel_triggered_pipelines.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # Arguments
 PROJECT=$1        # GitLab project name, e.g., "NeoN" or "FoamAdapter"
 BRANCH=$2         # Branch/ref to filter pipelines
-TOKEN=$3          # GitLab private token
+TOKEN=$3
 
 # Read environment variables defined in GitHub workflow
 LRZ_GROUP="${LRZ_GROUP:?LRZ_GROUP is not set in environment}"
@@ -43,12 +43,23 @@ if [ -z "$pipeline_ids" ]; then
   exit 0
 fi
 
-# Cancel each pipeline
+# Cancel each pipeline only if NEON_BRANCH variable is set
 for id in $pipeline_ids; do
-  echo "Cancelling pipeline $id..."
-  curl -s --request POST \
-    --header "PRIVATE-TOKEN: $TOKEN" \
-    "https://${LRZ_HOST}/api/v4/projects/${project_path}/pipelines/${id}/cancel"
+  echo "Checking pipeline $id for NEON_BRANCH..."
+
+  vars=$(curl -s --header "PRIVATE-TOKEN: $TOKEN" \
+    "https://${LRZ_HOST}/api/v4/projects/${project_path}/pipelines/${id}/variables")
+
+  neon_branch=$(echo "$vars" | jq -r '.[] | select(.key=="NEON_BRANCH") | .value' || true)
+
+  if [[ -n "$neon_branch" && "$neon_branch" != "null" ]]; then
+    echo "Cancelling pipeline $id (NEON_BRANCH=$neon_branch)..."
+    curl -s --request POST \
+      --header "PRIVATE-TOKEN: $TOKEN" \
+      "https://${LRZ_HOST}/api/v4/projects/${project_path}/pipelines/${id}/cancel"
+  else
+    echo "Skipping pipeline $id (NEON_BRANCH not set)."
+  fi
 done
 
 echo "All applicable pipelines cancelled."

--- a/.github/scripts/cancel_triggered_pipelines.sh
+++ b/.github/scripts/cancel_triggered_pipelines.sh
@@ -1,8 +1,10 @@
+#!/usr/bin/env bash
+#----------------------------------------------------------------------------------------
 # This script cancels all running or pending LRZ GitLab CI pipelines on TUM COMA cluster
 # for a specified project and branch. Only pipelines triggered via the trigger token
 # (i.e., from NeoN GitHub CI) are considered.
+#----------------------------------------------------------------------------------------
 
-#!/usr/bin/env bash
 set -euo pipefail
 
 # Arguments

--- a/.github/scripts/trigger_pipeline.sh
+++ b/.github/scripts/trigger_pipeline.sh
@@ -7,12 +7,13 @@ set -euo pipefail
 # Arguments
 PROJECT=$1
 BRANCH=$2
-TOKEN=$3
-shift 3
-VARIABLES="$@"   # Optional extra variables in the form: "variables[KEY]=VALUE"
+CHECK_TOKEN=$3     # read_repository scope
+TRIGGER_TOKEN=$4   # LRZ GitLab trigger token
+shift 4
+VARIABLES="$@"     # Optional extra variables in the form: "variables[KEY]=VALUE"
 
-if [ -z "$PROJECT" ] || [ -z "$BRANCH" ] || [ -z "$TOKEN" ]; then
-  echo "Usage: $0 <project> <branch> <token> [optional variables]"
+if [ -z "$PROJECT" ] || [ -z "$BRANCH" ] || [ -z "$CHECK_TOKEN" ] || [ -z "$TRIGGER_TOKEN" ]; then
+  echo "Usage: $0 <project> <branch> <check_token> <trigger_token> [optional variables]"
   exit 1
 fi
 
@@ -20,20 +21,23 @@ fi
 : "${LRZ_HOST:?Need to set LRZ_HOST}"
 : "${LRZ_GROUP:?Need to set LRZ_GROUP}"
 
-# Check if branch exists in LRZ GitLab
-branch_exists=$(curl -s --header "PRIVATE-TOKEN: $TOKEN" \
-  "https://${LRZ_HOST}/api/v4/projects/${LRZ_GROUP}%2F${PROJECT}/repository/branches/${BRANCH}" \
+# URL-encode branch name
+BRANCH_ENC=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$BRANCH")
+
+# Check if branch exists in GitLab using CHECK_TOKEN
+branch_exists=$(curl -s --header "PRIVATE-TOKEN: $CHECK_TOKEN" \
+  "https://${LRZ_HOST}/api/v4/projects/${LRZ_GROUP}%2F${PROJECT}/repository/branches/${BRANCH_ENC}" \
   | jq -r '.name // empty')
 
 if [ -n "$branch_exists" ]; then
-  echo "Branch '$BRANCH' exists. Using it for pipeline trigger."
+  echo "Branch '$BRANCH' exists in $PROJECT. Using it for pipeline trigger."
 else
-  echo "Branch '$BRANCH' does not exist. Falling back to 'main'."
+  echo "Branch '$BRANCH' does not exist in $PROJECT. Falling back to 'main'."
   BRANCH="main"
 fi
 
 # Prepare curl form data for variables
-FORM_DATA="--form ref=$BRANCH --form token=$TOKEN"
+FORM_DATA="--form ref=$BRANCH --form token=$TRIGGER_TOKEN"
 for var in $VARIABLES; do
   FORM_DATA="$FORM_DATA --form $var"
 done
@@ -50,6 +54,6 @@ if [ -z "$pipeline_id" ] || [ "$pipeline_id" = "null" ]; then
   exit 1
 fi
 
-echo "pipeline_id=$pipeline_id"
+echo "Triggered pipeline $pipeline_id on branch $BRANCH"
 # Set GitHub Actions output
 echo "pipeline_id=$pipeline_id" >> "$GITHUB_OUTPUT"

--- a/.github/scripts/trigger_pipeline.sh
+++ b/.github/scripts/trigger_pipeline.sh
@@ -1,7 +1,9 @@
+#!/usr/bin/env bash
+#----------------------------------------------------------------------------------------
 # This script triggers a LRZ GitLab CI pipeline on TUM COMA cluster for a specified project and branch.
 # Optionally, extra variables can be passed in the form: "variables[KEY]=VALUE".
+#----------------------------------------------------------------------------------------
 
-#!/usr/bin/env bash
 set -euo pipefail
 
 # Arguments

--- a/.github/scripts/trigger_pipeline.sh
+++ b/.github/scripts/trigger_pipeline.sh
@@ -16,6 +16,22 @@ if [ -z "$PROJECT" ] || [ -z "$BRANCH" ] || [ -z "$TOKEN" ]; then
   exit 1
 fi
 
+# Default LRZ host and group must be set in environment
+: "${LRZ_HOST:?Need to set LRZ_HOST}"
+: "${LRZ_GROUP:?Need to set LRZ_GROUP}"
+
+# Check if branch exists in LRZ GitLab
+branch_exists=$(curl -s --header "PRIVATE-TOKEN: $TOKEN" \
+  "https://${LRZ_HOST}/api/v4/projects/${LRZ_GROUP}%2F${PROJECT}/repository/branches/${BRANCH}" \
+  | jq -r '.name // empty')
+
+if [ -n "$branch_exists" ]; then
+  echo "Branch '$BRANCH' exists. Using it for pipeline trigger."
+else
+  echo "Branch '$BRANCH' does not exist. Falling back to 'main'."
+  BRANCH="main"
+fi
+
 # Prepare curl form data for variables
 FORM_DATA="--form ref=$BRANCH --form token=$TOKEN"
 for var in $VARIABLES; do
@@ -30,7 +46,7 @@ echo "$response" | jq .
 
 pipeline_id=$(echo "$response" | jq -r '.id')
 if [ -z "$pipeline_id" ] || [ "$pipeline_id" = "null" ]; then
-  echo "Failed to trigger pipeline for project $PROJECT"
+  echo "Failed to trigger pipeline for project $PROJECT on branch $BRANCH"
   exit 1
 fi
 

--- a/.github/scripts/wait_pipeline.sh
+++ b/.github/scripts/wait_pipeline.sh
@@ -1,8 +1,10 @@
+#!/usr/bin/env bash
+#----------------------------------------------------------------------------------------
 # This script monitors the status of a LRZ GitLab CI pipeline on TUM COMA cluster
 # for a specified project and pipeline ID. It checks the status every minute until
 # the pipeline succeeds, fails, or a maximum wait time is reached.
+#----------------------------------------------------------------------------------------
 
-#!/usr/bin/env bash
 set -euo pipefail
 
 PROJECT=$1

--- a/.github/scripts/wait_pipeline.sh
+++ b/.github/scripts/wait_pipeline.sh
@@ -10,9 +10,6 @@ PIPELINE_ID=$2
 TOKEN=$3
 MAX_WAIT_MINUTES=${MAX_WAIT_MINUTES:-1440}
 
-SUCCESS_STATUSES=("success")
-FAILURE_STATUSES=("failed" "canceled" "skipped")
-
 # Construct pipeline URL
 pipeline_url="https://${LRZ_HOST}/${LRZ_GROUP}/${PROJECT}/-/pipelines/${PIPELINE_ID}"
 
@@ -28,11 +25,11 @@ for i in $(seq 1 "$MAX_WAIT_MINUTES"); do
   echo "[$i] $PROJECT pipeline status: $status"
 
   case "$status" in
-    ${SUCCESS_STATUSES[*]})
+    success)
       echo "$PROJECT CI pipeline succeeded"
       exit 0
       ;;
-    ${FAILURE_STATUSES[*]})
+    failed|canceled|skipped)
       echo "$PROJECT CI pipeline finished with status: $status"
       exit 1
       ;;

--- a/.github/workflows/build_adapter.yaml
+++ b/.github/workflows/build_adapter.yaml
@@ -23,7 +23,16 @@ concurrency:
 
 jobs:
   build:
-    if: ${{!contains(github.event.pull_request.labels.*.name, 'Skip-build')}}
+    if: |
+      (
+        github.event.action == 'opened' ||
+        github.event.action == 'synchronize' ||
+        github.event.action == 'reopened'
+      ) && !contains(toJson(github.event.pull_request.labels.*.name), 'Skip-build')
+      || (
+       github.event.action == 'unlabeled' &&
+        github.event.label.name == 'Skip-build'
+      )
     name: Build FoamAdapter
     strategy:
       fail-fast: false

--- a/.github/workflows/build_adapter.yaml
+++ b/.github/workflows/build_adapter.yaml
@@ -4,14 +4,13 @@ run-name: 'Adapter Integration Test'
 on:
   push:
     branches: [dev, main]
-    paths-ignore:
-      - 'doc/**'
+
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-    paths-ignore:
-      - 'doc/**'
+
   schedule:
     - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday
+
   workflow_dispatch:      # Optional: allows manual trigger
 
 env:

--- a/.github/workflows/build_adapter.yaml
+++ b/.github/workflows/build_adapter.yaml
@@ -5,14 +5,14 @@ on:
   push:
     branches: [dev, main]
     paths-ignore:
-      - 'docs/**'
-      - '**.md'
+      - 'doc/**'
+      - '*.md'
       - '**/*.md'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
-      - 'docs/**'
-      - '**.md'
+      - 'doc/**'
+      - '*.md'
       - '**/*.md'
   schedule:
     - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday

--- a/.github/workflows/build_adapter.yaml
+++ b/.github/workflows/build_adapter.yaml
@@ -3,13 +3,18 @@ run-name: 'Adapter Integration Test'
 
 on:
   push:
-    branches:
-      - dev
-      - main
+    branches: [dev, main]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
   pull_request:
-    types: synchronize
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
   schedule:
-    - cron: "0 6 * * 1"
+    - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday
+  workflow_dispatch:      # Optional: allows manual trigger
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1

--- a/.github/workflows/build_adapter.yaml
+++ b/.github/workflows/build_adapter.yaml
@@ -5,15 +5,11 @@ on:
   push:
     branches: [dev, main]
     paths-ignore:
-      - 'doc/**/*'
-      - '*.md'
-      - '**/*.md'
+      - 'doc/**'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
-      - 'doc/**/*'
-      - '*.md'
-      - '**/*.md'
+      - 'doc/**'
   schedule:
     - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday
   workflow_dispatch:      # Optional: allows manual trigger

--- a/.github/workflows/build_adapter.yaml
+++ b/.github/workflows/build_adapter.yaml
@@ -6,11 +6,13 @@ on:
     branches: [dev, main]
     paths-ignore:
       - 'docs/**'
+      - '**.md'
       - '**/*.md'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
       - 'docs/**'
+      - '**.md'
       - '**/*.md'
   schedule:
     - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday

--- a/.github/workflows/build_adapter.yaml
+++ b/.github/workflows/build_adapter.yaml
@@ -5,13 +5,13 @@ on:
   push:
     branches: [dev, main]
     paths-ignore:
-      - 'doc/**'
+      - 'doc/**/*'
       - '*.md'
       - '**/*.md'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
-      - 'doc/**'
+      - 'doc/**/*'
       - '*.md'
       - '**/*.md'
   schedule:

--- a/.github/workflows/build_adapter.yaml
+++ b/.github/workflows/build_adapter.yaml
@@ -4,13 +4,10 @@ run-name: 'Adapter Integration Test'
 on:
   push:
     branches: [dev, main]
-
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-
   schedule:
     - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday
-
   workflow_dispatch:      # Optional: allows manual trigger
 
 env:
@@ -23,16 +20,7 @@ concurrency:
 
 jobs:
   build:
-    if: |
-      (
-        github.event.action == 'opened' ||
-        github.event.action == 'synchronize' ||
-        github.event.action == 'reopened'
-      ) && !contains(toJson(github.event.pull_request.labels.*.name), 'Skip-build')
-      || (
-       github.event.action == 'unlabeled' &&
-        github.event.label.name == 'Skip-build'
-      )
+    if: "!contains(toJson(github.event.pull_request.labels.*.name), 'Skip-build')"
     name: Build FoamAdapter
     strategy:
       fail-fast: false

--- a/.github/workflows/build_on_macos.yaml
+++ b/.github/workflows/build_on_macos.yaml
@@ -3,15 +3,18 @@ run-name: 'Build workflow'
 
 on:
   push:
-    branches:
-      - dev
-      - main
+    branches: [dev, main]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
   pull_request:
-    types:
-      - synchronize
-      - opened
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
   schedule:
-    - cron: "0 9 * * *"
+    - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday
+  workflow_dispatch:      # Optional: allows manual trigger
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1

--- a/.github/workflows/build_on_macos.yaml
+++ b/.github/workflows/build_on_macos.yaml
@@ -5,14 +5,14 @@ on:
   push:
     branches: [dev, main]
     paths-ignore:
-      - 'docs/**'
-      - '**.md'
+      - 'doc/**'
+      - '*.md'
       - '**/*.md'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
-      - 'docs/**'
-      - '**.md'
+      - 'doc/**'
+      - '*.md'
       - '**/*.md'
   schedule:
     - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday

--- a/.github/workflows/build_on_macos.yaml
+++ b/.github/workflows/build_on_macos.yaml
@@ -23,7 +23,16 @@ concurrency:
 
 jobs:
   build:
-    if: ${{contains(github.event.pull_request.labels.*.name, 'full-ci')}}
+    if: |
+      (
+        github.event.action == 'opened' ||
+        github.event.action == 'synchronize' ||
+        github.event.action == 'reopened'
+      ) && !contains(toJson(github.event.pull_request.labels.*.name), 'Skip-build')
+      || (
+       github.event.action == 'unlabeled' &&
+        github.event.label.name == 'Skip-build'
+      )
     name: Build NeoN on MacOs
     strategy:
       fail-fast: false

--- a/.github/workflows/build_on_macos.yaml
+++ b/.github/workflows/build_on_macos.yaml
@@ -5,15 +5,11 @@ on:
   push:
     branches: [dev, main]
     paths-ignore:
-      - 'doc/**/*'
-      - '*.md'
-      - '**/*.md'
+      - 'doc/**'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
-      - 'doc/**/*'
-      - '*.md'
-      - '**/*.md'
+      - 'doc/**'
   schedule:
     - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday
   workflow_dispatch:      # Optional: allows manual trigger

--- a/.github/workflows/build_on_macos.yaml
+++ b/.github/workflows/build_on_macos.yaml
@@ -6,11 +6,13 @@ on:
     branches: [dev, main]
     paths-ignore:
       - 'docs/**'
+      - '**.md'
       - '**/*.md'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
       - 'docs/**'
+      - '**.md'
       - '**/*.md'
   schedule:
     - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday

--- a/.github/workflows/build_on_macos.yaml
+++ b/.github/workflows/build_on_macos.yaml
@@ -5,13 +5,13 @@ on:
   push:
     branches: [dev, main]
     paths-ignore:
-      - 'doc/**'
+      - 'doc/**/*'
       - '*.md'
       - '**/*.md'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
-      - 'doc/**'
+      - 'doc/**/*'
       - '*.md'
       - '**/*.md'
   schedule:

--- a/.github/workflows/build_on_macos.yaml
+++ b/.github/workflows/build_on_macos.yaml
@@ -4,14 +4,13 @@ run-name: 'Build workflow'
 on:
   push:
     branches: [dev, main]
-    paths-ignore:
-      - 'doc/**'
+
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-    paths-ignore:
-      - 'doc/**'
+
   schedule:
     - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday
+
   workflow_dispatch:      # Optional: allows manual trigger
 
 env:

--- a/.github/workflows/build_on_macos.yaml
+++ b/.github/workflows/build_on_macos.yaml
@@ -4,13 +4,10 @@ run-name: 'Build workflow'
 on:
   push:
     branches: [dev, main]
-
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-
   schedule:
     - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday
-
   workflow_dispatch:      # Optional: allows manual trigger
 
 env:
@@ -23,16 +20,7 @@ concurrency:
 
 jobs:
   build:
-    if: |
-      (
-        github.event.action == 'opened' ||
-        github.event.action == 'synchronize' ||
-        github.event.action == 'reopened'
-      ) && !contains(toJson(github.event.pull_request.labels.*.name), 'Skip-build')
-      || (
-       github.event.action == 'unlabeled' &&
-        github.event.label.name == 'Skip-build'
-      )
+    if: "!contains(toJson(github.event.pull_request.labels.*.name), 'Skip-build')"
     name: Build NeoN on MacOs
     strategy:
       fail-fast: false

--- a/.github/workflows/build_on_ubuntu.yaml
+++ b/.github/workflows/build_on_ubuntu.yaml
@@ -5,14 +5,14 @@ on:
   push:
     branches: [dev, main]
     paths-ignore:
-      - 'docs/**'
-      - '**.md'
+      - 'doc/**'
+      - '*.md'
       - '**/*.md'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
-      - 'docs/**'
-      - '**.md'
+      - 'doc/**'
+      - '*.md'
       - '**/*.md'
   schedule:
     - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday

--- a/.github/workflows/build_on_ubuntu.yaml
+++ b/.github/workflows/build_on_ubuntu.yaml
@@ -5,15 +5,11 @@ on:
   push:
     branches: [dev, main]
     paths-ignore:
-      - 'doc/**/*'
-      - '*.md'
-      - '**/*.md'
+      - 'doc/**'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
-      - 'doc/**/*'
-      - '*.md'
-      - '**/*.md'
+      - 'doc/**'
   schedule:
     - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday
   workflow_dispatch:      # Optional: allows manual trigger

--- a/.github/workflows/build_on_ubuntu.yaml
+++ b/.github/workflows/build_on_ubuntu.yaml
@@ -6,11 +6,13 @@ on:
     branches: [dev, main]
     paths-ignore:
       - 'docs/**'
+      - '**.md'
       - '**/*.md'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
       - 'docs/**'
+      - '**.md'
       - '**/*.md'
   schedule:
     - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday

--- a/.github/workflows/build_on_ubuntu.yaml
+++ b/.github/workflows/build_on_ubuntu.yaml
@@ -5,13 +5,13 @@ on:
   push:
     branches: [dev, main]
     paths-ignore:
-      - 'doc/**'
+      - 'doc/**/*'
       - '*.md'
       - '**/*.md'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
-      - 'doc/**'
+      - 'doc/**/*'
       - '*.md'
       - '**/*.md'
   schedule:

--- a/.github/workflows/build_on_ubuntu.yaml
+++ b/.github/workflows/build_on_ubuntu.yaml
@@ -4,14 +4,13 @@ run-name: 'Build workflow'
 on:
   push:
     branches: [dev, main]
-    paths-ignore:
-      - 'doc/**'
+
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-    paths-ignore:
-      - 'doc/**'
+
   schedule:
     - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday
+
   workflow_dispatch:      # Optional: allows manual trigger
 
 env:

--- a/.github/workflows/build_on_ubuntu.yaml
+++ b/.github/workflows/build_on_ubuntu.yaml
@@ -4,13 +4,10 @@ run-name: 'Build workflow'
 on:
   push:
     branches: [dev, main]
-
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-
   schedule:
     - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday
-
   workflow_dispatch:      # Optional: allows manual trigger
 
 env:
@@ -25,16 +22,7 @@ jobs:
   build:
     name: Build NeoN on ubuntu
     runs-on: ubuntu-latest
-    if: |
-      (
-        github.event.action == 'opened' ||
-        github.event.action == 'synchronize' ||
-        github.event.action == 'reopened'
-      ) && !contains(toJson(github.event.pull_request.labels.*.name), 'Skip-build')
-      || (
-       github.event.action == 'unlabeled' &&
-        github.event.label.name == 'Skip-build'
-      )
+    if: "!contains(toJson(github.event.pull_request.labels.*.name), 'Skip-build')"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build_on_ubuntu.yaml
+++ b/.github/workflows/build_on_ubuntu.yaml
@@ -25,7 +25,16 @@ jobs:
   build:
     name: Build NeoN on ubuntu
     runs-on: ubuntu-latest
-    if: "!contains(toJson(github.event.pull_request.labels.*.name), 'Skip-build')"
+    if: |
+      (
+        github.event.action == 'opened' ||
+        github.event.action == 'synchronize' ||
+        github.event.action == 'reopened'
+      ) && !contains(toJson(github.event.pull_request.labels.*.name), 'Skip-build')
+      || (
+       github.event.action == 'unlabeled' &&
+        github.event.label.name == 'Skip-build'
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build_on_ubuntu.yaml
+++ b/.github/workflows/build_on_ubuntu.yaml
@@ -3,13 +3,18 @@ run-name: 'Build workflow'
 
 on:
   push:
-    branches:
-      - dev
-      - main
+    branches: [dev, main]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
   schedule:
-    - cron: "0 9 * * *"
+    - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday
+  workflow_dispatch:      # Optional: allows manual trigger
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1

--- a/.github/workflows/build_on_windows.yaml
+++ b/.github/workflows/build_on_windows.yaml
@@ -3,13 +3,10 @@ name: Build NeoN on Windows
 on:
   push:
     branches: [dev, main]
-
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-
   schedule:
     - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday
-
   workflow_dispatch:      # Optional: allows manual trigger
 
 concurrency:
@@ -21,16 +18,7 @@ env:
 
 jobs:
   windows_msvc:
-    if: |
-      (
-        github.event.action == 'opened' ||
-        github.event.action == 'synchronize' ||
-        github.event.action == 'reopened'
-      ) && !contains(toJson(github.event.pull_request.labels.*.name), 'Skip-build')
-      || (
-        github.event.action == 'unlabeled' &&
-        github.event.label.name == 'Skip-build'
-      )
+    if: "!contains(toJson(github.event.pull_request.labels.*.name), 'Skip-build')"
     name: msvc
     runs-on: [windows-latest]
     steps:

--- a/.github/workflows/build_on_windows.yaml
+++ b/.github/workflows/build_on_windows.yaml
@@ -2,13 +2,18 @@ name: Build NeoN on Windows
 
 on:
   push:
-    branches:
-      - dev
-      - main
+    branches: [dev, main]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
   schedule:
-    - cron: "0 9 * * *"
+    - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday
+  workflow_dispatch:      # Optional: allows manual trigger
 
 concurrency:
   group: ${{ github.workflow }}-${{ (github.head_ref && github.ref) || github.run_id }}

--- a/.github/workflows/build_on_windows.yaml
+++ b/.github/workflows/build_on_windows.yaml
@@ -4,15 +4,11 @@ on:
   push:
     branches: [dev, main]
     paths-ignore:
-      - 'doc/**/*'
-      - '*.md'
-      - '**/*.md'
+      - 'doc/**'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
-      - 'doc/**/*'
-      - '*.md'
-      - '**/*.md'
+      - 'doc/**'
   schedule:
     - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday
   workflow_dispatch:      # Optional: allows manual trigger

--- a/.github/workflows/build_on_windows.yaml
+++ b/.github/workflows/build_on_windows.yaml
@@ -5,11 +5,13 @@ on:
     branches: [dev, main]
     paths-ignore:
       - 'docs/**'
+      - '**.md'
       - '**/*.md'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
       - 'docs/**'
+      - '**.md'
       - '**/*.md'
   schedule:
     - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday

--- a/.github/workflows/build_on_windows.yaml
+++ b/.github/workflows/build_on_windows.yaml
@@ -4,13 +4,13 @@ on:
   push:
     branches: [dev, main]
     paths-ignore:
-      - 'doc/**'
+      - 'doc/**/*'
       - '*.md'
       - '**/*.md'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
-      - 'doc/**'
+      - 'doc/**/*'
       - '*.md'
       - '**/*.md'
   schedule:

--- a/.github/workflows/build_on_windows.yaml
+++ b/.github/workflows/build_on_windows.yaml
@@ -3,14 +3,13 @@ name: Build NeoN on Windows
 on:
   push:
     branches: [dev, main]
-    paths-ignore:
-      - 'doc/**'
+
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-    paths-ignore:
-      - 'doc/**'
+
   schedule:
     - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday
+
   workflow_dispatch:      # Optional: allows manual trigger
 
 concurrency:

--- a/.github/workflows/build_on_windows.yaml
+++ b/.github/workflows/build_on_windows.yaml
@@ -4,14 +4,14 @@ on:
   push:
     branches: [dev, main]
     paths-ignore:
-      - 'docs/**'
-      - '**.md'
+      - 'doc/**'
+      - '*.md'
       - '**/*.md'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
-      - 'docs/**'
-      - '**.md'
+      - 'doc/**'
+      - '*.md'
       - '**/*.md'
   schedule:
     - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday

--- a/.github/workflows/build_on_windows.yaml
+++ b/.github/workflows/build_on_windows.yaml
@@ -21,7 +21,16 @@ env:
 
 jobs:
   windows_msvc:
-    if: "!contains(toJson(github.event.pull_request.labels.*.name), 'Skip-build')"
+    if: |
+      (
+        github.event.action == 'opened' ||
+        github.event.action == 'synchronize' ||
+        github.event.action == 'reopened'
+      ) && !contains(toJson(github.event.pull_request.labels.*.name), 'Skip-build')
+      || (
+        github.event.action == 'unlabeled' &&
+        github.event.label.name == 'Skip-build'
+      )
     name: msvc
     runs-on: [windows-latest]
     steps:

--- a/.github/workflows/trigger-lrz-gitlab-ci.yaml
+++ b/.github/workflows/trigger-lrz-gitlab-ci.yaml
@@ -5,7 +5,7 @@ on:
     branches: [dev, main]
 
   pull_request:
-    types: [opened, synchronize, reopened, unlabeled]
+    types: [opened, synchronize, reopened, unlabeled, labeled]
 
   schedule:
     - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday

--- a/.github/workflows/trigger-lrz-gitlab-ci.yaml
+++ b/.github/workflows/trigger-lrz-gitlab-ci.yaml
@@ -29,6 +29,10 @@ jobs:
       LRZ_HOST: gitlab-ce.lrz.de
       REPO_NAME: ${{ github.event.repository.name }}
       FOAMADAPTER_REPO: FoamAdapter
+      NEON_PROJECT_TOKEN: ${{ secrets.GITLAB_PROJECT_TOKEN }}
+      NEON_TRIGGER_TOKEN: ${{ secrets.LRZ_GITLAB_TRIGGER_TOKEN }}
+      ADAPTER_PROJECT_TOKEN: ${{ secrets.FOAMADAPTER_LRZ_GITLAB_PROJECT_TOKEN }}
+      ADAPTER_TRIGGER_TOKEN: ${{ secrets.FOAMADAPTER_LRZ_GITLAB_TRIGGER_TOKEN }}
       MAX_WAIT_MINUTES: 1440  # 24 hours
 
     steps:
@@ -51,7 +55,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git remote add lrz https://oauth2:${{ secrets.GITLAB_PROJECT_TOKEN }}@${{ env.LRZ_HOST }}/${{ env.LRZ_GROUP }}/${{ env.REPO_NAME }}.git
+          git remote add lrz https://oauth2:${NEON_PROJECT_TOKEN}@${{ env.LRZ_HOST }}/${{ env.LRZ_GROUP }}/${{ env.REPO_NAME }}.git
           git fetch origin ${{ steps.branch.outputs.branch }}
           git checkout -B ${{ steps.branch.outputs.branch }} origin/${{ steps.branch.outputs.branch }}
           git reset --hard origin/${{ steps.branch.outputs.branch }}
@@ -62,7 +66,7 @@ jobs:
           .github/scripts/cancel_triggered_pipelines.sh \
             "${{ env.REPO_NAME }}" \
             "${{ steps.branch.outputs.branch }}" \
-            "${{ secrets.GITLAB_PROJECT_TOKEN }}"
+            "${NEON_PROJECT_TOKEN}"
 
       - name: Trigger NeoN LRZ GitLab CI pipeline
         id: trigger-neon
@@ -70,23 +74,23 @@ jobs:
           .github/scripts/trigger_pipeline.sh \
             "${{ env.REPO_NAME }}" \
             "${{ steps.branch.outputs.branch }}" \
-            "${{ secrets.GITLAB_PROJECT_TOKEN }}" \
-            "${{ secrets.LRZ_GITLAB_TRIGGER_TOKEN }}" \
+            "${NEON_PROJECT_TOKEN}" \
+            "${NEON_TRIGGER_TOKEN}" \
             "variables[NEON_BRANCH]=${{ steps.branch.outputs.branch }}"
 
-      # - name: Wait for NeoN LRZ GitLab CI pipeline
-      #   run: |
-      #     .github/scripts/wait_pipeline.sh \
-      #       "${{ env.REPO_NAME }}" \
-      #       "${{ steps.trigger-neon.outputs.pipeline_id }}" \
-      #       "${{ secrets.GITLAB_PROJECT_TOKEN }}"
+      - name: Wait for NeoN LRZ GitLab CI pipeline
+        run: |
+          .github/scripts/wait_pipeline.sh \
+            "${{ env.REPO_NAME }}" \
+            "${{ steps.trigger-neon.outputs.pipeline_id }}" \
+            "${NEON_PROJECT_TOKEN}"
 
       - name: Cancel running/pending FoamAdapter LRZ CI pipelines
         run: |
           .github/scripts/cancel_triggered_pipelines.sh \
             "${{ env.FOAMADAPTER_REPO }}" \
             "${{ steps.branch.outputs.branch }}" \
-            "${{ secrets.FOAMADAPTER_LRZ_GITLAB_PROJECT_TOKEN }}"
+            "${ADAPTER_PROJECT_TOKEN}"
 
       - name: Trigger FoamAdapter LRZ GitLab CI pipeline
         id: trigger-adapter
@@ -94,16 +98,16 @@ jobs:
           .github/scripts/trigger_pipeline.sh \
             "${{ env.FOAMADAPTER_REPO }}" \
             "${{ steps.branch.outputs.branch }}" \
-            "${{ secrets.FOAMADAPTER_LRZ_GITLAB_PROJECT_TOKEN }}" \
-            "${{ secrets.FOAMADAPTER_LRZ_GITLAB_TRIGGER_TOKEN }}" \
+            "${ADAPTER_PROJECT_TOKEN}" \
+            "${ADAPTER_TRIGGER_TOKEN}" \
             "variables[NEON_BRANCH]=${{ steps.branch.outputs.branch }}"
 
-      # - name: Wait for FoamAdapter LRZ GitLab CI pipeline
-      #   run: |
-      #     .github/scripts/wait_pipeline.sh \
-      #       "${{ env.FOAMADAPTER_REPO }}" \
-      #       "${{ steps.trigger-adapter.outputs.pipeline_id }}" \
-      #       "${{ secrets.FOAMADAPTER_LRZ_GITLAB_PROJECT_TOKEN }}"
+      - name: Wait for FoamAdapter LRZ GitLab CI pipeline
+        run: |
+          .github/scripts/wait_pipeline.sh \
+            "${{ env.FOAMADAPTER_REPO }}" \
+            "${{ steps.trigger-adapter.outputs.pipeline_id }}" \
+            "${ADAPTER_PROJECT_TOKEN}"
 
   benchmark:
     name: Benchmark NeoN on GPU
@@ -118,6 +122,8 @@ jobs:
       LRZ_HOST: gitlab-ce.lrz.de
       REPO_NAME: ${{ github.event.repository.name }}
       BRANCH: ${{ needs.build-and-test-neon.outputs.branch }}
+      NEON_PROJECT_TOKEN: ${{ secrets.GITLAB_PROJECT_TOKEN }}
+      NEON_TRIGGER_TOKEN: ${{ secrets.LRZ_GITLAB_TRIGGER_TOKEN }}
 
     steps:
       - name: Checkout repository
@@ -128,7 +134,7 @@ jobs:
           .github/scripts/cancel_triggered_pipelines.sh \
             "${{ env.REPO_NAME }}" \
             "${BRANCH}" \
-            "${{ secrets.GITLAB_PROJECT_TOKEN }}"
+            "${NEON_PROJECT_TOKEN}"
 
       - name: Trigger NeoN LRZ GitLab CI pipeline for benchmarking
         id: trigger-neon
@@ -136,8 +142,8 @@ jobs:
           .github/scripts/trigger_pipeline.sh \
             "${{ env.REPO_NAME }}" \
             "${BRANCH}" \
-            "${{ secrets.GITLAB_PROJECT_TOKEN }}" \
-            "${{ secrets.LRZ_GITLAB_TRIGGER_TOKEN }}" \
+            "${NEON_PROJECT_TOKEN}" \
+            "${NEON_TRIGGER_TOKEN}" \
             "variables[NEON_BRANCH]=${BRANCH}" \
             "variables[BENCHMARK]=true"
 
@@ -146,4 +152,4 @@ jobs:
           .github/scripts/wait_pipeline.sh \
             "${{ env.REPO_NAME }}" \
             "${{ steps.trigger-neon.outputs.pipeline_id }}" \
-            "${{ secrets.GITLAB_PROJECT_TOKEN }}"
+            "${NEON_PROJECT_TOKEN}"

--- a/.github/workflows/trigger-lrz-gitlab-ci.yaml
+++ b/.github/workflows/trigger-lrz-gitlab-ci.yaml
@@ -4,18 +4,14 @@ on:
   push:
     branches: [dev, main]
     paths-ignore:
-      - 'doc/**/*'
-      - '*.md'
-      - '**/*.md'
+      - 'doc/**'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
-      - 'doc/**/*'
-      - '*.md'
-      - '**/*.md'
+      - 'doc/**'
   schedule:
     - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday
-  workflow_dispatch:      # Optional: allows manual trigger
+  workflow_dispatch:      # Allows manual trigger
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/trigger-lrz-gitlab-ci.yaml
+++ b/.github/workflows/trigger-lrz-gitlab-ci.yaml
@@ -5,11 +5,13 @@ on:
     branches: [dev, main]
     paths-ignore:
       - 'docs/**'
+      - '**.md'
       - '**/*.md'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
       - 'docs/**'
+      - '**.md'
       - '**/*.md'
   schedule:
     - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday

--- a/.github/workflows/trigger-lrz-gitlab-ci.yaml
+++ b/.github/workflows/trigger-lrz-gitlab-ci.yaml
@@ -3,14 +3,13 @@ name: NeoN + FoamAdapter LRZ GitLab CI
 on:
   push:
     branches: [dev, main]
-    paths-ignore:
-      - 'doc/**'
+
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-    paths-ignore:
-      - 'doc/**'
+
   schedule:
     - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday
+
   workflow_dispatch:      # Allows manual trigger
 
 concurrency:

--- a/.github/workflows/trigger-lrz-gitlab-ci.yaml
+++ b/.github/workflows/trigger-lrz-gitlab-ci.yaml
@@ -4,13 +4,13 @@ on:
   push:
     branches: [dev, main]
     paths-ignore:
-      - 'doc/**'
+      - 'doc/**/*'
       - '*.md'
       - '**/*.md'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
-      - 'doc/**'
+      - 'doc/**/*'
       - '*.md'
       - '**/*.md'
   schedule:

--- a/.github/workflows/trigger-lrz-gitlab-ci.yaml
+++ b/.github/workflows/trigger-lrz-gitlab-ci.yaml
@@ -26,12 +26,15 @@ jobs:
       branch: ${{ steps.branch.outputs.branch }}
 
     if: |
-      (github.event.action == 'opened' \
-      || github.event.action == 'synchronize' \
-      || github.event.action == 'reopened') \
-      && !contains(toJson(github.event.pull_request.labels.*.name), 'Skip-build')) \
-      || (github.event.action == 'unlabeled' \
-      && (github.event.label.name == 'Skip-build'))
+      (
+        github.event.action == 'opened' ||
+        github.event.action == 'synchronize' ||
+        github.event.action == 'reopened'
+      ) && !contains(toJson(github.event.pull_request.labels.*.name), 'Skip-build')
+      || (
+       github.event.action == 'unlabeled' &&
+        github.event.label.name == 'Skip-build'
+      )
 
     env:
       LRZ_GROUP: greole

--- a/.github/workflows/trigger-lrz-gitlab-ci.yaml
+++ b/.github/workflows/trigger-lrz-gitlab-ci.yaml
@@ -4,14 +4,14 @@ on:
   push:
     branches: [dev, main]
     paths-ignore:
-      - 'docs/**'
-      - '**.md'
+      - 'doc/**'
+      - '*.md'
       - '**/*.md'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
-      - 'docs/**'
-      - '**.md'
+      - 'doc/**'
+      - '*.md'
       - '**/*.md'
   schedule:
     - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday

--- a/.github/workflows/trigger-lrz-gitlab-ci.yaml
+++ b/.github/workflows/trigger-lrz-gitlab-ci.yaml
@@ -3,8 +3,14 @@ name: NeoN + FoamAdapter LRZ GitLab CI
 on:
   push:
     branches: [dev, main]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
   schedule:
     - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday
   workflow_dispatch:      # Optional: allows manual trigger

--- a/.github/workflows/trigger-lrz-gitlab-ci.yaml
+++ b/.github/workflows/trigger-lrz-gitlab-ci.yaml
@@ -3,13 +3,10 @@ name: NeoN + FoamAdapter LRZ GitLab CI
 on:
   push:
     branches: [dev, main]
-
   pull_request:
     types: [opened, synchronize, reopened, unlabeled, labeled]
-
   schedule:
     - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday
-
   workflow_dispatch:      # Allows manual trigger
 
 concurrency:
@@ -25,16 +22,7 @@ jobs:
     outputs:
       branch: ${{ steps.branch.outputs.branch }}
 
-    if: |
-      (
-        github.event.action == 'opened' ||
-        github.event.action == 'synchronize' ||
-        github.event.action == 'reopened'
-      ) && !contains(toJson(github.event.pull_request.labels.*.name), 'Skip-build')
-      || (
-       github.event.action == 'unlabeled' &&
-        github.event.label.name == 'Skip-build'
-      )
+    if: "!contains(toJson(github.event.pull_request.labels.*.name), 'Skip-build')"
 
     env:
       LRZ_GROUP: greole

--- a/.github/workflows/trigger-lrz-gitlab-ci.yaml
+++ b/.github/workflows/trigger-lrz-gitlab-ci.yaml
@@ -94,7 +94,7 @@ jobs:
           .github/scripts/trigger_pipeline.sh \
             "${{ env.FOAMADAPTER_REPO }}" \
             "${{ steps.branch.outputs.branch }}" \
-            "${{ FOAMADAPTER_LRZ_GITLAB_PROJECT_TOKEN }}" \
+            "${{ secrets.FOAMADAPTER_LRZ_GITLAB_PROJECT_TOKEN }}" \
             "${{ secrets.FOAMADAPTER_LRZ_GITLAB_TRIGGER_TOKEN }}" \
             "variables[NEON_BRANCH]=${{ steps.branch.outputs.branch }}"
 
@@ -128,6 +128,7 @@ jobs:
           .github/scripts/trigger_pipeline.sh \
             "${{ env.REPO_NAME }}" \
             "${{ needs.trigger-lrz-ci.outputs.branch }}" \
+            "${{ secrets.FOAMADAPTER_LRZ_GITLAB_PROJECT_TOKEN }}" \
             "${{ secrets.LRZ_GITLAB_TRIGGER_TOKEN }}" \
             "variables[BENCHMARK]=true"
 

--- a/.github/workflows/trigger-lrz-gitlab-ci.yaml
+++ b/.github/workflows/trigger-lrz-gitlab-ci.yaml
@@ -128,7 +128,7 @@ jobs:
           .github/scripts/trigger_pipeline.sh \
             "${{ env.REPO_NAME }}" \
             "${{ needs.trigger-lrz-ci.outputs.branch }}" \
-            "${{ secrets.FOAMADAPTER_LRZ_GITLAB_PROJECT_TOKEN }}" \
+            "${{ secrets.GITLAB_PROJECT_TOKEN }}" \
             "${{ secrets.LRZ_GITLAB_TRIGGER_TOKEN }}" \
             "variables[BENCHMARK]=true"
 

--- a/.github/workflows/trigger-lrz-gitlab-ci.yaml
+++ b/.github/workflows/trigger-lrz-gitlab-ci.yaml
@@ -70,7 +70,9 @@ jobs:
           .github/scripts/trigger_pipeline.sh \
             "${{ env.REPO_NAME }}" \
             "${{ steps.branch.outputs.branch }}" \
-            "${{ secrets.LRZ_GITLAB_TRIGGER_TOKEN }}"
+            "${{ secrets.GITLAB_PROJECT_TOKEN }}" \
+            "${{ secrets.LRZ_GITLAB_TRIGGER_TOKEN }}" \
+            "variables[NEON_BRANCH]=${{ steps.branch.outputs.branch }}"
 
       - name: Wait for NeoN LRZ GitLab CI pipeline
         run: |
@@ -92,6 +94,7 @@ jobs:
           .github/scripts/trigger_pipeline.sh \
             "${{ env.FOAMADAPTER_REPO }}" \
             "${{ steps.branch.outputs.branch }}" \
+            "${{ FOAMADAPTER_LRZ_GITLAB_PROJECT_TOKEN }}" \
             "${{ secrets.FOAMADAPTER_LRZ_GITLAB_TRIGGER_TOKEN }}" \
             "variables[NEON_BRANCH]=${{ steps.branch.outputs.branch }}"
 

--- a/.github/workflows/trigger-lrz-gitlab-ci.yaml
+++ b/.github/workflows/trigger-lrz-gitlab-ci.yaml
@@ -5,7 +5,7 @@ on:
     branches: [dev, main]
 
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, unlabeled]
 
   schedule:
     - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday
@@ -25,7 +25,13 @@ jobs:
     outputs:
       branch: ${{ steps.branch.outputs.branch }}
 
-    if: "!contains(toJson(github.event.pull_request.labels.*.name), 'Skip-build')"
+    if: |
+      (github.event.action == 'opened' \
+      || github.event.action == 'synchronize' \
+      || github.event.action == 'reopened') \
+      && !contains(toJson(github.event.pull_request.labels.*.name), 'Skip-build')) \
+      || (github.event.action == 'unlabeled' \
+      && (github.event.label.name == 'Skip-build'))
 
     env:
       LRZ_GROUP: greole

--- a/.github/workflows/trigger-lrz-gitlab-ci.yaml
+++ b/.github/workflows/trigger-lrz-gitlab-ci.yaml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  trigger-lrz-ci:
+  build-and-test-neon:
     name: Trigger NeoN + FoamAdapter CI on GPU
     runs-on: ubuntu-latest
     timeout-minutes: 1440
@@ -74,12 +74,12 @@ jobs:
             "${{ secrets.LRZ_GITLAB_TRIGGER_TOKEN }}" \
             "variables[NEON_BRANCH]=${{ steps.branch.outputs.branch }}"
 
-      - name: Wait for NeoN LRZ GitLab CI pipeline
-        run: |
-          .github/scripts/wait_pipeline.sh \
-            "${{ env.REPO_NAME }}" \
-            "${{ steps.trigger-neon.outputs.pipeline_id }}" \
-            "${{ secrets.GITLAB_PROJECT_TOKEN }}"
+      # - name: Wait for NeoN LRZ GitLab CI pipeline
+      #   run: |
+      #     .github/scripts/wait_pipeline.sh \
+      #       "${{ env.REPO_NAME }}" \
+      #       "${{ steps.trigger-neon.outputs.pipeline_id }}" \
+      #       "${{ secrets.GITLAB_PROJECT_TOKEN }}"
 
       - name: Cancel running/pending FoamAdapter LRZ CI pipelines
         run: |
@@ -98,38 +98,47 @@ jobs:
             "${{ secrets.FOAMADAPTER_LRZ_GITLAB_TRIGGER_TOKEN }}" \
             "variables[NEON_BRANCH]=${{ steps.branch.outputs.branch }}"
 
-      - name: Wait for FoamAdapter LRZ GitLab CI pipeline
-        run: |
-          .github/scripts/wait_pipeline.sh \
-            "${{ env.FOAMADAPTER_REPO }}" \
-            "${{ steps.trigger-adapter.outputs.pipeline_id }}" \
-            "${{ secrets.FOAMADAPTER_LRZ_GITLAB_PROJECT_TOKEN }}"
+      # - name: Wait for FoamAdapter LRZ GitLab CI pipeline
+      #   run: |
+      #     .github/scripts/wait_pipeline.sh \
+      #       "${{ env.FOAMADAPTER_REPO }}" \
+      #       "${{ steps.trigger-adapter.outputs.pipeline_id }}" \
+      #       "${{ secrets.FOAMADAPTER_LRZ_GITLAB_PROJECT_TOKEN }}"
 
   benchmark:
     name: Benchmark NeoN on GPU
     runs-on: ubuntu-latest
     timeout-minutes: 1440 # 24 hours
 
-    needs: [trigger-lrz-ci]
+    needs: [build-and-test-neon]
     if: contains(toJson(github.event.pull_request.labels), 'benchmark')
 
     env:
       LRZ_GROUP: greole
       LRZ_HOST: gitlab-ce.lrz.de
       REPO_NAME: ${{ github.event.repository.name }}
+      BRANCH: ${{ needs.build-and-test-neon.outputs.branch }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Cancel running/pending NeoN LRZ CI pipelines
+        run: |
+          .github/scripts/cancel_triggered_pipelines.sh \
+            "${{ env.REPO_NAME }}" \
+            "${BRANCH}" \
+            "${{ secrets.GITLAB_PROJECT_TOKEN }}"
 
       - name: Trigger NeoN LRZ GitLab CI pipeline for benchmarking
         id: trigger-neon
         run: |
           .github/scripts/trigger_pipeline.sh \
             "${{ env.REPO_NAME }}" \
-            "${{ needs.trigger-lrz-ci.outputs.branch }}" \
+            "${BRANCH}" \
             "${{ secrets.GITLAB_PROJECT_TOKEN }}" \
             "${{ secrets.LRZ_GITLAB_TRIGGER_TOKEN }}" \
+            "variables[NEON_BRANCH]=${BRANCH}" \
             "variables[BENCHMARK]=true"
 
       - name: Wait for NeoN LRZ GitLab CI pipeline for benchmarking

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@
     # Skip in all other cases
     - when: never
 
-  before_script:
+  script:
     # Install pre-commit
     - pip3 install --user --break-system-packages pre-commit
     - export PATH="$HOME/.local/bin:$PATH"
@@ -21,21 +21,28 @@
     - nvidia-smi
     - nvcc --version
 
-  script:
-    - cmake --preset develop -DCMAKE_CUDA_ARCHITECTURES=90 -DNeoN_WITH_THREADS=OFF
-    - cmake --build --preset develop
-    - ctest --preset develop --output-on-failure
-
 # Run jobs on NVIDIA GPUs
 build-and-test-neon-nvidia:
   extends: .build-and-test-neon
   image: greole/neon-cuda
   tags: ["nvidia-h100-gpus"]
+  script:
+    - cmake --preset develop -DCMAKE_CUDA_ARCHITECTURES=90 -DNeoN_WITH_THREADS=OFF
+    - cmake --build --preset develop
+    - ctest --preset develop --output-on-failure
 
 # Run jobs on AMD GPUs
-# build-and-test-neon-amd:
-#   extends: .build-and-test-neon
-#   tags: ["amd-gpus"]
+build-and-test-neon-amd:
+  extends: .build-and-test-neon
+  image: chihtaw/neon-rocm:6.4.1-complete
+  tags: ["amd-gpus"]
+  script:
+    - cmake --preset develop \
+        -DCMAKE_HIP_ARCHITECTURES=gfx90a \
+        -DKokkos_ARCH_AMD_GFX90A=ON \
+        -DNeoN_WITH_THREADS=OFF
+    - cmake --build --preset develop
+    - ctest --preset develop --output-on-failure
 
 benchmark-neon-on-gpu:
   tags: ["nvidia-h100-gpus"]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,8 +36,8 @@ build-and-test-neon-nvidia:
 # Build and test on AMD GPUs
 build-and-test-neon-amd:
   extends: .build-and-test-neon-common
-  image: chihtaw/neon-rocm:6.4.1-complete
   tags: ["amd-gpus"]
+  image: chihtaw/neon-rocm:6.4.1-complete
   script:
     # Set ROCm environment
     - export PATH=/opt/rocm/bin:$PATH
@@ -45,6 +45,9 @@ build-and-test-neon-amd:
 
     # Set host compiler for hipcc (default is Clang bundled in ROCm)
     - export HIPCC_CXX=/usr/bin/g++
+
+    # Show GPU info
+    - rocminfo | grep "AMD"
 
     # Configure, build, and test
     - |
@@ -77,67 +80,16 @@ build-and-test-neon-amd:
     # Install dependencies
     - pip3 install --user --break-system-packages xmltodict
 
-    # Collect system info (CPU, GPU, compilers)
-    - mkdir ${RESULTS_DIR}
-    - |
-      {
-        echo "===== CPU INFO ====="
-        lscpu
-        echo ""
-        echo "===== GPU INFO ====="
-        nvidia-smi --query-gpu=gpu_name,memory.total,driver_version --format=csv || echo "No GPU found"
-        echo ""
-        echo "===== COMPILER INFO ====="
-        echo "CMake:"
-        cmake --version
-        echo ""
-        echo "C++ compiler:"
-        clang++ --version || g++ --version || echo "No C++ compiler found"
-        echo ""
-        echo "CUDA compiler:"
-        nvcc --version || echo "nvcc not available"
-      } > ${RESULTS_DIR}/system-info.log
-
 benchmark-neon-nvidia:
   extends: .benchmark-neon-common
   tags: ["nvidia-h100-gpus"]
+  image: greole/neon-cuda
   script:
-    # Build & benchmark current branch
-    - echo ">>> Build current branch"
-    - cmake --preset profiling -DCMAKE_CUDA_ARCHITECTURES=90 -DNeoN_WITH_THREADS=OFF
-    - cmake --build --preset profiling
-    - echo ">>> Running benchmarks...(current branch)"
-    - ctest --preset profiling
-    - cd build/profiling/bin/benchmarks
-    - python3 ../../../../scripts/catch2json.py
-    - cd ../../../..
-    - cp build/profiling/bin/benchmarks/*.json ${RESULTS_DIR}/
+    - bash ci/benchmark.sh
 
-    - rm -rf build
-
-    # Build & benchmark main branch
-    - echo ">>> Build main branch"
-    - git fetch origin main
-    - git checkout main
-    - cmake --preset profiling -DCMAKE_CUDA_ARCHITECTURES=90 -DNeoN_WITH_THREADS=OFF
-    - cmake --build --preset profiling
-    - echo ">>> Running benchmarks...(main branch)"
-    - ctest --preset profiling
-    - cd build/profiling/bin/benchmarks
-    - python3 ../../../../scripts/catch2json.py
-    - cd ../../../..
-    - mkdir -p ${RESULTS_DIR}/main
-    - cp build/profiling/bin/benchmarks/*.json ${RESULTS_DIR}/main/
-
-    # Push benchmark results to GitHub
-    - git config --global user.email "gitlab-ci@users.noreply.github.com"
-    - git config --global user.name "GitLab CI"
-    - git clone https://oauth2:${API_TOKEN_GITHUB}@${TARGET_REPO}
-    - cd ${REPO_NAME}
-    - git checkout "${TARGET_BRANCH}" || git checkout -b "${TARGET_BRANCH}"
-    - mkdir -p "${RUN_IDENTIFIER}/${CI_RUNNER_DESCRIPTION}"
-    - cp -r ../${RESULTS_DIR}/* "${RUN_IDENTIFIER}/${CI_RUNNER_DESCRIPTION}"
-    - git add .
-    - git commit -m "Benchmarks from GitLab pipeline ${RUN_IDENTIFIER}" || echo "No changes to commit"
-    - git pull --rebase || true
-    - git push origin "${TARGET_BRANCH}"
+benchmark-neon-amd:
+  extends: .benchmark-neon-common
+  tags: ["amd-gpus"]
+  image: chihtaw/neon-rocm:6.4.1-complete
+  script:
+    - bash ci/benchmark.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,8 +18,8 @@
     # Optional: show versions of tools
     - cmake --version
     - clang++ --version || g++ --version
-    - nvidia-smi
-    - nvcc --version
+    # - nvidia-smi
+    # - nvcc --version
 
 # # Run jobs on NVIDIA GPUs
 # build-and-test-neon-nvidia:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,9 +33,9 @@ build-and-test-neon-nvidia:
   extends: .build-and-test-neon
   tags: ["nvidia-h100-gpus"]
 
-build-and-test-neon-amd:
-  extends: .build-and-test-neon
-  tags: ["amd-gpus"]
+# build-and-test-neon-amd:
+#   extends: .build-and-test-neon
+#   tags: ["amd-gpus"]
 
 benchmark-neon-on-gpu:
   tags: ["nvidia-h100-gpus"]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,8 +4,7 @@
 
 image: greole/neon-cuda
 
-build-and-test-neon:
-  tags: ["nvidia-h100-gpus"]
+.build-and-test-neon:
   rules:
     # Run only when triggered via API
     - if: $CI_PIPELINE_SOURCE == "trigger" && $BENCHMARK != "true"
@@ -28,6 +27,15 @@ build-and-test-neon:
     - cmake --preset develop -DCMAKE_CUDA_ARCHITECTURES=90 -DNeoN_WITH_THREADS=OFF
     - cmake --build --preset develop
     - ctest --preset develop --output-on-failure
+
+# Run jobs on different GPUs
+build-and-test-neon-nvidia:
+  extends: .build-and-test-neon
+  tags: ["nvidia-h100-gpus"]
+
+build-and-test-neon-amd:
+  extends: .build-and-test-neon
+  tags: ["amd-gpus"]
 
 benchmark-neon-on-gpu:
   tags: ["nvidia-h100-gpus"]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Unlicense
 
 stages:
-- build-and-test
-- benchmark
+  - build-and-test
+  - benchmark
 
 .build-and-test-neon: &build-and-test-neon-common
   stage: build-and-test
@@ -64,6 +64,7 @@ build-and-test-neon-amd:
     - ctest --preset develop --output-on-failure
 
 benchmark-neon-on-gpu:
+  stage: benchmark
   tags: ["nvidia-h100-gpus"]
   rules:
     # Run only when triggered via API for benchmarking

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,15 +21,15 @@
     - nvidia-smi
     - nvcc --version
 
-# Run jobs on NVIDIA GPUs
-build-and-test-neon-nvidia:
-  extends: .build-and-test-neon
-  image: greole/neon-cuda
-  tags: ["nvidia-h100-gpus"]
-  script:
-    - cmake --preset develop -DCMAKE_CUDA_ARCHITECTURES=90 -DNeoN_WITH_THREADS=OFF
-    - cmake --build --preset develop
-    - ctest --preset develop --output-on-failure
+# # Run jobs on NVIDIA GPUs
+# build-and-test-neon-nvidia:
+#   extends: .build-and-test-neon
+#   image: greole/neon-cuda
+#   tags: ["nvidia-h100-gpus"]
+#   script:
+#     - cmake --preset develop -DCMAKE_CUDA_ARCHITECTURES=90 -DNeoN_WITH_THREADS=OFF
+#     - cmake --build --preset develop
+#     - ctest --preset develop --output-on-failure
 
 # Run jobs on AMD GPUs
 build-and-test-neon-amd:
@@ -37,10 +37,7 @@ build-and-test-neon-amd:
   image: chihtaw/neon-rocm:6.4.1-complete
   tags: ["amd-gpus"]
   script:
-    - cmake --preset develop \
-        -DCMAKE_HIP_ARCHITECTURES=gfx90a \
-        -DKokkos_ARCH_AMD_GFX90A=ON \
-        -DNeoN_WITH_THREADS=OFF
+    - cmake --preset develop -DCMAKE_HIP_ARCHITECTURES=gfx90a -DKokkos_ARCH_AMD_GFX90A=ON -DNeoN_WITH_THREADS=OFF
     - cmake --build --preset develop
     - ctest --preset develop --output-on-failure
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,10 +25,6 @@
     - pip3 install --user --break-system-packages pre-commit
     - export PATH="$HOME/.local/bin:$PATH"
 
-    # Optional: show versions of tools
-    - cmake --version
-    - clang++ --version || g++ --version
-
 # Common configuration for all benchmark jobs
 .benchmark-neon-common:
   rules:
@@ -63,7 +59,6 @@ build-and-test-neon-amd:
     - .use-amd-gpu
   script:
     - ./ci/build-and-test.sh amd
-
 
 # benchmark jobs for NeoN
 benchmark-neon-nvidia:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,9 @@
 #   extends: .build-and-test-neon
 #   image: greole/neon-cuda
 #   tags: ["nvidia-h100-gpus"]
+    # before_script:
+    #   - nvidia-smi
+    #   - nvcc --version
 #   script:
 #     - cmake --preset develop -DCMAKE_CUDA_ARCHITECTURES=90 -DNeoN_WITH_THREADS=OFF
 #     - cmake --build --preset develop
@@ -36,7 +39,7 @@ build-and-test-neon-amd:
   extends: .build-and-test-neon
   image: chihtaw/neon-rocm:6.4.1-complete
   tags: ["amd-gpus"]
-  script:
+  before_script:
     # Set ROCm environment
     - export PATH=/opt/rocm/bin:$PATH
     - export LD_LIBRARY_PATH=/opt/rocm/lib:/opt/rocm/lib64:$LD_LIBRARY_PATH
@@ -44,7 +47,7 @@ build-and-test-neon-amd:
     # Set host compiler for hipcc (default is Clang bundled in ROCm)
     - export HIPCC_CXX=/usr/bin/g++
 
-    # Configure the project with CMake
+  script:
     - |
       cmake --preset develop \
         -DCMAKE_C_COMPILER=gcc \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,12 +2,7 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-stages:
-  - build-and-test
-  - benchmark
-
 .build-and-test-neon-common:
-  stage: build-and-test
   rules:
     # Run only when triggered via API
     - if: $CI_PIPELINE_SOURCE == "trigger" && $BENCHMARK != "true"
@@ -64,7 +59,6 @@ build-and-test-neon-amd:
     - ctest --preset develop --output-on-failure
 
 .benchmark-neon-common:
-  stage: benchmark
   rules:
     # Run only when triggered via API for benchmarking
     - if: $CI_PIPELINE_SOURCE == "trigger" && $BENCHMARK == "true"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-image: greole/neon-cuda
-
 .build-and-test-neon:
   rules:
     # Run only when triggered via API
@@ -28,11 +26,13 @@ image: greole/neon-cuda
     - cmake --build --preset develop
     - ctest --preset develop --output-on-failure
 
-# Run jobs on different GPUs
+# Run jobs on NVIDIA GPUs
 build-and-test-neon-nvidia:
   extends: .build-and-test-neon
+  image: greole/neon-cuda
   tags: ["nvidia-h100-gpus"]
 
+# Run jobs on AMD GPUs
 # build-and-test-neon-amd:
 #   extends: .build-and-test-neon
 #   tags: ["amd-gpus"]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,21 +14,18 @@
 # Common configuration for all build and test jobs
 .build-and-test-neon-common:
   rules:
-    # Run only when triggered via API
     - if: $CI_PIPELINE_SOURCE == "trigger" && $BENCHMARK != "true"
       when: always
     # Skip in all other cases
     - when: never
 
   before_script:
-    # Install pre-commit
     - pip3 install --user --break-system-packages pre-commit
     - export PATH="$HOME/.local/bin:$PATH"
 
 # Common configuration for all benchmark jobs
 .benchmark-neon-common:
   rules:
-    # Run only when triggered via API for benchmarking
     - if: $CI_PIPELINE_SOURCE == "trigger" && $BENCHMARK == "true"
       when: always
     # Skip in all other cases
@@ -42,7 +39,6 @@
     TARGET_BRANCH: "ci-benchmarks"
 
   before_script:
-    # Install dependencies
     - pip3 install --user --break-system-packages xmltodict
 
 # build and test jobs for NeoN
@@ -53,12 +49,12 @@ build-and-test-neon-nvidia:
   script:
     - ./ci/build-and-test.sh nvidia
 
-# build-and-test-neon-amd:
-#   extends:
-#     - .build-and-test-neon-common
-#     - .use-amd-gpu
-#   script:
-#     - ./ci/build-and-test.sh amd
+build-and-test-neon-amd:
+  extends:
+    - .build-and-test-neon-common
+    - .use-amd-gpu
+  script:
+    - ./ci/build-and-test.sh amd
 
 # benchmark jobs for NeoN
 benchmark-neon-nvidia:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-stage:
+stages:
 - build-and-test
 - benchmark
 
@@ -43,7 +43,6 @@ build-and-test-neon-amd:
   <<: *build-and-test-neon-common
   image: chihtaw/neon-rocm:6.4.1-complete
   tags: ["amd-gpus"]
-
   script:
     # Set ROCm environment
     - export PATH=/opt/rocm/bin:$PATH

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@
     # Skip in all other cases
     - when: never
 
-  script:
+  before_script:
     # Install pre-commit
     - pip3 install --user --break-system-packages pre-commit
     - export PATH="$HOME/.local/bin:$PATH"
@@ -37,7 +37,22 @@ build-and-test-neon-amd:
   image: chihtaw/neon-rocm:6.4.1-complete
   tags: ["amd-gpus"]
   script:
-    - cmake --preset develop -DCMAKE_HIP_ARCHITECTURES=gfx90a -DKokkos_ARCH_AMD_GFX90A=ON -DNeoN_WITH_THREADS=OFF
+    # Set ROCm environment
+    - export PATH=/opt/rocm/bin:$PATH
+    - export LD_LIBRARY_PATH=/opt/rocm/lib:/opt/rocm/lib64:$LD_LIBRARY_PATH
+
+    # Set host compiler for hipcc (default is Clang bundled in ROCm)
+    - export HIPCC_CXX=/usr/bin/g++
+
+    # Configure the project with CMake
+    - |
+      cmake --preset develop \
+        -DCMAKE_C_COMPILER=gcc \
+        -DCMAKE_CXX_COMPILER=hipcc \
+        -DCMAKE_HIP_ARCHITECTURES=gfx90a \
+        -DKokkos_ARCH_AMD_GFX90A=ON \
+        -DNeoN_WITH_THREADS=OFF
+
     - cmake --build --preset develop
     - ctest --preset develop --output-on-failure
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,12 @@
 #
 # SPDX-License-Identifier: Unlicense
 
+stage:
+- build-and-test
+- benchmark
+
 .build-and-test-neon: &build-and-test-neon-common
+  stage: build-and-test
   rules:
     # Run only when triggered via API
     - if: $CI_PIPELINE_SOURCE == "trigger" && $BENCHMARK != "true"
@@ -22,12 +27,13 @@
 # On NVIDIA GPUs
 build-and-test-neon-nvidia:
   <<: *build-and-test-neon-common
-  image: greole/neon-cuda
   tags: ["nvidia-h100-gpus"]
-  before_script:
-      - nvidia-smi
-      - nvcc --version
+  image: greole/neon-cuda
   script:
+    - nvidia-smi
+    - nvcc --version
+
+    # Configure, build, and test
     - cmake --preset develop -DCMAKE_CUDA_ARCHITECTURES=90 -DNeoN_WITH_THREADS=OFF
     - cmake --build --preset develop
     - ctest --preset develop --output-on-failure
@@ -37,7 +43,8 @@ build-and-test-neon-amd:
   <<: *build-and-test-neon-common
   image: chihtaw/neon-rocm:6.4.1-complete
   tags: ["amd-gpus"]
-  before_script:
+
+  script:
     # Set ROCm environment
     - export PATH=/opt/rocm/bin:$PATH
     - export LD_LIBRARY_PATH=/opt/rocm/lib:/opt/rocm/lib64:$LD_LIBRARY_PATH
@@ -45,7 +52,7 @@ build-and-test-neon-amd:
     # Set host compiler for hipcc (default is Clang bundled in ROCm)
     - export HIPCC_CXX=/usr/bin/g++
 
-  script:
+    # Configure, build, and test
     - |
       cmake --preset develop \
         -DCMAKE_C_COMPILER=gcc \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,16 @@
 #
 # SPDX-License-Identifier: Unlicense
 
+# Available GPUs and corresponding Docker images
+.use-nvidia-gpu:
+  tags: ["nvidia-h100-gpus"]
+  image: greole/neon-cuda
+
+.use-amd-gpu:
+  tags: ["amd-gpus"]
+  image: chihtaw/neon-rocm:6.4.1-complete
+
+# Common configuration for all build and test jobs
 .build-and-test-neon-common:
   rules:
     # Run only when triggered via API
@@ -19,20 +29,7 @@
     - cmake --version
     - clang++ --version || g++ --version
 
-build-and-test-neon-nvidia:
-  extends: .build-and-test-neon-common
-  tags: ["nvidia-h100-gpus"]
-  image: greole/neon-cuda
-  script:
-    - ./ci/build-and-test.sh nvidia
-
-build-and-test-neon-amd:
-  extends: .build-and-test-neon-common
-  tags: ["amd-gpus"]
-  image: chihtaw/neon-rocm:6.4.1-complete
-  script:
-    - ./ci/build-and-test.sh amd
-
+# Common configuration for all benchmark jobs
 .benchmark-neon-common:
   rules:
     # Run only when triggered via API for benchmarking
@@ -52,16 +49,33 @@ build-and-test-neon-amd:
     # Install dependencies
     - pip3 install --user --break-system-packages xmltodict
 
+# build and test jobs for NeoN
+build-and-test-neon-nvidia:
+  extends:
+    - .build-and-test-neon-common
+    - .use-nvidia-gpu
+  script:
+    - ./ci/build-and-test.sh nvidia
+
+build-and-test-neon-amd:
+  extends:
+    - .build-and-test-neon-common
+    - .use-amd-gpu
+  script:
+    - ./ci/build-and-test.sh amd
+
+
+# benchmark jobs for NeoN
 benchmark-neon-nvidia:
-  extends: .benchmark-neon-common
-  tags: ["nvidia-h100-gpus"]
-  image: greole/neon-cuda
+  extends:
+    - .benchmark-neon-common
+    - .use-nvidia-gpu
   script:
     - ./ci/benchmark.sh nvidia
 
 benchmark-neon-amd:
-  extends: .benchmark-neon-common
-  tags: ["amd-gpus"]
-  image: chihtaw/neon-rocm:6.4.1-complete
+  extends:
+    - .benchmark-neon-common
+    - .use-amd-gpu
   script:
     - ./ci/benchmark.sh amd

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-.build-and-test-neon:
+.build-and-test-neon: &build-and-test-neon-common
   rules:
     # Run only when triggered via API
     - if: $CI_PIPELINE_SOURCE == "trigger" && $BENCHMARK != "true"
@@ -18,25 +18,23 @@
     # Optional: show versions of tools
     - cmake --version
     - clang++ --version || g++ --version
-    # - nvidia-smi
-    # - nvcc --version
 
-# # Run jobs on NVIDIA GPUs
-# build-and-test-neon-nvidia:
-#   extends: .build-and-test-neon
-#   image: greole/neon-cuda
-#   tags: ["nvidia-h100-gpus"]
-    # before_script:
-    #   - nvidia-smi
-    #   - nvcc --version
-#   script:
-#     - cmake --preset develop -DCMAKE_CUDA_ARCHITECTURES=90 -DNeoN_WITH_THREADS=OFF
-#     - cmake --build --preset develop
-#     - ctest --preset develop --output-on-failure
+# On NVIDIA GPUs
+build-and-test-neon-nvidia:
+  <<: *build-and-test-neon-common
+  image: greole/neon-cuda
+  tags: ["nvidia-h100-gpus"]
+  before_script:
+      - nvidia-smi
+      - nvcc --version
+  script:
+    - cmake --preset develop -DCMAKE_CUDA_ARCHITECTURES=90 -DNeoN_WITH_THREADS=OFF
+    - cmake --build --preset develop
+    - ctest --preset develop --output-on-failure
 
-# Run jobs on AMD GPUs
+# On AMD GPUs
 build-and-test-neon-amd:
-  extends: .build-and-test-neon
+  <<: *build-and-test-neon-common
   image: chihtaw/neon-rocm:6.4.1-complete
   tags: ["amd-gpus"]
   before_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ stages:
   - build-and-test
   - benchmark
 
-.build-and-test-neon: &build-and-test-neon-common
+.build-and-test-neon:
   stage: build-and-test
   rules:
     # Run only when triggered via API
@@ -26,7 +26,7 @@ stages:
 
 # On NVIDIA GPUs
 build-and-test-neon-nvidia:
-  <<: *build-and-test-neon-common
+  extends: .build-and-test-neon
   tags: ["nvidia-h100-gpus"]
   image: greole/neon-cuda
   script:
@@ -40,7 +40,7 @@ build-and-test-neon-nvidia:
 
 # On AMD GPUs
 build-and-test-neon-amd:
-  <<: *build-and-test-neon-common
+  extends: .build-and-test-neon
   image: chihtaw/neon-rocm:6.4.1-complete
   tags: ["amd-gpus"]
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,47 +19,19 @@
     - cmake --version
     - clang++ --version || g++ --version
 
-# Build and test on NVIDIA GPUs
 build-and-test-neon-nvidia:
   extends: .build-and-test-neon-common
   tags: ["nvidia-h100-gpus"]
   image: greole/neon-cuda
   script:
-    - nvidia-smi
-    - nvcc --version
+    - ./ci/build-and-test.sh nvidia
 
-    # Configure, build, and test
-    - cmake --preset develop -DCMAKE_CUDA_ARCHITECTURES=90 -DNeoN_WITH_THREADS=OFF
-    - cmake --build --preset develop
-    - ctest --preset develop --output-on-failure
-
-# Build and test on AMD GPUs
 build-and-test-neon-amd:
   extends: .build-and-test-neon-common
   tags: ["amd-gpus"]
   image: chihtaw/neon-rocm:6.4.1-complete
   script:
-    # Set ROCm environment
-    - export PATH=/opt/rocm/bin:$PATH
-    - export LD_LIBRARY_PATH=/opt/rocm/lib:/opt/rocm/lib64:$LD_LIBRARY_PATH
-
-    # Set host compiler for hipcc (default is Clang bundled in ROCm)
-    - export HIPCC_CXX=/usr/bin/g++
-
-    # Show GPU info
-    - rocminfo | grep "AMD"
-
-    # Configure, build, and test
-    - |
-      cmake --preset develop \
-        -DCMAKE_C_COMPILER=gcc \
-        -DCMAKE_CXX_COMPILER=hipcc \
-        -DCMAKE_HIP_ARCHITECTURES=gfx90a \
-        -DKokkos_ARCH_AMD_GFX90A=ON \
-        -DNeoN_WITH_THREADS=OFF
-
-    - cmake --build --preset develop
-    - ctest --preset develop --output-on-failure
+    - ./ci/build-and-test.sh amd
 
 .benchmark-neon-common:
   rules:
@@ -85,11 +57,11 @@ benchmark-neon-nvidia:
   tags: ["nvidia-h100-gpus"]
   image: greole/neon-cuda
   script:
-    - bash ci/benchmark.sh
+    - ./ci/benchmark.sh nvidia
 
 benchmark-neon-amd:
   extends: .benchmark-neon-common
   tags: ["amd-gpus"]
   image: chihtaw/neon-rocm:6.4.1-complete
   script:
-    - bash ci/benchmark.sh
+    - ./ci/benchmark.sh amd

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ stages:
   - build-and-test
   - benchmark
 
-.build-and-test-neon:
+.build-and-test-neon-common:
   stage: build-and-test
   rules:
     # Run only when triggered via API
@@ -24,9 +24,9 @@ stages:
     - cmake --version
     - clang++ --version || g++ --version
 
-# On NVIDIA GPUs
+# Build and test on NVIDIA GPUs
 build-and-test-neon-nvidia:
-  extends: .build-and-test-neon
+  extends: .build-and-test-neon-common
   tags: ["nvidia-h100-gpus"]
   image: greole/neon-cuda
   script:
@@ -38,9 +38,9 @@ build-and-test-neon-nvidia:
     - cmake --build --preset develop
     - ctest --preset develop --output-on-failure
 
-# On AMD GPUs
+# Build and test on AMD GPUs
 build-and-test-neon-amd:
-  extends: .build-and-test-neon
+  extends: .build-and-test-neon-common
   image: chihtaw/neon-rocm:6.4.1-complete
   tags: ["amd-gpus"]
   script:
@@ -63,9 +63,8 @@ build-and-test-neon-amd:
     - cmake --build --preset develop
     - ctest --preset develop --output-on-failure
 
-benchmark-neon-on-gpu:
+.benchmark-neon-common:
   stage: benchmark
-  tags: ["nvidia-h100-gpus"]
   rules:
     # Run only when triggered via API for benchmarking
     - if: $CI_PIPELINE_SOURCE == "trigger" && $BENCHMARK == "true"
@@ -105,6 +104,9 @@ benchmark-neon-on-gpu:
         nvcc --version || echo "nvcc not available"
       } > ${RESULTS_DIR}/system-info.log
 
+benchmark-neon-nvidia:
+  extends: .benchmark-neon-common
+  tags: ["nvidia-h100-gpus"]
   script:
     # Build & benchmark current branch
     - echo ">>> Build current branch"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,12 +53,12 @@ build-and-test-neon-nvidia:
   script:
     - ./ci/build-and-test.sh nvidia
 
-build-and-test-neon-amd:
-  extends:
-    - .build-and-test-neon-common
-    - .use-amd-gpu
-  script:
-    - ./ci/build-and-test.sh amd
+# build-and-test-neon-amd:
+#   extends:
+#     - .build-and-test-neon-common
+#     - .use-amd-gpu
+#   script:
+#     - ./ci/build-and-test.sh amd
 
 # benchmark jobs for NeoN
 benchmark-neon-nvidia:

--- a/README.md
+++ b/README.md
@@ -71,5 +71,6 @@ Examples how to integrate NeoN into CFD frameworks and how to write applications
 ## Documentation
 
 An online documentation can be found [here](https://exasim-project.com/NeoN/latest), be cautious since this repository is currently evolving the documentation might not always reflect the latest stage.
+
 For building the documentation further dependencies like doxygen and sphinx are requirement.
 The list of requirements can be found [here](https://github.com/exasim-project/NeoN/actions/workflows/build_doc.yaml)

--- a/README.md
+++ b/README.md
@@ -71,6 +71,5 @@ Examples how to integrate NeoN into CFD frameworks and how to write applications
 ## Documentation
 
 An online documentation can be found [here](https://exasim-project.com/NeoN/latest), be cautious since this repository is currently evolving the documentation might not always reflect the latest stage.
-
 For building the documentation further dependencies like doxygen and sphinx are requirement.
 The list of requirements can be found [here](https://github.com/exasim-project/NeoN/actions/workflows/build_doc.yaml)

--- a/ci/benchmark.sh
+++ b/ci/benchmark.sh
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+#
+# SPDX-License-Identifier: Unlicense
+
+#!/usr/bin/env bash
+set -euo pipefail
+
+RESULTS_DIR=${RESULTS_DIR:-results}
+TARGET_REPO=${TARGET_REPO:?Must set TARGET_REPO}
+REPO_NAME=$(basename "$TARGET_REPO" .git)
+TARGET_BRANCH=${TARGET_BRANCH:?Must set TARGET_BRANCH}
+RUN_IDENTIFIER=${RUN_IDENTIFIER:?Must set RUN_IDENTIFIER}
+API_TOKEN_GITHUB=${API_TOKEN_GITHUB:?Must set API_TOKEN_GITHUB}
+
+# Detect GPU vendor
+detect_gpu() {
+    if command -v nvidia-smi &>/dev/null; then
+        echo "nvidia"
+    elif command -v rocm-smi &>/dev/null; then
+        echo "amd"
+    else
+        echo "none"
+    fi
+}
+
+# Collect system info
+collect_system_info() {
+    mkdir -p "$RESULTS_DIR"
+    {
+        echo "===== CPU INFO ====="
+        lscpu || echo "lscpu not available"
+        echo ""
+
+        echo "===== GPU INFO ====="
+        if [[ "$1" == "nvidia" ]]; then
+            nvidia-smi --query-gpu=gpu_name,memory.total,driver_version --format=csv || echo "No NVIDIA GPU found"
+        elif [[ "$1" == "amd" ]]; then
+            rocm-smi --showproductname --showvbios || echo "No AMD GPU found"
+        else
+            echo "No GPU detected"
+        fi
+        echo ""
+
+        echo "===== COMPILER INFO ====="
+        echo "CMake:"
+        cmake --version || echo "cmake not available"
+        echo ""
+        echo "C++ compiler:"
+        clang++ --version || g++ --version || echo "No C++ compiler found"
+        echo ""
+        echo "CUDA/ROCm compiler:"
+        nvcc --version 2>/dev/null || hipcc --version 2>/dev/null || echo "No GPU compiler available"
+    } > "${RESULTS_DIR}/system-info.log"
+}
+
+# Build & benchmark given branch
+build_and_benchmark() {
+    local branch=$1
+    local output_dir=$2
+
+    echo ">>> Checking out ${branch}"
+    git fetch origin "${branch}"
+    git checkout "${branch}"
+
+    echo ">>> Configuring build"
+    if [[ "$GPU_VENDOR" == "nvidia" ]]; then
+        cmake --preset profiling -DCMAKE_CUDA_ARCHITECTURES=90 -DNeoN_WITH_THREADS=OFF
+    elif [[ "$GPU_VENDOR" == "amd" ]]; then
+        # Set ROCm environment
+        export PATH=/opt/rocm/bin:$PATH
+        export LD_LIBRARY_PATH=/opt/rocm/lib:/opt/rocm/lib64:$LD_LIBRARY_PATH
+
+        # Set host compiler for hipcc (default is Clang bundled in ROCm)
+        export HIPCC_CXX=/usr/bin/g++
+
+        cmake --preset profiling \
+            -DCMAKE_C_COMPILER=gcc \
+            -DCMAKE_CXX_COMPILER=hipcc \
+            -DCMAKE_HIP_ARCHITECTURES=gfx90a \
+            -DKokkos_ARCH_AMD_GFX90A=ON \
+            -DNeoN_WITH_THREADS=OFF
+    else
+        cmake --preset profiling -DNeoN_WITH_THREADS=OFF
+    fi
+
+    echo ">>> Building"
+    cmake --build --preset profiling
+
+    echo ">>> Running benchmarks..."
+    ctest --preset profiling
+
+    pushd build/profiling/bin/benchmarks >/dev/null
+    python3 ../../../../scripts/catch2json.py
+    popd >/dev/null
+
+    mkdir -p "${output_dir}"
+    cp build/profiling/bin/benchmarks/*.json "${output_dir}/"
+
+    rm -rf build
+}
+
+# Push benchmark results to GitHub
+push_results() {
+    git config --global user.email "gitlab-ci@users.noreply.github.com"
+    git config --global user.name "GitLab CI"
+
+    git clone "https://oauth2:${API_TOKEN_GITHUB}@${TARGET_REPO}"
+    cd "${REPO_NAME}"
+
+    git checkout "${TARGET_BRANCH}" || git checkout -b "${TARGET_BRANCH}"
+    mkdir -p "${RUN_IDENTIFIER}/${CI_RUNNER_DESCRIPTION}"
+    cp -r ../${RESULTS_DIR}/* "${RUN_IDENTIFIER}/${CI_RUNNER_DESCRIPTION}"
+
+    git add .
+    git commit -m "Benchmarks from GitLab pipeline ${RUN_IDENTIFIER}" || echo "No changes to commit"
+    git pull --rebase || true
+    git push origin "${TARGET_BRANCH}"
+}
+
+### Main execution ###
+GPU_VENDOR=$(detect_gpu)
+echo "Detected GPU vendor: ${GPU_VENDOR}"
+
+collect_system_info "${GPU_VENDOR}"
+
+# Current branch
+build_and_benchmark "$(git rev-parse --abbrev-ref HEAD)" "${RESULTS_DIR}"
+
+# Main branch
+build_and_benchmark "main" "${RESULTS_DIR}/main"
+
+# Push results
+push_results

--- a/ci/benchmark.sh
+++ b/ci/benchmark.sh
@@ -45,7 +45,7 @@ collect_system_info() {
         cmake --version || echo "cmake not available"
         echo ""
         echo "C++ compiler:"
-        clang++ --version || g++ --version || echo "No C++ compiler found"
+        g++ --version || clang++ --version || echo "No C++ compiler found"
         echo ""
         echo "CUDA/ROCm compiler:"
         nvcc --version 2>/dev/null || hipcc --version 2>/dev/null || echo "No GPU compiler available"

--- a/ci/benchmark.sh
+++ b/ci/benchmark.sh
@@ -67,15 +67,11 @@ build_and_benchmark() {
     if [[ "$GPU_VENDOR" == "nvidia" ]]; then
         cmake --preset profiling -DCMAKE_CUDA_ARCHITECTURES=90 -DNeoN_WITH_THREADS=OFF
     elif [[ "$GPU_VENDOR" == "amd" ]]; then
-        # Set ROCm environment
+        # Set up environment
         export PATH=/opt/rocm/bin:$PATH
-        export LD_LIBRARY_PATH=/opt/rocm/lib:/opt/rocm/lib64:$LD_LIBRARY_PATH
-
-        # Set host compiler for hipcc (default is Clang bundled in ROCm)
         export HIPCC_CXX=/usr/bin/g++
 
         cmake --preset profiling \
-            -DCMAKE_C_COMPILER=gcc \
             -DCMAKE_CXX_COMPILER=hipcc \
             -DCMAKE_HIP_ARCHITECTURES=gfx90a \
             -DKokkos_ARCH_AMD_GFX90A=ON \

--- a/ci/benchmark.sh
+++ b/ci/benchmark.sh
@@ -12,16 +12,15 @@ TARGET_BRANCH=${TARGET_BRANCH:?Must set TARGET_BRANCH}
 RUN_IDENTIFIER=${RUN_IDENTIFIER:?Must set RUN_IDENTIFIER}
 API_TOKEN_GITHUB=${API_TOKEN_GITHUB:?Must set API_TOKEN_GITHUB}
 
-# Detect GPU vendor
-detect_gpu() {
-    if command -v nvidia-smi &>/dev/null; then
-        echo "nvidia"
-    elif command -v rocm-smi &>/dev/null; then
-        echo "amd"
-    else
-        echo "none"
-    fi
-}
+# Check GPU type argument
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <gpu_type>"
+    echo "  gpu_type: nvidia | amd | none"
+    exit 1
+fi
+
+GPU_VENDOR="$1"
+echo "Selected GPU vendor: ${GPU_VENDOR}"
 
 # Collect system info
 collect_system_info() {
@@ -33,11 +32,11 @@ collect_system_info() {
 
         echo "===== GPU INFO ====="
         if [[ "$1" == "nvidia" ]]; then
-            nvidia-smi --query-gpu=gpu_name,memory.total,driver_version --format=csv || echo "No NVIDIA GPU found"
+            nvidia-smi
         elif [[ "$1" == "amd" ]]; then
-            rocm-smi --showproductname --showvbios || echo "No AMD GPU found"
+            rocm-smi --showproductname --showvbios
         else
-            echo "No GPU detected"
+            echo "No GPU selected"
         fi
         echo ""
 
@@ -118,9 +117,6 @@ push_results() {
 }
 
 ### Main execution ###
-GPU_VENDOR=$(detect_gpu)
-echo "Detected GPU vendor: ${GPU_VENDOR}"
-
 collect_system_info "${GPU_VENDOR}"
 
 # Current branch

--- a/ci/benchmark.sh
+++ b/ci/benchmark.sh
@@ -1,8 +1,10 @@
+#!/usr/bin/env bash
+#----------------------------------------------------------------------------------------
 # SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
+#----------------------------------------------------------------------------------------
 
-#!/usr/bin/env bash
 set -euo pipefail
 
 RESULTS_DIR=${RESULTS_DIR:-results}

--- a/ci/build-and-test.sh
+++ b/ci/build-and-test.sh
@@ -30,9 +30,6 @@ if [ "$GPU_TYPE" == "nvidia" ]; then
     ctest --preset develop --output-on-failure
 
 elif [ "$GPU_TYPE" == "amd" ]; then
-    # Set ROCm environment
-    export PATH=/opt/rocm/bin:$PATH
-    export LD_LIBRARY_PATH=/opt/rocm/lib:/opt/rocm/lib64:$LD_LIBRARY_PATH
     export HIPCC_CXX=/usr/bin/g++
 
     echo "=== AMD GPU and compiler driver info ==="
@@ -41,8 +38,6 @@ elif [ "$GPU_TYPE" == "amd" ]; then
 
     echo "=== Configuring, building, and testing NeoN on AMD ==="
     cmake --preset develop \
-        -DCMAKE_C_COMPILER=gcc \
-        -DCMAKE_CXX_COMPILER=hipcc \
         -DCMAKE_HIP_ARCHITECTURES=gfx90a \
         -DKokkos_ARCH_AMD_GFX90A=ON \
         -DNeoN_WITH_THREADS=OFF

--- a/ci/build-and-test.sh
+++ b/ci/build-and-test.sh
@@ -15,6 +15,10 @@ fi
 GPU_TYPE="$1"
 echo "Selected GPU type: $GPU_TYPE"
 
+echo "=== Tool versions ==="
+cmake --version
+g++ --version || clang++ --version
+
 if [ "$GPU_TYPE" == "nvidia" ]; then
     echo "=== NVIDIA GPU and compiler driver info ==="
     nvidia-smi --query-gpu=gpu_name,memory.total,driver_version --format=csv

--- a/ci/build-and-test.sh
+++ b/ci/build-and-test.sh
@@ -30,6 +30,8 @@ if [ "$GPU_TYPE" == "nvidia" ]; then
     ctest --preset develop --output-on-failure
 
 elif [ "$GPU_TYPE" == "amd" ]; then
+    # Set up environment
+    export PATH=/opt/rocm/bin:$PATH
     export HIPCC_CXX=/usr/bin/g++
 
     echo "=== AMD GPU and compiler driver info ==="

--- a/ci/build-and-test.sh
+++ b/ci/build-and-test.sh
@@ -38,6 +38,7 @@ elif [ "$GPU_TYPE" == "amd" ]; then
 
     echo "=== Configuring, building, and testing NeoN on AMD ==="
     cmake --preset develop \
+        -DCMAKE_CXX_COMPILER=hipcc \
         -DCMAKE_HIP_ARCHITECTURES=gfx90a \
         -DKokkos_ARCH_AMD_GFX90A=ON \
         -DNeoN_WITH_THREADS=OFF

--- a/ci/build-and-test.sh
+++ b/ci/build-and-test.sh
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+#
+# SPDX-License-Identifier: Unlicense
+
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check arguments
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <gpu_type>"
+    echo "  gpu_type: nvidia | amd"
+    exit 1
+fi
+
+GPU_TYPE="$1"
+echo "Selected GPU type: $GPU_TYPE"
+
+if [ "$GPU_TYPE" == "nvidia" ]; then
+    echo "=== NVIDIA GPU and compiler driver info ==="
+    nvidia-smi --query-gpu=gpu_name,memory.total,driver_version --format=csv
+    nvcc --version
+
+    echo "=== Configuring, building, and testing NeoN on NVIDIA ==="
+    cmake --preset develop -DCMAKE_CUDA_ARCHITECTURES=90 -DNeoN_WITH_THREADS=OFF
+    cmake --build --preset develop
+    ctest --preset develop --output-on-failure
+
+elif [ "$GPU_TYPE" == "amd" ]; then
+    # Set ROCm environment
+    export PATH=/opt/rocm/bin:$PATH
+    export LD_LIBRARY_PATH=/opt/rocm/lib:/opt/rocm/lib64:$LD_LIBRARY_PATH
+    export HIPCC_CXX=/usr/bin/g++
+
+    echo "=== AMD GPU and compiler driver info ==="
+    rocminfo | grep "AMD"
+    hipcc --version
+
+    echo "=== Configuring, building, and testing NeoN on AMD ==="
+    cmake --preset develop \
+        -DCMAKE_C_COMPILER=gcc \
+        -DCMAKE_CXX_COMPILER=hipcc \
+        -DCMAKE_HIP_ARCHITECTURES=gfx90a \
+        -DKokkos_ARCH_AMD_GFX90A=ON \
+        -DNeoN_WITH_THREADS=OFF
+    cmake --build --preset develop
+    ctest --preset develop --output-on-failure
+
+else
+    echo "Unknown GPU type: $GPU_TYPE"
+    exit 1
+fi

--- a/ci/build-and-test.sh
+++ b/ci/build-and-test.sh
@@ -1,8 +1,10 @@
+#!/usr/bin/env bash
+#----------------------------------------------------------------------------------------
 # SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
+#----------------------------------------------------------------------------------------
 
-#!/usr/bin/env bash
 set -euo pipefail
 
 # Check arguments

--- a/doc/timeIntegration/forwardEuler.rst
+++ b/doc/timeIntegration/forwardEuler.rst
@@ -11,7 +11,7 @@ It advances the solution from time step n to n+1 using:
     y_{n+1} = y_n + \Delta t \cdot f(t_n, y_n)
 
 Implementation
-_-------------
+-------------
 
 The implementation is entirely self-contained within NeoN, requiring no external libraries.
 The ``ForwardEuler`` class template inherits from ``TimeIntegratorBase`` and implements straightforward time-stepping functionality through its ``solve`` method:

--- a/doc/timeIntegration/forwardEuler.rst
+++ b/doc/timeIntegration/forwardEuler.rst
@@ -11,7 +11,7 @@ It advances the solution from time step n to n+1 using:
     y_{n+1} = y_n + \Delta t \cdot f(t_n, y_n)
 
 Implementation
---------------
+_-------------
 
 The implementation is entirely self-contained within NeoN, requiring no external libraries.
 The ``ForwardEuler`` class template inherits from ``TimeIntegratorBase`` and implements straightforward time-stepping functionality through its ``solve`` method:

--- a/doc/timeIntegration/forwardEuler.rst
+++ b/doc/timeIntegration/forwardEuler.rst
@@ -11,7 +11,7 @@ It advances the solution from time step n to n+1 using:
     y_{n+1} = y_n + \Delta t \cdot f(t_n, y_n)
 
 Implementation
--------------
+--------------
 
 The implementation is entirely self-contained within NeoN, requiring no external libraries.
 The ``ForwardEuler`` class template inherits from ``TimeIntegratorBase`` and implements straightforward time-stepping functionality through its ``solve`` method:


### PR DESCRIPTION
## The current status:
GitHub CI triggers LRZ GitLab CI pipelines to run CI jobs for NeoN, but the current pipelines run only on NVIDIA GPUs. Since NeoN also supports AMD GPUs, we need CI pipelines running on AMD GPUs.

The GitHub workflow of triggering LRZ GitLab CI does not get stopped when an unsuccessful status (`failed`, `canceled` or `skipped`) of a triggered CI pipeline is detected. Instead, the GitHub CI continues to query the status of the triggered CI pipeline.


## The new status:
**New features**
New CI pipelines are set up for AMD GPUs, including the following CI jobs:
- build and test NeoN
- benchmark NeoN

Moreover, the GitLab configuration file is highly refactored to be more concise and flexible. Two shell scripts are prepared for the two different types of CI jobs mentioned above for NVIDIA and AMD GPUs.

**Enhancements**
The GitHub workflow of triggering LRZ Gitlab CI is stopped once an unsuccessful status (`failed`, `canceled` or `skipped`) of a triggered CI pipeline is detected.
