### PR TITLE
add ginkgo sycl support

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -5,8 +5,9 @@ Bevan Jones <bevanwsjones@gmail.com>\
 Chih-Ta Wang <chihta.wang@tum.de> Technical University of Munich\
 Feiteng Meng <fitanium2018@outlook.com>, Harbin Engineering University\
 Gabriel Gerlero <ggerlero@cimec.unl.edu.ar> Research Center for Computational Methods (CIMEC)\
-Gregor Olenik  <gregor.olenik@kit.edu>, Karlsruhe Institute of Technology\
+Gregor Olenik  <gregor.olenik@tum.de>, Technical University of Munich\
 Gregor Weiss <gregor.weiss@hlrs.de>, High-Performance Computing Center Stuttgart (HLRS)\
 Henning Scheufler <henning.scheufler@web.de>\
 Marcel Koch <marcel.koch@kit.edu>, Karlsruhe Institute of Technology\
-Roman Mishchuk <roman.mishchuk@tum.de> Technical University of Munich\
+Roman Mishchuk <roman.mishchuk@tum.de>, Technical University of Munich\
+Yu-Hsiang Tsai <yhmtsai@gmail.com>, Technical University of Munich

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@
 - Support for implicit operators in the DSL [#246](https://github.com/exasim-project/NeoN/pull/246)
 ### Linear Algebra Capabilities
 - Adds a minimal implementation linear algebra functionality [#219](https://github.com/exasim-project/NeoN/pull/219)
-- Add Ginkgo solver interface and config solver support [#250](https://github.com/exasim-project/NeoN/pull/250), [#272
+- Add Ginkgo solver interface and config solver support [#250](https://github.com/exasim-project/NeoN/pull/250), [#272]
 (https://github.com/exasim-project/NeoN/pull/272)
+- Add Ginkgo SYCL support [#384](https://github.com/exasim-project/NeoN/pull/384)
 ### Misc
 - Use current Ginkgo develop version [#362](https://github.com/exasim-project/NeoN/pull/362)
 - removed subscript operators from Field for improved safety. [#225](https://github.com/exasim-project/NeoN/pull/285)

--- a/src/linearAlgebra/ginkgo.cpp
+++ b/src/linearAlgebra/ginkgo.cpp
@@ -130,6 +130,10 @@ std::shared_ptr<gko::Executor> NeoN::la::ginkgo::getGkoExecutor(NeoN::Executor e
                 return gko::HipExecutor::create(
                     Kokkos::device_id(), gko::ReferenceExecutor::create()
                 );
+#elif defined(KOKKOS_ENABLE_SYCL)
+                return gko::DpcppExecutor::create(
+                    Kokkos::device_id(), gko::ReferenceExecutor::create()
+                );
 #endif
                 throw std::runtime_error("No valid GPU executor mapping available");
             }


### PR DESCRIPTION
# Motivation
It adds the support ginkgo DpcppExecutor configuration into NeoN.
It also requires the fix mentioned in #375 if Kokkos uses old version
