### PR TITLE
Use current ginkgo version

### DIFF
--- a/.github/workflows/build_on_macos.yaml
+++ b/.github/workflows/build_on_macos.yaml
@@ -60,6 +60,8 @@ jobs:
            -DNeoN_BUILD_TESTS=ON \
            -DNeoN_DEVEL_TOOLS=OFF \
            -DCMAKE_PREFIX_PATH=/opt/homebrew/opt/libomp/ \
+           -DNeoN_WITH_OMP=OFF \
+           -DKokkos_ENABLE_THREADS=OFF \
            -DNeoN_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF
          cmake --build  --preset ${{matrix.preset}}
 

--- a/.github/workflows/build_on_macos.yaml
+++ b/.github/workflows/build_on_macos.yaml
@@ -52,7 +52,7 @@ jobs:
          ninja --version
          cmake --version
 
-     - name: Build NeoN
+     - name: Build NeoN without Ginkgo
        run: |
          CC=${{matrix.compiler.CC}} \
          CXX=${{matrix.compiler.CXX}} \
@@ -62,6 +62,7 @@ jobs:
            -DCMAKE_PREFIX_PATH=/opt/homebrew/opt/libomp/ \
            -DNeoN_WITH_OMP=OFF \
            -DKokkos_ENABLE_THREADS=OFF \
+           -DNeoN_WITH_GINKGO=OFF \
            -DNeoN_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF
          cmake --build  --preset ${{matrix.preset}}
 

--- a/.github/workflows/build_on_ubuntu.yaml
+++ b/.github/workflows/build_on_ubuntu.yaml
@@ -95,18 +95,6 @@ jobs:
            -DNeoN_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF
          cmake --build  --preset ${{matrix.preset}}
 
-     - name: Build NeoN with Ginkgo
-       if: ${{contains(github.event.pull_request.labels.*.name, 'full-ci')}}
-       run: |
-         CC=${{matrix.compiler.CC}} \
-         CXX=${{matrix.compiler.CXX}} \
-         cmake --preset ${{matrix.preset}} \
-           -DNeoN_BUILD_TESTS=ON \
-           -DNeoN_DEVEL_TOOLS=OFF \
-           -DNeoN_WITH_GINKGO=OFF \
-           -DNeoN_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF
-         cmake --build  --preset ${{matrix.preset}}
-
      - name: Execute unit tests NeoN
        run: |
          ctest --preset ${{matrix.preset}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add Ginkgo solver interface and config solver support [#250](https://github.com/exasim-project/NeoN/pull/250), [#272
 (https://github.com/exasim-project/NeoN/pull/272)
 ### Misc
+- Use current Ginkgo develop version [#362](https://github.com/exasim-project/NeoN/pull/362)
 - removed subscript operators from Field for improved safety. [#225](https://github.com/exasim-project/NeoN/pull/285)
 - Templated Expression and Operator on ValueType [#268](https://github.com/exasim-project/NeoN/pull/268)
 - Ability to solve poisson equation similar required in the PISO algorithm [#267](https://github.com/exasim-project/NeoN/pull/267)

--- a/cmake/CxxThirdParty.cmake
+++ b/cmake/CxxThirdParty.cmake
@@ -199,7 +199,7 @@ if(${NeoN_WITH_GINKGO})
     GITHUB_REPOSITORY
     ginkgo-project/ginkgo
     GIT_TAG
-    neon
+    0b50e390e15d36fe5432e6584049fd3f880584f1
     SYSTEM
     YES
     OPTIONS

--- a/cmake/CxxThirdParty.cmake
+++ b/cmake/CxxThirdParty.cmake
@@ -199,7 +199,7 @@ if(${NeoN_WITH_GINKGO})
     GITHUB_REPOSITORY
     ginkgo-project/ginkgo
     GIT_TAG
-    develop
+    neon
     SYSTEM
     YES
     OPTIONS

--- a/cmake/CxxThirdParty.cmake
+++ b/cmake/CxxThirdParty.cmake
@@ -199,7 +199,7 @@ if(${NeoN_WITH_GINKGO})
     GITHUB_REPOSITORY
     ginkgo-project/ginkgo
     GIT_TAG
-    kokkos-threads
+    develop
     SYSTEM
     YES
     OPTIONS

--- a/include/NeoN/linearAlgebra/ginkgo.hpp
+++ b/include/NeoN/linearAlgebra/ginkgo.hpp
@@ -158,7 +158,7 @@ public:
 
         auto endEval = std::chrono::steady_clock::now();
         auto duration =
-            static_cast<float>(
+            static_cast<scalar>(
                 std::chrono::duration_cast<std::chrono::microseconds>(endEval - startEval).count()
             )
             / 1000.0;

--- a/src/linearAlgebra/ginkgo.cpp
+++ b/src/linearAlgebra/ginkgo.cpp
@@ -8,8 +8,15 @@
 
 #include "NeoN/linearAlgebra/ginkgo.hpp"
 
-gko::config::pnode NeoN::la::ginkgo::parse(const Dictionary& dict)
+gko::config::pnode NeoN::la::ginkgo::parse(const Dictionary& dictIn)
 {
+    Dictionary dict = dictIn;
+    // remove 'solver Ginkgo;' entry
+    if (dict.contains("solver") && std::any_cast<std::string>(dict["solver"]) == "Ginkgo")
+    {
+        dict.remove("solver");
+    }
+
     // check if an external file name is given
     if (dict.contains("configFile"))
     {
@@ -24,7 +31,7 @@ gko::config::pnode NeoN::la::ginkgo::parse(const Dictionary& dict)
         {
             auto token = std::any_cast<TokenList>(fn);
             std::stringstream s;
-            for (auto i = 0; i < token.size() - 1; i++)
+            for (NeoN::size_t i = 0; i < token.size() - 1; i++)
             {
                 s << token.next<std::string>() << "/";
             }


### PR DESCRIPTION
Since the kokkos-threads branch is not available anymore, we for now use a branch called neon which is a snapshot of the current develop.

Additionally:
- switches off the omp support on MacOs, since it fails to build. This should get a proper investigation.
- build without Ginkgo on MacOs for faster builds
- remove build_with_ginkgo section from ubuntu workflow since building with Ginkgo was turned off.