### PR TITLE
Improve third-party dependencies management, fix Ginkgo configure and GitHub CI

### DIFF
--- a/.github/workflows/build_adapter.yaml
+++ b/.github/workflows/build_adapter.yaml
@@ -57,7 +57,7 @@ jobs:
         with:
           repository: exasim-project/FoamAdapter
           ref: '${{ env.FOAMADAPTER_BRANCH }}'
-          fetch-depth: 1   # ensures full history
+          fetch-depth: 1
 
       # Optional NeoN checkout if needed
       # - name: Checkout NeoN submodule

--- a/.github/workflows/build_adapter.yaml
+++ b/.github/workflows/build_adapter.yaml
@@ -32,65 +32,85 @@ jobs:
             CXX: g++
     runs-on: ubuntu-24.04
     steps:
-     - name: Determine branch to checkout
-       run: |
-         # Use PR head branch if available, otherwise the branch of the push
-         BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
-         echo "checkout=$BRANCH" >> $GITHUB_ENV
+      # Determine NeoN branch
+      - name: Determine NeoN branch
+        run: |
+          NEON_BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+          echo "NEON_BRANCH=$NEON_BRANCH" >> $GITHUB_ENV
+          echo "Using NeoN branch: $NEON_BRANCH"
 
-     - name: Checkout FoamAdapter
-       uses: actions/checkout@v4
-       with:
-        repository: exasim-project/FoamAdapter
-        ref: '${{ env.checkout }}'
+      # Determine FoamAdapter branch safely
+      - name: Determine FoamAdapter branch
+        run: |
+          # Check if FoamAdapter has a branch with the same name as NeoN
+          if git ls-remote --exit-code --heads https://github.com/exasim-project/FoamAdapter "${{ env.NEON_BRANCH }}" >/dev/null 2>&1; then
+            echo "FoamAdapter branch exists: ${{ env.NEON_BRANCH }}"
+            echo "FOAMADAPTER_BRANCH=${{ env.NEON_BRANCH }}" >> $GITHUB_ENV
+          else
+            echo "FoamAdapter branch does not exist, using main"
+            echo "FOAMADAPTER_BRANCH=main" >> $GITHUB_ENV
+          fi
 
-     # Optional NeoN checkout if needed
-     # - name: Checkout NeoN submodule
-     #   uses: actions/checkout@v4
-     #   with:
-     #    repository: exasim-project/NeoN
-     #    path: NeoN
-     #    ref: '${{ env.checkout }}'
+      # Checkout FoamAdapter
+      - name: Checkout FoamAdapter
+        uses: actions/checkout@v4
+        with:
+          repository: exasim-project/FoamAdapter
+          ref: '${{ env.FOAMADAPTER_BRANCH }}'
+          fetch-depth: 0   # ensures full history
 
-     - name: Set up OpenFOAM
-       uses: gerlero/setup-openfoam@v1
-       with:
-         openfoam-version: 2406
+      # Optional NeoN checkout if needed
+      # - name: Checkout NeoN submodule
+      #   uses: actions/checkout@v4
+      #   with:
+      #     repository: exasim-project/NeoN
+      #     path: NeoN
+      #     ref: '${{ env.NEON_BRANCH }}'
 
-     - name: Install dependencies
-       uses: gerlero/apt-install@v1
-       with:
-         packages: >-
-           ninja-build
-           clang-16
-           gcc-10
-           libomp-16-dev
-           python3
-           python3-dev
-           build-essential
-           libopenmpi-dev
-           openmpi-bin
+      # Setup OpenFOAM
+      - name: Set up OpenFOAM
+        uses: gerlero/setup-openfoam@v1
+        with:
+          openfoam-version: 2406
 
-     - name: Get versions
-       run: |
-         clang --version
-         ninja --version
-         cmake --version
+      # Install dependencies
+      - name: Install dependencies
+        uses: gerlero/apt-install@v1
+        with:
+          packages: >-
+            ninja-build
+            clang-16
+            gcc-10
+            libomp-16-dev
+            python3
+            python3-dev
+            build-essential
+            libopenmpi-dev
+            openmpi-bin
 
-     - name: Build FoamAdapter
-       run: |
-         source /usr/lib/openfoam/openfoam2406/etc/bashrc || true
-         CC=${{matrix.compiler.CC}} \
-         CXX=${{matrix.compiler.CXX}} \
-         cmake --preset develop \
-           -DNeoN_DEVEL_TOOLS=OFF \
-           -DNeoN_BUILD_TESTS=OFF \
-           -DFOAMADAPTER_BUILD_BENCHMARKS=OFF \
-           -DNeoN_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF \
-           -DFOAMADAPTER_NEON_VERSION=${{env.checkout}}
-         cmake --build  --preset develop
+      # Print versions for debug
+      - name: Get versions
+        run: |
+          clang --version
+          ninja --version
+          cmake --version
 
-     - name: Execute unit tests NeoN
-       run: |
-         source /usr/lib/openfoam/openfoam2406/etc/bashrc || true
-         ctest --preset develop
+      # Build FoamAdapter
+      - name: Build FoamAdapter
+        run: |
+          source /usr/lib/openfoam/openfoam2406/etc/bashrc || true
+          CC=${{matrix.compiler.CC}} \
+          CXX=${{matrix.compiler.CXX}} \
+          cmake --preset develop \
+            -DNeoN_DEVEL_TOOLS=OFF \
+            -DNeoN_BUILD_TESTS=OFF \
+            -DFOAMADAPTER_BUILD_BENCHMARKS=OFF \
+            -DNeoN_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF \
+            -DFOAMADAPTER_NEON_VERSION=${{ env.NEON_BRANCH }}
+          cmake --build --preset develop
+
+      # Run tests
+      - name: Execute unit tests NeoN
+        run: |
+          source /usr/lib/openfoam/openfoam2406/etc/bashrc || true
+          ctest --preset develop

--- a/.github/workflows/build_adapter.yaml
+++ b/.github/workflows/build_adapter.yaml
@@ -7,8 +7,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
   schedule:
-    - cron: '00 8 * * 0'  # Runs at 10 AM CEST (08:00 UTC) every Sunday
-  workflow_dispatch:      # Optional: allows manual trigger
+    - cron: '00 8 * * 0'
+  workflow_dispatch:
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
@@ -32,16 +32,11 @@ jobs:
             CXX: g++
     runs-on: ubuntu-24.04
     steps:
-     - name: Select branch to checkout
+     - name: Determine branch to checkout
        run: |
-         if [[ -n "${{ github.head_ref }}" ]] && [[ $(git ls-remote --exit-code --heads https://github.com/exasim-project/FoamAdapter ${{ github.head_ref }}) ]]
-         then
-           echo "checkout ${{ github.head_ref }}"
-           echo checkout=${{ github.head_ref }} >> $GITHUB_ENV
-         else
-           echo "checkout main"
-           echo checkout=main >> $GITHUB_ENV
-         fi
+         # Use PR head branch if available, otherwise the branch of the push
+         BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+         echo "checkout=$BRANCH" >> $GITHUB_ENV
 
      - name: Checkout FoamAdapter
        uses: actions/checkout@v4
@@ -49,12 +44,13 @@ jobs:
         repository: exasim-project/FoamAdapter
         ref: '${{ env.checkout }}'
 
+     # Optional NeoN checkout if needed
      # - name: Checkout NeoN submodule
      #   uses: actions/checkout@v4
      #   with:
      #    repository: exasim-project/NeoN
      #    path: NeoN
-     #    ref: '${{ github.head_ref }}'
+     #    ref: '${{ env.checkout }}'
 
      - name: Set up OpenFOAM
        uses: gerlero/setup-openfoam@v1

--- a/.github/workflows/build_adapter.yaml
+++ b/.github/workflows/build_adapter.yaml
@@ -57,7 +57,7 @@ jobs:
         with:
           repository: exasim-project/FoamAdapter
           ref: '${{ env.FOAMADAPTER_BRANCH }}'
-          fetch-depth: 0   # ensures full history
+          fetch-depth: 1   # ensures full history
 
       # Optional NeoN checkout if needed
       # - name: Checkout NeoN submodule

--- a/cmake/CxxThirdParty.cmake
+++ b/cmake/CxxThirdParty.cmake
@@ -4,10 +4,8 @@
 
 # set(FETCHCONTENT_BASE_DIR ${CMAKE_BINARY_DIR}/cmake_packages)
 
-set(NeoN_KOKKOS_CHECKOUT_VERSION
-    "4.3.00"
-    CACHE STRING "Use specific version of Kokkos")
-mark_as_advanced(NeoN_KOKKOS_CHECKOUT_VERSION)
+include(cmake/Versions.cmake)
+
 if(NeoN_ENABLE_MPI_SUPPORT)
   if(WIN32)
     message(FATAL_ERROR "NeoN_ENABLE_MPI_SUPPORT not supported on Windows")
@@ -45,7 +43,7 @@ if(NOT Kokkos_FOUND)
 
   FetchContent_Declare(
     Kokkos
-    SYSTEM QUITE
+    SYSTEM QUIET
     GIT_SHALLOW ON
     GIT_REPOSITORY "https://github.com/kokkos/kokkos.git"
     GIT_TAG ${NeoN_KOKKOS_CHECKOUT_VERSION})
@@ -61,9 +59,9 @@ cpmaddpackage(
   NAME
   cpptrace
   URL
-  https://github.com/jeremy-rifkin/cpptrace/archive/refs/tags/v0.7.3.zip
+  https://github.com/jeremy-rifkin/cpptrace/archive/refs/tags/v${NeoN_CPPTRACE_VERSION}.zip
   VERSION
-  0.7.3
+  ${NeoN_CPPTRACE_VERSION}
   SYSTEM)
 
 if(${NeoN_WITH_ADIOS2})
@@ -90,8 +88,6 @@ if(${NeoN_WITH_ADIOS2})
     list(APPEND ADIOS2_OPTIONS "BUILD_SHARED_LIBS ON")
   endif()
 
-  # Checking for patched and cached ADIOS2 will become obsolete after this issue in CPM has been
-  # fixed: https://github.com/cpm-cmake/CPM.cmake/issues/618
   if(NOT ADIOS2_PATCHED)
     set(ADIOS2_PATCHED
         TRUE
@@ -104,7 +100,7 @@ if(${NeoN_WITH_ADIOS2})
       PATCH_COMMAND
       ${ADIOS2_KOKKOS_PATCH}
       VERSION
-      2.10.2
+      ${NeoN_ADIOS2_VERSION}
       OPTIONS
       ${ADIOS2_OPTIONS}
       ${ADIOS2_CUDA_OPTIONS}
@@ -116,7 +112,7 @@ if(${NeoN_WITH_ADIOS2})
       GITHUB_REPOSITORY
       ornladios/ADIOS2
       VERSION
-      2.10.2
+      ${NeoN_ADIOS2_VERSION}
       OPTIONS
       ${ADIOS2_OPTIONS}
       ${ADIOS2_CUDA_OPTIONS}
@@ -158,7 +154,7 @@ if(${NeoN_WITH_SUNDIALS})
     GITHUB_REPOSITORY
     LLNL/sundials
     VERSION
-    7.3.0
+    ${NeoN_SUNDIALS_VERSION}
     SYSTEM
     YES
     OPTIONS
@@ -166,23 +162,14 @@ if(${NeoN_WITH_SUNDIALS})
     ${SUNDIALS_CUDA_OPTIONS})
 endif()
 
-# currently not used cpmaddpackage( NAME spdlog URL
-# https://github.com/gabime/spdlog/archive/refs/tags/v1.13.0.zip VERSION 1.13.0 SYSTEM)
-
-# currently not used cpmaddpackage( NAME cxxopts URL
-# https://github.com/jarro2783/cxxopts/archive/refs/tags/v3.2.0.zip VERSION 3.2.0 SYSTEM)
-
 if(${NeoN_WITH_GINKGO})
-  # nlohmann json is only needed in combination with ginkgo. Getting the package via cpm+github
-  # takes ages. After pulling only the .zip no nlohmann_json::nlohman_json target is found. Thus we
-  # always prepare system install version of nlohmann_json if present.
-  find_package(nlohmann_json 3.11.3 QUIET)
+  find_package(nlohmann_json ${NeoN_JSON_VERSION} QUIET)
   if(NOT nlohmann_json_FOUND)
     cpmaddpackage(
       NAME
       nlohmann_json
       VERSION
-      3.11.3
+      ${NeoN_JSON_VERSION}
       GITHUB_REPOSITORY
       nlohmann/json
       SYSTEM
@@ -195,11 +182,11 @@ if(${NeoN_WITH_GINKGO})
     NAME
     Ginkgo
     VERSION
-    1.10.0
+    ${NeoN_GINKGO_VERSION}
     GITHUB_REPOSITORY
     ginkgo-project/ginkgo
     GIT_TAG
-    0b50e390e15d36fe5432e6584049fd3f880584f1
+    ${NeoN_GINKGO_TAG}
     SYSTEM
     YES
     OPTIONS
@@ -218,9 +205,9 @@ if(NeoN_BUILD_TESTS OR NeoN_BUILD_BENCHMARKS)
     NAME
     Catch2
     URL
-    https://github.com/catchorg/Catch2/archive/refs/tags/v3.4.0.zip
+    https://github.com/catchorg/Catch2/archive/refs/tags/v${NeoN_CATCH2_VERSION}.zip
     VERSION
-    3.4.0
+    ${NeoN_CATCH2_VERSION}
     SYSTEM
     YES)
 endif()

--- a/cmake/Versions.cmake
+++ b/cmake/Versions.cmake
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+#
+# SPDX-License-Identifier: Unlicense
+
+# Centralized version management for all third-party dependencies in NeoN
+
+set(NeoN_KOKKOS_CHECKOUT_VERSION
+    "4.3.00"
+    CACHE STRING "Use specific version of Kokkos")
+mark_as_advanced(NeoN_KOKKOS_CHECKOUT_VERSION)
+
+set(NeoN_CPPTRACE_VERSION "0.7.3")
+set(NeoN_ADIOS2_VERSION "2.10.2")
+set(NeoN_SUNDIALS_VERSION "7.3.0")
+set(NeoN_JSON_VERSION "3.11.3")
+set(NeoN_GINKGO_VERSION "1.10.0")
+set(NeoN_GINKGO_TAG "0b50e390e15d36fe5432e6584049fd3f880584f1") # avoid floating "develop" or branches
+set(NeoN_CATCH2_VERSION "3.4.0")

--- a/cmake/Versions.cmake
+++ b/cmake/Versions.cmake
@@ -14,5 +14,5 @@ set(NeoN_ADIOS2_VERSION "2.10.2")
 set(NeoN_SUNDIALS_VERSION "7.3.0")
 set(NeoN_JSON_VERSION "3.11.3")
 set(NeoN_GINKGO_VERSION "1.10.0")
-set(NeoN_GINKGO_TAG "0b50e390e15d36fe5432e6584049fd3f880584f1") # avoid floating "develop" or branches
+set(NeoN_GINKGO_TAG "0b50e390e15d36fe5432e6584049fd3f880584f1")
 set(NeoN_CATCH2_VERSION "3.4.0")


### PR DESCRIPTION
### New feature:
NeoN depends on many external libraries and tools. This PR makes it easier to manage the versions of all external libraries and tools by adding a centralized version management.

The versions of all third-party dependencies are now managed and visible in a single place instead of spreading across a larger third-party management file.

### Fix:
- Fix the tag used for fetching Ginkgo. The original tag `kokkos-threads` is deleted because the corresponding branch is merged on Ginkgo.
- Fix the selection logic of FoamAdapter and NeoN branch in the GitHub workflow of building FoamAdapter against NeoN on CPU.

