### PR TITLE
Refactor solver interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Version 0.2.0 (unreleased)
 ## Features
-- Improved support for assembling and solving expression of Field<Vec3>. [#370](https://github.com/exasim-project/NeoN/pull/370)
+- Improved support for assembling and solving expression of Field<Vec3>. [#370](https://github.com/exasim-project/NeoN/pull/370),[#374](https://github.com/exasim-project/NeoN/pull/374)
 ### Refactoring
 - Vector split into an generic container class, Array, and the Vector class specialized for as a mathematical operations.  [#318](https://github.com/exasim-project/NeoN/pull/318)
 - General refactor of span and spans to view and views.  [#311](https://github.com/exasim-project/NeoN/pull/311)

--- a/include/NeoN/core/executor/executor.hpp
+++ b/include/NeoN/core/executor/executor.hpp
@@ -17,9 +17,9 @@ namespace NeoN
 
 using Executor = std::variant<SerialExecutor, CPUExecutor, GPUExecutor>;
 
+/* @brief calls Kokkos::fence to wait for GPU kernels to be finished */
 inline void fence(const Executor& exec)
 {
-    // check if executor is GPU
     if (std::holds_alternative<NeoN::GPUExecutor>(exec))
     {
         Kokkos::fence();

--- a/include/NeoN/core/executor/executor.hpp
+++ b/include/NeoN/core/executor/executor.hpp
@@ -17,6 +17,11 @@ namespace NeoN
 
 using Executor = std::variant<SerialExecutor, CPUExecutor, GPUExecutor>;
 
+// FIXME
+// void fence(const Executor&){
+// Kokkos::fence();
+// }
+
 /**
  * @brief Checks if two executors are equal, i.e. they are of the same type.
  * @param lhs The first executor.

--- a/include/NeoN/core/executor/executor.hpp
+++ b/include/NeoN/core/executor/executor.hpp
@@ -17,10 +17,14 @@ namespace NeoN
 
 using Executor = std::variant<SerialExecutor, CPUExecutor, GPUExecutor>;
 
-// FIXME
-// void fence(const Executor&){
-// Kokkos::fence();
-// }
+inline void fence(const Executor& exec)
+{
+    // check if executor is GPU
+    if (std::holds_alternative<NeoN::GPUExecutor>(exec))
+    {
+        Kokkos::fence();
+    }
+}
 
 /**
  * @brief Checks if two executors are equal, i.e. they are of the same type.

--- a/include/NeoN/dsl/ddt.hpp
+++ b/include/NeoN/dsl/ddt.hpp
@@ -22,9 +22,12 @@ public:
 
     std::string getName() const { return "TimeOperator"; }
 
-    void explicitOperation(Vector<scalar>&, scalar, scalar) { NF_ERROR_EXIT("Not implemented"); }
+    void explicitOperation(Vector<scalar>&, scalar, scalar) const
+    {
+        NF_ERROR_EXIT("Not implemented");
+    }
 
-    void implicitOperation(la::LinearSystem<scalar, localIdx>&, scalar, scalar)
+    void implicitOperation(la::LinearSystem<scalar, localIdx>&, scalar, scalar) const
     {
         NF_ERROR_EXIT("Not implemented");
     }

--- a/include/NeoN/dsl/expression.hpp
+++ b/include/NeoN/dsl/expression.hpp
@@ -85,9 +85,7 @@ public:
         return source;
     }
 
-    /*@brief compute matrix coefficients based on all spatial operators
-     *
-     */
+    /*@brief compute matrix coefficients based on all spatial operators */
     void assembleSpatialOperator(la::LinearSystem<ValueType, localIdx>& ls) const
     {
         for (auto& op : spatialOperators_)
@@ -116,7 +114,8 @@ public:
 
     /* @brief construct a linear system and force assembly
      *
-     * @return the assembled linear system
+     * @param ps a vector of functor performing transformation on the created linear system
+     * @return a tuple of the sparsity pattern and the assembled linear system
      */
     std::tuple<la::SparsityPattern, la::LinearSystem<ValueType, localIdx>> assemble(
         const UnstructuredMesh& mesh, scalar t, scalar dt, std::vector<OpFunctor<ValueType>> ps = {}
@@ -130,6 +129,7 @@ public:
 
     /* @brief assemble into a given linear system
      *
+     * @param ps a vector of functor performing transformation on the created linear system
      */
     void assemble(
         scalar t,

--- a/include/NeoN/dsl/expression.hpp
+++ b/include/NeoN/dsl/expression.hpp
@@ -22,7 +22,7 @@ namespace NeoN::dsl
 {
 
 template<typename VectorType>
-struct OpFunctor
+struct PostAssemblyBase
 {
     virtual void operator()(const la::SparsityPattern&, la::LinearSystem<VectorType, localIdx>&) {};
 };
@@ -118,7 +118,10 @@ public:
      * @return a tuple of the sparsity pattern and the assembled linear system
      */
     std::tuple<la::SparsityPattern, la::LinearSystem<ValueType, localIdx>> assemble(
-        const UnstructuredMesh& mesh, scalar t, scalar dt, std::vector<OpFunctor<ValueType>> ps = {}
+        const UnstructuredMesh& mesh,
+        scalar t,
+        scalar dt,
+        std::vector<PostAssemblyBase<ValueType>> ps = {}
     ) const
     {
         auto sp = la::SparsityPattern(mesh);
@@ -136,7 +139,7 @@ public:
         scalar dt,
         const la::SparsityPattern& sp,
         la::LinearSystem<ValueType, localIdx>& ls,
-        std::vector<OpFunctor<ValueType>> ps = {}
+        std::vector<PostAssemblyBase<ValueType>> ps = {}
     ) const
     {
         assembleSpatialOperator(ls);         // add spatial operator

--- a/include/NeoN/dsl/expression.hpp
+++ b/include/NeoN/dsl/expression.hpp
@@ -16,14 +16,13 @@
 #include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
 #include "NeoN/finiteVolume/cellCentred/fields/volumeField.hpp"
 
-namespace la = la;
-
 namespace NeoN::dsl
 {
 
 template<typename VectorType>
 struct PostAssemblyBase
 {
+    virtual ~PostAssemblyBase() = default;
     virtual void operator()(const la::SparsityPattern&, la::LinearSystem<VectorType, localIdx>&) {};
 };
 
@@ -121,7 +120,7 @@ public:
         const UnstructuredMesh& mesh,
         scalar t,
         scalar dt,
-        std::vector<PostAssemblyBase<ValueType>> ps = {}
+        std::span<const PostAssemblyBase<ValueType>> ps = {}
     ) const
     {
         auto sp = la::SparsityPattern(mesh);
@@ -139,7 +138,7 @@ public:
         scalar dt,
         const la::SparsityPattern& sp,
         la::LinearSystem<ValueType, localIdx>& ls,
-        std::vector<PostAssemblyBase<ValueType>> ps = {}
+        std::span<const PostAssemblyBase<ValueType>> ps = {}
     ) const
     {
         assembleSpatialOperator(ls);         // add spatial operator
@@ -199,9 +198,9 @@ private:
 
     const Executor exec_;
 
-    mutable std::vector<TemporalOperator<ValueType>> temporalOperators_;
+    std::vector<TemporalOperator<ValueType>> temporalOperators_;
 
-    mutable std::vector<SpatialOperator<ValueType>> spatialOperators_;
+    std::vector<SpatialOperator<ValueType>> spatialOperators_;
 };
 
 template<typename ValueType>

--- a/include/NeoN/dsl/expression.hpp
+++ b/include/NeoN/dsl/expression.hpp
@@ -85,9 +85,10 @@ public:
         return source;
     }
 
-    // TODO: rename to assembleMatrixCoefficients ?
-    /* @brief perform all implicit operation and accumulate the result */
-    void implicitOperation(la::LinearSystem<ValueType, localIdx>& ls)
+    /*@brief compute matrix coefficients based on all spatial operators
+     *
+     */
+    void assembleSpatialOperator(la::LinearSystem<ValueType, localIdx>& ls)
     {
         for (auto& op : spatialOperators_)
         {
@@ -98,7 +99,10 @@ public:
         }
     }
 
-    void implicitOperation(la::LinearSystem<ValueType, localIdx>& ls, scalar t, scalar dt)
+    /*@brief compute matrix coefficients based on all temporal operators
+     * assemble directly into linear system
+     */
+    void assembleTemporalOperator(la::LinearSystem<ValueType, localIdx>& ls, scalar t, scalar dt)
     {
         for (auto& op : temporalOperators_)
         {
@@ -133,8 +137,8 @@ public:
         std::vector<OpFunctor<ValueType>> ps
     )
     {
-        implicitOperation(ls);        // add spatial operator
-        implicitOperation(ls, t, dt); // add temporal operators
+        assembleSpatialOperator(ls);         // add spatial operator
+        assembleTemporalOperator(ls, t, dt); // add temporal operators
 
         // perform post assembly transformations
         for (auto p : ps)

--- a/include/NeoN/dsl/solver.hpp
+++ b/include/NeoN/dsl/solver.hpp
@@ -30,7 +30,7 @@ namespace detail
 
 // TODO VectorType not needed use ValueType
 template<typename VectorType>
-la::SolverStats iterative_solve_impl(
+la::SolverStats iterativeSolveImpl(
     Expression<typename VectorType::ElementType>& exp,
     VectorType& solution,
     scalar t,
@@ -97,7 +97,7 @@ la::SolverStats solve(
     }
     else
     {
-        return detail::iterative_solve_impl(exp, solution, t, dt, fvSchemes, fvSolution, p);
+        return detail::iterativeSolveImpl(exp, solution, t, dt, fvSchemes, fvSolution, p);
     }
 }
 

--- a/include/NeoN/dsl/solver.hpp
+++ b/include/NeoN/dsl/solver.hpp
@@ -37,7 +37,7 @@ la::SolverStats iterativeSolveImpl(
     scalar dt,
     const Dictionary& fvSchemes,
     const Dictionary& fvSolution,
-    std::vector<OpFunctor<typename VectorType::ElementType>> ps
+    std::vector<PostAssemblyBase<typename VectorType::ElementType>> ps
 )
 {
     using ValueType = typename VectorType::ElementType;
@@ -78,7 +78,7 @@ la::SolverStats solve(
     scalar dt,
     const Dictionary& fvSchemes,
     const Dictionary& fvSolution,
-    std::vector<OpFunctor<typename VectorType::ElementType>> p = {}
+    std::vector<PostAssemblyBase<typename VectorType::ElementType>> p = {}
 )
 {
     if (exp.temporalOperators().size() == 0 && exp.spatialOperators().size() == 0)

--- a/include/NeoN/dsl/solver.hpp
+++ b/include/NeoN/dsl/solver.hpp
@@ -41,7 +41,7 @@ la::SolverStats iterative_solve_impl(
 )
 {
     using ValueType = typename VectorType::ElementType;
-    auto ls = exp.assemble(solution.mesh(), t, dt, ps);
+    auto [sparsity, ls] = exp.assemble(solution.mesh(), t, dt, ps);
 
     // TODO move that to expression explicit operation or
     // into functor ?

--- a/include/NeoN/dsl/solver.hpp
+++ b/include/NeoN/dsl/solver.hpp
@@ -28,7 +28,6 @@ namespace NeoN::dsl
 namespace detail
 {
 
-// TODO VectorType not needed use ValueType
 template<typename VectorType>
 la::SolverStats iterativeSolveImpl(
     Expression<typename VectorType::ElementType>& exp,
@@ -40,7 +39,6 @@ la::SolverStats iterativeSolveImpl(
     std::vector<PostAssemblyBase<typename VectorType::ElementType>> ps
 )
 {
-    using ValueType = typename VectorType::ElementType;
     auto [sparsity, ls] = exp.assemble(solution.mesh(), t, dt, ps);
 
     // TODO move that to expression explicit operation or
@@ -89,7 +87,7 @@ la::SolverStats solve(
     auto integrator =
         timeIntegration::TimeIntegration<VectorType>(fvSchemes.subDict("ddtSchemes"), fvSolution);
 
-    if (exp.temporalOperators().size() > 0 && integrator.direct())
+    if (exp.temporalOperators().size() > 0 && integrator.explicitIntegration())
     {
         // integrate equations in time
         integrator.solve(exp, solution, t, dt);

--- a/include/NeoN/dsl/solver.hpp
+++ b/include/NeoN/dsl/solver.hpp
@@ -58,7 +58,7 @@ la::SolverStats iterative_solve_impl(
     );
 
     auto solver = la::Solver(solution.exec(), fvSolution);
-    // fence(solution.exec());
+    fence(solution.exec());
     return solver.solve(ls, solution.internalVector());
 }
 

--- a/include/NeoN/dsl/spatialOperator.hpp
+++ b/include/NeoN/dsl/spatialOperator.hpp
@@ -73,7 +73,7 @@ public:
 
     void explicitOperation(Vector<ValueType>& source) const { model_->explicitOperation(source); }
 
-    void implicitOperation(la::LinearSystem<ValueType, localIdx>& ls)
+    void implicitOperation(la::LinearSystem<ValueType, localIdx>& ls) const
     {
         model_->implicitOperation(ls);
     }
@@ -104,9 +104,9 @@ private:
     {
         virtual ~OperatorConcept() = default;
 
-        virtual void explicitOperation(Vector<ValueType>& source) = 0;
+        virtual void explicitOperation(Vector<ValueType>& source) const = 0;
 
-        virtual void implicitOperation(la::LinearSystem<ValueType, localIdx>& ls) = 0;
+        virtual void implicitOperation(la::LinearSystem<ValueType, localIdx>& ls) const = 0;
 
         /* @brief Given an input this function reads required coeffs */
         virtual void read(const Input& input) = 0;
@@ -140,7 +140,7 @@ private:
         /* returns the name of the operator */
         std::string getName() const override { return concreteOp_.getName(); }
 
-        virtual void explicitOperation(Vector<ValueType>& source) override
+        virtual void explicitOperation(Vector<ValueType>& source) const override
         {
             if constexpr (HasExplicitOperator<ConcreteOperatorType>)
             {
@@ -148,7 +148,7 @@ private:
             }
         }
 
-        virtual void implicitOperation(la::LinearSystem<ValueType, localIdx>& ls) override
+        virtual void implicitOperation(la::LinearSystem<ValueType, localIdx>& ls) const override
         {
             if constexpr (HasImplicitOperator<ConcreteOperatorType>)
             {

--- a/include/NeoN/dsl/temporalOperator.hpp
+++ b/include/NeoN/dsl/temporalOperator.hpp
@@ -74,7 +74,7 @@ public:
         model_->explicitOperation(source, t, dt);
     }
 
-    void implicitOperation(la::LinearSystem<ValueType, localIdx>& ls, scalar t, scalar dt)
+    void implicitOperation(la::LinearSystem<ValueType, localIdx>& ls, scalar t, scalar dt) const
     {
         model_->implicitOperation(ls, t, dt);
     }

--- a/include/NeoN/timeIntegration/backwardEuler.hpp
+++ b/include/NeoN/timeIntegration/backwardEuler.hpp
@@ -38,9 +38,7 @@ public:
 
     static std::string schema() { return "none"; }
 
-    void solve(
-        dsl::Expression<ValueType>& eqn, SolutionVectorType& solutionVector, scalar t, scalar dt
-    ) override
+    void solve(dsl::Expression<ValueType>&, SolutionVectorType&, scalar, scalar) override
     {
         NF_ERROR_EXIT("Not implemented, use NeoN::dsl::detail::iterative_solve_impl");
     };
@@ -50,7 +48,7 @@ public:
         return std::make_unique<BackwardEuler>(*this);
     }
 
-    bool direct() const override { return false; }
+    bool explicitIntegration() const override { return false; }
 };
 
 

--- a/include/NeoN/timeIntegration/backwardEuler.hpp
+++ b/include/NeoN/timeIntegration/backwardEuler.hpp
@@ -42,26 +42,15 @@ public:
         dsl::Expression<ValueType>& eqn, SolutionVectorType& solutionVector, scalar t, scalar dt
     ) override
     {
-        auto source = eqn.explicitOperation(solutionVector.size());
-        auto sparsity = la::SparsityPattern(solutionVector.mesh());
-        auto ls = la::createEmptyLinearSystem<ValueType, localIdx>(solutionVector.mesh(), sparsity);
-
-        eqn.implicitOperation(ls);        // add spatial operators
-        eqn.implicitOperation(ls, t, dt); // add temporal operators
-
-        auto solver = NeoN::la::Solver(solutionVector.exec(), this->solutionDict_);
-        solver.solve(ls, solutionVector.internalVector());
-        // check if executor is GPU
-        if (std::holds_alternative<NeoN::GPUExecutor>(eqn.exec()))
-        {
-            Kokkos::fence();
-        }
+        NF_ERROR_EXIT("Not implemented, use NeoN::dsl::detail::iterative_solve_impl");
     };
 
     std::unique_ptr<TimeIntegratorBase<SolutionVectorType>> clone() const override
     {
         return std::make_unique<BackwardEuler>(*this);
     }
+
+    bool direct() const override { return false; }
 };
 
 

--- a/include/NeoN/timeIntegration/forwardEuler.hpp
+++ b/include/NeoN/timeIntegration/forwardEuler.hpp
@@ -48,11 +48,7 @@ public:
         solutionVector.internalVector() = oldSolutionVector.internalVector() - source * dt;
         solutionVector.correctBoundaryConditions();
 
-        // check if executor is GPU
-        if (std::holds_alternative<NeoN::GPUExecutor>(eqn.exec()))
-        {
-            Kokkos::fence();
-        }
+        fence(eqn.exec());
     };
 
     std::unique_ptr<TimeIntegratorBase<SolutionVectorType>> clone() const override

--- a/include/NeoN/timeIntegration/sundials.hpp
+++ b/include/NeoN/timeIntegration/sundials.hpp
@@ -209,10 +209,7 @@ int explicitRKSolve([[maybe_unused]] sunrealtype t, N_Vector y, N_Vector ydot, v
     auto size = static_cast<localIdx>(N_VGetLength(y));
     // Copy initial value from y to source.
     NeoN::Vector<NeoN::scalar> source = pdeExpre->explicitOperation(size) * -1.0; // compute spatial
-    if (std::holds_alternative<NeoN::GPUExecutor>(pdeExpre->exec()))
-    {
-        Kokkos::fence();
-    }
+    fence(pdeExpre->exec());
     NeoN::sundials::fieldToSunNVector(source, ydot); // assign rhs to ydot.
     return 0;
 }

--- a/include/NeoN/timeIntegration/timeIntegration.hpp
+++ b/include/NeoN/timeIntegration/timeIntegration.hpp
@@ -43,6 +43,8 @@ public:
     // Pure virtual function for cloning
     virtual std::unique_ptr<TimeIntegratorBase> clone() const = 0;
 
+    virtual bool direct() const { return true; }
+
 protected:
 
     const Dictionary& schemeDict_;
@@ -77,8 +79,12 @@ public:
 
     void solve(Expression& eqn, SolutionVectorType& sol, scalar t, scalar dt)
     {
+        std::cout << __FILE__ << ":" << __LINE__ << "\n";
         timeIntegratorStrategy_->solve(eqn, sol, t, dt);
+        std::cout << __FILE__ << ":" << __LINE__ << "\n";
     }
+
+    bool direct() const { return timeIntegratorStrategy_->direct(); }
 
 private:
 

--- a/include/NeoN/timeIntegration/timeIntegration.hpp
+++ b/include/NeoN/timeIntegration/timeIntegration.hpp
@@ -79,9 +79,7 @@ public:
 
     void solve(Expression& eqn, SolutionVectorType& sol, scalar t, scalar dt)
     {
-        std::cout << __FILE__ << ":" << __LINE__ << "\n";
         timeIntegratorStrategy_->solve(eqn, sol, t, dt);
-        std::cout << __FILE__ << ":" << __LINE__ << "\n";
     }
 
     bool direct() const { return timeIntegratorStrategy_->direct(); }

--- a/include/NeoN/timeIntegration/timeIntegration.hpp
+++ b/include/NeoN/timeIntegration/timeIntegration.hpp
@@ -43,7 +43,7 @@ public:
     // Pure virtual function for cloning
     virtual std::unique_ptr<TimeIntegratorBase> clone() const = 0;
 
-    virtual bool direct() const { return true; }
+    virtual bool explicitIntegration() const { return true; }
 
 protected:
 
@@ -82,7 +82,7 @@ public:
         timeIntegratorStrategy_->solve(eqn, sol, t, dt);
     }
 
-    bool direct() const { return timeIntegratorStrategy_->direct(); }
+    bool explicitIntegration() const { return timeIntegratorStrategy_->explicitIntegration(); }
 
 private:
 

--- a/src/linearAlgebra/ginkgo.cpp
+++ b/src/linearAlgebra/ginkgo.cpp
@@ -188,6 +188,7 @@ gkoVecView(std::shared_ptr<const gko::Executor> exec, const scalar* ptr, localId
 }
 
 
+/* @brief create a ginkgo csr matrix by creating views into Csr<scalar> avoiding copies */
 template<typename IndexType>
 std::shared_ptr<const gko::matrix::Csr<scalar, IndexType>>
 createGkoMtx(std::shared_ptr<const gko::Executor> exec, const LinearSystem<scalar, IndexType>& sys)
@@ -276,9 +277,7 @@ SolverStats GinkgoSolver::solve(const LinearSystem<scalar, localIdx>& sys, Vecto
     return solve_impl(gkoExec_, sys.rhs(), x, gkoMtx, std::move(solver));
 }
 
-/*
- *
- */
+/* @brief create a ginkgo csr matrix by unpacking and copying the Csr<Vec3> input */
 template<typename IndexType>
 std::shared_ptr<const gko::matrix::Csr<scalar, IndexType>>
 createGkoMtx(std::shared_ptr<const gko::Executor> exec, const LinearSystem<Vec3, IndexType>& sys)

--- a/test/dsl/expression.cpp
+++ b/test/dsl/expression.cpp
@@ -83,37 +83,37 @@ TEMPLATE_TEST_CASE("Expression", "[template]", NeoN::scalar, NeoN::Vec3)
         REQUIRE(eqnC.size() == 2);
 
         // 2 + 2 = 4
-        eqnA.implicitOperation(ls);
+        eqnA.assembleSpatialOperator(ls);
         REQUIRE(getDiag(ls) == 4 * NeoN::one<TestType>());
         REQUIRE(getRhs(ls) == 4 * NeoN::one<TestType>());
 
         // 4*2 + 2*2 = 12
         ls.reset();
-        eqnB.implicitOperation(ls);
+        eqnB.assembleSpatialOperator(ls);
         REQUIRE(getDiag(ls) == 12 * NeoN::one<TestType>());
         REQUIRE(getRhs(ls) == 12 * NeoN::one<TestType>());
 
         // 2*2 - 2 = 2
         ls.reset();
-        eqnC.implicitOperation(ls);
+        eqnC.assembleSpatialOperator(ls);
         REQUIRE(getDiag(ls) == 2 * NeoN::one<TestType>());
         REQUIRE(getRhs(ls) == 2 * NeoN::one<TestType>());
 
         // 3*(2*2 - 2) = 6
         ls.reset();
-        eqnD.implicitOperation(ls);
+        eqnD.assembleSpatialOperator(ls);
         REQUIRE(getDiag(ls) == 6 * NeoN::one<TestType>());
         REQUIRE(getRhs(ls) == 6 * NeoN::one<TestType>());
 
         // 2*2 - 2 + 2*2 - 2 = 4
         ls.reset();
-        eqnE.implicitOperation(ls);
+        eqnE.assembleSpatialOperator(ls);
         REQUIRE(getDiag(ls) == 4 * NeoN::one<TestType>());
         REQUIRE(getRhs(ls) == 4 * NeoN::one<TestType>());
 
         // // 2*2 - 2 - 2*2 + 2 = 0
         ls.reset();
-        eqnF.implicitOperation(ls);
+        eqnF.assembleSpatialOperator(ls);
         REQUIRE(getDiag(ls) == 0 * NeoN::one<TestType>());
         REQUIRE(getRhs(ls) == 0 * NeoN::one<TestType>());
     }

--- a/test/timeIntegration/timeIntegration.cpp
+++ b/test/timeIntegration/timeIntegration.cpp
@@ -43,7 +43,6 @@ TEST_CASE("TimeIntegration")
         double dt {2.0};
         double time {1.0};
 
-
         // int(ddt(U)) + f = 0
         // (U^1-U^0)/dt = -f
         // U^1 = - f * dt + U^0, where dt = 2, f = 2, U^0=2.0 -> U^1=-2.0


### PR DESCRIPTION
**The issue:**
currently, we have several implementations of the matrix assembly and linear solver procedure. E.g. in  the `backwardEuler.hpp` and on the FoamAdapter side.

This PR tries to unify the procedure of calling the linear solver.

Adds:
- free `fence(exec)` function
- modify `dsl::solve` signature allowing to pass postAssemblyFunctors


Depends on #370
