### PR TITLE
Cover benchmark code in CI

### DIFF
--- a/ci/lrz-gitlab/build-and-test.sh
+++ b/ci/lrz-gitlab/build-and-test.sh
@@ -71,7 +71,7 @@ elif [ "$GPU_TYPE" == "intel" ]; then
         -DCMAKE_BUILD_TYPE="release"
     cmake --build --preset develop
     export ONEAPI_DEVICE_SELECTOR=level_zero:gpu
-    ctest --preset develop --E bench -output-on-failure
+    ctest --preset develop -E bench --output-on-failure
 
 else
     echo "Unknown GPU type: $GPU_TYPE"

--- a/ci/lrz-gitlab/build-and-test.sh
+++ b/ci/lrz-gitlab/build-and-test.sh
@@ -27,7 +27,10 @@ if [ "$GPU_TYPE" == "nvidia" ]; then
     nvcc --version
 
     echo "=== Configuring, building, and testing NeoN on NVIDIA ==="
-    cmake --preset develop -DCMAKE_CUDA_ARCHITECTURES=90 -DNeoN_WITH_THREADS=OFF
+    cmake --preset develop \
+        -DCMAKE_CUDA_ARCHITECTURES=90 \
+        -DNeoN_WITH_THREADS=OFF \
+        -DNeoN_BUILD_BENCHMARKS=ON
     cmake --build --preset develop
     ctest --preset develop --output-on-failure
 
@@ -45,7 +48,8 @@ elif [ "$GPU_TYPE" == "amd" ]; then
         -DCMAKE_CXX_COMPILER=hipcc \
         -DCMAKE_HIP_ARCHITECTURES=gfx90a \
         -DKokkos_ARCH_AMD_GFX90A=ON \
-        -DNeoN_WITH_THREADS=OFF
+        -DNeoN_WITH_THREADS=OFF \
+        -DNeoN_BUILD_BENCHMARKS=ON
     cmake --build --preset develop
     ctest --preset develop --output-on-failure
 
@@ -63,6 +67,7 @@ elif [ "$GPU_TYPE" == "intel" ]; then
         -DCMAKE_CXX_FLAGS="-Wno-deprecated-declarations -Wno-sycl-2020-compat" \
         -DKokkos_ENABLE_SYCL=ON \
         -DNeoN_WITH_THREADS=OFF \
+        -DNeoN_BUILD_BENCHMARKS=ON \
         -DCMAKE_BUILD_TYPE="release"
     cmake --build --preset develop
     export ONEAPI_DEVICE_SELECTOR=level_zero:gpu

--- a/ci/lrz-gitlab/build-and-test.sh
+++ b/ci/lrz-gitlab/build-and-test.sh
@@ -32,7 +32,7 @@ if [ "$GPU_TYPE" == "nvidia" ]; then
         -DNeoN_WITH_THREADS=OFF \
         -DNeoN_BUILD_BENCHMARKS=ON
     cmake --build --preset develop
-    ctest --preset develop --output-on-failure
+    ctest --preset develop -E bench --output-on-failure
 
 elif [ "$GPU_TYPE" == "amd" ]; then
     # Set up environment
@@ -51,7 +51,7 @@ elif [ "$GPU_TYPE" == "amd" ]; then
         -DNeoN_WITH_THREADS=OFF \
         -DNeoN_BUILD_BENCHMARKS=ON
     cmake --build --preset develop
-    ctest --preset develop --output-on-failure
+    ctest --preset develop -E bench --output-on-failure
 
 elif [ "$GPU_TYPE" == "intel" ]; then
     if ! sycl-ls --ignore-device-selectors 2>/dev/null | grep -qi intel; then
@@ -71,7 +71,7 @@ elif [ "$GPU_TYPE" == "intel" ]; then
         -DCMAKE_BUILD_TYPE="release"
     cmake --build --preset develop
     export ONEAPI_DEVICE_SELECTOR=level_zero:gpu
-    ctest --preset develop --output-on-failure
+    ctest --preset develop --E bench -output-on-failure
 
 else
     echo "Unknown GPU type: $GPU_TYPE"


### PR DESCRIPTION
# Motivation
In the current CI setup, we do not build benchmarks for CI pipelines by default. It means that the default CI pipelines are not able to capture the failure of benchmark code.

This PR makes the default CI pipelines to build benchmark code additionally.
