### PR TITLE
Vector Matrix Solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Version 0.2.0 (unreleased)
 ## Features
+- Improved support for assembling and solving expression of Field<Vec3>. [#370](https://github.com/exasim-project/NeoN/pull/370)
 ### Refactoring
 - Vector split into an generic container class, Array, and the Vector class specialized for as a mathematical operations.  [#318](https://github.com/exasim-project/NeoN/pull/318)
 - General refactor of span and spans to view and views.  [#311](https://github.com/exasim-project/NeoN/pull/311)

--- a/include/NeoN/linearAlgebra/ginkgo.hpp
+++ b/include/NeoN/linearAlgebra/ginkgo.hpp
@@ -41,37 +41,6 @@ gko::array<T> createGkoArray(std::shared_ptr<const gko::Executor> exec, std::spa
 //     return gko::make_const_array_view(exec, values.size(), values.data());
 // }
 
-template<typename ValueType, typename IndexType>
-std::shared_ptr<gko::matrix::Csr<ValueType, IndexType>> createGkoMtx(
-    std::shared_ptr<const gko::Executor> exec, const LinearSystem<ValueType, IndexType>& sys
-)
-{
-    auto nrows = static_cast<gko::dim<2>::dimension_type>(sys.rhs().size());
-    auto mtx = sys.view().matrix;
-    // NOTE we get a const view of the system but need a non const view to vals and indices
-    // auto vals = createConstGkoArray(exec, mtx.values).copy_to_array();
-    auto vals = gko::array<ValueType>::view(
-        exec,
-        static_cast<gko::size_type>(mtx.values.size()),
-        const_cast<ValueType*>(mtx.values.data())
-    );
-    // auto col = createGkoArray(exec, mtx.colIdxs);
-    auto col = gko::array<IndexType>::view(
-        exec,
-        static_cast<gko::size_type>(mtx.colIdxs.size()),
-        const_cast<IndexType*>(mtx.colIdxs.data())
-    );
-    // auto row = createGkoArray(exec, mtx.rowOffs);
-    auto row = gko::array<IndexType>::view(
-        exec,
-        static_cast<gko::size_type>(mtx.rowOffs.size()),
-        const_cast<IndexType*>(mtx.rowOffs.data())
-    );
-    return gko::share(gko::matrix::Csr<ValueType, IndexType>::create(
-        exec, gko::dim<2> {nrows, nrows}, vals, col, row
-    ));
-}
-
 template<typename ValueType>
 std::shared_ptr<gko::matrix::Dense<ValueType>>
 createGkoDense(std::shared_ptr<const gko::Executor> exec, ValueType* ptr, localIdx s)
@@ -118,100 +87,9 @@ public:
     static std::string schema() { return "none"; }
 
     virtual SolverStats
-    solve(const LinearSystem<scalar, localIdx>& sys, Vector<scalar>& x) const final
-    {
-        auto startEval = std::chrono::steady_clock::now();
-        using vec = gko::matrix::Dense<scalar>;
+    solve(const LinearSystem<scalar, localIdx>& sys, Vector<scalar>& x) const final;
 
-        auto retrieve = [](const auto& in)
-        {
-            auto host = vec::create(in->get_executor()->get_master(), gko::dim<2> {1});
-            scalar res = host->copy_from(in)->at(0);
-            return res;
-        };
-
-        auto nrows = sys.rhs().size();
-
-        auto gkoMtx = detail::createGkoMtx(gkoExec_, sys);
-        auto solver = factory_->generate(gkoMtx);
-
-        std::shared_ptr<const gko::log::Convergence<scalar>> logger =
-            gko::log::Convergence<scalar>::create();
-        solver->add_logger(logger);
-
-        auto rhs = detail::createGkoDense(gkoExec_, sys.rhs().data(), nrows);
-        auto rhs2 = detail::createGkoDense(gkoExec_, sys.rhs().data(), nrows);
-        auto gkoX = detail::createGkoDense(gkoExec_, x.data(), nrows);
-
-        auto one = gko::initialize<vec>({1.0}, gkoExec_);
-        auto neg_one = gko::initialize<vec>({-1.0}, gkoExec_);
-        auto init = gko::initialize<vec>({0.0}, gkoExec_);
-        gkoMtx->apply(one, gkoX, neg_one, rhs2);
-        rhs->compute_norm2(init);
-        scalar initResNorm = retrieve(init);
-
-        solver->apply(rhs, gkoX);
-
-        scalar finalResNorm = retrieve(gko::as<vec>(logger->get_residual_norm()));
-
-        auto numIter = label(logger->get_num_iterations());
-
-        auto endEval = std::chrono::steady_clock::now();
-        auto duration =
-            static_cast<scalar>(
-                std::chrono::duration_cast<std::chrono::microseconds>(endEval - startEval).count()
-            )
-            / 1000.0;
-        return {numIter, initResNorm, finalResNorm, duration};
-    }
-
-    virtual SolverStats solve(const LinearSystem<Vec3, localIdx>& sys, Vector<Vec3>& x) const final
-    {
-        // auto startEval = std::chrono::steady_clock::now();
-        // using vec = gko::matrix::Dense<scalar>;
-
-        // auto retrieve = [](const auto& in)
-        // {
-        //     auto host = vec::create(in->get_executor()->get_master(), gko::dim<2> {1});
-        //     scalar res = host->copy_from(in)->at(0);
-        //     return res;
-        // };
-
-        // auto nrows = sys.rhs().size();
-
-        // auto gkoMtx = detail::createGkoMtx(gkoExec_, sys);
-        // auto solver = factory_->generate(gkoMtx);
-
-        // std::shared_ptr<const gko::log::Convergence<scalar>> logger =
-        //     gko::log::Convergence<scalar>::create();
-        // solver->add_logger(logger);
-
-        // auto rhs = detail::createGkoDense(gkoExec_, sys.rhs().data(), nrows);
-        // auto rhs2 = detail::createGkoDense(gkoExec_, sys.rhs().data(), nrows);
-        // auto gkoX = detail::createGkoDense(gkoExec_, x.data(), nrows);
-
-        // auto one = gko::initialize<vec>({1.0}, gkoExec_);
-        // auto neg_one = gko::initialize<vec>({-1.0}, gkoExec_);
-        // auto init = gko::initialize<vec>({0.0}, gkoExec_);
-        // gkoMtx->apply(one, gkoX, neg_one, rhs2);
-        // rhs->compute_norm2(init);
-        // scalar initResNorm = retrieve(init);
-
-        // solver->apply(rhs, gkoX);
-
-        // scalar finalResNorm = retrieve(gko::as<vec>(logger->get_residual_norm()));
-
-        // auto numIter = label(logger->get_num_iterations());
-
-        // auto endEval = std::chrono::steady_clock::now();
-        // auto duration =
-        //     static_cast<scalar>(
-        //         std::chrono::duration_cast<std::chrono::microseconds>(endEval -
-        //         startEval).count()
-        //     )
-        //     / 1000.0;
-        // return {numIter, initResNorm, finalResNorm, duration};
-    }
+    virtual SolverStats solve(const LinearSystem<Vec3, localIdx>& sys, Vector<Vec3>& x) const final;
 
     // TODO why use a smart pointer here?
     virtual std::unique_ptr<SolverFactory> clone() const final

--- a/include/NeoN/linearAlgebra/ginkgo.hpp
+++ b/include/NeoN/linearAlgebra/ginkgo.hpp
@@ -25,44 +25,6 @@ namespace NeoN::la::ginkgo
 
 std::shared_ptr<gko::Executor> getGkoExecutor(Executor exec);
 
-namespace detail
-{
-
-template<typename T>
-gko::array<T> createGkoArray(std::shared_ptr<const gko::Executor> exec, std::span<T> values)
-{
-    return gko::make_array_view(exec, values.size(), values.data());
-}
-
-// template<typename T>
-// gko::detail::const_array_view<T>
-// createConstGkoArray(std::shared_ptr<const gko::Executor> exec, const std::span<const T> values)
-// {
-//     return gko::make_const_array_view(exec, values.size(), values.data());
-// }
-
-template<typename ValueType>
-std::shared_ptr<gko::matrix::Dense<ValueType>>
-createGkoDense(std::shared_ptr<const gko::Executor> exec, ValueType* ptr, localIdx s)
-{
-    auto size = static_cast<std::size_t>(s);
-    return gko::share(gko::matrix::Dense<ValueType>::create(
-        exec, gko::dim<2> {size, 1}, createGkoArray(exec, std::span {ptr, size}), 1
-    ));
-}
-
-template<typename ValueType>
-std::shared_ptr<gko::matrix::Dense<ValueType>>
-createGkoDense(std::shared_ptr<const gko::Executor> exec, const ValueType* ptr, localIdx s)
-{
-    auto size = static_cast<std::size_t>(s);
-    auto const_array_view = gko::array<ValueType>::const_view(exec, size, ptr);
-    return gko::share(gko::matrix::Dense<ValueType>::create(
-        exec, gko::dim<2> {size, 1}, const_array_view.copy_to_array(), 1
-    ));
-}
-
-}
 gko::config::pnode parse(const Dictionary& dict);
 
 class GinkgoSolver : public SolverFactory::template Register<GinkgoSolver>

--- a/include/NeoN/linearAlgebra/ginkgo.hpp
+++ b/include/NeoN/linearAlgebra/ginkgo.hpp
@@ -165,6 +165,54 @@ public:
         return {numIter, initResNorm, finalResNorm, duration};
     }
 
+    virtual SolverStats solve(const LinearSystem<Vec3, localIdx>& sys, Vector<Vec3>& x) const final
+    {
+        // auto startEval = std::chrono::steady_clock::now();
+        // using vec = gko::matrix::Dense<scalar>;
+
+        // auto retrieve = [](const auto& in)
+        // {
+        //     auto host = vec::create(in->get_executor()->get_master(), gko::dim<2> {1});
+        //     scalar res = host->copy_from(in)->at(0);
+        //     return res;
+        // };
+
+        // auto nrows = sys.rhs().size();
+
+        // auto gkoMtx = detail::createGkoMtx(gkoExec_, sys);
+        // auto solver = factory_->generate(gkoMtx);
+
+        // std::shared_ptr<const gko::log::Convergence<scalar>> logger =
+        //     gko::log::Convergence<scalar>::create();
+        // solver->add_logger(logger);
+
+        // auto rhs = detail::createGkoDense(gkoExec_, sys.rhs().data(), nrows);
+        // auto rhs2 = detail::createGkoDense(gkoExec_, sys.rhs().data(), nrows);
+        // auto gkoX = detail::createGkoDense(gkoExec_, x.data(), nrows);
+
+        // auto one = gko::initialize<vec>({1.0}, gkoExec_);
+        // auto neg_one = gko::initialize<vec>({-1.0}, gkoExec_);
+        // auto init = gko::initialize<vec>({0.0}, gkoExec_);
+        // gkoMtx->apply(one, gkoX, neg_one, rhs2);
+        // rhs->compute_norm2(init);
+        // scalar initResNorm = retrieve(init);
+
+        // solver->apply(rhs, gkoX);
+
+        // scalar finalResNorm = retrieve(gko::as<vec>(logger->get_residual_norm()));
+
+        // auto numIter = label(logger->get_num_iterations());
+
+        // auto endEval = std::chrono::steady_clock::now();
+        // auto duration =
+        //     static_cast<scalar>(
+        //         std::chrono::duration_cast<std::chrono::microseconds>(endEval -
+        //         startEval).count()
+        //     )
+        //     / 1000.0;
+        // return {numIter, initResNorm, finalResNorm, duration};
+    }
+
     // TODO why use a smart pointer here?
     virtual std::unique_ptr<SolverFactory> clone() const final
     {

--- a/include/NeoN/linearAlgebra/solver.hpp
+++ b/include/NeoN/linearAlgebra/solver.hpp
@@ -46,8 +46,6 @@ public:
     virtual SolverStats solve(const LinearSystem<scalar, localIdx>&, Vector<scalar>&) const = 0;
 
     virtual SolverStats solve(const LinearSystem<Vec3, localIdx>&, Vector<Vec3>&) const = 0;
-    // virtual void
-    // solve(const LinearSystem<ValueType, int>&, Vector<Vec3>& ) const = 0;
 
     // Pure virtual function for cloning
     virtual std::unique_ptr<SolverFactory> clone() const = 0;

--- a/include/NeoN/linearAlgebra/solver.hpp
+++ b/include/NeoN/linearAlgebra/solver.hpp
@@ -45,6 +45,7 @@ public:
 
     virtual SolverStats solve(const LinearSystem<scalar, localIdx>&, Vector<scalar>&) const = 0;
 
+    virtual SolverStats solve(const LinearSystem<Vec3, localIdx>&, Vector<Vec3>&) const = 0;
     // virtual void
     // solve(const LinearSystem<ValueType, int>&, Vector<Vec3>& ) const = 0;
 
@@ -74,6 +75,11 @@ public:
         : exec_(exec), solverInstance_(SolverFactory::create(exec, dict)) {};
 
     SolverStats solve(const LinearSystem<scalar, localIdx>& ls, Vector<scalar>& field) const
+    {
+        return solverInstance_->solve(ls, field);
+    }
+
+    SolverStats solve(const LinearSystem<Vec3, localIdx>& ls, Vector<Vec3>& field) const
     {
         return solverInstance_->solve(ls, field);
     }

--- a/include/NeoN/linearAlgebra/utilities.hpp
+++ b/include/NeoN/linearAlgebra/utilities.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "NeoN/core/primitives/scalar.hpp"
+#include "NeoN/core/primitives/vec3.hpp"
 #include "NeoN/core/vector/vector.hpp"
 #include "NeoN/linearAlgebra/CSRMatrix.hpp"
 
@@ -12,7 +13,58 @@
 namespace NeoN::la
 {
 
-/* @brief given a linear system consisting of A, b and x the operator computes the residual vector
+/* @brief given a vector a [0,1,0,1,2,1,2] this returns [0,1,2,3,4,5,0,1,2,...]
+ *
+ * @param[in] in the vector to duplicate
+ * @return A vector containing duplicated entries
+ */
+Vector<localIdx> duplicateColIdx(
+    const Vector<localIdx>& in,
+    const Vector<localIdx>& newRowOffs,
+    const Vector<localIdx>& oldRowOffs
+);
+
+/* @brief given a vector of rowOffs [0,3,6] this returns [0,3,6,9,12,15,18,21]
+ *
+ * @param[in] in the vector to duplicate
+ * @return A vector containing duplicated entries
+ */
+Vector<localIdx> stretchRowPtrs(const Vector<localIdx>& in);
+
+/* @brief given a vector [{1,2,3},{4,5,6},{7,8,9}] this returns [1,2,3,4,5,6,7,8,9]
+ *
+ * @param[in] in the vector to duplicate
+ * @return A vector containing duplicated entries
+ */
+Vector<scalar> flatten(const Vector<Vec3>& in);
+
+/* @brief given a vector [{1,2,3},{4,5,6},{7,8,9}] this returns [1,2,3,4,5,6,7,8,9]
+ *
+ * @param[in] in the vector to duplicate
+ * @return A vector containing duplicated entries
+ */
+void pack(const Vector<scalar>& in, Vector<Vec3>& out);
+void pack(const Vector<scalar>& in, Vector<scalar>& out);
+
+/* @brief given a vector [{1,2,3},{4,5,6},{7,8,9}] this returns [1,2,3,4,5,6,7,8,9]
+ *
+ * @param[in] in the vector to duplicate
+ * @return A vector containing duplicated entries
+ */
+Vector<scalar> unpack(const Vector<Vec3>& in);
+
+/* @brief given a vector [{1,2,3},{4,5,6},{7,8,9}]
+ * this returns [1,4,7,2,5,8,3,6,9]
+ *
+ * @param[in] in the vector to duplicate
+ * @return A vector containing duplicated entries
+ */
+Vector<scalar> unpackMtxValues(
+    const Vector<Vec3>& in, const Vector<localIdx>& rowOffs, const Vector<localIdx>& newRowOffs
+);
+
+
+/* @brief given a linear system consisting of A, b and x the operator computes the residual vector *
  * Ax-b
  *
  * @param[in] mtx, the corresponding matrix

--- a/include/NeoN/linearAlgebra/utilities.hpp
+++ b/include/NeoN/linearAlgebra/utilities.hpp
@@ -14,9 +14,12 @@ namespace NeoN::la
 {
 
 /* @brief given a vector of column indices for vector matrices it creates the unpacked scalar
- * version
- *
- * E.g.: input [0,1,0,1,2,1,2] this function returns [0,3,1,4,2,5,0,3,6,1,4,7 ...] see example
+ * version.
+ * @param[in] in the vector of column indices for a packed Csr<Vec3> matrix
+ * @param[in] unpackedRowOffs corresponding rowOffsets of the unpacked matrix
+ * @param[in] packedRowOffs corresponding rowOffsets of the packed matrix
+ * @return A vector containing duplicated entries
+ * @details Example input [0,1,0,1,2,1,2] this function returns [0,3,1,4,2,5,0,3,6,1,4,7 ...] see example
  *
  *   0 1 2       0 1 2 3 4 5 6 7 9
  *              [x . . x . . . . . ]
@@ -31,11 +34,7 @@ namespace NeoN::la
  *
  *  packed      unpacked
  *  sparsity    sparsity
- *
- * @param[in] in the vector of column indices for a packed Csr<Vec3> matrix
- * @param[in] unpackedRowOffs corresponding rowOffsets of the unpacked matrix
- * @param[in] packedRowOffs corresponding rowOffsets of the packed matrix
- * @return A vector containing duplicated entries
+ */
  */
 Vector<localIdx> convertColIdx(
     const Vector<localIdx>& in,
@@ -77,7 +76,7 @@ Vector<scalar> unpackMtxValues(
 );
 
 
-/* @brief given a linear system consisting of A, b and x the operator computes the residual vector *
+/* @brief given a linear system consisting of A, b and x the operator computes the residual vector
  * Ax-b
  *
  * @param[in] mtx, the corresponding matrix

--- a/include/NeoN/linearAlgebra/utilities.hpp
+++ b/include/NeoN/linearAlgebra/utilities.hpp
@@ -37,7 +37,7 @@ namespace NeoN::la
  *  packed      unpacked
  *  sparsity    sparsity
  */
-Vector<localIdx> convertColIdx(
+Vector<localIdx> unpackColIdx(
     const Vector<localIdx>& in,
     const Vector<localIdx>& unpackedRowOffs,
     const Vector<localIdx>& packedRowOffs
@@ -66,14 +66,14 @@ Vector<localIdx> unpackRowOffs(const Vector<localIdx>& in);
  * @param[in] in the vector to unpack
  * @return A vector containing duplicated entries
  */
-Vector<scalar> unpack(const Vector<Vec3>& in);
+Vector<scalar> unpackVecValues(const Vector<Vec3>& in);
 
 /* @brief given a vector [1,2,3,4,5,6,7,8,9] this packs it into [{1,2,3},{4,5,6},{7,8,9}]
  *
  * @param[in] in the vector to duplicate
  * @param[out] out the vector to duplicate
  */
-void pack(const Vector<scalar>& in, Vector<Vec3>& out);
+void packVecValues(const Vector<scalar>& in, Vector<Vec3>& out);
 
 /* @brief given a vector of packed matrix values this returns unpacked matrix values
  * @details
@@ -82,7 +82,7 @@ void pack(const Vector<scalar>& in, Vector<Vec3>& out);
  * this returns [1,4,7,2,5,8,3,6,9]
  *
  * @param[in] in vector of packed matrix values
- * @param[in] rowOffs the rowOffs of the packed packed matrix
+ * @param[in] rowOffs the rowOffs of the packed matrix
  * @param[in] newRowOffs the rowOffs of the unpacked matrix
  * @return A vector of the unpacked matrix values
  */

--- a/include/NeoN/linearAlgebra/utilities.hpp
+++ b/include/NeoN/linearAlgebra/utilities.hpp
@@ -18,10 +18,12 @@ namespace NeoN::la
  * @param[in] in the vector of column indices for a packed Csr<Vec3> matrix
  * @param[in] unpackedRowOffs corresponding rowOffsets of the unpacked matrix
  * @param[in] packedRowOffs corresponding rowOffsets of the packed matrix
- * @return A vector containing duplicated entries
- * @details Example input [0,1,0,1,2,1,2] this function returns [0,3,1,4,2,5,0,3,6,1,4,7 ...] see example
+ * @return A vector containing new unpacked column indices
+ * @details Example input [0,1,0,1,2,1,2] this function returns [0,3,1,4,2,5,0,3,6,1,4,7 ...] see
+ * example
  *
- *   0 1 2       0 1 2 3 4 5 6 7 9
+ * Example:
+ *   0 1 2       0 1 2 3 4 5 6 7 9     column index
  *              [x . . x . . . . . ]
  *  [x x . ]    [. x . . x . . . . ]
  *  [x x x ] -> [. . x . . x . . . ]
@@ -34,7 +36,6 @@ namespace NeoN::la
  *
  *  packed      unpacked
  *  sparsity    sparsity
- */
  */
 Vector<localIdx> convertColIdx(
     const Vector<localIdx>& in,

--- a/include/NeoN/linearAlgebra/utilities.hpp
+++ b/include/NeoN/linearAlgebra/utilities.hpp
@@ -13,15 +13,34 @@
 namespace NeoN::la
 {
 
-/* @brief given a vector a [0,1,0,1,2,1,2] this returns [0,1,2,3,4,5,0,1,2,...]
+/* @brief given a vector of column indices for vector matrices it creates the unpacked scalar
+ * version
  *
- * @param[in] in the vector to duplicate
+ * E.g.: input [0,1,0,1,2,1,2] this function returns [0,3,1,4,2,5,0,3,6,1,4,7 ...] see example
+ *
+ *   0 1 2       0 1 2 3 4 5 6 7 9
+ *              [x . . x . . . . . ]
+ *  [x x . ]    [. x . . x . . . . ]
+ *  [x x x ] -> [. . x . . x . . . ]
+ *  [. x x ]    [x . . x . . x . . ]
+ *              [. x . . x . . x . ]
+ *              [. . x . . x . . x ]
+ *              [. . . x . . x . . ]
+ *              [. . . . x . . x . ]
+ *              [. . . . . x . . x ]
+ *
+ *  packed      unpacked
+ *  sparsity    sparsity
+ *
+ * @param[in] in the vector of column indices for a packed Csr<Vec3> matrix
+ * @param[in] unpackedRowOffs corresponding rowOffsets of the unpacked matrix
+ * @param[in] packedRowOffs corresponding rowOffsets of the packed matrix
  * @return A vector containing duplicated entries
  */
-Vector<localIdx> duplicateColIdx(
+Vector<localIdx> convertColIdx(
     const Vector<localIdx>& in,
-    const Vector<localIdx>& newRowOffs,
-    const Vector<localIdx>& oldRowOffs
+    const Vector<localIdx>& unpackedRowOffs,
+    const Vector<localIdx>& packedRowOffs
 );
 
 /* @brief given a vector of rowOffs [0,3,6] this returns [0,3,6,9,12,15,18,21]
@@ -29,29 +48,23 @@ Vector<localIdx> duplicateColIdx(
  * @param[in] in the vector to duplicate
  * @return A vector containing duplicated entries
  */
-Vector<localIdx> stretchRowPtrs(const Vector<localIdx>& in);
+Vector<localIdx> unpackRowPtrs(const Vector<localIdx>& in);
 
-/* @brief given a vector [{1,2,3},{4,5,6},{7,8,9}] this returns [1,2,3,4,5,6,7,8,9]
+/* @brief given a vector of Vec3 (packed) this returns vector of consecutive scalars (unpacked)
  *
- * @param[in] in the vector to duplicate
- * @return A vector containing duplicated entries
- */
-Vector<scalar> flatten(const Vector<Vec3>& in);
-
-/* @brief given a vector [{1,2,3},{4,5,6},{7,8,9}] this returns [1,2,3,4,5,6,7,8,9]
+ * E.g. given a vector [{1,2,3},{4,5,6},{7,8,9}] this returns [1,2,3,4,5,6,7,8,9]
  *
- * @param[in] in the vector to duplicate
- * @return A vector containing duplicated entries
- */
-void pack(const Vector<scalar>& in, Vector<Vec3>& out);
-void pack(const Vector<scalar>& in, Vector<scalar>& out);
-
-/* @brief given a vector [{1,2,3},{4,5,6},{7,8,9}] this returns [1,2,3,4,5,6,7,8,9]
- *
- * @param[in] in the vector to duplicate
+ * @param[in] in the vector to unpack
  * @return A vector containing duplicated entries
  */
 Vector<scalar> unpack(const Vector<Vec3>& in);
+
+/* @brief given a vector [1,2,3,4,5,6,7,8,9] this packs it into [{1,2,3},{4,5,6},{7,8,9}]
+ *
+ * @param[in] in the vector to duplicate
+ * @param[out] out the vector to duplicate
+ */
+void pack(const Vector<scalar>& in, Vector<Vec3>& out);
 
 /* @brief given a vector [{1,2,3},{4,5,6},{7,8,9}]
  * this returns [1,4,7,2,5,8,3,6,9]

--- a/include/NeoN/linearAlgebra/utilities.hpp
+++ b/include/NeoN/linearAlgebra/utilities.hpp
@@ -43,12 +43,21 @@ Vector<localIdx> convertColIdx(
     const Vector<localIdx>& packedRowOffs
 );
 
-/* @brief given a vector of rowOffs [0,3,6] this returns [0,3,6,9,12,15,18,21]
+/* @brief computed unpacked rowOffs from packed rowOffs
+ * @details given a sparsity pattern every row with Vec3 entries is unpacked
+ * by copying its y and z components after the initial row. For
+ * example [{x,y,z}] will result in
+ * [x . .]
+ * [. y .]
+ * [. . z]
+ * Thus, each row with given length will result 2 new entries of the same length
+ * in the unpacked vector. E.g. a vector of packed rowOffs [0,2,5,7] returns
+ * [0,2,4,6,9,12,15,17,19,21] where the last entries is the total number of rows
  *
- * @param[in] in the vector to duplicate
- * @return A vector containing duplicated entries
+ * @param[in] in the vector rowPtrs to unpack
+ * @return A vector containing unpacked rowPtrs
  */
-Vector<localIdx> unpackRowPtrs(const Vector<localIdx>& in);
+Vector<localIdx> unpackRowOffs(const Vector<localIdx>& in);
 
 /* @brief given a vector of Vec3 (packed) this returns vector of consecutive scalars (unpacked)
  *
@@ -66,11 +75,16 @@ Vector<scalar> unpack(const Vector<Vec3>& in);
  */
 void pack(const Vector<scalar>& in, Vector<Vec3>& out);
 
-/* @brief given a vector [{1,2,3},{4,5,6},{7,8,9}]
+/* @brief given a vector of packed matrix values this returns unpacked matrix values
+ * @details
+ *
+ * Given an input row [{1,2,3},{4,5,6},{7,8,9}]
  * this returns [1,4,7,2,5,8,3,6,9]
  *
- * @param[in] in the vector to duplicate
- * @return A vector containing duplicated entries
+ * @param[in] in vector of packed matrix values
+ * @param[in] rowOffs the rowOffs of the packed packed matrix
+ * @param[in] newRowOffs the rowOffs of the unpacked matrix
+ * @return A vector of the unpacked matrix values
  */
 Vector<scalar> unpackMtxValues(
     const Vector<Vec3>& in, const Vector<localIdx>& rowOffs, const Vector<localIdx>& newRowOffs

--- a/src/linearAlgebra/ginkgo.cpp
+++ b/src/linearAlgebra/ginkgo.cpp
@@ -286,7 +286,7 @@ createGkoMtx(std::shared_ptr<const gko::Executor> exec, const LinearSystem<Vec3,
     // NOTE we get a const view of the system but need a non const view to vals and indices
     const auto mtx = sys.matrix();
     const auto rowsCopy = unpackRowOffs(mtx.rowOffs());
-    const auto colsCopy = convertColIdx(mtx.colIdxs(), rowsCopy, mtx.rowOffs());
+    const auto colsCopy = unpackColIdx(mtx.colIdxs(), rowsCopy, mtx.rowOffs());
     const auto valuesCopy = unpackMtxValues(mtx.values(), mtx.rowOffs(), rowsCopy);
     auto nrows = static_cast<gko::size_type>(computeNRows(sys));
     return gko::share(gko::matrix::Csr<scalar, IndexType>::create(
@@ -303,12 +303,12 @@ SolverStats GinkgoSolver::solve(const LinearSystem<Vec3, localIdx>& sys, Vector<
     const auto gkoMtx = createGkoMtx(gkoExec_, sys);
     auto solver = factory_->generate(gkoMtx);
 
-    auto rhsCopy = unpack(sys.rhs());
-    auto xCopy = unpack(x);
+    auto rhsCopy = unpackVecValues(sys.rhs());
+    auto xCopy = unpackVecValues(x);
 
     auto stats = solve_impl(gkoExec_, rhsCopy, xCopy, gkoMtx, std::move(solver));
 
-    pack(xCopy, x);
+    packVecValues(xCopy, x);
     return stats;
 }
 

--- a/src/linearAlgebra/ginkgo.cpp
+++ b/src/linearAlgebra/ginkgo.cpp
@@ -185,17 +185,14 @@ createGkoMtx(std::shared_ptr<const gko::Executor> exec, const LinearSystem<scala
     auto nrows = computeNRows(sys);
     auto mtx = sys.view().matrix;
     // NOTE we get a const view of the system but need a non const view to vals and indices
-    // auto vals = createConstGkoArray(exec, mtx.values).copy_to_array();
     auto vals = gko::array<scalar>::view(
         exec, static_cast<gko::size_type>(mtx.values.size()), const_cast<scalar*>(mtx.values.data())
     );
-    // auto col = createGkoArray(exec, mtx.colIdxs);
     auto col = gko::array<IndexType>::view(
         exec,
         static_cast<gko::size_type>(mtx.colIdxs.size()),
         const_cast<IndexType*>(mtx.colIdxs.data())
     );
-    // auto row = createGkoArray(exec, mtx.rowOffs);
     auto row = gko::array<IndexType>::view(
         exec,
         static_cast<gko::size_type>(mtx.rowOffs.size()),

--- a/src/linearAlgebra/ginkgo.cpp
+++ b/src/linearAlgebra/ginkgo.cpp
@@ -182,7 +182,6 @@ template<typename IndexType>
 std::shared_ptr<gko::matrix::Csr<scalar, IndexType>>
 createGkoMtx(std::shared_ptr<const gko::Executor> exec, const LinearSystem<scalar, IndexType>& sys)
 {
-    auto nrows = computeNRows(sys);
     auto mtx = sys.view().matrix;
     // NOTE we get a const view of the system but need a non const view to vals and indices
     auto vals = gko::array<scalar>::view(
@@ -199,6 +198,7 @@ createGkoMtx(std::shared_ptr<const gko::Executor> exec, const LinearSystem<scala
         const_cast<IndexType*>(mtx.rowOffs.data())
     );
 
+    auto nrows = static_cast<gko::size_type>(computeNRows(sys));
     return gko::share(gko::matrix::Csr<scalar, IndexType>::create(
         exec, gko::dim<2> {nrows, nrows}, vals, col, row
     ));
@@ -285,7 +285,7 @@ createGkoMtx(std::shared_ptr<const gko::Executor> exec, const LinearSystem<Vec3,
         exec, static_cast<gko::size_type>(3 * mtx.values().size()), valuesCopy.data()
     );
 
-    auto nrows = computeNRows(sys);
+    auto nrows = static_cast<gko::size_type>(computeNRows(sys));
     return gko::share(gko::matrix::Csr<scalar, IndexType>::create(
         exec, gko::dim<2> {nrows, nrows}, vals.copy_to_array(), std::move(cols), std::move(rows)
     ));

--- a/src/linearAlgebra/ginkgo.cpp
+++ b/src/linearAlgebra/ginkgo.cpp
@@ -148,11 +148,41 @@ std::shared_ptr<gko::Executor> NeoN::la::ginkgo::getGkoExecutor(NeoN::Executor e
 namespace NeoN::la::ginkgo
 {
 
+label computeNRows(const LinearSystem<Vec3, localIdx>& sys) { return 3 * sys.rhs().size(); }
+
+label computeNRows(const LinearSystem<scalar, localIdx>& sys) { return sys.rhs().size(); }
+
+template<typename T>
+gko::array<T> createGkoArray(std::shared_ptr<const gko::Executor> exec, std::span<T> values)
+{
+    return gko::make_array_view(exec, values.size(), values.data());
+}
+
+std::shared_ptr<gko::matrix::Dense<scalar>>
+createGkoDense(std::shared_ptr<const gko::Executor> exec, scalar* ptr, localIdx s)
+{
+    auto size = static_cast<std::size_t>(s);
+    return gko::share(gko::matrix::Dense<scalar>::create(
+        exec, gko::dim<2> {size, 1}, createGkoArray(exec, std::span {ptr, size}), 1
+    ));
+}
+
+std::shared_ptr<gko::matrix::Dense<scalar>>
+createGkoDense(std::shared_ptr<const gko::Executor> exec, const scalar* ptr, localIdx s)
+{
+    auto size = static_cast<std::size_t>(s);
+    auto const_array_view = gko::array<scalar>::const_view(exec, size, ptr);
+    return gko::share(gko::matrix::Dense<scalar>::create(
+        exec, gko::dim<2> {size, 1}, const_array_view.copy_to_array(), 1
+    ));
+}
+
+
 template<typename IndexType>
 std::shared_ptr<gko::matrix::Csr<scalar, IndexType>>
 createGkoMtx(std::shared_ptr<const gko::Executor> exec, const LinearSystem<scalar, IndexType>& sys)
 {
-    auto nrows = static_cast<gko::dim<2>::dimension_type>(sys.rhs().size());
+    auto nrows = computeNRows(sys);
     auto mtx = sys.view().matrix;
     // NOTE we get a const view of the system but need a non const view to vals and indices
     // auto vals = createConstGkoArray(exec, mtx.values).copy_to_array();
@@ -171,136 +201,118 @@ createGkoMtx(std::shared_ptr<const gko::Executor> exec, const LinearSystem<scala
         static_cast<gko::size_type>(mtx.rowOffs.size()),
         const_cast<IndexType*>(mtx.rowOffs.data())
     );
+
     return gko::share(gko::matrix::Csr<scalar, IndexType>::create(
         exec, gko::dim<2> {nrows, nrows}, vals, col, row
     ));
 }
 
 
-SolverStats GinkgoSolver::solve(const LinearSystem<scalar, localIdx>& sys, Vector<scalar>& x) const
+template<typename InType>
+scalar retrieve(const InType& in)
+{
+    using vec = gko::matrix::Dense<scalar>;
+    auto host = vec::create(in->get_executor()->get_master(), gko::dim<2> {1});
+    return host->copy_from(in)->at(0);
+};
+
+SolverStats solve_impl(
+    std::shared_ptr<const gko::Executor> exec,
+    const Vector<scalar>& rhs,
+    Vector<scalar>& x,
+    std::shared_ptr<gko::matrix::Csr<scalar, label>> mtx,
+    std::unique_ptr<gko::LinOp> solver
+)
 {
     auto startEval = std::chrono::steady_clock::now();
     using vec = gko::matrix::Dense<scalar>;
+    label nrows = rhs.size();
+    auto rhs2 = Vector<scalar>(rhs);
+    auto b = createGkoDense(exec, rhs.data(), nrows);
+    auto b2 = createGkoDense(exec, rhs2.data(), nrows);
+    auto gkoX = createGkoDense(exec, x.data(), nrows);
 
-    auto retrieve = [](const auto& in)
-    {
-        auto host = vec::create(in->get_executor()->get_master(), gko::dim<2> {1});
-        scalar res = host->copy_from(in)->at(0);
-        return res;
-    };
+    auto one = gko::initialize<vec>({1.0}, exec);
+    auto neg_one = gko::initialize<vec>({-1.0}, exec);
+    auto init = gko::initialize<vec>({0.0}, exec);
+    mtx->apply(one, gkoX, neg_one, b2);
 
-    auto nrows = sys.rhs().size();
-
-    auto gkoMtx = createGkoMtx(gkoExec_, sys);
-    auto solver = factory_->generate(gkoMtx);
+    b->compute_norm2(init);
+    scalar initResNorm = retrieve(init);
 
     std::shared_ptr<const gko::log::Convergence<scalar>> logger =
         gko::log::Convergence<scalar>::create();
     solver->add_logger(logger);
+    solver->apply(b, gkoX);
 
-    auto rhs = detail::createGkoDense(gkoExec_, sys.rhs().data(), nrows);
-    auto rhs2 = detail::createGkoDense(gkoExec_, sys.rhs().data(), nrows);
-    auto gkoX = detail::createGkoDense(gkoExec_, x.data(), nrows);
-
-    auto one = gko::initialize<vec>({1.0}, gkoExec_);
-    auto neg_one = gko::initialize<vec>({-1.0}, gkoExec_);
-    auto init = gko::initialize<vec>({0.0}, gkoExec_);
-    gkoMtx->apply(one, gkoX, neg_one, rhs2);
-    rhs->compute_norm2(init);
-    scalar initResNorm = retrieve(init);
-
-    solver->apply(rhs, gkoX);
-
+    // since we work on a copy we need to copy back
     scalar finalResNorm = retrieve(gko::as<vec>(logger->get_residual_norm()));
 
     auto numIter = label(logger->get_num_iterations());
-
     auto endEval = std::chrono::steady_clock::now();
     auto duration =
         static_cast<scalar>(
             std::chrono::duration_cast<std::chrono::microseconds>(endEval - startEval).count()
         )
         / 1000.0;
+
     return {numIter, initResNorm, finalResNorm, duration};
 }
 
+
+SolverStats GinkgoSolver::solve(const LinearSystem<scalar, localIdx>& sys, Vector<scalar>& x) const
+{
+    auto gkoMtx = createGkoMtx(gkoExec_, sys);
+    auto solver = factory_->generate(gkoMtx);
+    return solve_impl(
+        gkoExec_, sys.rhs(), x, gkoMtx, std::move(solver)
+
+    );
+}
+
 template<typename IndexType>
-std::shared_ptr<gko::matrix::Csr<Vec3, IndexType>>
+std::shared_ptr<gko::matrix::Csr<scalar, IndexType>>
 createGkoMtx(std::shared_ptr<const gko::Executor> exec, const LinearSystem<Vec3, IndexType>& sys)
 {
-    auto nrows = static_cast<gko::dim<2>::dimension_type>(sys.rhs().size());
-    auto mtx = sys.view().matrix;
-    // NOTE we get a const view of the system but need a non const view to vals and indices
-    // auto vals = createConstGkoArray(exec, mtx.values).copy_to_array();
-    // auto vals = gko::array<Vec3>::view(
-    //     exec,
-    //     static_cast<gko::size_type>(mtx.values.size()),
-    //     const_cast<Vec3*>(mtx.values.data())
-    // );
-    // // auto col = createGkoArray(exec, mtx.colIdxs);
-    // auto col = gko::array<IndexType>::view(
-    //     exec,
-    //     static_cast<gko::size_type>(mtx.colIdxs.size()),
-    //     const_cast<IndexType*>(mtx.colIdxs.data())
-    // );
-    // // auto row = createGkoArray(exec, mtx.rowOffs);
-    // auto row = gko::array<IndexType>::view(
-    //     exec,
-    //     static_cast<gko::size_type>(mtx.rowOffs.size()),
-    //     const_cast<IndexType*>(mtx.rowOffs.data())
-    // );
+    auto nrows = computeNRows(sys);
 
-    // return gko::share(gko::matrix::Csr<Vec3, IndexType>::create(
-    //     exec, gko::dim<2> {nrows, nrows}, vals, col, row
-    // ));
+    // NOTE we get a const view of the system but need a non const view to vals and indices
+    auto mtx = sys.matrix();
+
+    auto rowsCopy = stretchRowPtrs(mtx.rowOffs());
+    auto rows = createGkoArray(exec, rowsCopy.view());
+
+    auto colsCopy = duplicateColIdx(mtx.colIdxs(), rowsCopy, mtx.rowOffs());
+    auto cols = createGkoArray(exec, colsCopy.view());
+
+    auto valuesCopy = unpackMtxValues(mtx.values(), mtx.rowOffs(), rowsCopy);
+    auto vals = gko::array<scalar>::const_view(
+        exec,
+        static_cast<gko::size_type>(3 * mtx.values().size()),
+        // const_cast<scalar*>(&(mtx.values().view()[0][0]))
+        valuesCopy.data()
+    );
+
+    return gko::share(gko::matrix::Csr<scalar, IndexType>::create(
+        exec, gko::dim<2> {nrows, nrows}, vals.copy_to_array(), std::move(cols), std::move(rows)
+    ));
 }
 
 SolverStats GinkgoSolver::solve(const LinearSystem<Vec3, localIdx>& sys, Vector<Vec3>& x) const
 {
-    auto startEval = std::chrono::steady_clock::now();
-    using vec = gko::matrix::Dense<scalar>;
-
-    auto retrieve = [](const auto& in)
-    {
-        auto host = vec::create(in->get_executor()->get_master(), gko::dim<2> {1});
-        scalar res = host->copy_from(in)->at(0);
-        return res;
-    };
-
-    auto nrows = 3 * sys.rhs().size();
-
     auto gkoMtx = createGkoMtx(gkoExec_, sys);
-    // auto solver = factory_->generate(gkoMtx);
+    auto solver = factory_->generate(gkoMtx);
 
-    // std::shared_ptr<const gko::log::Convergence<scalar>> logger =
-    //     gko::log::Convergence<scalar>::create();
-    // solver->add_logger(logger);
+    auto rhsCopy = flatten(sys.rhs());
+    auto xCopy = flatten(x);
 
-    // auto rhs = detail::createGkoDense(gkoExec_, sys.rhs().data(), nrows);
-    // auto rhs2 = detail::createGkoDense(gkoExec_, sys.rhs().data(), nrows);
-    // auto gkoX = detail::createGkoDense(gkoExec_, x.data(), nrows);
+    auto stats = solve_impl(
+        gkoExec_, rhsCopy, xCopy, gkoMtx, std::move(solver)
 
-    // auto one = gko::initialize<vec>({1.0}, gkoExec_);
-    // auto neg_one = gko::initialize<vec>({-1.0}, gkoExec_);
-    // auto init = gko::initialize<vec>({0.0}, gkoExec_);
-    // gkoMtx->apply(one, gkoX, neg_one, rhs2);
-    // rhs->compute_norm2(init);
-    // scalar initResNorm = retrieve(init);
+    );
 
-    // solver->apply(rhs, gkoX);
-
-    // scalar finalResNorm = retrieve(gko::as<vec>(logger->get_residual_norm()));
-
-    // auto numIter = label(logger->get_num_iterations());
-
-    // auto endEval = std::chrono::steady_clock::now();
-    // auto duration =
-    //     static_cast<scalar>(
-    //         std::chrono::duration_cast<std::chrono::microseconds>(endEval -
-    //         startEval).count()
-    //     )
-    //     / 1000.0;
-    // return {numIter, initResNorm, finalResNorm, duration};
+    pack(xCopy, x);
+    return stats;
 }
 
 

--- a/src/linearAlgebra/utilities.cpp
+++ b/src/linearAlgebra/utilities.cpp
@@ -3,11 +3,180 @@
 // SPDX-License-Identifier: MIT
 
 #include "NeoN/core/parallelAlgorithms.hpp"
+#include "NeoN/core/containerFreeFunctions.hpp"
 #include "NeoN/linearAlgebra/utilities.hpp"
 
 
 namespace NeoN::la
 {
+
+Vector<localIdx> duplicateColIdx(
+    const Vector<localIdx>& in,
+    const Vector<localIdx>& newRowOffs,
+    const Vector<localIdx>& oldRowOffs
+)
+{
+    const auto exec = in.exec();
+    const auto inV = in.view();
+    auto out = Vector<localIdx> {exec, 3 * in.size()};
+    auto outV = out.view();
+    auto rowV = newRowOffs.view();
+    auto oldRowV = oldRowOffs.view();
+
+    NeoN::parallelFor(
+        exec,
+        {0, newRowOffs.size() - 1},
+        KOKKOS_LAMBDA(const localIdx i) {
+            auto j {rowV[i]};        // new row start
+            auto l {oldRowV[i / 3]}; // original row start
+            auto length {rowV[i + 1] - rowV[i]};
+            auto offs = i % 3;
+            // iterate all entries of the row
+            // every column is shifted by a factor of 3
+            // plus an offset based on the dimension 0,1,2
+            for (auto k = 0; k < length; k++)
+            {
+                outV[j + k] = (3 * inV[l + k]) + offs;
+            }
+        }
+    );
+
+    return out;
+}
+
+Vector<scalar> flatten(const Vector<Vec3>& in)
+{
+    const auto exec = in.exec();
+    const auto inV = in.view();
+    auto out = Vector<scalar> {exec, 3 * in.size()};
+    auto outV = out.view();
+
+    NeoN::parallelFor(
+        exec,
+        {0, in.size()},
+        KOKKOS_LAMBDA(const localIdx i) {
+            localIdx j = 3 * i;
+            outV[j + 0] = inV[i][0];
+            outV[j + 1] = inV[i][1];
+            outV[j + 2] = inV[i][2];
+        }
+    );
+
+    return out;
+}
+
+Vector<scalar> unpackMtxValues(
+    const Vector<Vec3>& in, const Vector<localIdx>& rowOffs, const Vector<localIdx>& newRowOffs
+)
+{
+    const auto exec = in.exec();
+    const auto inV = in.view();
+    auto out = Vector<scalar> {exec, 3 * in.size()};
+    auto outV = out.view();
+    auto rowV = rowOffs.view();
+    auto newRowV = newRowOffs.view();
+
+    NeoN::parallelFor(
+        exec,
+        {0, rowOffs.size() - 1},
+        KOKKOS_LAMBDA(const localIdx i) {
+            auto length {rowV[i + 1] - rowV[i]};
+            for (auto k = 0; k < length; k++)
+            {
+                outV[newRowV[3 * i + 0] + k] = inV[rowV[i] + k][0];
+                outV[newRowV[3 * i + 1] + k] = inV[rowV[i] + k][1];
+                outV[newRowV[3 * i + 2] + k] = inV[rowV[i] + k][2];
+            }
+        }
+    );
+
+    return out;
+}
+
+Vector<localIdx> stretchRowPtrs(const Vector<localIdx>& in)
+{
+    const auto exec = in.exec();
+    const auto inV = in.view();
+    // for a 3x3 matrix with 7 nnz 4
+    // 0, 2, 5, 7  -> size = 4
+    auto length = Vector<localIdx> {exec, 3 * (in.size() - 1)};
+    fill(length, 0);
+    auto lengthV = length.view();
+
+    // compute the length of each row and stretch it out
+    // [0, 2, 5, 7] -> [2, 2, 2, ..., 2,2,2 ]
+    NeoN::parallelFor(
+        exec,
+        {0, in.size() - 1},
+        KOKKOS_LAMBDA(const localIdx i) {
+            localIdx j = 3 * i;
+            auto val = inV[i + 1] - inV[i];
+            lengthV[j + 0] = val;
+            lengthV[j + 1] = val;
+            lengthV[j + 2] = val;
+        }
+    );
+
+    auto ret = Vector<localIdx> {exec, 3 * (in.size() - 1) + 1};
+    fill(ret, 0);
+    auto retV = ret.view();
+
+    // [2, 2, 2] -> [0, 2, 4, 6, 8]
+    NeoN::parallelScan(
+        exec,
+        {1, length.size() + 1},
+        KOKKOS_LAMBDA(const NeoN::localIdx i, NeoN::localIdx& update, const bool final) {
+            update += lengthV[i - 1];
+            if (final)
+            {
+                retV[i] = update;
+            }
+        }
+    );
+    return ret;
+}
+
+
+void pack(const Vector<scalar>& in, Vector<Vec3>& out)
+{
+    const auto exec = in.exec();
+    const auto inV = in.view();
+    auto outV = out.view();
+
+    NeoN::parallelFor(
+        exec,
+        {0, out.size()},
+        KOKKOS_LAMBDA(const localIdx i) {
+            localIdx j = 3 * i;
+            outV[i][0] = inV[j + 0];
+            outV[i][1] = inV[j + 1];
+            outV[i][2] = inV[j + 2];
+        }
+    );
+}
+
+void pack(const Vector<scalar>& in, Vector<scalar>& out) {}
+
+Vector<scalar> unpack(const Vector<Vec3>& in)
+{
+    const auto exec = in.exec();
+    const auto inV = in.view();
+    auto out = Vector<scalar> {exec, 3 * in.size()};
+    auto outV = out.view();
+
+    NeoN::parallelFor(
+        exec,
+        {0, in.size()},
+        KOKKOS_LAMBDA(const localIdx i) {
+            localIdx j = 3 * i;
+            outV[j + 0] = inV[i][0];
+            outV[j + 1] = inV[i][1];
+            outV[j + 2] = inV[i][2];
+        }
+    );
+
+    return out;
+}
 
 void computeResidual(
     const CSRMatrix<scalar, localIdx>& mtx,

--- a/src/linearAlgebra/utilities.cpp
+++ b/src/linearAlgebra/utilities.cpp
@@ -27,10 +27,10 @@ Vector<localIdx> convertColIdx(
         exec,
         {0, unpackedRowOffs.size() - 1},
         KOKKOS_LAMBDA(const localIdx i) {
-           const auto j {rowV[i]};        // new row start
-           const auto l {oldRowV[i / 3]}; // original row start
-           const auto length {rowV[i + 1] - rowV[i]};
-           const auto offs = i % 3;
+            const auto j {rowV[i]};        // new row start
+            const auto l {oldRowV[i / 3]}; // original row start
+            const auto length {rowV[i + 1] - rowV[i]};
+            const auto offs = i % 3;
             // iterate all entries of the row
             // every column is shifted by a factor of 3
             // plus an offset based on the dimension 0,1,2
@@ -93,7 +93,7 @@ Vector<scalar> unpackMtxValues(
     return out;
 }
 
-Vector<localIdx> unpackRowPtrs(const Vector<localIdx>& in)
+Vector<localIdx> unpackRowOffs(const Vector<localIdx>& in)
 {
     const auto exec = in.exec();
     const auto inV = in.view();

--- a/src/linearAlgebra/utilities.cpp
+++ b/src/linearAlgebra/utilities.cpp
@@ -10,7 +10,7 @@
 namespace NeoN::la
 {
 
-Vector<localIdx> convertColIdx(
+Vector<localIdx> unpackColIdx(
     const Vector<localIdx>& in,
     const Vector<localIdx>& unpackedRowOffs,
     const Vector<localIdx>& packedRowOffs
@@ -44,7 +44,7 @@ Vector<localIdx> convertColIdx(
     return out;
 }
 
-Vector<scalar> unpack(const Vector<Vec3>& in)
+Vector<scalar> unpackVecValues(const Vector<Vec3>& in)
 {
     const auto exec = in.exec();
     const auto inV = in.view();
@@ -137,7 +137,7 @@ Vector<localIdx> unpackRowOffs(const Vector<localIdx>& in)
 }
 
 
-void pack(const Vector<scalar>& in, Vector<Vec3>& out)
+void packVecValues(const Vector<scalar>& in, Vector<Vec3>& out)
 {
     const auto exec = in.exec();
     const auto inV = in.view();

--- a/src/linearAlgebra/utilities.cpp
+++ b/src/linearAlgebra/utilities.cpp
@@ -27,10 +27,10 @@ Vector<localIdx> convertColIdx(
         exec,
         {0, unpackedRowOffs.size() - 1},
         KOKKOS_LAMBDA(const localIdx i) {
-            auto j {rowV[i]};        // new row start
-            auto l {oldRowV[i / 3]}; // original row start
-            auto length {rowV[i + 1] - rowV[i]};
-            auto offs = i % 3;
+           const auto j {rowV[i]};        // new row start
+           const auto l {oldRowV[i / 3]}; // original row start
+           const auto length {rowV[i + 1] - rowV[i]};
+           const auto offs = i % 3;
             // iterate all entries of the row
             // every column is shifted by a factor of 3
             // plus an offset based on the dimension 0,1,2
@@ -80,7 +80,7 @@ Vector<scalar> unpackMtxValues(
         exec,
         {0, rowOffs.size() - 1},
         KOKKOS_LAMBDA(const localIdx i) {
-            auto length {rowV[i + 1] - rowV[i]};
+            const auto length {rowV[i + 1] - rowV[i]};
             for (auto k = 0; k < length; k++)
             {
                 outV[newRowV[3 * i + 0] + k] = inV[rowV[i] + k][0];
@@ -110,7 +110,7 @@ Vector<localIdx> unpackRowPtrs(const Vector<localIdx>& in)
         {0, in.size() - 1},
         KOKKOS_LAMBDA(const localIdx i) {
             localIdx j = 3 * i;
-            auto val = inV[i + 1] - inV[i];
+            const auto val = inV[i + 1] - inV[i];
             lengthV[j + 0] = val;
             lengthV[j + 1] = val;
             lengthV[j + 2] = val;

--- a/test/core/parallelAlgorithms.cpp
+++ b/test/core/parallelAlgorithms.cpp
@@ -77,12 +77,7 @@ TEST_CASE("parallelFor")
 
 TEST_CASE("parallelReduce")
 {
-    NeoN::Executor exec = GENERATE(
-        NeoN::Executor(NeoN::SerialExecutor {}),
-        NeoN::Executor(NeoN::CPUExecutor {}),
-        NeoN::Executor(NeoN::GPUExecutor {})
-    );
-    std::string execName = std::visit([](auto e) { return e.name(); }, exec);
+    auto [execName, exec] = GENERATE(allAvailableExecutor());
 
     SECTION("parallelReduce_" + execName)
     {
@@ -161,12 +156,7 @@ TEST_CASE("parallelReduce")
 
 TEST_CASE("parallelScan")
 {
-    NeoN::Executor exec = GENERATE(NeoN::Executor(NeoN::SerialExecutor {})
-                                   // NeoN::Executor(NeoN::CPUExecutor {}),
-                                   // NeoN::Executor(NeoN::GPUExecutor {})
-    );
-    std::string execName = std::visit([](auto e) { return e.name(); }, exec);
-
+    auto [execName, exec] = GENERATE(allAvailableExecutor());
 
     SECTION("parallelScan_withoutReturn" + execName)
     {

--- a/test/dsl/expression.cpp
+++ b/test/dsl/expression.cpp
@@ -12,7 +12,6 @@
 namespace dsl = NeoN::dsl;
 
 
-// TEST_CASE("Expression")
 TEMPLATE_TEST_CASE("Expression", "[template]", NeoN::scalar, NeoN::Vec3)
 {
     auto [execName, exec] = GENERATE(allAvailableExecutor());

--- a/test/linearAlgebra/ginkgo.cpp
+++ b/test/linearAlgebra/ginkgo.cpp
@@ -127,15 +127,12 @@ TEST_CASE("MatrixAssembly - Ginkgo")
 
     SECTION("Solve linear system vector " + execName)
     {
-
         Vector<NeoN::Vec3> values(
             exec,
             {{1.0, 1.0, 1.0},
              {-0.1, -0.1, -0.1},
              {-0.1, -0.1, -0.1},
-             {-0.1, -0.1, -0.1},
              {1.0, 1.0, 1.0},
-             {-0.1, -0.1, -0.1},
              {-0.1, -0.1, -0.1},
              {-0.1, -0.1, -0.1},
              {1.0, 1.0, 1.0}}
@@ -145,10 +142,9 @@ TEST_CASE("MatrixAssembly - Ginkgo")
         Vector<localIdx> rowOffs(exec, {0, 2, 5, 7});
         CSRMatrix<NeoN::Vec3, localIdx> csrMatrix(values, colIdx, rowOffs);
 
-        Vector<NeoN::Vec3> rhs(exec, {{1.0, 1.0, 1.0}, {2.0, 2.0, 2.0}, {3.0, 2.0, 2.0}});
+        Vector<NeoN::Vec3> rhs(exec, {{1.0, 1.0, 1.0}, {2.0, 2.0, 2.0}, {3.0, 3.0, 3.0}});
         LinearSystem<NeoN::Vec3, localIdx> linearSystem(csrMatrix, rhs);
         Vector<NeoN::Vec3> x(exec, {{0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}});
-
 
         Dictionary solverDict {
             {{"solver", std::string {"Ginkgo"}},
@@ -167,8 +163,17 @@ TEST_CASE("MatrixAssembly - Ginkgo")
         REQUIRE((hostXS[0][0]) == Catch::Approx(1.24489796).margin(1e-8));
         REQUIRE((hostXS[1][0]) == Catch::Approx(2.44897959).margin(1e-8));
         REQUIRE((hostXS[2][0]) == Catch::Approx(3.24489796).margin(1e-8));
+
+        REQUIRE((hostXS[0][1]) == Catch::Approx(1.24489796).margin(1e-8));
+        REQUIRE((hostXS[1][1]) == Catch::Approx(2.44897959).margin(1e-8));
+        REQUIRE((hostXS[2][1]) == Catch::Approx(3.24489796).margin(1e-8));
+
+        REQUIRE((hostXS[0][2]) == Catch::Approx(1.24489796).margin(1e-8));
+        REQUIRE((hostXS[1][2]) == Catch::Approx(2.44897959).margin(1e-8));
+        REQUIRE((hostXS[2][2]) == Catch::Approx(3.24489796).margin(1e-8));
+
         REQUIRE(numIter == 3);
-        REQUIRE(initResNorm == Catch::Approx(3.741657386).margin(1e-8));
+        REQUIRE(initResNorm == Catch::Approx(6.4807406984).margin(1e-8));
         REQUIRE(finalResNorm < 1.0e-04);
     }
 }

--- a/test/linearAlgebra/linearSystem.cpp
+++ b/test/linearAlgebra/linearSystem.cpp
@@ -16,7 +16,7 @@ using NeoN::Vector;
 using NeoN::la::LinearSystem;
 using NeoN::la::CSRMatrix;
 
-TEST_CASE("LinearSystem")
+TEMPLATE_TEST_CASE("LinearSystem", "[template]", NeoN::scalar)
 {
     auto [execName, exec] = GENERATE(allAvailableExecutor());
 

--- a/test/linearAlgebra/utilities.cpp
+++ b/test/linearAlgebra/utilities.cpp
@@ -115,10 +115,10 @@ TEST_CASE("Utilities")
         REQUIRE(resHost.view()[11] == 6.0);
     }
 
-    SECTION("Can convertColIdx " + execName)
+    SECTION("Can unpackColIdx " + execName)
     {
         auto newRowOffs = NeoN::la::unpackRowOffs(rowOffsS);
-        auto res = NeoN::la::convertColIdx(colIdxS, newRowOffs, rowOffsS);
+        auto res = NeoN::la::unpackColIdx(colIdxS, newRowOffs, rowOffsS);
         auto resHost = res.copyToHost();
 
         REQUIRE(res.size() == 3 * colIdxS.size());
@@ -163,10 +163,10 @@ TEST_CASE("Utilities")
         REQUIRE(resHost.view()[20] == 8);
     }
 
-    SECTION("Can convertColIdx " + execName)
+    SECTION("Can unpackColIdx " + execName)
     {
         auto newRowOffs = NeoN::la::unpackRowOffs(rowOffs);
-        auto res = NeoN::la::convertColIdx(colIdx, newRowOffs, rowOffs);
+        auto res = NeoN::la::unpackColIdx(colIdx, newRowOffs, rowOffs);
         auto resHost = res.copyToHost();
 
         REQUIRE(res.size() == 3 * colIdx.size()); // 0

--- a/test/linearAlgebra/utilities.cpp
+++ b/test/linearAlgebra/utilities.cpp
@@ -59,10 +59,10 @@ TEST_CASE("Utilities")
     );
     Vector<localIdx> colIdxS(exec, {0, 1, 0, 1, 2, 1, 2});
     Vector<localIdx> rowOffsS(exec, {0, 2, 5, 7});
-    // CSRMatrix<scalar, localIdx> csrMatrix(values, colIdx, rowOffs);
+
     SECTION("Can stretchRowPtrs " + execName)
     {
-        auto res = NeoN::la::stretchRowPtrs(rowOffs);
+        auto res = NeoN::la::unpackRowPtrs(rowOffs);
         auto resHost = res.copyToHost();
 
         REQUIRE(resHost.view()[0] == 0);
@@ -75,7 +75,7 @@ TEST_CASE("Utilities")
 
     SECTION("Can stretchRowPtrs2 " + execName)
     {
-        auto res = NeoN::la::stretchRowPtrs(rowOffsS);
+        auto res = NeoN::la::unpackRowPtrs(rowOffsS);
         auto resHost = res.copyToHost();
 
         REQUIRE(resHost.view()[0] == 0);
@@ -93,7 +93,7 @@ TEST_CASE("Utilities")
 
     SECTION("Can unpack mtxValues " + execName)
     {
-        auto newRowOffs = NeoN::la::stretchRowPtrs(rowOffs);
+        auto newRowOffs = NeoN::la::unpackRowPtrs(rowOffs);
         auto res = NeoN::la::unpackMtxValues(mtxValues, rowOffs, newRowOffs);
         auto resHost = res.copyToHost();
 
@@ -114,17 +114,17 @@ TEST_CASE("Utilities")
         REQUIRE(resHost.view()[11] == 6.0);
     }
 
-    SECTION("Can duplicateColIdx " + execName)
+    SECTION("Can convertColIdx " + execName)
     {
-        auto newRowOffs = NeoN::la::stretchRowPtrs(rowOffsS);
-        auto res = NeoN::la::duplicateColIdx(colIdxS, newRowOffs, rowOffsS);
+        auto newRowOffs = NeoN::la::unpackRowPtrs(rowOffsS);
+        auto res = NeoN::la::convertColIdx(colIdxS, newRowOffs, rowOffsS);
         auto resHost = res.copyToHost();
 
-        REQUIRE(res.size() == 3 * colIdxS.size()); // 0
+        REQUIRE(res.size() == 3 * colIdxS.size());
 
         // row 1
-        REQUIRE(resHost.view()[0] == 0); // 0
-        REQUIRE(resHost.view()[1] == 3); // 1
+        REQUIRE(resHost.view()[0] == 0);
+        REQUIRE(resHost.view()[1] == 3);
 
         // row 2
         REQUIRE(resHost.view()[2] == 1);
@@ -162,10 +162,10 @@ TEST_CASE("Utilities")
         REQUIRE(resHost.view()[20] == 8);
     }
 
-    SECTION("Can duplicateColIdx " + execName)
+    SECTION("Can convertColIdx " + execName)
     {
-        auto newRowOffs = NeoN::la::stretchRowPtrs(rowOffs);
-        auto res = NeoN::la::duplicateColIdx(colIdx, newRowOffs, rowOffs);
+        auto newRowOffs = NeoN::la::unpackRowPtrs(rowOffs);
+        auto res = NeoN::la::convertColIdx(colIdx, newRowOffs, rowOffs);
         auto resHost = res.copyToHost();
 
         REQUIRE(res.size() == 3 * colIdx.size()); // 0

--- a/test/linearAlgebra/utilities.cpp
+++ b/test/linearAlgebra/utilities.cpp
@@ -13,6 +13,7 @@
 using NeoN::scalar;
 using NeoN::localIdx;
 using NeoN::Vector;
+using NeoN::Vec3;
 using NeoN::la::LinearSystem;
 using NeoN::la::CSRMatrix;
 
@@ -20,13 +21,200 @@ TEST_CASE("Utilities")
 {
     auto [execName, exec] = GENERATE(allAvailableExecutor());
 
+    // Dense matrix
     // [ 1 2 3 ]   [1]   [2]   [6]     [2]
     // [ 4 5 6 ] x [1] - [2] = [15]  - [2]
     // [ 7 8 9 ]   [1]   [2]   [24]    [2]
     Vector<scalar> values(exec, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0});
+    Vector<Vec3> mtxValues(
+        exec,
+        {{1.0, 1.0, 1.0},
+         {2.0, 2.0, 2.0},
+         {3.0, 3.0, 3.0},
+         {4.0, 4.0, 4.0},
+         {5.0, 5.0, 5.0},
+         {6.0, 6.0, 6.0},
+         {7.0, 7.0, 7.0},
+         {8.0, 8.0, 8.0},
+         {9.0, 9.0, 9.0}}
+    );
     Vector<localIdx> colIdx(exec, {0, 1, 2, 0, 1, 2, 0, 1, 2});
     Vector<localIdx> rowOffs(exec, {0, 3, 6, 9});
     CSRMatrix<scalar, localIdx> csrMatrix(values, colIdx, rowOffs);
+
+    // Sparse matrix
+    // [ 1 2 0 ]
+    // [ 4 5 6 ]
+    // [ 0 8 9 ]
+    Vector<scalar> valuesS(exec, {1.0, 2.0, 4.0, 5.0, 6.0, 8.0, 9.0});
+    Vector<Vec3> mtxValuesS(
+        exec,
+        {{1.0, 1.0, 1.0},
+         {2.0, 2.0, 2.0},
+         {4.0, 4.0, 4.0},
+         {5.0, 5.0, 5.0},
+         {6.0, 6.0, 6.0},
+         {8.0, 8.0, 8.0},
+         {9.0, 9.0, 9.0}}
+    );
+    Vector<localIdx> colIdxS(exec, {0, 1, 0, 1, 2, 1, 2});
+    Vector<localIdx> rowOffsS(exec, {0, 2, 5, 7});
+    // CSRMatrix<scalar, localIdx> csrMatrix(values, colIdx, rowOffs);
+    SECTION("Can stretchRowPtrs " + execName)
+    {
+        auto res = NeoN::la::stretchRowPtrs(rowOffs);
+        auto resHost = res.copyToHost();
+
+        REQUIRE(resHost.view()[0] == 0);
+        REQUIRE(resHost.view()[1] == 3);
+        REQUIRE(resHost.view()[2] == 6);
+        REQUIRE(resHost.view()[3] == 9);
+        REQUIRE(resHost.view()[4] == 12);
+        REQUIRE(resHost.view()[5] == 15);
+    }
+
+    SECTION("Can stretchRowPtrs2 " + execName)
+    {
+        auto res = NeoN::la::stretchRowPtrs(rowOffsS);
+        auto resHost = res.copyToHost();
+
+        REQUIRE(resHost.view()[0] == 0);
+        REQUIRE(resHost.view()[1] == 2);
+        REQUIRE(resHost.view()[2] == 4);
+        REQUIRE(resHost.view()[3] == 6);
+        REQUIRE(resHost.view()[4] == 9);
+        REQUIRE(resHost.view()[5] == 12);
+        REQUIRE(resHost.view()[6] == 15);
+        REQUIRE(resHost.view()[7] == 17);
+        REQUIRE(resHost.view()[8] == 19);
+        REQUIRE(resHost.view()[9] == 21);
+    }
+
+
+    SECTION("Can unpack mtxValues " + execName)
+    {
+        auto newRowOffs = NeoN::la::stretchRowPtrs(rowOffs);
+        auto res = NeoN::la::unpackMtxValues(mtxValues, rowOffs, newRowOffs);
+        auto resHost = res.copyToHost();
+
+        REQUIRE(resHost.view()[0] == 1.0);
+        REQUIRE(resHost.view()[1] == 2.0);
+        REQUIRE(resHost.view()[2] == 3.0);
+
+        REQUIRE(resHost.view()[3] == 1.0);
+        REQUIRE(resHost.view()[4] == 2.0);
+        REQUIRE(resHost.view()[5] == 3.0);
+
+        REQUIRE(resHost.view()[6] == 1.0);
+        REQUIRE(resHost.view()[7] == 2.0);
+        REQUIRE(resHost.view()[8] == 3.0);
+
+        REQUIRE(resHost.view()[9] == 4.0);
+        REQUIRE(resHost.view()[10] == 5.0);
+        REQUIRE(resHost.view()[11] == 6.0);
+    }
+
+    SECTION("Can duplicateColIdx " + execName)
+    {
+        auto newRowOffs = NeoN::la::stretchRowPtrs(rowOffsS);
+        auto res = NeoN::la::duplicateColIdx(colIdxS, newRowOffs, rowOffsS);
+        auto resHost = res.copyToHost();
+
+        REQUIRE(res.size() == 3 * colIdxS.size()); // 0
+
+        // row 1
+        REQUIRE(resHost.view()[0] == 0); // 0
+        REQUIRE(resHost.view()[1] == 3); // 1
+
+        // row 2
+        REQUIRE(resHost.view()[2] == 1);
+        REQUIRE(resHost.view()[3] == 4);
+
+        // row 3
+        REQUIRE(resHost.view()[4] == 2);
+        REQUIRE(resHost.view()[5] == 5);
+
+        // row 4
+        REQUIRE(resHost.view()[6] == 0);
+        REQUIRE(resHost.view()[7] == 3);
+        REQUIRE(resHost.view()[8] == 6);
+
+        // row 5
+        REQUIRE(resHost.view()[9] == 1);
+        REQUIRE(resHost.view()[10] == 4);
+        REQUIRE(resHost.view()[11] == 7);
+
+        // row 6
+        REQUIRE(resHost.view()[12] == 2);
+        REQUIRE(resHost.view()[13] == 5);
+        REQUIRE(resHost.view()[14] == 8);
+
+        // row 7
+        REQUIRE(resHost.view()[15] == 3);
+        REQUIRE(resHost.view()[16] == 6);
+
+        // row 8
+        REQUIRE(resHost.view()[17] == 4);
+        REQUIRE(resHost.view()[18] == 7);
+
+        // row 9
+        REQUIRE(resHost.view()[19] == 5);
+        REQUIRE(resHost.view()[20] == 8);
+    }
+
+    SECTION("Can duplicateColIdx " + execName)
+    {
+        auto newRowOffs = NeoN::la::stretchRowPtrs(rowOffs);
+        auto res = NeoN::la::duplicateColIdx(colIdx, newRowOffs, rowOffs);
+        auto resHost = res.copyToHost();
+
+        REQUIRE(res.size() == 3 * colIdx.size()); // 0
+
+        // row 1
+        REQUIRE(resHost.view()[0] == 0); // 0
+        REQUIRE(resHost.view()[1] == 3); // 1
+        REQUIRE(resHost.view()[2] == 6); // 2
+
+        // row 2
+        REQUIRE(resHost.view()[3] == 1);
+        REQUIRE(resHost.view()[4] == 4);
+        REQUIRE(resHost.view()[5] == 7);
+
+        // row 3
+        REQUIRE(resHost.view()[6] == 2);
+        REQUIRE(resHost.view()[7] == 5);
+        REQUIRE(resHost.view()[8] == 8);
+
+        // row 4
+        REQUIRE(resHost.view()[9] == 0);
+        REQUIRE(resHost.view()[10] == 3);
+        REQUIRE(resHost.view()[11] == 6);
+
+        // row 5
+        REQUIRE(resHost.view()[12] == 1);
+        REQUIRE(resHost.view()[13] == 4);
+        REQUIRE(resHost.view()[14] == 7);
+
+        // row 6
+        REQUIRE(resHost.view()[15] == 2);
+        REQUIRE(resHost.view()[16] == 5);
+        REQUIRE(resHost.view()[17] == 8);
+
+        // row 7
+        REQUIRE(resHost.view()[18] == 0);
+        REQUIRE(resHost.view()[19] == 3);
+        REQUIRE(resHost.view()[20] == 6);
+
+        // row 8
+        REQUIRE(resHost.view()[21] == 1);
+        REQUIRE(resHost.view()[22] == 4);
+        REQUIRE(resHost.view()[23] == 7);
+
+        // row 9
+        REQUIRE(resHost.view()[24] == 2);
+        REQUIRE(resHost.view()[25] == 5);
+        REQUIRE(resHost.view()[26] == 8);
+    }
 
     SECTION("Can compute residual on " + execName)
     {


### PR DESCRIPTION
This PR implements a solve function that operates on `LinearSystem<Vec3, localIdx>`, which is a required functionality for assembling and solving PDEs of vector fields.  

### Approach

**Strided copy**

Currently, the given matrix on the NeoN side which holds elements of type `Vec3` is copied in the following way:

$$   \begin{bmatrix}
    \left[ a_1 a_2 a_3 \right] &   \left[ b_1 b_2 b_3 \right]    \\
      &  \left[ c_1 c_2 c_3 \right]   \\
    \end{bmatrix}\ \rightarrow \begin{bmatrix}
    a_1 &  &  & b_1  & & \\
          & a_2 &  &   & b_2 & \\
          &  & a_3 &   &  & b_3 \\
         &  &  & c_1  & & \\
          &  &  &   & c_2 & \\
          &  &  &   &  & c_3 \\
    \end{bmatrix} $$ 

this might not be optimal because of the required copying, but I think it is more important to the vector field dsl to work and improve performance later.

### Alternative Approaches

In order to reduce the copy overhead we ideally should create CSR matrices based on views into the assembled data. There are several ways to do so:
1. Disallow `Csr<Vec3>` entirely and enforce assembly into Csr<scalar>.
2. Use ginkgos batched functionalities and only copy matrix values.

I think, however, approach 1 is the preferred way, but for now it would require more implementation work, which we could do in separate PRs.

### Adds:
- tests for assembly of CsrMatrix<Vec3>
- move ginkgo related implementations to ginkgo.cpp
- use all executors in parallelAlgorithms tests

Future work:
- Add benchmarks for the matrix assembly and conversion to allow optimaztions