### PR TITLE
Field database registration mixin

### DIFF
--- a/include/NeoN/core/database/fieldDatabase.hpp
+++ b/include/NeoN/core/database/fieldDatabase.hpp
@@ -55,6 +55,7 @@ public:
         return *db_.value();
     }
 
+    /* @brief tests whether the given object has been registred in a database */
     bool registered() const
     {
         return !key.empty() && !fieldCollectionName.empty() && db_.has_value();

--- a/include/NeoN/finiteVolume/cellCentred/fields/fieldDatabase.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/fields/fieldDatabase.hpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2025 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <stdexcept>
+
+#include "NeoN/core/database/database.hpp"
+
+namespace NeoN::finiteVolume::cellCentred
+{
+
+/**
+ * @brief Mixin for database registration for fields (volume/surface).
+ *
+ * Provides:
+ *   - optional Database* storage
+ *   - key, fieldCollectionName
+ *   - hasDatabase(), db(), registered()
+ */
+class FieldDatabaseMixin
+{
+public:
+
+    FieldDatabaseMixin() = default;
+
+    FieldDatabaseMixin(Database& db, std::string key, std::string collectionName)
+        : db_(&db), key(std::move(key)), fieldCollectionName(std::move(collectionName))
+    {}
+
+    bool hasDatabase() const { return db_.has_value(); }
+
+    Database& db()
+    {
+        if (!db_.has_value())
+        {
+            throw std::runtime_error {
+                "Database not set: make sure the field is registered in the database"
+            };
+        }
+        return *db_.value();
+    }
+
+    const Database& db() const
+    {
+        if (!db_.has_value())
+        {
+            throw std::runtime_error(
+                "Database not set: make sure the field is registered in the database"
+            );
+        }
+        return *db_.value();
+    }
+
+    bool registered() const
+    {
+        return !key.empty() && !fieldCollectionName.empty() && db_.has_value();
+    }
+
+    // Keep names to match your existing API
+    std::string key;                 // key in DB
+    std::string fieldCollectionName; // collection name in DB
+
+protected:
+
+    std::optional<Database*> db_;
+};
+
+} // namespace NeoN::finiteVolume::cellCentred

--- a/include/NeoN/finiteVolume/cellCentred/fields/surfaceField.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/fields/surfaceField.hpp
@@ -8,7 +8,7 @@
 #include "NeoN/core/database/database.hpp"
 #include "NeoN/finiteVolume/cellCentred/fields/domain.hpp"
 #include "NeoN/finiteVolume/cellCentred/boundary/surfaceBoundaryFactory.hpp"
-#include "NeoN/finiteVolume/cellCentred/fields/fieldDatabase.hpp"
+#include "NeoN/core/database/fieldDatabase.hpp"
 
 namespace NeoN::finiteVolume::cellCentred
 {

--- a/include/NeoN/finiteVolume/cellCentred/fields/surfaceField.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/fields/surfaceField.hpp
@@ -5,9 +5,10 @@
 #pragma once
 
 #include <vector>
-
+#include "NeoN/core/database/database.hpp"
 #include "NeoN/finiteVolume/cellCentred/fields/domain.hpp"
 #include "NeoN/finiteVolume/cellCentred/boundary/surfaceBoundaryFactory.hpp"
+#include "NeoN/finiteVolume/cellCentred/fields/fieldDatabase.hpp"
 
 namespace NeoN::finiteVolume::cellCentred
 {
@@ -23,10 +24,12 @@ namespace NeoN::finiteVolume::cellCentred
  * @tparam ValueType The value type of the field.
  */
 template<typename ValueType>
-class SurfaceField : public DomainMixin<ValueType>
+class SurfaceField : public DomainMixin<ValueType>, public FieldDatabaseMixin
 {
 
 public:
+
+    using VectorValueType = ValueType;
 
     /**
      * @brief Constructor for a surfaceVector with a given name and mesh.
@@ -50,7 +53,7 @@ public:
                 exec, mesh.nInternalFaces() + mesh.nBoundaryFaces(), mesh.boundaryMesh().offset()
             )
         ),
-          boundaryConditions_(boundaryConditions)
+          FieldDatabaseMixin(), boundaryConditions_(boundaryConditions)
     {}
 
     /* @brief Constructor for a surfaceVector with a given internal field
@@ -66,7 +69,8 @@ public:
         const Field<ValueType>& domainVector,
         const std::vector<SurfaceBoundary<ValueType>>& boundaryConditions
     )
-        : DomainMixin<ValueType>(exec, mesh, domainVector), boundaryConditions_(boundaryConditions)
+        : DomainMixin<ValueType>(exec, mesh, domainVector), FieldDatabaseMixin(),
+          boundaryConditions_(boundaryConditions)
     {}
 
     /* @brief Constructor for a surfaceVector with a given internal field
@@ -74,6 +78,7 @@ public:
      * @param exec The executor
      * @param mesh The underlying mesh
      * @param internalVector the underlying internal field
+     * @param boundaryVectors the underlying boundary data fields
      * @param boundaryConditions a vector of boundary conditions
      */
     SurfaceField(
@@ -84,6 +89,34 @@ public:
         const std::vector<SurfaceBoundary<ValueType>>& boundaryConditions
     )
         : DomainMixin<ValueType>(exec, mesh, {exec, mesh, internalVector, boundaryVectors}),
+          FieldDatabaseMixin(), boundaryConditions_(boundaryConditions)
+    {}
+
+    /* @brief Constructor for a surface field with a given internal field and database registration.
+     *
+     * Mirrors the VolumeField db-registering constructor.
+     *
+     * @param exec The executor
+     * @param fieldName The name of the field
+     * @param mesh The underlying mesh
+     * @param domainVector the underlying domain field (internal + boundary laid out as Field)
+     * @param boundaryConditions a vector of boundary conditions
+     * @param db The database to register with
+     * @param dbKey The key of the field in the database
+     * @param collectionName The name of the field collection in the database
+     */
+    SurfaceField(
+        const Executor& exec,
+        std::string fieldName,
+        const UnstructuredMesh& mesh,
+        const Field<ValueType>& domainVector,
+        const std::vector<SurfaceBoundary<ValueType>>& boundaryConditions,
+        Database& db,
+        std::string dbKey,
+        std::string collectionName
+    )
+        : DomainMixin<ValueType>(exec, fieldName, mesh, domainVector),
+          FieldDatabaseMixin(db, std::move(dbKey), std::move(collectionName)),
           boundaryConditions_(boundaryConditions)
     {}
 
@@ -93,7 +126,8 @@ public:
      * @param other The surface field to copy.
      */
     SurfaceField(const SurfaceField& other)
-        : DomainMixin<ValueType>(other), boundaryConditions_(other.boundaryConditions_)
+        : DomainMixin<ValueType>(other), FieldDatabaseMixin(other),
+          boundaryConditions_(other.boundaryConditions_)
     {}
 
     /**
@@ -110,12 +144,33 @@ public:
         }
     }
 
+    std::vector<SurfaceBoundary<ValueType>> boundaryConditions() const
+    {
+        return boundaryConditions_;
+    }
 
 private:
 
     std::vector<SurfaceBoundary<ValueType>>
-        boundaryConditions_; // The vector of boundary conditions
+        boundaryConditions_;      // The vector of boundary conditions
+    std::optional<Database*> db_; // The optional pointer to the database
 };
 
+inline SurfaceField<scalar>
+operator*(const SurfaceField<scalar>& lhs, const SurfaceField<scalar>& rhs)
+{
+    SurfaceField<scalar> result(lhs);
+    result.internalVector() *= rhs.internalVector();
+    result.boundaryData().value() *= rhs.boundaryData().value();
+    return result;
+}
+inline SurfaceField<scalar>
+operator+(const SurfaceField<scalar>& lhs, const SurfaceField<scalar>& rhs)
+{
+    SurfaceField<scalar> result(lhs);
+    result.internalVector() += rhs.internalVector();
+    result.boundaryData().value() += rhs.boundaryData().value();
+    return result;
+}
 
 } // namespace NeoN

--- a/include/NeoN/finiteVolume/cellCentred/fields/volumeField.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/fields/volumeField.hpp
@@ -7,7 +7,7 @@
 #include "NeoN/core/database/database.hpp"
 #include "NeoN/finiteVolume/cellCentred/fields/domain.hpp"
 #include "NeoN/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp"
-#include "NeoN/finiteVolume/cellCentred/fields/fieldDatabase.hpp"
+#include "NeoN/core/database/fieldDatabase.hpp"
 
 #include <vector>
 

--- a/include/NeoN/finiteVolume/cellCentred/fields/volumeField.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/fields/volumeField.hpp
@@ -7,6 +7,7 @@
 #include "NeoN/core/database/database.hpp"
 #include "NeoN/finiteVolume/cellCentred/fields/domain.hpp"
 #include "NeoN/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp"
+#include "NeoN/finiteVolume/cellCentred/fields/fieldDatabase.hpp"
 
 #include <vector>
 
@@ -24,7 +25,7 @@ namespace NeoN::finiteVolume::cellCentred
  * @tparam ValueType The value type of the field.
  */
 template<typename ValueType>
-class VolumeField : public DomainMixin<ValueType>
+class VolumeField : public DomainMixin<ValueType>, public FieldDatabaseMixin
 {
 
 public:
@@ -120,59 +121,10 @@ public:
      */
     void correctBoundaryConditions();
 
-    /**
-     * @brief Returns true if the field has a database, false otherwise.
-     *
-     * @return true if the field has a database, false otherwise.
-     */
-    bool hasDatabase() const { return db_.has_value(); }
-
-    /**
-     * @brief Retrieves the database.
-     *
-     * @return Database& A reference to the database.
-     */
-    Database& db()
-    {
-        if (!db_.has_value())
-        {
-            throw std::runtime_error {
-                "Database not set: make sure the field is registered in the database"
-            };
-        }
-        return *db_.value();
-    }
-
-    /**
-     * @brief Retrieves the database.
-     *
-     * @return const Database& A const reference to the database.
-     */
-    const Database& db() const
-    {
-        if (!db_.has_value())
-        {
-            throw std::runtime_error(
-                "Database not set: make sure the field is registered in the database"
-            );
-        }
-        return *db_.value();
-    }
-
-    /**
-     * @brief Returns true if the field is registered in the database, false otherwise.
-     *
-     * @return true if the field is registered in the database, false otherwise.
-     */
-    bool registered() const { return key != "" && fieldCollectionName != "" && db_.has_value(); }
-
     std::vector<VolumeBoundary<ValueType>> boundaryConditions() const
     {
         return boundaryConditions_;
     }
-
-    std::string key;                 // The key of the field in the database
-    std::string fieldCollectionName; // The name of the field collection in the database
 
 private:
 

--- a/src/finiteVolume/cellCentred/fields/volumeField.cpp
+++ b/src/finiteVolume/cellCentred/fields/volumeField.cpp
@@ -20,7 +20,7 @@ VolumeField<ValueType>::VolumeField(
     : DomainMixin<ValueType>(
         exec, name, mesh, Field<ValueType>(exec, mesh.nCells(), mesh.boundaryMesh().offset())
     ),
-      key(""), fieldCollectionName(""), boundaryConditions_(boundaryConditions), db_(std::nullopt)
+      FieldDatabaseMixin(), boundaryConditions_(boundaryConditions)
 {}
 
 template<typename ValueType>
@@ -34,7 +34,7 @@ VolumeField<ValueType>::VolumeField(
     : DomainMixin<ValueType>(
         exec, name, mesh, Field<ValueType>(exec, internalVector, mesh.boundaryMesh().offset())
     ),
-      key(""), fieldCollectionName(""), boundaryConditions_(boundaryConditions), db_(std::nullopt)
+      FieldDatabaseMixin(), boundaryConditions_(boundaryConditions)
 {}
 
 template<typename ValueType>
@@ -46,8 +46,8 @@ VolumeField<ValueType>::VolumeField(
     const BoundaryData<ValueType>& boundaryVectors,
     const std::vector<VolumeBoundary<ValueType>>& boundaryConditions
 )
-    : DomainMixin<ValueType>(exec, name, mesh, internalVector, boundaryVectors), key(""),
-      fieldCollectionName(""), boundaryConditions_(boundaryConditions), db_(std::nullopt)
+    : DomainMixin<ValueType>(exec, name, mesh, internalVector, boundaryVectors),
+      FieldDatabaseMixin(), boundaryConditions_(boundaryConditions)
 {}
 
 
@@ -62,14 +62,15 @@ VolumeField<ValueType>::VolumeField(
     std::string dbKey,
     std::string collectionName
 )
-    : DomainMixin<ValueType>(exec, fieldName, mesh, domainVector), key(dbKey),
-      fieldCollectionName(collectionName), boundaryConditions_(boundaryConditions), db_(&db)
+    : DomainMixin<ValueType>(exec, fieldName, mesh, domainVector),
+      FieldDatabaseMixin(db, std::move(dbKey), std::move(collectionName)),
+      boundaryConditions_(boundaryConditions)
 {}
 
 template<typename ValueType>
 VolumeField<ValueType>::VolumeField(const VolumeField& other)
-    : DomainMixin<ValueType>(other), key(other.key), fieldCollectionName(other.fieldCollectionName),
-      boundaryConditions_(other.boundaryConditions_), db_(other.db_)
+    : DomainMixin<ValueType>(other), FieldDatabaseMixin(other),
+      boundaryConditions_(other.boundaryConditions_)
 {}
 
 template<typename ValueType>


### PR DESCRIPTION
Moved database registration into a Mixin. Used now in volume AND surfaceField.

- This is required to register phi in the db and use it's oldTime values e.g. for ddtPhiCorr.
- One also needs surfaceField addition and multiplication to later be able to do:
`auto phiHbyA = nf::flux(hByA) + rAU * NeoN::dsl::ddtPhiCorr()`

Taken out of https://github.com/exasim-project/NeoN/pull/402
