### PR TITLE
Fix issues with int to scalar conversion in dictonary.get

### DIFF
--- a/include/NeoN/core/database/document.hpp
+++ b/include/NeoN/core/database/document.hpp
@@ -80,7 +80,7 @@ public:
      *
      * @return std::string The ID of the Document.
      */
-    std::string id() const { return get<std::string>("id"); }
+    std::string id() const { return getRef<std::string>("id"); }
 
 private:
 

--- a/include/NeoN/core/database/fieldCollection.hpp
+++ b/include/NeoN/core/database/fieldCollection.hpp
@@ -112,7 +112,7 @@ public:
     template<class VectorType>
     VectorType& field()
     {
-        return doc_.get<VectorType&>("field");
+        return doc_.getRef<VectorType&>("field");
     }
 
     /**
@@ -124,7 +124,7 @@ public:
     template<class VectorType>
     const VectorType& field() const
     {
-        return doc_.get<const VectorType&>("field");
+        return doc_.getRef<const VectorType&>("field");
     }
 
     /**

--- a/include/NeoN/core/dictionary.hpp
+++ b/include/NeoN/core/dictionary.hpp
@@ -89,27 +89,24 @@ public:
      * T.
      */
     template<typename T>
-    [[nodiscard]] T get(const std::string& key) const
+    [[nodiscard]] T getVal(const std::string& key) const
     {
 
-        bool convertToIntFirst = false;
+        // NOTE in certain cases the expected type T
+        // might not match the stored type. For example
+        // we might expect a scalar when instead an int
+        // is stored. In that case we any_cast to int first
+        // and convert to scalar later
         if constexpr (std::is_same_v<T, scalar>)
         {
             if (isType<int>(key))
             {
-                convertToIntFirst = true;
+                return T(std::any_cast<int>(operator[](key)));
             }
         }
 
         try
         {
-            if constexpr (std::is_same_v<T, scalar>)
-            {
-                if (convertToIntFirst)
-                {
-                    return T(std::any_cast<int>(operator[](key)));
-                }
-            }
             return std::any_cast<T>(operator[](key));
         }
         catch (const std::bad_any_cast& e)

--- a/include/NeoN/finiteVolume/cellCentred/boundary/surface/fixedValue.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/surface/fixedValue.hpp
@@ -51,7 +51,7 @@ class FixedValue :
 public:
 
     FixedValue(const UnstructuredMesh& mesh, const Dictionary& dict, localIdx patchID)
-        : Base(mesh, dict, patchID), mesh_(mesh), fixedValue_(dict.get<ValueType>("fixedValue"))
+        : Base(mesh, dict, patchID), mesh_(mesh), fixedValue_(dict.getVal<ValueType>("fixedValue"))
     {}
 
     virtual void correctBoundaryCondition(Field<ValueType>& domainVector) override

--- a/include/NeoN/finiteVolume/cellCentred/boundary/surfaceBoundaryFactory.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/surfaceBoundaryFactory.hpp
@@ -53,7 +53,7 @@ public:
             patchID
         ),
           boundaryCorrectionStrategy_(SurfaceBoundaryFactory<ValueType>::create(
-              dict.get<std::string>("type"), mesh, dict, patchID
+              dict.getVal<std::string>("type"), mesh, dict, patchID
           ))
     {}
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedGradient.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedGradient.hpp
@@ -67,7 +67,7 @@ public:
 
     FixedGradient(const UnstructuredMesh& mesh, const Dictionary& dict, localIdx patchID)
         : Base(mesh, dict, patchID, {.assignable = true}), mesh_(mesh),
-          fixedGradient_(dict.get<ValueType>("fixedGradient"))
+          fixedGradient_(dict.getVal<ValueType>("fixedGradient"))
     {}
 
     virtual void correctBoundaryCondition(Field<ValueType>& domainVector) final

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedValue.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedValue.hpp
@@ -54,7 +54,7 @@ public:
 
     FixedValue(const UnstructuredMesh& mesh, const Dictionary& dict, localIdx patchID)
         : Base(mesh, dict, patchID, {.assignable = false}),
-          fixedValue_(dict.get<ValueType>("fixedValue"))
+          fixedValue_(dict.getVal<ValueType>("fixedValue"))
     {}
 
     virtual void correctBoundaryCondition(Field<ValueType>& domainVector) final

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp
@@ -73,7 +73,7 @@ public:
             patchID
         ),
           boundaryCorrectionStrategy_(VolumeBoundaryFactory<ValueType>::create(
-              dict.get<std::string>("type"), mesh, dict, patchID
+              dict.getRef<std::string>("type"), mesh, dict, patchID
           ))
     {}
 

--- a/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/faceNormalGradient.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/faceNormalGradient.hpp
@@ -34,7 +34,7 @@ public:
         // input is dictionary the key is "interpolation"
         std::string key =
             (std::holds_alternative<NeoN::Dictionary>(inputs))
-                ? std::get<NeoN::Dictionary>(inputs).get<std::string>("faceNormalGradient")
+                ? std::get<NeoN::Dictionary>(inputs).getVal<std::string>("faceNormalGradient")
                 : std::get<NeoN::TokenList>(inputs).next<std::string>();
 
         FaceNormalGradientFactory<ValueType>::keyExistsOrError(key);

--- a/include/NeoN/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
@@ -38,7 +38,7 @@ public:
         // input is dictionary the key is "interpolation"
         std::string key =
             (std::holds_alternative<NeoN::Dictionary>(inputs))
-                ? std::get<NeoN::Dictionary>(inputs).get<std::string>("surfaceInterpolation")
+                ? std::get<NeoN::Dictionary>(inputs).getVal<std::string>("surfaceInterpolation")
                 : std::get<NeoN::TokenList>(inputs).next<std::string>();
 
         SurfaceInterpolationFactory<ValueType>::keyExistsOrError(key);

--- a/include/NeoN/finiteVolume/cellCentred/operators/divOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/divOperator.hpp
@@ -31,7 +31,7 @@ public:
     create(const Executor& exec, const UnstructuredMesh& uMesh, const Input& inputs)
     {
         std::string key = (std::holds_alternative<Dictionary>(inputs))
-                            ? std::get<Dictionary>(inputs).get<std::string>("DivOperator")
+                            ? std::get<Dictionary>(inputs).getVal<std::string>("DivOperator")
                             : std::get<TokenList>(inputs).next<std::string>();
         DivOperatorFactory<ValueType>::keyExistsOrError(key);
         return DivOperatorFactory<ValueType>::table().at(key)(exec, uMesh, inputs);
@@ -169,7 +169,7 @@ public:
         {
             auto dict = std::get<NeoN::Dictionary>(input);
             std::string schemeName = "div(" + faceFlux_.name + "," + this->getVector().name + ")";
-            auto tokens = dict.subDict("divSchemes").get<NeoN::TokenList>(schemeName);
+            auto tokens = dict.subDict("divSchemes").getVal<NeoN::TokenList>(schemeName);
             divOperatorStrategy_ =
                 DivOperatorFactory<ValueType>::create(this->exec(), mesh, tokens);
         }

--- a/include/NeoN/finiteVolume/cellCentred/operators/gradOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gradOperator.hpp
@@ -31,7 +31,7 @@ public:
     create(const Executor& exec, const UnstructuredMesh& uMesh, const Input& inputs)
     {
         std::string key = (std::holds_alternative<Dictionary>(inputs))
-                            ? std::get<Dictionary>(inputs).get<std::string>("GradOperator")
+                            ? std::get<Dictionary>(inputs).getVal<std::string>("GradOperator")
                             : std::get<TokenList>(inputs).next<std::string>();
         GradOperatorFactory<ValueType>::keyExistsOrError(key);
         return GradOperatorFactory<ValueType>::table().at(key)(exec, uMesh);
@@ -175,7 +175,7 @@ public:
         {
             auto dict = std::get<NeoN::Dictionary>(input);
             std::string schemeName = "grad(" + this->getVector().name + ")";
-            auto tokens = dict.subDict("gradSchemes").get<NeoN::TokenList>(schemeName);
+            auto tokens = dict.subDict("gradSchemes").getVal<NeoN::TokenList>(schemeName);
             gradOperatorStrategy_ =
                 GradOperatorFactory<ValueType>::create(this->exec(), mesh, tokens);
         }

--- a/include/NeoN/finiteVolume/cellCentred/operators/laplacianOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/laplacianOperator.hpp
@@ -33,7 +33,7 @@ public:
     create(const Executor& exec, const UnstructuredMesh& mesh, const Input& inputs)
     {
         std::string key = (std::holds_alternative<Dictionary>(inputs))
-                            ? std::get<Dictionary>(inputs).get<std::string>("LaplacianOperator")
+                            ? std::get<Dictionary>(inputs).getVal<std::string>("LaplacianOperator")
                             : std::get<TokenList>(inputs).next<std::string>();
         LaplacianOperatorFactory<ValueType>::keyExistsOrError(key);
         return LaplacianOperatorFactory<ValueType>::table().at(key)(exec, mesh, inputs);
@@ -180,7 +180,7 @@ public:
         {
             auto dict = std::get<NeoN::Dictionary>(input);
             std::string schemeName = "laplacian(" + gamma_.name + "," + this->field_.name + ")";
-            auto tokens = dict.subDict("laplacianSchemes").get<NeoN::TokenList>(schemeName);
+            auto tokens = dict.subDict("laplacianSchemes").getVal<NeoN::TokenList>(schemeName);
             laplacianOperatorStrategy_ =
                 LaplacianOperatorFactory<ValueType>::create(this->exec(), mesh, tokens);
         }

--- a/include/NeoN/linearAlgebra/solver.hpp
+++ b/include/NeoN/linearAlgebra/solver.hpp
@@ -34,7 +34,7 @@ public:
 
     static std::unique_ptr<SolverFactory> create(const Executor& exec, const Dictionary& dict)
     {
-        auto key = dict.get<std::string>("solver");
+        auto key = dict.getVal<std::string>("solver");
         SolverFactory::keyExistsOrError(key);
         return SolverFactory::table().at(key)(exec, dict);
     }

--- a/include/NeoN/timeIntegration/timeIntegration.hpp
+++ b/include/NeoN/timeIntegration/timeIntegration.hpp
@@ -74,7 +74,7 @@ public:
 
     TimeIntegration(const Dictionary& schemeDict, const Dictionary& solutionDict)
         : timeIntegratorStrategy_(TimeIntegratorBase<SolutionVectorType>::create(
-            schemeDict.get<std::string>("type"), schemeDict, solutionDict
+            schemeDict.getVal<std::string>("type"), schemeDict, solutionDict
         )) {};
 
     void solve(Expression& eqn, SolutionVectorType& sol, scalar t, scalar dt)

--- a/src/core/database/document.cpp
+++ b/src/core/database/document.cpp
@@ -36,9 +36,9 @@ bool Document::validate() const
     return true;
 }
 
-const std::string& name(const NeoN::Document& doc) { return doc.get<std::string>("name"); }
+const std::string& name(const NeoN::Document& doc) { return doc.getRef<std::string>("name"); }
 
-std::string& name(NeoN::Document& doc) { return doc.get<std::string>("name"); }
+std::string& name(NeoN::Document& doc) { return doc.getRef<std::string>("name"); }
 
 
 } // namespace NeoN

--- a/src/core/database/fieldCollection.cpp
+++ b/src/core/database/fieldCollection.cpp
@@ -24,17 +24,17 @@ Document& VectorDocument::doc() { return doc_; }
 
 const Document& VectorDocument::doc() const { return doc_; }
 
-std::string VectorDocument::name() const { return doc_.get<std::string>("name"); }
+std::string VectorDocument::name() const { return doc_.getVal<std::string>("name"); }
 
 std::string& VectorDocument::name() { return doc_.getRef<std::string>("name"); }
 
-std::int64_t VectorDocument::timeIndex() const { return doc_.get<std::int64_t>("timeIndex"); }
+std::int64_t VectorDocument::timeIndex() const { return doc_.getVal<std::int64_t>("timeIndex"); }
 
 std::int64_t& VectorDocument::timeIndex() { return doc_.getRef<std::int64_t>("timeIndex"); }
 
 std::int64_t VectorDocument::iterationIndex() const
 {
-    return doc_.get<std::int64_t>("iterationIndex");
+    return doc_.getVal<std::int64_t>("iterationIndex");
 }
 
 std::int64_t& VectorDocument::iterationIndex()
@@ -44,7 +44,7 @@ std::int64_t& VectorDocument::iterationIndex()
 
 std::int64_t VectorDocument::subCycleIndex() const
 {
-    return doc_.get<std::int64_t>("subCycleIndex");
+    return doc_.getVal<std::int64_t>("subCycleIndex");
 }
 
 std::int64_t& VectorDocument::subCycleIndex() { return doc_.getRef<std::int64_t>("subCycleIndex"); }

--- a/src/core/database/fieldCollection.cpp
+++ b/src/core/database/fieldCollection.cpp
@@ -26,25 +26,28 @@ const Document& VectorDocument::doc() const { return doc_; }
 
 std::string VectorDocument::name() const { return doc_.get<std::string>("name"); }
 
-std::string& VectorDocument::name() { return doc_.get<std::string>("name"); }
+std::string& VectorDocument::name() { return doc_.getRef<std::string>("name"); }
 
 std::int64_t VectorDocument::timeIndex() const { return doc_.get<std::int64_t>("timeIndex"); }
 
-std::int64_t& VectorDocument::timeIndex() { return doc_.get<std::int64_t>("timeIndex"); }
+std::int64_t& VectorDocument::timeIndex() { return doc_.getRef<std::int64_t>("timeIndex"); }
 
 std::int64_t VectorDocument::iterationIndex() const
 {
     return doc_.get<std::int64_t>("iterationIndex");
 }
 
-std::int64_t& VectorDocument::iterationIndex() { return doc_.get<std::int64_t>("iterationIndex"); }
+std::int64_t& VectorDocument::iterationIndex()
+{
+    return doc_.getRef<std::int64_t>("iterationIndex");
+}
 
 std::int64_t VectorDocument::subCycleIndex() const
 {
     return doc_.get<std::int64_t>("subCycleIndex");
 }
 
-std::int64_t& VectorDocument::subCycleIndex() { return doc_.get<std::int64_t>("subCycleIndex"); }
+std::int64_t& VectorDocument::subCycleIndex() { return doc_.getRef<std::int64_t>("subCycleIndex"); }
 
 
 VectorCollection::VectorCollection(NeoN::Database& db, std::string name)

--- a/src/core/database/oldTimeCollection.cpp
+++ b/src/core/database/oldTimeCollection.cpp
@@ -20,27 +20,30 @@ OldTimeDocument::OldTimeDocument(
     ))
 {}
 
-std::string& OldTimeDocument::nextTime() { return doc_.get<std::string>("nextTime"); }
+std::string& OldTimeDocument::nextTime() { return doc_.getRef<std::string>("nextTime"); }
 
-const std::string& OldTimeDocument::nextTime() const { return doc_.get<std::string>("nextTime"); }
+const std::string& OldTimeDocument::nextTime() const
+{
+    return doc_.getRef<std::string>("nextTime");
+}
 
-std::string& OldTimeDocument::previousTime() { return doc_.get<std::string>("previousTime"); }
+std::string& OldTimeDocument::previousTime() { return doc_.getRef<std::string>("previousTime"); }
 
 const std::string& OldTimeDocument::previousTime() const
 {
-    return doc_.get<std::string>("previousTime");
+    return doc_.getRef<std::string>("previousTime");
 }
 
-std::string& OldTimeDocument::currentTime() { return doc_.get<std::string>("currentTime"); }
+std::string& OldTimeDocument::currentTime() { return doc_.getRef<std::string>("currentTime"); }
 
 const std::string& OldTimeDocument::currentTime() const
 {
-    return doc_.get<std::string>("currentTime");
+    return doc_.getRef<std::string>("currentTime");
 }
 
-int32_t& OldTimeDocument::level() { return doc_.get<int32_t>("level"); }
+int32_t& OldTimeDocument::level() { return doc_.getRef<int32_t>("level"); }
 
-const int32_t& OldTimeDocument::level() const { return doc_.get<int32_t>("level"); }
+const int32_t& OldTimeDocument::level() const { return doc_.getRef<int32_t>("level"); }
 
 Document& OldTimeDocument::doc() { return doc_; }
 

--- a/src/core/database/oldTimeCollection.cpp
+++ b/src/core/database/oldTimeCollection.cpp
@@ -103,7 +103,8 @@ bool OldTimeCollection::insert(const OldTimeDocument& otd)
 
 std::string OldTimeCollection::findNextTime(std::string id) const
 {
-    auto keys = find([id](const Document& doc) { return doc.get<std::string>("nextTime") == id; });
+    auto keys =
+        find([id](const Document& doc) { return doc.getVal<std::string>("nextTime") == id; });
     if (keys.size() == 1)
     {
         return keys[0];
@@ -114,7 +115,7 @@ std::string OldTimeCollection::findNextTime(std::string id) const
 std::string OldTimeCollection::findPreviousTime(std::string id) const
 {
     auto keys =
-        find([id](const Document& doc) { return doc.get<std::string>("previousTime") == id; });
+        find([id](const Document& doc) { return doc.getVal<std::string>("previousTime") == id; });
     if (keys.size() == 1)
     {
         return keys[0];

--- a/src/core/dictionary.cpp
+++ b/src/core/dictionary.cpp
@@ -131,10 +131,7 @@ const Dictionary& Dictionary::subDict(const std::string& key) const
     return std::any_cast<const Dictionary&>(operator[](key));
 }
 
-bool Dictionary::isDict(const std::string& key) const
-{
-    return contains(key) && std::any_cast<Dictionary>(&data_.at(key));
-}
+bool Dictionary::isDict(const std::string& key) const { return isType<Dictionary>(key); }
 
 // get keys of the dictionary
 std::vector<std::string> Dictionary::keys() const

--- a/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
@@ -226,7 +226,7 @@ void computeDivImp(
     );
 
     auto& bcCoeffs =
-        ls.auxiliaryCoefficients().template get<la::BoundaryCoefficients<ValueType, localIdx>>(
+        ls.auxiliaryCoefficients().template getRef<la::BoundaryCoefficients<ValueType, localIdx>>(
             "boundaryCoefficients"
         );
 

--- a/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
@@ -144,7 +144,7 @@ void computeLaplacianImpl(
     );
 
     auto& bcCoeffs =
-        ls.auxiliaryCoefficients().template get<la::BoundaryCoefficients<ValueType, localIdx>>(
+        ls.auxiliaryCoefficients().template getRef<la::BoundaryCoefficients<ValueType, localIdx>>(
             "boundaryCoefficients"
         );
 

--- a/src/linearAlgebra/ginkgo.cpp
+++ b/src/linearAlgebra/ginkgo.cpp
@@ -48,7 +48,7 @@ gko::config::pnode NeoN::la::ginkgo::parse(const Dictionary& dictIn)
             using value_type = decltype(blueprint);
             if (dict[key].type() == typeid(value_type))
             {
-                return gko::config::pnode(dict.get<value_type>(key));
+                return gko::config::pnode(dict.getVal<value_type>(key));
             }
             else
             {

--- a/src/timeIntegration/rungeKutta.cpp
+++ b/src/timeIntegration/rungeKutta.cpp
@@ -140,7 +140,7 @@ void RungeKutta<SolutionVectorType>::initODEMemory(const scalar t)
     ERKStepSetTableNum(
         ark,
         NeoN::sundials::stringToERKTable(
-            this->schemeDict_.template get<std::string>("Runge-Kutta-Method")
+            this->schemeDict_.template getRef<std::string>("Runge-Kutta-Method")
         )
     );
     ARKodeSetUserData(ark, pdeExpr_.get());

--- a/test/core/database/collection.cpp
+++ b/test/core/database/collection.cpp
@@ -50,8 +50,8 @@ TEST_CASE("CustomDocument")
 
     REQUIRE(doc2.doc().id().find("doc_") != std::string::npos);
     REQUIRE(doc2.typeName() == "CustomDocument");
-    REQUIRE(doc2.doc().get<std::string>("name") == "doc2");
-    REQUIRE(doc2.doc().get<int>("testValue") == 42);
+    REQUIRE(doc2.doc().getVal<std::string>("name") == "doc2");
+    REQUIRE(doc2.doc().getVal<int>("testValue") == 42);
     CustomDocument doc3 = CustomDocument("doc3", 3.14);
     REQUIRE(doc3.name() == "doc3");
     REQUIRE(doc3.testValue() == 3.14);

--- a/test/core/database/customTestCollection.hpp
+++ b/test/core/database/customTestCollection.hpp
@@ -27,13 +27,13 @@ public:
         : doc_(NeoN::Document({{"name", name}, {"testValue", testValue}}, validateCustomDoc))
     {}
 
-    std::string& name() { return doc_.get<std::string>("name"); }
+    std::string& name() { return doc_.getRef<std::string>("name"); }
 
-    const std::string& name() const { return doc_.get<std::string>("name"); }
+    const std::string& name() const { return doc_.getRef<std::string>("name"); }
 
-    double testValue() const { return doc_.get<double>("testValue"); }
+    double testValue() const { return doc_.getRef<double>("testValue"); }
 
-    double& testValue() { return doc_.get<double>("testValue"); }
+    double& testValue() { return doc_.getRef<double>("testValue"); }
 
     NeoN::Document& doc() { return doc_; }
 

--- a/test/core/database/database.cpp
+++ b/test/core/database/database.cpp
@@ -88,7 +88,7 @@ TEST_CASE("Database")
 
             std::vector<std::string> foundKeys =
                 collection1.find([](const NeoN::Document& doc)
-                                 { return doc.get<std::string>("name") == "doc1"; });
+                                 { return doc.getVal<std::string>("name") == "doc1"; });
 
             REQUIRE(foundKeys.size() == 1);
             REQUIRE(foundKeys[0].substr(0, 4) == "doc_");
@@ -99,7 +99,7 @@ TEST_CASE("Database")
 
             std::vector<std::string> foundKeys2 =
                 collection1.find([](const NeoN::Document& doc)
-                                 { return doc.get<int>("testValue") == 42; });
+                                 { return doc.getVal<int>("testValue") == 42; });
 
             REQUIRE(foundKeys2.size() == 2);
         }

--- a/test/core/database/document.cpp
+++ b/test/core/database/document.cpp
@@ -25,16 +25,16 @@ TEST_CASE("Document")
         NeoN::Document doc({{"key1", std::string("value1")}, {"key2", 2.0}});
         REQUIRE(doc.keys().size() == 3);
         REQUIRE(doc.id().substr(0, 4) == "doc_");
-        REQUIRE(doc.get<std::string>("key1") == "value1");
-        REQUIRE(doc.get<double>("key2") == 2.0);
+        REQUIRE(doc.getVal<std::string>("key1") == "value1");
+        REQUIRE(doc.getVal<double>("key2") == 2.0);
 
         SECTION("insert values")
         {
             doc.insert("key3", std::string("value3"));
             doc.insert("key4", 4.0);
             REQUIRE(doc.keys().size() == 5);
-            REQUIRE(doc.get<std::string>("key3") == "value3");
-            REQUIRE(doc.get<double>("key4") == 4.0);
+            REQUIRE(doc.getVal<std::string>("key3") == "value3");
+            REQUIRE(doc.getVal<double>("key4") == 4.0);
         }
     }
 
@@ -48,8 +48,8 @@ TEST_CASE("Document")
             NeoN::Document doc({{"key1", std::string("value1")}, {"key2", 2.0}}, validator);
             REQUIRE_NOTHROW(doc.validate());
             REQUIRE(doc.keys().size() == 3);
-            REQUIRE(doc.get<std::string>("key1") == "value1");
-            REQUIRE(doc.get<double>("key2") == 2.0);
+            REQUIRE(doc.getVal<std::string>("key1") == "value1");
+            REQUIRE(doc.getVal<double>("key2") == 2.0);
         }
 
         SECTION("invalid document")

--- a/test/core/database/fieldCollection.cpp
+++ b/test/core/database/fieldCollection.cpp
@@ -192,18 +192,19 @@ TEST_CASE("VectorCollection")
         {
             auto resTimeIndex =
                 fieldCollection.find([](const NeoN::Document& doc)
-                                     { return doc.get<std::int64_t>("timeIndex") == 1; });
+                                     { return doc.getVal<std::int64_t>("timeIndex") == 1; });
 
             REQUIRE(resTimeIndex.size() == 3);
 
             auto resSubCycleIndex =
                 fieldCollection.find([](const NeoN::Document& doc)
-                                     { return doc.get<std::int64_t>("subCycleIndex") == 5; });
+                                     { return doc.getVal<std::int64_t>("subCycleIndex") == 5; });
 
             REQUIRE(resSubCycleIndex.size() == 0);
 
-            auto resName = fieldCollection.find([](const NeoN::Document& doc)
-                                                { return doc.get<std::string>("name") == "T3"; });
+            auto resName =
+                fieldCollection.find([](const NeoN::Document& doc)
+                                     { return doc.getVal<std::string>("name") == "T3"; });
 
             REQUIRE(resName.size() == 1);
 

--- a/test/core/dictionary.cpp
+++ b/test/core/dictionary.cpp
@@ -16,9 +16,9 @@ TEST_CASE("Dictionary operations", "[dictionary]")
         dict.insert("key2", std::string("Hello"));
 
         REQUIRE(std::any_cast<int>(dict["key1"]) == 42);
-        REQUIRE(dict.get<int>("key1") == 42);
+        REQUIRE(dict.getRef<int>("key1") == 42);
         REQUIRE(std::any_cast<std::string>(dict["key2"]) == "Hello");
-        REQUIRE(dict.get<std::string>("key2") == "Hello");
+        REQUIRE(dict.getRef<std::string>("key2") == "Hello");
     }
 
     SECTION("check values")
@@ -65,7 +65,7 @@ TEST_CASE("Dictionary operations", "[dictionary]")
         REQUIRE(sDict.get<int>("key1") == 42);
         REQUIRE(sDict.get<std::string>("key2") == "Hello");
 
-        sDict.get<int>("key1") = 100;
+        sDict.getRef<int>("key1") = 100;
 
         // check if the value is modified
         REQUIRE(dict.isDict("subDict"));

--- a/test/core/dictionary.cpp
+++ b/test/core/dictionary.cpp
@@ -35,7 +35,7 @@ TEST_CASE("Dictionary operations", "[dictionary]")
         dict.insert("key", 42);
         dict["key"] = 43;
 
-        REQUIRE(dict.get<int>("key") == 43);
+        REQUIRE(dict.getVal<int>("key") == 43);
     }
 
     SECTION("remove values")
@@ -50,7 +50,7 @@ TEST_CASE("Dictionary operations", "[dictionary]")
     SECTION("Access non-existent key")
     {
         REQUIRE_THROWS_AS(dict["non_existent_key"], std::out_of_range);
-        REQUIRE_THROWS_AS(dict.get<int>("non_existent_key"), std::out_of_range);
+        REQUIRE_THROWS_AS(dict.getVal<int>("non_existent_key"), std::out_of_range);
     }
 
     SECTION("subDict")
@@ -62,22 +62,22 @@ TEST_CASE("Dictionary operations", "[dictionary]")
         dict.insert("subDict", subDict);
 
         NeoN::Dictionary& sDict = dict.subDict("subDict");
-        REQUIRE(sDict.get<int>("key1") == 42);
-        REQUIRE(sDict.get<std::string>("key2") == "Hello");
+        REQUIRE(sDict.getVal<int>("key1") == 42);
+        REQUIRE(sDict.getVal<std::string>("key2") == "Hello");
 
         sDict.getRef<int>("key1") = 100;
 
         // check if the value is modified
         REQUIRE(dict.isDict("subDict"));
         NeoN::Dictionary& sDict2 = dict.subDict("subDict");
-        REQUIRE(sDict2.get<int>("key1") == 100);
+        REQUIRE(sDict2.getVal<int>("key1") == 100);
     }
 
     SECTION("initialize with map")
     {
         NeoN::Dictionary dictInit({{"key1", 42}, {"key2", std::string("Hello")}});
 
-        REQUIRE(dictInit.get<int>("key1") == 42);
-        REQUIRE(dictInit.get<std::string>("key2") == "Hello");
+        REQUIRE(dictInit.getVal<int>("key1") == 42);
+        REQUIRE(dictInit.getVal<std::string>("key2") == "Hello");
     }
 }

--- a/test/core/input.cpp
+++ b/test/core/input.cpp
@@ -17,9 +17,9 @@ struct TestInput
     static TestInput read(const NeoN::Dictionary& dict)
     {
         TestInput ti;
-        ti.label_ = dict.get<NeoN::label>("label");
-        ti.scalar_ = dict.get<NeoN::scalar>("scalar");
-        ti.string_ = dict.get<std::string>("string");
+        ti.label_ = dict.getVal<NeoN::label>("label");
+        ti.scalar_ = dict.getVal<NeoN::scalar>("scalar");
+        ti.string_ = dict.getVal<std::string>("string");
         return ti;
     }
 


### PR DESCRIPTION
This PR implements a converting version of  `dictonary.get`. The issue typically arises if a dictionary is serialised with values like "0" which are interpreted as `int` but later requested to be a `scalar`. A fundamental issue is that the dictionary.get always returns a reference, however if we want to return a different type then the originally stored we need to create a copy. Thus this PR introduces a copying `getVal` and a reference returning `getRef` function.

See also https://github.com/exasim-project/NeoFOAM/pull/163 and https://github.com/exasim-project/NeoFOAM/issues/158

Another alternative would have been implementing a single `get` like this
```
template<typename T>
T get(int a, std::vector<int>& b) {
    if constexpr (std::is_reference_v<T>) {
        return b[a];
    } else {
        return T(b[a]);
    }    
}
```
which could be used like `auto a = get<int>(0, c)` or `auto& b = get<int&>(1, c)` however this might be too error prone.
