### PR TITLE
Improve documentation to include description of GPU support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ NeoN has the following requirements
 *  _gcc >= 10_ or  _clang >= 16_
 *  _Kokkos 4.3.0_
 
-For NVIDIA GPU support
-* cuda _12+_
+For GPU support
+* NVIDIA: CUDA _12+_
+* AMD: ROCm _6.4.1_
 
 For development it is required to use [pre-commit](https://pre-commit.com/).
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -51,19 +51,25 @@ If NeoN does not detect the GPU backend automatically, you can set some relevant
 during the configure step.
 
 For NVIDIA GPUs, specifying the GPU architecture via ``CMAKE_CUDA_ARCHITECTURES`` should be sufficient.
-   .. code-block:: bash
-    -DCMAKE_CUDA_ARCHITECTURES=<GPU_ARCH>
+
+.. code-block:: bash
+
+   -DCMAKE_CUDA_ARCHITECTURES=<GPU_ARCH>
 
 For AMD GPUs, you may need to set up some relevant HIP environment variables before the configure step.
-   .. code-block:: bash
-    export PATH=/opt/rocm/bin:$PATH
-    export HIPCC_CXX=/usr/bin/g++ # If you want to use g++ as the host compiler
+
+.. code-block:: bash
+
+   export PATH=/opt/rocm/bin:$PATH
+   export HIPCC_CXX=/usr/bin/g++  # If you want to use g++ as the host compiler
 
 Then you can enable HIP during the configure step with the following flags.
-   .. code-block:: bash
-    -DCMAKE_CXX_COMPILER=hipcc
-    -DCMAKE_HIP_ARCHITECTURES=<GPU_ARCH>
-    -DKokkos_ARCH_AMD_<GPU_ARCH>=ON # e.g., -DKokkos_ARCH_AMD_GFX90A=ON
+
+.. code-block:: bash
+
+   -DCMAKE_CXX_COMPILER=hipcc
+   -DCMAKE_HIP_ARCHITECTURES=<GPU_ARCH>
+   -DKokkos_ARCH_AMD_<GPU_ARCH>=ON  # e.g., -DKokkos_ARCH_AMD_GFX90A=ON
 
 After configuring for GPU support, you can continue to build NeoN.
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -15,7 +15,7 @@ Navigate to the NeoN directory:
 
       cd NeoN
 
-NeoN uses CMake to build, thus the standard CMake procedure should work, however, we recommend using one of the provided CMake presets detailed below `<Building with CMake Presets>`_. From a build directory, you can execute:
+NeoN uses CMake to build, thus the standard CMake procedure should work, however, we recommend using one of the provided CMake presets detailed below in :ref:`Building with CMake Presets`. From a build directory, you can execute:
 
    .. code-block:: bash
 
@@ -76,6 +76,8 @@ Then you can enable HIP during the configure step with the following flags.
    -DKokkos_ARCH_AMD_<GPU_ARCH>=ON  # e.g., -DKokkos_ARCH_AMD_GFX90A=ON
 
 After configuring for GPU support, you can continue to build NeoN.
+
+.. _Building with CMake Presets:
 
 Building with CMake Presets
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -15,7 +15,7 @@ Navigate to the NeoN directory:
 
       cd NeoN
 
-NeoN uses CMake to build, thus the standard CMake procedure should work, however, we recommend using one of the provided CMake presets detailed below `below <Building with CMake Presets>`_. From a build directory, you can execute:
+NeoN uses CMake to build, thus the standard CMake procedure should work, however, we recommend using one of the provided CMake presets detailed below `<Building with CMake Presets>`_. From a build directory, you can execute:
 
    .. code-block:: bash
 
@@ -25,22 +25,22 @@ NeoN uses CMake to build, thus the standard CMake procedure should work, however
         cmake --build . -j<the number of CPU cores>
         cmake --install .
 
-By default, the command `cmake --build .` will use all the CPU cores available. It can consume a significant
-amount of memory when building with many cores. If you want to limit the number of cores used during the build,
-you can specify it with the `-j` flag as shown above.
+By default, the command `cmake --build . -j` will use all the CPU cores available. It can consume a significant
+amount of memory when building with many cores. If you want to limit the number of cores used during the build step,
+you can specify the number of CPU cores as shown above.
 
 The following can be chained with -D<DesiredBuildFlags>=<Value> to the CMake command.
 Most relevant build flags are:
 
-+---------------------------+-----------------------------------+---------+
-| Flag                      | Description                       | Default |
-+===========================+===================================+=========+
-| CMAKE_BUILD_TYPE          | Build in debug or release mode    | Debug   |
-+---------------------------+-----------------------------------+---------+
-| NeoN_BUILD_DOC            | Build NeoN with documentation     | ON      |
-+---------------------------+-----------------------------------+---------+
-| NeoN_BUILD_TESTS          | Build NeoN with tests             | OFF     |
-+---------------------------+-----------------------------------+---------+
++------------------+--------------------------------+---------+
+| Flag             | Description                    | Default |
++==================+================================+=========+
+| CMAKE_BUILD_TYPE | Build in debug or release mode | Debug   |
++------------------+--------------------------------+---------+
+| NeoN_BUILD_DOC   | Build NeoN with documentation  | ON      |
++------------------+--------------------------------+---------+
+| NeoN_BUILD_TESTS | Build NeoN with tests          | OFF     |
++------------------+--------------------------------+---------+
 
 To browse the full list of build options it is recommended to use a build tool like ``ccmake``.
 By opening the the project with cmake-gui you can easily set these flags and configure the build.

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -22,8 +22,12 @@ NeoN uses CMake to build, thus the standard CMake procedure should work, however
         mkdir build
         cd build
         cmake <DesiredBuildFlags> ..
-        cmake --build .
+        cmake --build . -j<the number of CPU cores>
         cmake --install .
+
+By default, the command `cmake --build .` will use all the CPU cores available. It can consume a significant
+amount of memory when building with many cores. If you want to limit the number of cores used during the build,
+you can specify it with the `-j` flag as shown above.
 
 The following can be chained with -D<DesiredBuildFlags>=<Value> to the CMake command.
 Most relevant build flags are:

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -42,10 +42,30 @@ To browse the full list of build options it is recommended to use a build tool l
 By opening the the project with cmake-gui you can easily set these flags and configure the build.
 NeoN specific build flags are prefixed by ``NeoN_``.
 
-.. note::
+Building for GPUs
+^^^^^^^^^^^^^^^^^^
+NeoN will automatically enable ``Kokkos_ENABLE_CUDA`` or ``Kokkos_ENABLE_HIP`` if either of this is available on
+the system. This can be prevented by setting both options explicitly.
 
-   NeoN will automatically enable ``Kokkos_ENABLE_CUDA`` or ``Kokkos_ENABLE_HIP`` if either of this is available on
-   the system. This can be prevented by setting both options explicitly.
+If NeoN does not detect the GPU backend automatically, you can set some relevant flags to enable GPU support
+during the configure step.
+
+For NVIDIA GPUs, specifying the GPU architecture via ``CMAKE_CUDA_ARCHITECTURES`` should be sufficient.
+   .. code-block:: bash
+    -DCMAKE_CUDA_ARCHITECTURES=<GPU_ARCH>
+
+For AMD GPUs, you may need to set up some relevant HIP environment variables before the configure step.
+   .. code-block:: bash
+    export PATH=/opt/rocm/bin:$PATH
+    export HIPCC_CXX=/usr/bin/g++ # If you want to use g++ as the host compiler
+
+Then you can enable HIP during the configure step with the following flags.
+   .. code-block:: bash
+    -DCMAKE_CXX_COMPILER=hipcc
+    -DCMAKE_HIP_ARCHITECTURES=<GPU_ARCH>
+    -DKokkos_ARCH_AMD_<GPU_ARCH>=ON # e.g., -DKokkos_ARCH_AMD_GFX90A=ON
+
+After configuring for GPU support, you can continue to build NeoN.
 
 Building with CMake Presets
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -25,16 +25,17 @@ NeoN uses CMake to build, thus the standard CMake procedure should work, however
         cmake --build .
         cmake --install .
 
-The following can be chained with -D<DesiredBuildFlags>=<Value> to the CMake command most and most relevant build flags are:
+The following can be chained with -D<DesiredBuildFlags>=<Value> to the CMake command.
+Most relevant build flags are:
 
 +---------------------------+-----------------------------------+---------+
 | Flag                      | Description                       | Default |
 +===========================+===================================+=========+
 | CMAKE_BUILD_TYPE          | Build in debug or release mode    | Debug   |
 +---------------------------+-----------------------------------+---------+
-| NeoN_BUILD_DOC         | Build NeoN with documentation  | ON      |
+| NeoN_BUILD_DOC            | Build NeoN with documentation     | ON      |
 +---------------------------+-----------------------------------+---------+
-| NeoN_BUILD_TESTS       | Build NeoN with tests          | OFF     |
+| NeoN_BUILD_TESTS          | Build NeoN with tests             | OFF     |
 +---------------------------+-----------------------------------+---------+
 
 To browse the full list of build options it is recommended to use a build tool like ``ccmake``.


### PR DESCRIPTION
# Motivation
- README lacks the description of support for AMD GPUs
- The table of relevant build flags is not displayed on the documentation webpage
- Documentation lacks the description of the compilation for NVIDIA or AMD GPUs

This PR addresses the above issues.

Closes #386 
Closes #389 

