### PR TITLE
Make repo's documentation updated only when a PR is merged to main brancgh

### DIFF
--- a/.github/workflows/build_doc.yaml
+++ b/.github/workflows/build_doc.yaml
@@ -46,8 +46,9 @@ jobs:
       with:
         folder: docs_build
         target-folder: ${{ github.ref_name }}
+
     - name: Deploy Latest Build
-      if: ${{ github.event.pull_request.merged }}
+      if: ${{ github.event.pull_request.merged && github.event.pull_request.base.ref == 'main' }}
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         folder: docs_build


### PR DESCRIPTION
# Motivation
The documentation of the repo is updated whenever a PR is merged to a branch. However, it should be updated only when the target branch is the main branch.

This PR modifies the CI job of documentation deployment so that the repo's documentation gets updated only when a PR is merged to the main branch.
