### PR TITLE
Fix Ginkgo config solver issue.

### DIFF
--- a/include/NeoN/linearAlgebra/ginkgo.hpp
+++ b/include/NeoN/linearAlgebra/ginkgo.hpp
@@ -158,7 +158,7 @@ public:
 
         auto endEval = std::chrono::steady_clock::now();
         auto duration =
-            static_cast<float>(
+            static_cast<scalar>(
                 std::chrono::duration_cast<std::chrono::microseconds>(endEval - startEval).count()
             )
             / 1000.0;

--- a/src/linearAlgebra/ginkgo.cpp
+++ b/src/linearAlgebra/ginkgo.cpp
@@ -8,8 +8,15 @@
 
 #include "NeoN/linearAlgebra/ginkgo.hpp"
 
-gko::config::pnode NeoN::la::ginkgo::parse(const Dictionary& dict)
+gko::config::pnode NeoN::la::ginkgo::parse(const Dictionary& dictIn)
 {
+    Dictionary dict = dictIn;
+    // remove 'solver Ginkgo;' entry
+    if (dict.contains("solver") && std::any_cast<std::string>(dict["solver"]) == "Ginkgo")
+    {
+        dict.remove("solver");
+    }
+
     // check if an external file name is given
     if (dict.contains("configFile"))
     {
@@ -24,7 +31,7 @@ gko::config::pnode NeoN::la::ginkgo::parse(const Dictionary& dict)
         {
             auto token = std::any_cast<TokenList>(fn);
             std::stringstream s;
-            for (auto i = 0; i < token.size() - 1; i++)
+            for (NeoN::size_t i = 0; i < token.size() - 1; i++)
             {
                 s << token.next<std::string>() << "/";
             }


### PR DESCRIPTION
This PR fixes an issue with Ginkgos config solver. After bumping the Ginkgo version Ginkgo now checks for wrong key values pairs in the config. Thus this PR removes `solver Gingko;` from the parsed dictionary.