### PR TITLE
Grad operator implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Version 0.2.0 (unreleased)
 ## Features
-- Improved support for assembling and solving expression of Field<Vec3>. [#370](https://github.com/exasim-project/NeoN/pull/370),[#374](https://github.com/exasim-project/NeoN/pull/374)
+- Improved support for assembling and solving expression of Field<Vec3>. [#370](https://github.com/exasim-project/NeoN/pull/370),[#374](https://github.com/exasim-project/NeoN/pull/374), [#379](https://github.com/exasim-project/NeoN/pull/379)
 ### Refactoring
 - Vector split into an generic container class, Array, and the Vector class specialized for as a mathematical operations.  [#318](https://github.com/exasim-project/NeoN/pull/318)
 - General refactor of span and spans to view and views.  [#311](https://github.com/exasim-project/NeoN/pull/311)

--- a/doc/dsl/equation.rst
+++ b/doc/dsl/equation.rst
@@ -1,6 +1,5 @@
 Expression
----------
-
+----------
 
 The `Expression` class in NeoN holds a set of operators to express an expression and ultimately helps to formulate equations.
 Its core responsibility lies in the answering of the following questions:

--- a/include/NeoN/dsl/explicit.hpp
+++ b/include/NeoN/dsl/explicit.hpp
@@ -16,6 +16,7 @@
 #include "NeoN/finiteVolume/cellCentred/operators/ddtOperator.hpp"
 #include "NeoN/finiteVolume/cellCentred/operators/laplacianOperator.hpp"
 #include "NeoN/finiteVolume/cellCentred/operators/divOperator.hpp"
+#include "NeoN/finiteVolume/cellCentred/operators/gradOperator.hpp"
 #include "NeoN/finiteVolume/cellCentred/operators/surfaceIntegrate.hpp"
 #include "NeoN/finiteVolume/cellCentred/operators/sourceTerm.hpp"
 
@@ -42,6 +43,8 @@ laplacian(const fvcc::SurfaceField<scalar>& gamma, fvcc::VolumeField<scalar>& ph
 
 SpatialOperator<Vec3>
 laplacian(const fvcc::SurfaceField<scalar>& gamma, fvcc::VolumeField<Vec3>& phi);
+
+SpatialOperator<Vec3> grad(fvcc::VolumeField<scalar>& phi);
 
 SpatialOperator<scalar> source(fvcc::VolumeField<scalar>& coeff, fvcc::VolumeField<scalar>& phi);
 

--- a/include/NeoN/dsl/implicit.hpp
+++ b/include/NeoN/dsl/implicit.hpp
@@ -21,7 +21,7 @@ namespace fvcc = NeoN::finiteVolume::cellCentred;
 namespace NeoN::dsl::imp
 {
 
-
+// TODO all arguments could be const
 template<typename ValueType>
 TemporalOperator<ValueType> ddt(fvcc::VolumeField<ValueType>& phi)
 {

--- a/include/NeoN/dsl/operator.hpp
+++ b/include/NeoN/dsl/operator.hpp
@@ -24,23 +24,26 @@ public:
 
 /* @class OperatorMixin
  * @brief A mixin class to simplify implementations of concrete operators
- * in NeoNs dsl
+ * in NeoNs dsl.
+ *
+ * @detail Operators perform either an explicit or implicit operation on a field or vector.
  *
  * @ingroup dsl
- * @tparam VectorType the type of the resulting field after evaluation
- * @tparam VectorInType the type of the input field
+ * @tparam OutType the type of the resulting field after evaluation
+ * @tparam InType the type of the input field
  */
-template<typename VectorType, typename VectorInType = VectorType>
+template<typename OutType, typename InType = OutType>
 class OperatorMixin
 {
 
 public:
 
     OperatorMixin(
-        const Executor exec, const Coeff& coeffs, const VectorInType& field, Operator::Type type
+        const Executor exec, const Coeff& coeffs, const InType& field, Operator::Type type
     )
         : exec_(exec), coeffs_(coeffs), field_(field), type_(type) {};
 
+    /*@brief return the type of the operator i.e. Implicit or Explicit */
     Operator::Type getType() const { return type_; }
 
     virtual ~OperatorMixin() = default;
@@ -51,7 +54,7 @@ public:
 
     const Coeff& getCoefficient() const { return coeffs_; }
 
-    const VectorInType& getVector() const { return field_; }
+    const InType& getVector() const { return field_; }
 
     /* @brief Given an input this function reads required coeffs */
     void read([[maybe_unused]] const Input& input) {}
@@ -62,7 +65,7 @@ protected:
 
     Coeff coeffs_;
 
-    const VectorInType& field_;
+    const InType& field_;
 
     Operator::Type type_;
 };

--- a/include/NeoN/dsl/operator.hpp
+++ b/include/NeoN/dsl/operator.hpp
@@ -27,14 +27,18 @@ public:
  * in NeoNs dsl
  *
  * @ingroup dsl
+ * @tparam VectorType the type of the resulting field after evaluation
+ * @tparam VectorInType the type of the input field
  */
-template<typename VectorType>
+template<typename VectorType, typename VectorInType = VectorType>
 class OperatorMixin
 {
 
 public:
 
-    OperatorMixin(const Executor exec, const Coeff& coeffs, VectorType& field, Operator::Type type)
+    OperatorMixin(
+        const Executor exec, const Coeff& coeffs, VectorInType& field, Operator::Type type
+    )
         : exec_(exec), coeffs_(coeffs), field_(field), type_(type) {};
 
     Operator::Type getType() const { return type_; }
@@ -47,9 +51,9 @@ public:
 
     const Coeff& getCoefficient() const { return coeffs_; }
 
-    VectorType& getVector() { return field_; }
+    VectorInType& getVector() { return field_; }
 
-    const VectorType& getVector() const { return field_; }
+    const VectorInType& getVector() const { return field_; }
 
     /* @brief Given an input this function reads required coeffs */
     void read([[maybe_unused]] const Input& input) {}
@@ -60,7 +64,7 @@ protected:
 
     Coeff coeffs_;
 
-    VectorType& field_;
+    VectorInType& field_;
 
     Operator::Type type_;
 };

--- a/include/NeoN/dsl/operator.hpp
+++ b/include/NeoN/dsl/operator.hpp
@@ -37,7 +37,7 @@ class OperatorMixin
 public:
 
     OperatorMixin(
-        const Executor exec, const Coeff& coeffs, VectorInType& field, Operator::Type type
+        const Executor exec, const Coeff& coeffs, const VectorInType& field, Operator::Type type
     )
         : exec_(exec), coeffs_(coeffs), field_(field), type_(type) {};
 
@@ -51,8 +51,6 @@ public:
 
     const Coeff& getCoefficient() const { return coeffs_; }
 
-    VectorInType& getVector() { return field_; }
-
     const VectorInType& getVector() const { return field_; }
 
     /* @brief Given an input this function reads required coeffs */
@@ -64,7 +62,7 @@ protected:
 
     Coeff coeffs_;
 
-    VectorInType& field_;
+    const VectorInType& field_;
 
     Operator::Type type_;
 };

--- a/include/NeoN/dsl/solver.hpp
+++ b/include/NeoN/dsl/solver.hpp
@@ -65,7 +65,6 @@ la::SolverStats iterativeSolveImpl(
     VectorType& solution,
     scalar t,
     scalar dt,
-    const Dictionary& fvSchemes,
     const Dictionary& fvSolution,
     std::vector<PostAssemblyBase<typename VectorType::ElementType>> ps
 )
@@ -126,7 +125,7 @@ la::SolverStats solve(
     }
     else
     {
-        return detail::iterativeSolveImpl(exp, solution, t, dt, fvSchemes, fvSolution, p);
+        return detail::iterativeSolveImpl(exp, solution, t, dt, fvSolution, p);
     }
 }
 

--- a/include/NeoN/dsl/spatialOperator.hpp
+++ b/include/NeoN/dsl/spatialOperator.hpp
@@ -83,7 +83,6 @@ public:
 
     std::string getName() const { return model_->getName(); }
 
-
     Coeff& getCoefficient() { return model_->getCoefficient(); }
 
     Coeff getCoefficient() const { return model_->getCoefficient(); }

--- a/include/NeoN/finiteVolume/cellCentred/operators/divOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/divOperator.hpp
@@ -102,7 +102,7 @@ public:
     DivOperator(
         dsl::Operator::Type termType,
         const SurfaceField<scalar>& faceFlux,
-        VolumeField<ValueType>& phi,
+        const VolumeField<ValueType>& phi,
         Input input
     )
         : dsl::OperatorMixin<VolumeField<ValueType>>(phi.exec(), dsl::Coeff(1.0), phi, termType),
@@ -113,7 +113,7 @@ public:
     DivOperator(
         dsl::Operator::Type termType,
         const SurfaceField<scalar>& faceFlux,
-        VolumeField<ValueType>& phi,
+        const VolumeField<ValueType>& phi,
         std::unique_ptr<DivOperatorFactory<ValueType>> divOperatorStrategy
     )
         : dsl::OperatorMixin<VolumeField<scalar>>(phi.exec(), dsl::Coeff(1.0), phi, termType),
@@ -122,7 +122,7 @@ public:
     DivOperator(
         dsl::Operator::Type termType,
         const SurfaceField<scalar>& faceFlux,
-        VolumeField<ValueType>& phi
+        const VolumeField<ValueType>& phi
     )
         : dsl::OperatorMixin<VolumeField<ValueType>>(phi.exec(), dsl::Coeff(1.0), phi, termType),
           faceFlux_(faceFlux), divOperatorStrategy_(nullptr) {};

--- a/include/NeoN/finiteVolume/cellCentred/operators/divOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/divOperator.hpp
@@ -44,9 +44,6 @@ public:
 
     virtual ~DivOperatorFactory() {} // Virtual destructor
 
-    // NOTE currently simple overloading is used here, because templating the virtual function
-    // does not work and we cant template the entire class because the static create function
-    // cannot access keyExistsOrError and table anymore.
     virtual void
     div(VolumeField<ValueType>& divPhi,
         const SurfaceField<scalar>& faceFlux,
@@ -153,22 +150,12 @@ public:
         divOperatorStrategy_->div(ls, faceFlux_, this->getVector(), operatorScaling);
     }
 
-    void div(Vector<ValueType>& divPhi) const
+    [[deprecated("use explicit or implicit operation")]] void div(auto&&... args) const
     {
         const auto operatorScaling = this->getCoefficient();
-        divOperatorStrategy_->div(divPhi, faceFlux_, this->getVector(), operatorScaling);
-    }
-
-    void div(la::LinearSystem<ValueType, localIdx>& ls) const
-    {
-        const auto operatorScaling = this->getCoefficient();
-        divOperatorStrategy_->div(ls, faceFlux_, this->getVector(), operatorScaling);
-    };
-
-    void div(VolumeField<ValueType>& divPhi) const
-    {
-        const auto operatorScaling = this->getCoefficient();
-        divOperatorStrategy_->div(divPhi, faceFlux_, this->getVector(), operatorScaling);
+        divOperatorStrategy_->div(
+            std::forward<decltype(args)>(args)..., faceFlux_, this->getVector(), operatorScaling
+        );
     }
 
     void read(const Input& input)

--- a/include/NeoN/finiteVolume/cellCentred/operators/divOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/divOperator.hpp
@@ -67,7 +67,11 @@ public:
         const VolumeField<ValueType>& phi,
         const dsl::Coeff operatorScaling) const = 0;
 
-    const la::SparsityPattern& getSparsityPattern() const { return sparsityPattern_; }
+    [[deprecated("This function will be removed")]] const la::SparsityPattern&
+    getSparsityPattern() const
+    {
+        return sparsityPattern_;
+    }
 
     // Pure virtual function for cloning
     virtual std::unique_ptr<DivOperatorFactory<ValueType>> clone() const = 0;

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp
@@ -33,6 +33,9 @@ void computeDivImp(
     const la::SparsityPattern& sparsityPattern
 );
 
+/* @brief
+ *
+ */
 template<typename ValueType>
 class GaussGreenDiv :
     public DivOperatorFactory<ValueType>::template Register<GaussGreenDiv<ValueType>>
@@ -49,37 +52,6 @@ public:
 
     GaussGreenDiv(const Executor& exec, const UnstructuredMesh& mesh, const Input& inputs)
         : Base(exec, mesh), surfaceInterpolation_(exec, mesh, inputs) {};
-
-    virtual void
-    div(VolumeField<ValueType>& divPhi,
-        const SurfaceField<scalar>& faceFlux,
-        const VolumeField<ValueType>& phi,
-        const dsl::Coeff operatorScaling) const override
-    {
-        computeDivExp<ValueType>(
-            faceFlux, phi, surfaceInterpolation_, divPhi.internalVector(), operatorScaling
-        );
-    }
-
-    virtual void
-    div(la::LinearSystem<ValueType, localIdx>& ls,
-        const SurfaceField<scalar>& faceFlux,
-        const VolumeField<ValueType>& phi,
-        const dsl::Coeff operatorScaling) const override
-    {
-        computeDivImp(
-            ls, faceFlux, phi, surfaceInterpolation_, operatorScaling, this->getSparsityPattern()
-        );
-    };
-
-    virtual void
-    div(Vector<ValueType>& divPhi,
-        const SurfaceField<scalar>& faceFlux,
-        const VolumeField<ValueType>& phi,
-        const dsl::Coeff operatorScaling) const override
-    {
-        computeDivExp<ValueType>(faceFlux, phi, surfaceInterpolation_, divPhi, operatorScaling);
-    };
 
     virtual VolumeField<ValueType>
     div(const SurfaceField<scalar>& faceFlux,
@@ -99,6 +71,37 @@ public:
             faceFlux, phi, surfaceInterpolation_, divPhi.internalVector(), operatorScaling
         );
         return divPhi;
+    };
+
+    virtual void
+    div(VolumeField<ValueType>& divPhi,
+        const SurfaceField<scalar>& faceFlux,
+        const VolumeField<ValueType>& phi,
+        const dsl::Coeff operatorScaling) const override
+    {
+        computeDivExp<ValueType>(
+            faceFlux, phi, surfaceInterpolation_, divPhi.internalVector(), operatorScaling
+        );
+    }
+
+    virtual void
+    div(Vector<ValueType>& divPhi,
+        const SurfaceField<scalar>& faceFlux,
+        const VolumeField<ValueType>& phi,
+        const dsl::Coeff operatorScaling) const override
+    {
+        computeDivExp<ValueType>(faceFlux, phi, surfaceInterpolation_, divPhi, operatorScaling);
+    };
+
+    virtual void
+    div(la::LinearSystem<ValueType, localIdx>& ls,
+        const SurfaceField<scalar>& faceFlux,
+        const VolumeField<ValueType>& phi,
+        const dsl::Coeff operatorScaling) const override
+    {
+        computeDivImp(
+            ls, faceFlux, phi, surfaceInterpolation_, operatorScaling, this->getSparsityPattern()
+        );
     };
 
     std::unique_ptr<DivOperatorFactory<ValueType>> clone() const override

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp
@@ -30,12 +30,14 @@ public:
 
     // fvcc::VolumeField<Vec3> grad(const fvcc::VolumeField<scalar>& phi);
 
-    // virtual void grad(const VolumeField<scalar>& phi, VolumeField<Vec3>& gradPhi) const;
-
+    /* @brief compute gradient for implicit operator
+     *
+     * @param ls [in,out] - assemble gradient operator into the given linear system
+     * @param phi [in] -
+     * @param operatorScaling [in] -
+     */
     virtual void grad(
-        la::LinearSystem<Vec3, localIdx>& ls,
-        const VolumeField<scalar>& phi,
-        const dsl::Coeff operatorScaling
+        la::LinearSystem<Vec3, localIdx>&, const VolumeField<scalar>&, const dsl::Coeff
     ) const override
     {
         NF_ERROR_EXIT("Not implemented");
@@ -45,9 +47,13 @@ public:
         const VolumeField<scalar>& phi, const dsl::Coeff operatorScaling, Vector<Vec3>& gradPhi
     ) const;
 
-    virtual void grad(
-        const VolumeField<scalar>& phi, const dsl::Coeff operatorScaling, VolumeField<Vec3>& gradPhi
-    ) const
+    /* @brief compute grad
+     *
+     * @param phi [in]
+     * @param operatorScaling [in]
+     * @param gradPhi [in,out] - resulting gradient field
+     */
+    virtual void grad(const VolumeField<scalar>&, const dsl::Coeff, VolumeField<Vec3>&) const
     {
         NF_ERROR_EXIT("Not implemented");
     };

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp
@@ -6,27 +6,65 @@
 
 #include "NeoN/core/executor/executor.hpp"
 #include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
+#include "NeoN/finiteVolume/cellCentred/operators/gradOperator.hpp"
 #include "NeoN/finiteVolume/cellCentred/fields/volumeField.hpp"
 #include "NeoN/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp"
 
 namespace NeoN::finiteVolume::cellCentred
 {
 
-class GaussGreenGrad
+class GaussGreenGrad : public GradOperatorFactory<Vec3>::template Register<GaussGreenGrad>
 {
+
+    using Base = GradOperatorFactory<Vec3>::template Register<GaussGreenGrad>;
+
 public:
+
+    static std::string name() { return "Gauss"; }
+
+    static std::string doc() { return "Gauss-Green Gradient"; }
+
+    static std::string schema() { return "none"; }
 
     GaussGreenGrad(const Executor& exec, const UnstructuredMesh& mesh);
 
     // fvcc::VolumeField<Vec3> grad(const fvcc::VolumeField<scalar>& phi);
 
-    void grad(const VolumeField<scalar>& phi, VolumeField<Vec3>& gradPhi);
+    // virtual void grad(const VolumeField<scalar>& phi, VolumeField<Vec3>& gradPhi) const;
 
-    VolumeField<Vec3> grad(const VolumeField<scalar>& phi);
+    virtual VolumeField<Vec3> grad(const VolumeField<scalar>& phi);
+
+    virtual void grad(
+        la::LinearSystem<Vec3, localIdx>& ls,
+        const VolumeField<scalar>& phi,
+        const dsl::Coeff operatorScaling
+    ) const override
+    {
+        NF_ERROR_EXIT("Not implemented");
+    };
+
+    virtual void grad(const VolumeField<scalar>& phi, Vector<Vec3>& gradPhi) const;
+
+    virtual void grad(
+        VolumeField<Vec3>& gradPhi, const VolumeField<scalar>& phi, const dsl::Coeff operatorScaling
+    ) const
+    {
+        NF_ERROR_EXIT("Not implemented");
+    };
+
+    virtual VolumeField<Vec3>
+    grad(const VolumeField<scalar>& phi, const dsl::Coeff operatorScaling) const
+    {
+        NF_ERROR_EXIT("Not implemented");
+    }
+
+    virtual std::unique_ptr<GradOperatorFactory<Vec3>> clone() const
+    {
+        NF_ERROR_EXIT("Not implemented");
+    };
 
 private:
 
-    const UnstructuredMesh& mesh_;
     SurfaceInterpolation<scalar> surfaceInterpolation_;
 };
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp
@@ -32,8 +32,6 @@ public:
 
     // virtual void grad(const VolumeField<scalar>& phi, VolumeField<Vec3>& gradPhi) const;
 
-    virtual VolumeField<Vec3> grad(const VolumeField<scalar>& phi);
-
     virtual void grad(
         la::LinearSystem<Vec3, localIdx>& ls,
         const VolumeField<scalar>& phi,
@@ -43,20 +41,19 @@ public:
         NF_ERROR_EXIT("Not implemented");
     };
 
-    virtual void grad(const VolumeField<scalar>& phi, Vector<Vec3>& gradPhi) const;
+    virtual void grad(
+        const VolumeField<scalar>& phi, const dsl::Coeff operatorScaling, Vector<Vec3>& gradPhi
+    ) const;
 
     virtual void grad(
-        VolumeField<Vec3>& gradPhi, const VolumeField<scalar>& phi, const dsl::Coeff operatorScaling
+        const VolumeField<scalar>& phi, const dsl::Coeff operatorScaling, VolumeField<Vec3>& gradPhi
     ) const
     {
         NF_ERROR_EXIT("Not implemented");
     };
 
-    virtual VolumeField<Vec3>
-    grad(const VolumeField<scalar>& phi, const dsl::Coeff operatorScaling) const
-    {
-        NF_ERROR_EXIT("Not implemented");
-    }
+    VolumeField<Vec3>
+    grad(const VolumeField<scalar>& phi, const dsl::Coeff operatorScaling = dsl::Coeff {}) const;
 
     virtual std::unique_ptr<GradOperatorFactory<Vec3>> clone() const
     {

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp
@@ -30,15 +30,15 @@ public:
 
     // fvcc::VolumeField<Vec3> grad(const fvcc::VolumeField<scalar>& phi);
 
-    /* @brief compute gradient for implicit operator
+    /* @brief compute implicit gradient operator contribution
      *
+     * @param phi [in] - field for which the gradient is computed
+     * @param operatorScaling [in] - scales operator by a coefficient
      * @param ls [in,out] - assemble gradient operator into the given linear system
-     * @param phi [in] -
-     * @param operatorScaling [in] -
      */
-    virtual void grad(
-        la::LinearSystem<Vec3, localIdx>&, const VolumeField<scalar>&, const dsl::Coeff
-    ) const override
+    virtual void
+    grad(const VolumeField<scalar>&, const dsl::Coeff, la::LinearSystem<Vec3, localIdx>&)
+        const override
     {
         NF_ERROR_EXIT("Not implemented");
     };
@@ -49,8 +49,8 @@ public:
 
     /* @brief compute grad
      *
-     * @param phi [in]
-     * @param operatorScaling [in]
+     * @param phi [in] - field for which the gradient is computed
+     * @param operatorScaling [in] - scales operator by a coefficient
      * @param gradPhi [in,out] - resulting gradient field
      */
     virtual void grad(const VolumeField<scalar>&, const dsl::Coeff, VolumeField<Vec3>&) const
@@ -58,6 +58,12 @@ public:
         NF_ERROR_EXIT("Not implemented");
     };
 
+    /* @brief compute explicit gradient operator and return result
+     *
+     * @param phi [in]
+     * @param operatorScaling [in] - scales operator by a coefficient
+     * @return gradPhi - resulting gradient field
+     */
     VolumeField<Vec3>
     grad(const VolumeField<scalar>& phi, const dsl::Coeff operatorScaling = dsl::Coeff {}) const;
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp
@@ -19,7 +19,7 @@ template<typename ValueType>
 void computeLaplacianExp(
     const FaceNormalGradient<ValueType>&,
     const SurfaceField<scalar>&,
-    VolumeField<ValueType>&,
+    const VolumeField<ValueType>&,
     Vector<ValueType>&,
     const dsl::Coeff
 );
@@ -28,7 +28,7 @@ template<typename ValueType>
 void computeLaplacianImpl(
     la::LinearSystem<ValueType, localIdx>& ls,
     const SurfaceField<scalar>& gamma,
-    VolumeField<ValueType>& phi,
+    const VolumeField<ValueType>& phi,
     const dsl::Coeff operatorScaling,
     const la::SparsityPattern& sparsityPattern,
     const FaceNormalGradient<ValueType>& faceNormalGradient
@@ -56,7 +56,7 @@ public:
     virtual void laplacian(
         VolumeField<ValueType>& lapPhi,
         const SurfaceField<scalar>& gamma,
-        VolumeField<ValueType>& phi,
+        const VolumeField<ValueType>& phi,
         const dsl::Coeff operatorScaling
     ) override
     {
@@ -67,7 +67,7 @@ public:
 
     virtual VolumeField<ValueType> laplacian(
         const SurfaceField<scalar>& gamma,
-        VolumeField<ValueType>& phi,
+        const VolumeField<ValueType>& phi,
         const dsl::Coeff operatorScaling
     ) const override
     {
@@ -89,7 +89,7 @@ public:
     virtual void laplacian(
         Vector<ValueType>& lapPhi,
         const SurfaceField<scalar>& gamma,
-        VolumeField<ValueType>& phi,
+        const VolumeField<ValueType>& phi,
         const dsl::Coeff operatorScaling
     ) override
     {
@@ -99,7 +99,7 @@ public:
     virtual void laplacian(
         la::LinearSystem<ValueType, localIdx>& ls,
         const SurfaceField<scalar>& gamma,
-        VolumeField<ValueType>& phi,
+        const VolumeField<ValueType>& phi,
         const dsl::Coeff operatorScaling
     ) override
     {

--- a/include/NeoN/finiteVolume/cellCentred/operators/gradOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gradOperator.hpp
@@ -91,7 +91,7 @@ public:
               gradOp.gradOperatorStrategy_ ? gradOp.gradOperatorStrategy_->clone() : nullptr
           ) {};
 
-    GradOperator(dsl::Operator::Type termType, VolumeField<scalar>& phi, Input input)
+    GradOperator(dsl::Operator::Type termType, const VolumeField<scalar>& phi, Input input)
         : dsl::OperatorMixin<VolumeField<ValueType>, VolumeField<scalar>>(
             phi.exec(), dsl::Coeff(1.0), phi, termType
         ),
@@ -101,7 +101,7 @@ public:
 
     GradOperator(
         dsl::Operator::Type termType,
-        VolumeField<scalar>& phi,
+        const VolumeField<scalar>& phi,
         std::unique_ptr<GradOperatorFactory<ValueType>> gradOperatorStrategy
     )
         : dsl::OperatorMixin<VolumeField<ValueType>, VolumeField<scalar>>(
@@ -109,7 +109,7 @@ public:
         ),
           gradOperatorStrategy_(std::move(gradOperatorStrategy)) {};
 
-    GradOperator(dsl::Operator::Type termType, VolumeField<scalar>& phi)
+    GradOperator(dsl::Operator::Type termType, const VolumeField<scalar>& phi)
         : dsl::OperatorMixin<VolumeField<ValueType>, VolumeField<scalar>>(
             phi.exec(), dsl::Coeff(1.0), phi, termType
         ),

--- a/include/NeoN/finiteVolume/cellCentred/operators/gradOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gradOperator.hpp
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "NeoN/fields/field.hpp"
+#include "NeoN/linearAlgebra/linearSystem.hpp"
+#include "NeoN/core/executor/executor.hpp"
+#include "NeoN/core/input.hpp"
+#include "NeoN/dsl/spatialOperator.hpp"
+#include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
+#include "NeoN/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp"
+
+namespace NeoN::finiteVolume::cellCentred
+{
+
+/* @class Factory class to create gradient operators by a given name using
+ * using NeoNs runTimeFactory mechanism
+ */
+template<typename ValueType>
+class GradOperatorFactory :
+    public RuntimeSelectionFactory<
+        GradOperatorFactory<ValueType>,
+        Parameters<const Executor&, const UnstructuredMesh&>>
+{
+
+public:
+
+    static std::unique_ptr<GradOperatorFactory<ValueType>>
+    create(const Executor& exec, const UnstructuredMesh& uMesh, const Input& inputs)
+    {
+        std::string key = (std::holds_alternative<Dictionary>(inputs))
+                            ? std::get<Dictionary>(inputs).get<std::string>("GradOperator")
+                            : std::get<TokenList>(inputs).next<std::string>();
+        GradOperatorFactory<ValueType>::keyExistsOrError(key);
+        return GradOperatorFactory<ValueType>::table().at(key)(exec, uMesh);
+    }
+
+    static std::string name() { return "GradOperatorFactory"; }
+
+    GradOperatorFactory(const Executor& exec, const UnstructuredMesh& mesh)
+        : exec_(exec), mesh_(mesh), sparsityPattern_(la::SparsityPattern::readOrCreate(mesh)) {};
+
+    virtual ~GradOperatorFactory() {} // Virtual destructor
+
+    // NOTE currently simple overloading is used here, because templating the virtual function
+    // does not work and we cant template the entire class because the static create function
+    // cannot access keyExistsOrError and table anymore.
+    virtual void grad(
+        la::LinearSystem<ValueType, localIdx>& ls,
+        const VolumeField<scalar>& phi,
+        const dsl::Coeff operatorScaling
+    ) const = 0;
+
+    virtual void grad(const VolumeField<scalar>& phi, Vector<Vec3>& gradPhi) const = 0;
+
+
+    virtual void grad(
+        VolumeField<Vec3>& gradPhi, const VolumeField<scalar>& phi, const dsl::Coeff operatorScaling
+    ) const = 0;
+
+    virtual VolumeField<ValueType>
+    grad(const VolumeField<scalar>& phi, const dsl::Coeff operatorScaling) const = 0;
+
+    const la::SparsityPattern& getSparsityPattern() const { return sparsityPattern_; }
+
+    // Pure virtual function for cloning
+    virtual std::unique_ptr<GradOperatorFactory<ValueType>> clone() const = 0;
+
+protected:
+
+    const Executor exec_;
+
+    const UnstructuredMesh& mesh_;
+
+    const la::SparsityPattern& sparsityPattern_;
+};
+
+template<typename ValueType>
+class GradOperator : public dsl::OperatorMixin<VolumeField<ValueType>, VolumeField<scalar>>
+{
+
+public:
+
+    using VectorValueType = ValueType;
+
+    // copy constructor
+    GradOperator(const GradOperator& gradOp)
+        : dsl::OperatorMixin<VolumeField<ValueType>, VolumeField<scalar>>(
+            gradOp.exec_, gradOp.coeffs_, gradOp.field_, gradOp.type_
+        ),
+          gradOperatorStrategy_(
+              gradOp.gradOperatorStrategy_ ? gradOp.gradOperatorStrategy_->clone() : nullptr
+          ) {};
+
+    GradOperator(dsl::Operator::Type termType, VolumeField<scalar>& phi, Input input)
+        : dsl::OperatorMixin<VolumeField<ValueType>, VolumeField<scalar>>(
+            phi.exec(), dsl::Coeff(1.0), phi, termType
+        ),
+          gradOperatorStrategy_(
+              GradOperatorFactory<ValueType>::create(phi.exec(), phi.mesh(), input)
+          ) {};
+
+    GradOperator(
+        dsl::Operator::Type termType,
+        VolumeField<scalar>& phi,
+        std::unique_ptr<GradOperatorFactory<ValueType>> gradOperatorStrategy
+    )
+        : dsl::OperatorMixin<VolumeField<ValueType>, VolumeField<scalar>>(
+            phi.exec(), dsl::Coeff(1.0), phi, termType
+        ),
+          gradOperatorStrategy_(std::move(gradOperatorStrategy)) {};
+
+    GradOperator(dsl::Operator::Type termType, VolumeField<scalar>& phi)
+        : dsl::OperatorMixin<VolumeField<ValueType>, VolumeField<scalar>>(
+            phi.exec(), dsl::Coeff(1.0), phi, termType
+        ),
+          gradOperatorStrategy_(nullptr) {};
+
+
+    void explicitOperation(Vector<Vec3>& source) const
+    {
+        NF_ASSERT(gradOperatorStrategy_, "GradOperatorStrategy not initialized");
+        auto tmpsource = Vector<Vec3>(source.exec(), source.size(), zero<Vec3>());
+        const auto operatorScaling = this->getCoefficient();
+        gradOperatorStrategy_->grad(this->getVector(),
+                                    tmpsource); //, operatorScaling);
+        source += tmpsource;
+    }
+
+    la::LinearSystem<ValueType, localIdx> createEmptyLinearSystem() const
+    {
+        NF_ERROR_EXIT("Not implemented");
+        NF_ASSERT(gradOperatorStrategy_, "GradOperatorStrategy not initialized");
+        return gradOperatorStrategy_->createEmptyLinearSystem();
+    }
+
+    void implicitOperation(la::LinearSystem<ValueType, localIdx>& ls) const
+    {
+        NF_ERROR_EXIT("Not implemented");
+    }
+
+    void grad(Vector<ValueType>& gradPhi) const
+    {
+        const auto operatorScaling = this->getCoefficient();
+        gradOperatorStrategy_->grad(gradPhi, this->getVector(), operatorScaling);
+    }
+
+    void grad(la::LinearSystem<ValueType, localIdx>& ls) const
+    {
+        const auto operatorScaling = this->getCoefficient();
+        gradOperatorStrategy_->grad(ls, this->getVector(), operatorScaling);
+    };
+
+    void grad(VolumeField<ValueType>& gradPhi) const
+    {
+        const auto operatorScaling = this->getCoefficient();
+        gradOperatorStrategy_->grad(gradPhi, this->getVector(), operatorScaling);
+    }
+
+    void read(const Input& input)
+    {
+        const UnstructuredMesh& mesh = this->getVector().mesh();
+        if (std::holds_alternative<NeoN::Dictionary>(input))
+        {
+            auto dict = std::get<NeoN::Dictionary>(input);
+            std::string schemeName = "grad(" + this->getVector().name + ")";
+            auto tokens = dict.subDict("gradSchemes").get<NeoN::TokenList>(schemeName);
+            gradOperatorStrategy_ =
+                GradOperatorFactory<ValueType>::create(this->exec(), mesh, tokens);
+        }
+        else
+        {
+            auto tokens = std::get<NeoN::TokenList>(input);
+            gradOperatorStrategy_ =
+                GradOperatorFactory<ValueType>::create(this->exec(), mesh, tokens);
+        }
+    }
+
+    std::string getName() const { return "GradOperator"; }
+
+private:
+
+    std::unique_ptr<GradOperatorFactory<ValueType>> gradOperatorStrategy_;
+};
+
+
+} // namespace NeoN

--- a/include/NeoN/finiteVolume/cellCentred/operators/gradOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gradOperator.hpp
@@ -125,16 +125,19 @@ public:
         source += tmpsource;
     }
 
-    la::LinearSystem<ValueType, localIdx> createEmptyLinearSystem() const
+    [[deprecated("This function will be removed")]] la::LinearSystem<ValueType, localIdx>
+    createEmptyLinearSystem() const
     {
-        NF_ERROR_EXIT("Not implemented");
         NF_ASSERT(gradOperatorStrategy_, "GradOperatorStrategy not initialized");
         return gradOperatorStrategy_->createEmptyLinearSystem();
     }
 
+    /* @brief forwards to implicit gradOperatorStrategy_->grad() with arguments */
     void implicitOperation(la::LinearSystem<ValueType, localIdx>& ls) const
     {
-        NF_ERROR_EXIT("Not implemented");
+        NF_ASSERT(gradOperatorStrategy_, "GradOperatorStrategy not initialized");
+        const auto operatorScaling = this->getCoefficient();
+        gradOperatorStrategy_->grad(ls, this->getVector(), operatorScaling);
     }
 
     /* @brief forwards to  gradOperatorStrategy_->grad() with arguments */

--- a/include/NeoN/finiteVolume/cellCentred/operators/gradOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gradOperator.hpp
@@ -42,7 +42,7 @@ public:
     GradOperatorFactory(const Executor& exec, const UnstructuredMesh& mesh)
         : exec_(exec), mesh_(mesh), sparsityPattern_(la::SparsityPattern::readOrCreate(mesh)) {};
 
-    virtual ~GradOperatorFactory() {} // Virtual destructor
+    virtual ~GradOperatorFactory()  = default;  // Virtual destructor
 
     /* @brief compute implicit gradient operator contribution
      *

--- a/include/NeoN/finiteVolume/cellCentred/operators/gradOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gradOperator.hpp
@@ -53,11 +53,8 @@ public:
         const dsl::Coeff operatorScaling
     ) const = 0;
 
-    virtual void grad(const VolumeField<scalar>& phi, Vector<Vec3>& gradPhi) const = 0;
-
-
     virtual void grad(
-        VolumeField<Vec3>& gradPhi, const VolumeField<scalar>& phi, const dsl::Coeff operatorScaling
+        const VolumeField<scalar>& phi, const dsl::Coeff operatorScaling, Vector<Vec3>& gradPhi
     ) const = 0;
 
     virtual VolumeField<ValueType>
@@ -124,8 +121,7 @@ public:
         NF_ASSERT(gradOperatorStrategy_, "GradOperatorStrategy not initialized");
         auto tmpsource = Vector<Vec3>(source.exec(), source.size(), zero<Vec3>());
         const auto operatorScaling = this->getCoefficient();
-        gradOperatorStrategy_->grad(this->getVector(),
-                                    tmpsource); //, operatorScaling);
+        gradOperatorStrategy_->grad(this->getVector(), operatorScaling, tmpsource);
         source += tmpsource;
     }
 
@@ -141,22 +137,13 @@ public:
         NF_ERROR_EXIT("Not implemented");
     }
 
-    void grad(Vector<ValueType>& gradPhi) const
+    /* @brief forwards to  gradOperatorStrategy_->grad() with arguments */
+    [[deprecated("use explicit or implicit operation")]] void grad(auto&&... args) const
     {
         const auto operatorScaling = this->getCoefficient();
-        gradOperatorStrategy_->grad(gradPhi, this->getVector(), operatorScaling);
-    }
-
-    void grad(la::LinearSystem<ValueType, localIdx>& ls) const
-    {
-        const auto operatorScaling = this->getCoefficient();
-        gradOperatorStrategy_->grad(ls, this->getVector(), operatorScaling);
-    };
-
-    void grad(VolumeField<ValueType>& gradPhi) const
-    {
-        const auto operatorScaling = this->getCoefficient();
-        gradOperatorStrategy_->grad(gradPhi, this->getVector(), operatorScaling);
+        gradOperatorStrategy_->grad(
+            std::forward<decltype(args)>(args)..., this->getVector(), operatorScaling
+        );
     }
 
     void read(const Input& input)

--- a/include/NeoN/finiteVolume/cellCentred/operators/gradOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gradOperator.hpp
@@ -42,7 +42,7 @@ public:
     GradOperatorFactory(const Executor& exec, const UnstructuredMesh& mesh)
         : exec_(exec), mesh_(mesh), sparsityPattern_(la::SparsityPattern::readOrCreate(mesh)) {};
 
-    virtual ~GradOperatorFactory()  = default;  // Virtual destructor
+    virtual ~GradOperatorFactory() = default; // Virtual destructor
 
     /* @brief compute implicit gradient operator contribution
      *

--- a/include/NeoN/finiteVolume/cellCentred/operators/laplacianOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/laplacianOperator.hpp
@@ -149,23 +149,13 @@ public:
         laplacianOperatorStrategy_->laplacian(ls, gamma_, this->field_, operatorScaling);
     }
 
-    // void laplacian(Vector<scalar>& lapPhi)
-    // {
-    //     laplacianOperatorStrategy_->laplacian(lapPhi, gamma_, getVector());
-    // }
-
-    // void laplacian(la::LinearSystem<scalar, localIdx>& ls)
-    // {
-    //     laplacianOperatorStrategy_->laplacian(ls, gamma_, getVector());
-    // };
-
-    void laplacian(VolumeField<scalar>& lapPhi)
+    [[deprecated("use explicit or implicit operation")]] void laplacian(VolumeField<scalar>& lapPhi)
     {
         const auto operatorScaling = this->getCoefficient();
         laplacianOperatorStrategy_->laplacian(lapPhi, gamma_, this->getVector(), operatorScaling);
     }
 
-    VolumeField<scalar> laplacian()
+    [[deprecated("use explicit or implicit operation")]] VolumeField<scalar> laplacian()
     {
         const auto operatorScaling = this->getCoefficient();
         std::string name = "laplacian(" + gamma_.name + "," + this->field_.name + ")";

--- a/include/NeoN/finiteVolume/cellCentred/operators/laplacianOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/laplacianOperator.hpp
@@ -76,7 +76,11 @@ public:
     // Pure virtual function for cloning
     virtual std::unique_ptr<LaplacianOperatorFactory<ValueType>> clone() const = 0;
 
-    const la::SparsityPattern& getSparsityPattern() const { return sparsityPattern_; }
+    [[deprecated("This function will be removed")]] const la::SparsityPattern&
+    getSparsityPattern() const
+    {
+        return sparsityPattern_;
+    }
 
 protected:
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/laplacianOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/laplacianOperator.hpp
@@ -49,27 +49,27 @@ public:
     virtual void laplacian(
         VolumeField<ValueType>& lapPhi,
         const SurfaceField<scalar>& gamma,
-        VolumeField<ValueType>& phi,
+        const VolumeField<ValueType>& phi,
         const dsl::Coeff operatorScaling
     ) = 0;
 
     virtual VolumeField<ValueType> laplacian(
         const SurfaceField<scalar>& gamma,
-        VolumeField<ValueType>& phi,
+        const VolumeField<ValueType>& phi,
         const dsl::Coeff operatorScaling
     ) const = 0;
 
     virtual void laplacian(
         Vector<ValueType>& lapPhi,
         const SurfaceField<scalar>& gamma,
-        VolumeField<ValueType>& phi,
+        const VolumeField<ValueType>& phi,
         const dsl::Coeff operatorScaling
     ) = 0;
 
     virtual void laplacian(
         la::LinearSystem<ValueType, localIdx>& ls,
         const SurfaceField<scalar>& gamma,
-        VolumeField<ValueType>& phi,
+        const VolumeField<ValueType>& phi,
         const dsl::Coeff operatorScaling
     ) = 0;
 

--- a/include/NeoN/timeIntegration/backwardEuler.hpp
+++ b/include/NeoN/timeIntegration/backwardEuler.hpp
@@ -12,9 +12,12 @@
 #include "NeoN/linearAlgebra/linearSystem.hpp"
 #include "NeoN/linearAlgebra/sparsityPattern.hpp"
 
+#include "NeoN/finiteVolume/cellCentred/fields/volumeField.hpp"
 
 namespace NeoN::timeIntegration
 {
+
+namespace fvcc = NeoN::finiteVolume::cellCentred;
 
 template<typename SolutionVectorType>
 class BackwardEuler :
@@ -50,6 +53,5 @@ public:
 
     bool explicitIntegration() const override { return false; }
 };
-
 
 } // namespace NeoN

--- a/src/dsl/explicit.cpp
+++ b/src/dsl/explicit.cpp
@@ -22,8 +22,8 @@ SpatialOperator<scalar> div(const fvcc::SurfaceField<NeoN::scalar>& flux)
 SpatialOperator<scalar>
 laplacian(const fvcc::SurfaceField<NeoN::scalar>& gamma, fvcc::VolumeField<NeoN::scalar>& phi)
 {
-    return SpatialOperator<scalar>(
-        fvcc::LaplacianOperator(dsl::Operator::Type::Explicit, gamma, phi)
+    return SpatialOperator<NeoN::scalar>(
+        fvcc::LaplacianOperator<NeoN::scalar>(dsl::Operator::Type::Explicit, gamma, phi)
     );
 }
 
@@ -31,6 +31,13 @@ SpatialOperator<Vec3>
 laplacian(const fvcc::SurfaceField<NeoN::scalar>& gamma, fvcc::VolumeField<NeoN::Vec3>& phi)
 {
     return SpatialOperator<Vec3>(fvcc::LaplacianOperator(dsl::Operator::Type::Explicit, gamma, phi)
+    );
+}
+
+SpatialOperator<NeoN::Vec3> grad(fvcc::VolumeField<NeoN::scalar>& phi)
+{
+    return SpatialOperator<NeoN::Vec3>(
+        fvcc::GradOperator<NeoN::Vec3>(dsl::Operator::Type::Explicit, phi)
     );
 }
 

--- a/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
@@ -12,7 +12,7 @@ template<typename ValueType>
 void computeLaplacianExp(
     const FaceNormalGradient<ValueType>& faceNormalGradient,
     const SurfaceField<scalar>&, // gamma,
-    VolumeField<ValueType>& phi,
+    const VolumeField<ValueType>& phi,
     Vector<ValueType>& lapPhi,
     const dsl::Coeff operatorScaling
 )
@@ -64,7 +64,7 @@ void computeLaplacianExp(
     template void computeLaplacianExp<TYPENAME>(                                                   \
         const FaceNormalGradient<TYPENAME>&,                                                       \
         const SurfaceField<scalar>&,                                                               \
-        VolumeField<TYPENAME>&,                                                                    \
+        const VolumeField<TYPENAME>&,                                                              \
         Vector<TYPENAME>&,                                                                         \
         const dsl::Coeff                                                                           \
     )
@@ -77,7 +77,7 @@ template<typename ValueType>
 void computeLaplacianImpl(
     la::LinearSystem<ValueType, localIdx>& ls,
     const SurfaceField<scalar>& gamma,
-    VolumeField<ValueType>& phi,
+    const VolumeField<ValueType>& phi,
     const dsl::Coeff operatorScaling,
     const la::SparsityPattern& sparsityPattern,
     const FaceNormalGradient<ValueType>& faceNormalGradient
@@ -178,7 +178,7 @@ void computeLaplacianImpl(
 
 #define NN_DECLARE_COMPUTE_IMP_LAP(TYPENAME)                                                       \
     template void computeLaplacianImpl<                                                            \
-        TYPENAME>(la::LinearSystem<TYPENAME, localIdx>&, const SurfaceField<scalar>&, VolumeField<TYPENAME>&, const dsl::Coeff, const la::SparsityPattern&, const FaceNormalGradient<TYPENAME>&)
+        TYPENAME>(la::LinearSystem<TYPENAME, localIdx>&, const SurfaceField<scalar>&, const VolumeField<TYPENAME>&, const dsl::Coeff, const la::SparsityPattern&, const FaceNormalGradient<TYPENAME>&)
 
 NN_DECLARE_COMPUTE_IMP_LAP(scalar);
 NN_DECLARE_COMPUTE_IMP_LAP(Vec3);

--- a/src/linearAlgebra/ginkgo.cpp
+++ b/src/linearAlgebra/ginkgo.cpp
@@ -20,7 +20,6 @@ gko::config::pnode NeoN::la::ginkgo::parse(const Dictionary& dictIn)
     // check if an external file name is given
     if (dict.contains("configFile"))
     {
-
         std::string fn_str {};
         auto fn = dict["configFile"];
         if (fn.type() == typeid(std::string))

--- a/src/timeIntegration/timeIntegration.cpp
+++ b/src/timeIntegration/timeIntegration.cpp
@@ -12,7 +12,9 @@ namespace NeoN::timeIntegration
 {
 
 template class ForwardEuler<fvcc::VolumeField<scalar>>;
+template class ForwardEuler<fvcc::VolumeField<Vec3>>;
 
 template class BackwardEuler<fvcc::VolumeField<scalar>>;
+template class BackwardEuler<fvcc::VolumeField<Vec3>>;
 
 } // namespace NeoN::dsl


### PR DESCRIPTION
See the issue #378, which prohibits using` exp::grad(p)` in an expression.

The approach used here is to add a second template parameter to  `OperatorMixin`, i.e.

```
template<typename VectorType, typename VectorInType = VectorType>
class OperatorMixin
```

Where `VectorInType` is the type of the Field the operator acts on. 

**Other considerations:**
- Currently, no unit tests exists testing whether grad(p) can be used with an operator on `Field<Vec3>`
- The amount of boilerplate code needed to get exp::grad to connect to gaussGreenGrad is ridiculous. To reduce the burden somewhat the holder type eg GradOperator implements a forwarding function.

**Further changes:** 
- fix constness of `phi` in operators, since the in field should never be modified by the operator.
- improve documentation of operators.