### PR TITLE
Use system-installed Ginkgo for CI jobs on GPUs if available

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@
 
 .use-amd-gpu:
   tags: ["amd-gpus"]
-  image: chihtaw/neon-rocm:6.4.1-complete
+  image: chihtaw/rocm-openfoam-ginkgo:6.4.1-v2412
 
 # Common configuration for all build and test jobs
 .build-and-test-neon-common:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@
 # Available GPUs and corresponding Docker images
 .use-nvidia-gpu:
   tags: ["nvidia-h100-gpus"]
-  image: greole/neon-cuda
+  image: chihtaw/cuda-openfoam-ginkgo:v2412
 
 .use-amd-gpu:
   tags: ["amd-gpus"]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,11 +5,11 @@
 # Available GPUs and corresponding Docker images
 .use-nvidia-gpu:
   tags: ["nvidia-h100-gpus"]
-  image: chihtaw/cuda-openfoam-ginkgo:v2412
+  image: chihtaw/cuda-openfoam-ginkgo:arch_90-v2412
 
 .use-amd-gpu:
   tags: ["amd-gpus"]
-  image: chihtaw/rocm-openfoam-ginkgo:6.4.1-v2412
+  image: chihtaw/rocm-openfoam-ginkgo:arch_gfx90a-6.4.1-v2412
 
 # Common configuration for all build and test jobs
 .build-and-test-neon-common:

--- a/cmake/CxxThirdParty.cmake
+++ b/cmake/CxxThirdParty.cmake
@@ -163,8 +163,10 @@ if(${NeoN_WITH_SUNDIALS})
 endif()
 
 if(${NeoN_WITH_GINKGO})
+  # --- nlohmann_json ---
   find_package(nlohmann_json ${NeoN_JSON_VERSION} QUIET)
   if(NOT nlohmann_json_FOUND)
+    message(STATUS "System nlohmann_json not found — fetching from GitHub via CPM.cmake...")
     cpmaddpackage(
       NAME
       nlohmann_json
@@ -176,28 +178,37 @@ if(${NeoN_WITH_GINKGO})
       YES
       OPTIONS
       "JSON_Install ON")
+  else()
+    message(STATUS "Using system-installed nlohmann_json (version: ${nlohmann_json_VERSION})")
   endif()
 
-  cpmaddpackage(
-    NAME
-    Ginkgo
-    VERSION
-    ${NeoN_GINKGO_VERSION}
-    GITHUB_REPOSITORY
-    ginkgo-project/ginkgo
-    GIT_TAG
-    ${NeoN_GINKGO_TAG}
-    SYSTEM
-    YES
-    OPTIONS
-    "GINKGO_BUILD_TESTS OFF"
-    "GINKGO_BUILD_BENCHMARKS OFF"
-    "GINKGO_BUILD_EXAMPLES OFF"
-    "GINKGO_BUILD_OMP ${NeoN_WITH_OMP}"
-    "GINKGO_ENABLE_HALF OFF"
-    "GINKGO_BUILD_MPI OFF"
-    "GINKGO_BUILD_CUDA ${Kokkos_ENABLE_CUDA}"
-    "GINKGO_BUILD_HIP ${Kokkos_ENABLE_HIP}")
+  # --- Ginkgo ---
+  find_package(Ginkgo ${NeoN_GINKGO_VERSION} QUIET)
+  if(Ginkgo_FOUND)
+    message(STATUS "Using system-installed Ginkgo (version: ${Ginkgo_VERSION})")
+  else()
+    message(STATUS "System Ginkgo not found — fetching from GitHub via CPM.cmake...")
+    cpmaddpackage(
+      NAME
+      Ginkgo
+      VERSION
+      ${NeoN_GINKGO_VERSION}
+      GITHUB_REPOSITORY
+      ginkgo-project/ginkgo
+      GIT_TAG
+      ${NeoN_GINKGO_TAG}
+      SYSTEM
+      YES
+      OPTIONS
+      "GINKGO_BUILD_TESTS OFF"
+      "GINKGO_BUILD_BENCHMARKS OFF"
+      "GINKGO_BUILD_EXAMPLES OFF"
+      "GINKGO_BUILD_OMP ${NeoN_WITH_OMP}"
+      "GINKGO_ENABLE_HALF OFF"
+      "GINKGO_BUILD_MPI OFF"
+      "GINKGO_BUILD_CUDA ${Kokkos_ENABLE_CUDA}"
+      "GINKGO_BUILD_HIP ${Kokkos_ENABLE_HIP}")
+  endif()
 endif()
 
 if(NeoN_BUILD_TESTS OR NeoN_BUILD_BENCHMARKS)


### PR DESCRIPTION
**Make CMake to check if a system installed Ginkgo is available**:

- If it is the case, use the system-installed Ginkgo.
- Otherwise, fetch Ginkgo via CPM.

**Use docker images with Ginkgo pre-installed for particular GPUs in LRZ GitLab CI**:

- NVIDIA H100
- AMD MI210

With the new docker images, all CI jobs on LRZ GitLab use the system-installed Ginkgo instead of building Ginkgo from scratch. Therefore, the time required for build step is significantly reduced.

**In short**: 
The PR decreases the time developers spend waiting for CI to finish.