### PR TITLE
Dont build benchmarks in github pipelines

### DIFF
--- a/.github/workflows/build_on_macos.yaml
+++ b/.github/workflows/build_on_macos.yaml
@@ -28,7 +28,7 @@ jobs:
         compiler:
           - CC: gcc
             CXX: g++
-        preset: ["develop" ]
+        preset: ["develop"]
     runs-on: macos-latest
     steps:
      - name: Checkout to repository

--- a/.github/workflows/build_on_ubuntu.yaml
+++ b/.github/workflows/build_on_ubuntu.yaml
@@ -92,6 +92,7 @@ jobs:
            -DNeoN_BUILD_TESTS=ON \
            -DNeoN_DEVEL_TOOLS=OFF \
            -DNeoN_WITH_GINKGO=OFF \
+           -DNeoN_BUILD_BENCHMARKS=OFF \
            -DNeoN_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF
          cmake --build  --preset ${{matrix.preset}}
 


### PR DESCRIPTION
Since we execute the benchmarks on the lrz cluster i think it is not necessary to build and execute the benchmarks here.