### PR TITLE
wrap kokkos

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ option(NeoN_BUILD_BENCHMARKS "Build benchmarks" OFF)
 option(NeoN_BUILD_DOC "Build documentation" OFF)
 
 # Third party dependencies
+option(NeoN_WITH_KOKKOS "Enable using Kokkos as platform portability layer." ON)
 option(NeoN_WITH_ADIOS2 "Build NeoN with ADIOS2 support" OFF)
 option(NeoN_WITH_SUNDIALS "Build NeoN with Sundials support [currently required]" ON)
 option(NeoN_WITH_GINKGO "Enable using Ginkgo as linear algebra backend." ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/benchmarks/catch_main.hpp
+++ b/benchmarks/catch_main.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 NeoN authors
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/benchmarks/fields/CMakeLists.txt
+++ b/benchmarks/fields/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/benchmarks/fields/field.cpp
+++ b/benchmarks/fields/field.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/benchmarks/finiteVolume/cellCentred/interpolation/CMakeLists.txt
+++ b/benchmarks/finiteVolume/cellCentred/interpolation/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 NeoN authors
+# SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/benchmarks/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/benchmarks/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 NeoN authors
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/benchmarks/finiteVolume/cellCentred/interpolation/upwind.cpp
+++ b/benchmarks/finiteVolume/cellCentred/interpolation/upwind.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 NeoN authors
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/benchmarks/finiteVolume/cellCentred/operator/CMakeLists.txt
+++ b/benchmarks/finiteVolume/cellCentred/operator/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 NeoN authors
+# SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/benchmarks/finiteVolume/cellCentred/operator/divOperator.cpp
+++ b/benchmarks/finiteVolume/cellCentred/operator/divOperator.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/benchmarks/finiteVolume/cellCentred/operator/gaussGreenGrad.cpp
+++ b/benchmarks/finiteVolume/cellCentred/operator/gaussGreenGrad.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/benchmarks/finiteVolume/cellCentred/operator/gradOperator.cpp
+++ b/benchmarks/finiteVolume/cellCentred/operator/gradOperator.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/cmake/AutoEnableDevice.cmake
+++ b/cmake/AutoEnableDevice.cmake
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 # SPDX-FileCopyrightText: 2023 Jason Turner
 #
 # SPDX-License-Identifier: Unlicense

--- a/cmake/CxxThirdParty.cmake
+++ b/cmake/CxxThirdParty.cmake
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/cmake/Docs.cmake
+++ b/cmake/Docs.cmake
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/cmake/FindSphinx.cmake
+++ b/cmake/FindSphinx.cmake
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/cmake/PreventInSourceBuilds.cmake
+++ b/cmake/PreventInSourceBuilds.cmake
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 # SPDX-FileCopyrightText: 2023 Jason Turner
 #
 # SPDX-License-Identifier: Unlicense

--- a/cmake/Sanitizer.cmake
+++ b/cmake/Sanitizer.cmake
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 # SPDX-FileCopyrightText: 2023 Jason Turner
 #
 # SPDX-License-Identifier: Unlicense

--- a/cmake/StandardProjectSettings.cmake
+++ b/cmake/StandardProjectSettings.cmake
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 # SPDX-FileCopyrightText: 2023 Jason Turner
 #
 # SPDX-License-Identifier: Unlicense

--- a/cmake/StaticAnalyzers.cmake
+++ b/cmake/StaticAnalyzers.cmake
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 # SPDX-FileCopyrightText: 2023 Jason Turner
 #
 # SPDX-License-Identifier: Unlicense

--- a/cmake/Versions.cmake
+++ b/cmake/Versions.cmake
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/cmake/banner.cmake
+++ b/cmake/banner.cmake
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 NeoN authors
+# SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/doc/basics/algorithms.rst
+++ b/doc/basics/algorithms.rst
@@ -36,7 +36,7 @@ The following code block shows the implementation of a parallelFor for fields
             Kokkos::parallel_for(
                 "parallelFor",
                 Kokkos::RangePolicy<runOn>(0, field.size()),
-                KOKKOS_LAMBDA(const localIdx i) { view[i] = kernel(i); }
+                NEON_LAMBDA(const localIdx i) { view[i] = kernel(i); }
             );
         }
     }
@@ -45,7 +45,7 @@ The following code block shows the implementation of a parallelFor for fields
 based on the Executor type a kernel function is either run directly within a for loop or dispatched to ``Kokkos::parallel_for`` for all non ``SerialExecutors``.
 The executor type determines the ``Kokkos::RangePolicy<runOn>`` and thus dispatches to GPUs if a ``GPUExecutor`` was used.
 Additionally, we name the kernel as ``"parallelFor"`` to improve visibility in profiling tools like nsys.
-Finally, a ``KOKKOS_LAMBDA`` is dispatched assigning the result of the given kernel function to the view of the field.
+Finally, a ``NEON_LAMBDA`` is dispatched assigning the result of the given kernel function to the view of the field.
 Here the view holds data pointers to the device data and defines the begin and end pointer of the data.
 Several overloads of the ``parallelFor`` functions exists to simplify running parallelFor on fields and views with and without an explicitly defined data range.
 

--- a/doc/basics/fields.rst
+++ b/doc/basics/fields.rst
@@ -64,7 +64,7 @@ The ``fieldBinaryOp``  is implemented using our parallelFor implementations whic
     void add(Vector<ValueType>& a, const Vector<std::type_identity_t<ValueType>>& b)
     {
       detail::fieldBinaryOp(
-          a, b, KOKKOS_LAMBDA(ValueType va, ValueType vb) { return va + vb; }
+          a, b, NEON_LAMBDA(ValueType va, ValueType vb) { return va + vb; }
       );
     }
 
@@ -87,7 +87,7 @@ A simplified version of the ``parallelFor`` function is shown below.
             Kokkos::parallel_for(
                 "parallelFor",
                 Kokkos::RangePolicy<runOn>(start, end),
-                KOKKOS_LAMBDA(const localIdx i) { kernel(i); }
+                NEON_LAMBDA(const localIdx i) { kernel(i); }
             );
         }
     }

--- a/doc/basics/freeFunctions/map.rst
+++ b/doc/basics/freeFunctions/map.rst
@@ -27,8 +27,8 @@ Example
     NeoN::Executor = NeoN::GPUExecutor{};
 
     NeoN::Vector<NeoN::scalar> field(exec, 2);
-    NeoN::map(field, KOKKOS_LAMBDA(const std::size_t i) { return 1.0; });
-    NeoN::map(field, KOKKOS_LAMBDA(const std::size_t i) { return 2.0; }, {1, 2}); // apply a function to a subfield
+    NeoN::map(field, NEON_LAMBDA(const std::size_t i) { return 1.0; });
+    NeoN::map(field, NEON_LAMBDA(const std::size_t i) { return 2.0; }, {1, 2}); // apply a function to a subfield
     // copy to host
     auto hostVector = field.copyToHost();
     for (auto i = 0; i < field.size(); ++i)

--- a/doc/basics/segmentedField.rst
+++ b/doc/basics/segmentedField.rst
@@ -23,7 +23,7 @@ It can be used to represent cell to cell stencil.
     parallelFor(
         exec,
         {0, segVector.numSegments()},
-        KOKKOS_LAMBDA(const localIdx segI) {
+        NEON_LAMBDA(const localIdx segI) {
             // check if it works with bounds
             auto [bStart, bEnd] = segView.bounds(segI);
             auto bVals = valueView.subview(bStart, bEnd - bStart);

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/doc/dsl/operator.rst
+++ b/doc/dsl/operator.rst
@@ -70,7 +70,7 @@ To fit the specification of the Expression (storage in a vector), the Operator n
 
         // Operator also supports the use of a lambda as scaling function to reduce the number of temporaries generated
         auto lambdaScaledTerm =
-            (KOKKOS_LAMBDA(const NeoN::size_t i) { return sF[i] + sF[i] + sF[i]  + sF[i]; }) * customTerm;
+            (NEON_LAMBDA(const NeoN::size_t i) { return sF[i] + sF[i] + sF[i]  + sF[i]; }) * customTerm;
 
 To add a user-defined `Operator`, a new derived class must be created, inheriting from `OperatorMixin`,
  and provide the definitions of the below virtual functions that are required for the `Operator` interface:

--- a/doc/finiteVolume/cellCentred/boundaryConditions.rst
+++ b/doc/finiteVolume/cellCentred/boundaryConditions.rst
@@ -52,7 +52,7 @@ The logic is implemented in the kernel classes:
         Kokkos::parallel_for(
             "fvccScalarFixedValueBoundaryVector",
             Kokkos::RangePolicy<executor>(start_, end_),
-            KOKKOS_LAMBDA(const localIdx i) {
+            NEON_LAMBDA(const localIdx i) {
                 s_value[i] = uniformValue;
                 s_refValue[i] = uniformValue;
             }

--- a/doc/finiteVolume/cellCentred/case_study.rst
+++ b/doc/finiteVolume/cellCentred/case_study.rst
@@ -32,7 +32,7 @@ the corresponding NeoN version is implemented as
     parallelFor(
         exec,
         {0, nInternalFaces},
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             scalar flux = surfFaceFlux[i]*surfPhif[i];
             threadsafe_add(&surfDivPhi[static_cast<size_t>(surfOwner[i])], flux);
             threadsafe_sub(&surfDivPhi[static_cast<size_t>(surfNeighbour[i])], flux);

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 
@@ -12,10 +12,25 @@ target_include_directories(
   NeoN_public_api INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
                             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:.>)
 if(NeoN_WITH_KOKKOS)
-  target_compile_definitions(NeoN_public_api INTERFACE NF_WITH_KOKKOS=1)
+  target_compile_definitions(NeoN_public_api INTERFACE NN_WITH_KOKKOS=1)
   target_link_libraries(NeoN_public_api INTERFACE Kokkos::kokkos)
+  if(Kokkos_ENABLE_CUDA)
+    target_compile_definitions(NeoN_public_api INTERFACE NEON_ENABLE_CUDA=1)
+  endif()
+  if(Kokkos_ENABLE_HIP)
+    target_compile_definitions(NeoN_public_api INTERFACE NEON_ENABLE_HIP=1)
+  endif()
+  if(Kokkos_ENABLE_CYCLE)
+    target_compile_definitions(NeoN_public_api INTERFACE NEON_ENABLE_CYCLE=1)
+  endif()
+  if(Kokkos_ENABLE_OPENMP)
+    target_compile_definitions(NeoN_public_api INTERFACE NEON_ENABLE_OPENMP=1)
+  endif()
+  if(Kokkos_ENABLE_THREADS)
+    target_compile_definitions(NeoN_public_api INTERFACE NEON_ENABLE_THREADS=1)
+  endif()
 else()
-  target_compile_definitions(NeoN_public_api INTERFACE NF_WITH_KOKKOS=0)
+  target_compile_definitions(NeoN_public_api INTERFACE NN_WITH_KOKKOS=0)
 endif()
 
 if(NeoN_WITH_GINKGO)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -11,6 +11,12 @@ add_library(NeoN::NeoN_public_api ALIAS NeoN_public_api) # dummy target
 target_include_directories(
   NeoN_public_api INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
                             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:.>)
+if(NeoN_WITH_KOKKOS)
+  target_compile_definitions(NeoN_public_api INTERFACE NF_WITH_KOKKOS=1)
+  target_link_libraries(NeoN_public_api INTERFACE Kokkos::kokkos)
+else()
+  target_compile_definitions(NeoN_public_api INTERFACE NF_WITH_KOKKOS=0)
+endif()
 
 if(NeoN_WITH_GINKGO)
   target_link_libraries(NeoN_public_api INTERFACE nlohmann_json::nlohmann_json Ginkgo::ginkgo)
@@ -34,7 +40,7 @@ else()
   target_compile_definitions(NeoN_public_api INTERFACE NF_WITH_SPDLOG=0)
 endif()
 
-target_link_libraries(NeoN_public_api INTERFACE cpptrace::cpptrace Kokkos::kokkos)
+target_link_libraries(NeoN_public_api INTERFACE cpptrace::cpptrace)
 
 if(NeoN_WITH_PETSC)
   add_definitions(${PETSc_DEFINITIONS})

--- a/include/NeoN/core/array.hpp
+++ b/include/NeoN/core/array.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 NeoN authors
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/containerFreeFunctions.hpp
+++ b/include/NeoN/core/containerFreeFunctions.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/containerFreeFunctions.hpp
+++ b/include/NeoN/core/containerFreeFunctions.hpp
@@ -61,7 +61,7 @@ void map(ContType<ValueType>& cont, const Inner inner, std::pair<localIdx, local
     parallelFor(
         cont.exec(),
         {start, end},
-        KOKKOS_LAMBDA(const localIdx i) { contView[i] = inner(i); },
+        NEON_LAMBDA(const localIdx i) { contView[i] = inner(i); },
         "mapField"
     );
 }
@@ -89,7 +89,7 @@ void fill(
     }
     auto viewA = cont.view();
     parallelFor(
-        cont.exec(), {start, end}, KOKKOS_LAMBDA(const localIdx i) { viewA[i] = value; }, "fill"
+        cont.exec(), {start, end}, NEON_LAMBDA(const localIdx i) { viewA[i] = value; }, "fill"
     );
 }
 
@@ -117,7 +117,7 @@ void setContainer(
     parallelFor(
         cont.exec(),
         {start, end},
-        KOKKOS_LAMBDA(const localIdx i) { contView[i] = view[i]; },
+        NEON_LAMBDA(const localIdx i) { contView[i] = view[i]; },
         "setContainer"
     );
 }

--- a/include/NeoN/core/database/collection.hpp
+++ b/include/NeoN/core/database/collection.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/database/database.hpp
+++ b/include/NeoN/core/database/database.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/database/document.hpp
+++ b/include/NeoN/core/database/document.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/database/fieldCollection.hpp
+++ b/include/NeoN/core/database/fieldCollection.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/database/fieldDatabase.hpp
+++ b/include/NeoN/core/database/fieldDatabase.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 NeoN authors
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/demangle.hpp
+++ b/include/NeoN/core/demangle.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/dictionary.hpp
+++ b/include/NeoN/core/dictionary.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/error.hpp
+++ b/include/NeoN/core/error.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/executor/CPUExecutor.hpp
+++ b/include/NeoN/core/executor/CPUExecutor.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/executor/GPUExecutor.hpp
+++ b/include/NeoN/core/executor/GPUExecutor.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/executor/executor.hpp
+++ b/include/NeoN/core/executor/executor.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/executor/serialExecutor.hpp
+++ b/include/NeoN/core/executor/serialExecutor.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/info.hpp
+++ b/include/NeoN/core/info.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/initialization.hpp
+++ b/include/NeoN/core/initialization.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 NeoN authors
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/input.hpp
+++ b/include/NeoN/core/input.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/logging.hpp
+++ b/include/NeoN/core/logging.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 NeoN authors
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/macros.hpp
+++ b/include/NeoN/core/macros.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/mpi/environment.hpp
+++ b/include/NeoN/core/mpi/environment.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/mpi/fullDuplexCommBuffer.hpp
+++ b/include/NeoN/core/mpi/fullDuplexCommBuffer.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/mpi/halfDuplexCommBuffer.hpp
+++ b/include/NeoN/core/mpi/halfDuplexCommBuffer.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/mpi/operators.hpp
+++ b/include/NeoN/core/mpi/operators.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/parallelAlgorithms.hpp
+++ b/include/NeoN/core/parallelAlgorithms.hpp
@@ -11,8 +11,9 @@
 #include "NeoN/core/primitives/label.hpp"
 #include "NeoN/core/executor/executor.hpp"
 
-#ifdef NF_WITH_KOKKOS
+#ifdef NN_WITH_KOKKOS
 #define NEON_LAMBDA KOKKOS_LAMBDA
+#define NEON_INLINE_FUNCTION KOKKOS_INLINE_FUNCTION
 namespace NeoN
 {
 // just pull Kokkos::atomic_* functions into NeoN namespace
@@ -20,7 +21,7 @@ using Kokkos::atomic_add;
 using Kokkos::atomic_sub;
 }
 #else
-#define NEON_LAMBDA = [&]
+#define NEON_LAMBDA [&]
 namespace NeoN
 {
 // using atomic_add = [](auto& a, auto b){a+b;};

--- a/include/NeoN/core/parallelAlgorithms.hpp
+++ b/include/NeoN/core/parallelAlgorithms.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/parallelAlgorithms.hpp
+++ b/include/NeoN/core/parallelAlgorithms.hpp
@@ -11,6 +11,23 @@
 #include "NeoN/core/primitives/label.hpp"
 #include "NeoN/core/executor/executor.hpp"
 
+#ifdef NF_WITH_KOKKOS
+#define NEON_LAMBDA KOKKOS_LAMBDA
+namespace NeoN
+{
+// just pull Kokkos::atomic_* functions into NeoN namespace
+using Kokkos::atomic_add;
+using Kokkos::atomic_sub;
+}
+#else
+#define NEON_LAMBDA = [&]
+namespace NeoN
+{
+// using atomic_add = [](auto& a, auto b){a+b;};
+// using atomic_sub = [](auto& a, auto b){a-b;};
+}
+#endif
+
 namespace NeoN
 {
 
@@ -60,7 +77,7 @@ void parallelFor(
         Kokkos::parallel_for(
             name,
             Kokkos::RangePolicy<runOn>(start, end),
-            KOKKOS_LAMBDA(const localIdx i) { kernel(i); }
+            NEON_LAMBDA(const localIdx i) { kernel(i); }
         );
     }
 }
@@ -113,7 +130,7 @@ void parallelFor(
         Kokkos::parallel_for(
             name,
             Kokkos::RangePolicy<runOn>(0, view.size()),
-            KOKKOS_LAMBDA(const localIdx i) { view[i] = kernel(i); }
+            NEON_LAMBDA(const localIdx i) { view[i] = kernel(i); }
         );
     }
 }

--- a/include/NeoN/core/primitives/label.hpp
+++ b/include/NeoN/core/primitives/label.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/primitives/scalar.hpp
+++ b/include/NeoN/core/primitives/scalar.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/primitives/tensor.hpp
+++ b/include/NeoN/core/primitives/tensor.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/primitives/traits.hpp
+++ b/include/NeoN/core/primitives/traits.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 NeoN authors
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/primitives/vec3.hpp
+++ b/include/NeoN/core/primitives/vec3.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/runtimeSelectionFactory.hpp
+++ b/include/NeoN/core/runtimeSelectionFactory.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 // SPDX-FileCopyrightText: 2023 AMR Wind Authors
 //
 // SPDX-License-Identifier: MIT

--- a/include/NeoN/core/segmentedVector.hpp
+++ b/include/NeoN/core/segmentedVector.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/segmentedVector.hpp
+++ b/include/NeoN/core/segmentedVector.hpp
@@ -38,7 +38,7 @@ IndexType segmentsFromIntervals(const Vector<IndexType>& intervals, Vector<Index
     NeoN::parallelScan(
         intervals.exec(),
         {0, offsView.size()},
-        KOKKOS_LAMBDA(const localIdx i, IndexType& update, const bool final) {
+        NEON_LAMBDA(const localIdx i, IndexType& update, const bool final) {
             update += inView[i];
             if (final)
             {

--- a/include/NeoN/core/time.hpp
+++ b/include/NeoN/core/time.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/tokenList.hpp
+++ b/include/NeoN/core/tokenList.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/vector/vector.hpp
+++ b/include/NeoN/core/vector/vector.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/vector/vectorFreeFunctions.hpp
+++ b/include/NeoN/core/vector/vectorFreeFunctions.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 NeoN authors
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/vector/vectorTypeDefs.hpp
+++ b/include/NeoN/core/vector/vectorTypeDefs.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/core/view.hpp
+++ b/include/NeoN/core/view.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 NeoN authors
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/dsl/coeff.hpp
+++ b/include/NeoN/dsl/coeff.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/dsl/explicit.hpp
+++ b/include/NeoN/dsl/explicit.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/dsl/implicit.hpp
+++ b/include/NeoN/dsl/implicit.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/dsl/operator.hpp
+++ b/include/NeoN/dsl/operator.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/dsl/solver.hpp
+++ b/include/NeoN/dsl/solver.hpp
@@ -51,7 +51,7 @@ la::SolverStats iterativeSolveImpl(
     parallelFor(
         solution.exec(),
         {0, rhs.size()},
-        KOKKOS_LAMBDA(const localIdx i) { rhs[i] -= expSource[i] * vol[i]; }
+        NEON_LAMBDA(const localIdx i) { rhs[i] -= expSource[i] * vol[i]; }
     );
 
     auto solver = la::Solver(solution.exec(), fvSolution);
@@ -79,7 +79,7 @@ la::SolverStats iterativeSolveImpl(
     parallelFor(
         solution.exec(),
         {0, rhs.size()},
-        KOKKOS_LAMBDA(const localIdx i) { rhs[i] -= expSource[i] * vol[i]; }
+        NEON_LAMBDA(const localIdx i) { rhs[i] -= expSource[i] * vol[i]; }
     );
 
     auto solver = la::Solver(solution.exec(), fvSolution);

--- a/include/NeoN/dsl/spatialOperator.hpp
+++ b/include/NeoN/dsl/spatialOperator.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/fields/boundaryData.hpp
+++ b/include/NeoN/fields/boundaryData.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/fields/field.hpp
+++ b/include/NeoN/fields/field.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/auxiliary/coNum.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/auxiliary/coNum.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary/boundaryPatchMixin.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/boundaryPatchMixin.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary/surface/calculated.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/surface/calculated.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary/surface/empty.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/surface/empty.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary/surface/fixedValue.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/surface/fixedValue.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary/surface/fixedValue.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/surface/fixedValue.hpp
@@ -33,7 +33,7 @@ void setFixedValue(
     NeoN::parallelFor(
         domainVector.exec(),
         range,
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             refValue[i] = fixedValue;
             value[i] = fixedValue;
             internalValues[nInternalFaces + i] = fixedValue;

--- a/include/NeoN/finiteVolume/cellCentred/boundary/surface/symmetry.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/surface/symmetry.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary/surface/symmetry.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/surface/symmetry.hpp
@@ -32,7 +32,7 @@ inline void applySymmetry(
     NeoN::parallelFor(
         domainVector.exec(),
         range,
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             const localIdx owner = faceCellsV[i];
             const scalar v = internalValuesV[owner];
 
@@ -61,7 +61,7 @@ inline void applySymmetry(
     NeoN::parallelFor(
         domainVector.exec(),
         range,
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             const localIdx owner = faceCellsV[i];
             const Vec3 n = nHatV[i];
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary/surfaceBoundaryFactory.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/surfaceBoundaryFactory.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/calculated.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/calculated.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/empty.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/empty.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/extrapolated.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/extrapolated.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/extrapolated.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/extrapolated.hpp
@@ -41,7 +41,7 @@ void extrapolateValue(
     NeoN::parallelFor(
         domainVector.exec(),
         range,
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             // operator / is not defined for all ValueTypes
             ValueType internalCellValue = iVector[faceCells[i]];
             value[i] = internalCellValue;

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedGradient.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedGradient.hpp
@@ -43,7 +43,7 @@ void setGradientValue(
     NeoN::parallelFor(
         domainVector.exec(),
         range,
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             refGradient[i] = fixedGradient;
             // operator / is not defined for all ValueTypes
             value[i] = iVector[faceCells[i]] + fixedGradient * (1 / deltaCoeffs[i]);

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedGradient.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedGradient.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedValue.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedValue.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedValue.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedValue.hpp
@@ -34,7 +34,7 @@ void setFixedValue(
     NeoN::parallelFor(
         domainVector.exec(),
         range,
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             refValue[i] = fixedValue;
             value[i] = fixedValue;
             valueFraction[i] = 1.0;      // only used refValue

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/symmetry.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/symmetry.hpp
@@ -46,7 +46,7 @@ inline void setSymmetryValue<NeoN::scalar>(
     NeoN::parallelFor(
         domainVector.exec(),
         range,
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             const localIdx owner = faceCellsV[i];
             const auto v = internalV[owner];
 
@@ -82,7 +82,7 @@ inline void setSymmetryValue<NeoN::Vec3>(
     NeoN::parallelFor(
         domainVector.exec(),
         range,
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             const localIdx owner = faceCellsV[i];
             const auto v = internalV[owner];
             const auto n = nHatV[i];

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/symmetry.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/symmetry.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/faceNormalGradient.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/faceNormalGradient.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/uncorrected.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/uncorrected.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/fields/domain.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/fields/domain.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/fields/surfaceField.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/fields/surfaceField.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/fields/volumeField.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/fields/volumeField.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/interpolation/linear.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/interpolation/linear.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/interpolation/upwind.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/interpolation/upwind.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/ddtFluxCorr.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/ddtFluxCorr.hpp
@@ -50,7 +50,7 @@ inline void ddtFluxCorrBDF1Kernel(
     parallelFor(
         exec,
         {size_t(0), n},
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             const auto d = (SfV[i] & uf0V[i]);
             const auto corr = flux0V[i] - d;
 
@@ -92,7 +92,7 @@ inline void ddtFluxCorrBDF2Kernel(
     parallelFor(
         exec,
         {size_t(0), n},
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             const auto d1 = (SfV[i] & uf0V[i]);
             const auto corr1 = flux0V[i] - d1;
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/divOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/divOperator.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/gradOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gradOperator.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/laplacianOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/laplacianOperator.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/sourceTerm.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/sourceTerm.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/surfaceIntegrate.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/surfaceIntegrate.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 NeoN authors
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/stencil/basicGeometryScheme.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/stencil/basicGeometryScheme.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/stencil/cellToFaceStencil.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/stencil/cellToFaceStencil.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 NeoN authors
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/finiteVolume/cellCentred/stencil/geometryScheme.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/stencil/geometryScheme.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/helpers/exceptions.hpp
+++ b/include/NeoN/helpers/exceptions.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/linearAlgebra/CSRMatrix.hpp
+++ b/include/NeoN/linearAlgebra/CSRMatrix.hpp
@@ -233,13 +233,13 @@ private:
 //     Vector<ValueTypeOut> valuesTmp(exec, in.values.data(), in.values.size());
 
 //     parallelFor(
-//         colIdxsTmp, KOKKOS_LAMBDA(const localIdx i) { return IndexTypeOut {in.colIdxs[i]}; }
+//         colIdxsTmp, NEON_LAMBDA(const localIdx i) { return IndexTypeOut {in.colIdxs[i]}; }
 //     );
 //     parallelFor(
-//         rowOffsTmp, KOKKOS_LAMBDA(const localIdx i) { return IndexTypeOut {in.rowOffs[i]}; }
+//         rowOffsTmp, NEON_LAMBDA(const localIdx i) { return IndexTypeOut {in.rowOffs[i]}; }
 //     );
 //     parallelFor(
-//         valuesTmp, KOKKOS_LAMBDA(const localIdx i) { return ValueTypeOut {in.values[i]}; }
+//         valuesTmp, NEON_LAMBDA(const localIdx i) { return ValueTypeOut {in.values[i]}; }
 //     );
 
 //     return la::CSRMatrix<ValueTypeOut, IndexTypeOut> {valuesTmp, colIdxsTmp, rowOffsTmp};

--- a/include/NeoN/linearAlgebra/CSRMatrix.hpp
+++ b/include/NeoN/linearAlgebra/CSRMatrix.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/linearAlgebra/diagonalSolver.hpp
+++ b/include/NeoN/linearAlgebra/diagonalSolver.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 NeoN authors
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/linearAlgebra/diagonalSolver.hpp
+++ b/include/NeoN/linearAlgebra/diagonalSolver.hpp
@@ -39,7 +39,7 @@ public:
         parallelFor(
             x.exec(),
             {0, bV.size()},
-            KOKKOS_LAMBDA(const localIdx i) {
+            NEON_LAMBDA(const localIdx i) {
                 const auto rowBegin = mtxV.rowOffs[i];
                 const auto rowEnd = mtxV.rowOffs[i + 1];
 
@@ -84,7 +84,7 @@ public:
         parallelFor(
             x.exec(),
             {0, bV.size()},
-            KOKKOS_LAMBDA(const localIdx i) {
+            NEON_LAMBDA(const localIdx i) {
                 const auto rowBegin = mtxV.rowOffs[i];
                 const auto rowEnd = mtxV.rowOffs[i + 1];
 

--- a/include/NeoN/linearAlgebra/ginkgo.hpp
+++ b/include/NeoN/linearAlgebra/ginkgo.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/linearAlgebra/linearSystem.hpp
+++ b/include/NeoN/linearAlgebra/linearSystem.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/linearAlgebra/linearSystem.hpp
+++ b/include/NeoN/linearAlgebra/linearSystem.hpp
@@ -165,7 +165,7 @@ createEmptyLinearSystem(const UnstructuredMesh& mesh, const SparsityPattern& spa
     parallelFor(
         exec,
         {0, nBoundaryFaces},
-        KOKKOS_LAMBDA(const localIdx bfacei) {
+        NEON_LAMBDA(const localIdx bfacei) {
             localIdx celli = faceCells[bfacei];
 
             mValue[bfacei] = zero<ValueType>();

--- a/include/NeoN/linearAlgebra/petsc.hpp
+++ b/include/NeoN/linearAlgebra/petsc.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 NeoN authors
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/linearAlgebra/petscSolverContext.hpp
+++ b/include/NeoN/linearAlgebra/petscSolverContext.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 NeoN authors
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/linearAlgebra/solver.hpp
+++ b/include/NeoN/linearAlgebra/solver.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 NeoN authors
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/linearAlgebra/sparsityPattern.hpp
+++ b/include/NeoN/linearAlgebra/sparsityPattern.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 NeoN authors
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/linearAlgebra/utilities.hpp
+++ b/include/NeoN/linearAlgebra/utilities.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/mesh/unstructured/boundaryMesh.hpp
+++ b/include/NeoN/mesh/unstructured/boundaryMesh.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/mesh/unstructured/communicator.hpp
+++ b/include/NeoN/mesh/unstructured/communicator.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/mesh/unstructured/unstructuredMesh.hpp
+++ b/include/NeoN/mesh/unstructured/unstructuredMesh.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/timeIntegration/backwardEuler.hpp
+++ b/include/NeoN/timeIntegration/backwardEuler.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/timeIntegration/forwardEuler.hpp
+++ b/include/NeoN/timeIntegration/forwardEuler.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/timeIntegration/sundials.hpp
+++ b/include/NeoN/timeIntegration/sundials.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/include/NeoN/timeIntegration/sundials.hpp
+++ b/include/NeoN/timeIntegration/sundials.hpp
@@ -93,7 +93,7 @@ void fieldToSunNVectorImpl(const NeoN::Vector<ValueType>& field, N_Vector& vecto
     NeoN::parallelFor(
         field.exec(),
         field.range(),
-        KOKKOS_LAMBDA(const localIdx i) { view(i) = fieldView[i]; },
+        NEON_LAMBDA(const localIdx i) { view(i) = fieldView[i]; },
         "fieldToSunNVector"
     );
 };
@@ -147,7 +147,7 @@ void sunNVectorToVectorImpl(const N_Vector& vector, NeoN::Vector<ValueType>& fie
     NeoN::parallelFor(
         field.exec(),
         field.range(),
-        KOKKOS_LAMBDA(const localIdx i) { fieldData[i] = view(i); },
+        NEON_LAMBDA(const localIdx i) { fieldData[i] = view(i); },
         "sunNVectorToVectorImpl"
     );
 };

--- a/include/NeoN/timeIntegration/timeIntegration.hpp
+++ b/include/NeoN/timeIntegration/timeIntegration.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/scripts/catch2json.py
+++ b/scripts/catch2json.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: MIT
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/src/core/database/collection.cpp
+++ b/src/core/database/collection.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/core/database/database.cpp
+++ b/src/core/database/database.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/core/database/document.cpp
+++ b/src/core/database/document.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/core/database/fieldCollection.cpp
+++ b/src/core/database/fieldCollection.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/core/demangle.cpp
+++ b/src/core/demangle.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/core/dictionary.cpp
+++ b/src/core/dictionary.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/core/logging.cpp
+++ b/src/core/logging.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 NeoN authors
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/core/mpi/halfDuplexCommBuffer.cpp
+++ b/src/core/mpi/halfDuplexCommBuffer.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/core/primitives/vec3.cpp
+++ b/src/core/primitives/vec3.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/core/time.cpp
+++ b/src/core/time.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/core/tokenList.cpp
+++ b/src/core/tokenList.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/core/vector/vector.cpp
+++ b/src/core/vector/vector.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 NeoN authors
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/core/vector/vectorFreeFunctions.cpp
+++ b/src/core/vector/vectorFreeFunctions.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/core/vector/vectorFreeFunctions.cpp
+++ b/src/core/vector/vectorFreeFunctions.cpp
@@ -25,7 +25,7 @@ void scalarMul(Vector<ValueType>& vect, const scalar value)
     {
         auto viewA = vect.view();
         parallelFor(
-            vect, KOKKOS_LAMBDA(const localIdx i)->ValueType { return viewA[i] * value; }
+            vect, NEON_LAMBDA(const localIdx i)->ValueType { return viewA[i] * value; }
         );
     }
     else
@@ -33,7 +33,7 @@ void scalarMul(Vector<ValueType>& vect, const scalar value)
         auto viewA = vect.view();
         parallelFor(
             vect,
-            KOKKOS_LAMBDA(const localIdx i)->ValueType {
+            NEON_LAMBDA(const localIdx i)->ValueType {
                 return viewA[i] * static_cast<ValueType>(value);
             }
         );
@@ -51,7 +51,7 @@ void fieldBinaryOp(
 {
     auto view = vect.view();
     parallelFor(
-        vect, KOKKOS_LAMBDA(const localIdx i) { return op(view[i], value); }
+        vect, NEON_LAMBDA(const localIdx i) { return op(view[i], value); }
     );
 }
 
@@ -64,7 +64,7 @@ void fieldBinaryOp(
     auto viewA = vect1.view();
     auto viewB = vect2.view();
     parallelFor(
-        vect1, KOKKOS_LAMBDA(const localIdx i) { return op(viewA[i], viewB[i]); }
+        vect1, NEON_LAMBDA(const localIdx i) { return op(viewA[i], viewB[i]); }
     );
 }
 
@@ -74,7 +74,7 @@ template<typename ValueType>
 void add(Vector<ValueType>& vect, const std::type_identity_t<ValueType>& value)
 {
     detail::fieldBinaryOp(
-        vect, value, KOKKOS_LAMBDA(ValueType va, ValueType vb) { return va + vb; }
+        vect, value, NEON_LAMBDA(ValueType va, ValueType vb) { return va + vb; }
     );
 }
 
@@ -82,7 +82,7 @@ template<typename ValueType>
 void add(Vector<ValueType>& vect1, const Vector<std::type_identity_t<ValueType>>& vect2)
 {
     detail::fieldBinaryOp(
-        vect1, vect2, KOKKOS_LAMBDA(ValueType va, ValueType vb) { return va + vb; }
+        vect1, vect2, NEON_LAMBDA(ValueType va, ValueType vb) { return va + vb; }
     );
 }
 
@@ -90,7 +90,7 @@ template<typename ValueType>
 void sub(Vector<ValueType>& vect, const std::type_identity_t<ValueType>& value)
 {
     detail::fieldBinaryOp(
-        vect, value, KOKKOS_LAMBDA(ValueType va, ValueType vb) { return va - vb; }
+        vect, value, NEON_LAMBDA(ValueType va, ValueType vb) { return va - vb; }
     );
 }
 
@@ -98,7 +98,7 @@ template<typename ValueType>
 void sub(Vector<ValueType>& vect1, const Vector<std::type_identity_t<ValueType>>& vect2)
 {
     detail::fieldBinaryOp(
-        vect1, vect2, KOKKOS_LAMBDA(ValueType va, ValueType vb) { return va - vb; }
+        vect1, vect2, NEON_LAMBDA(ValueType va, ValueType vb) { return va - vb; }
     );
 }
 
@@ -107,7 +107,7 @@ void mul(Vector<ValueType>& vect, const std::type_identity_t<ValueType>& value)
     requires requires(ValueType a, ValueType b) { a* b; }
 {
     detail::fieldBinaryOp(
-        vect, value, KOKKOS_LAMBDA(ValueType va, ValueType vb) { return va * vb; }
+        vect, value, NEON_LAMBDA(ValueType va, ValueType vb) { return va * vb; }
     );
 }
 
@@ -116,7 +116,7 @@ void mul(Vector<ValueType>& vect1, const Vector<std::type_identity_t<ValueType>>
     requires requires(ValueType a, ValueType b) { a* b; }
 {
     detail::fieldBinaryOp(
-        vect1, vect2, KOKKOS_LAMBDA(ValueType va, ValueType vb) { return va * vb; }
+        vect1, vect2, NEON_LAMBDA(ValueType va, ValueType vb) { return va * vb; }
     );
 }
 

--- a/src/dsl/coeff.cpp
+++ b/src/dsl/coeff.cpp
@@ -58,7 +58,7 @@ void toVector(Coeff& coeff, Vector<scalar>& rhs)
         parallelFor(
             rhs.exec(),
             rhs.range(),
-            KOKKOS_LAMBDA(const localIdx i) { rhsView[i] *= coeff[i]; },
+            NEON_LAMBDA(const localIdx i) { rhsView[i] *= coeff[i]; },
             "coeffToVector"
         );
     }

--- a/src/dsl/coeff.cpp
+++ b/src/dsl/coeff.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/dsl/explicit.cpp
+++ b/src/dsl/explicit.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 NeoN authors
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/dsl/spatialOperator.cpp
+++ b/src/dsl/spatialOperator.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/dsl/temporalOperator.cpp
+++ b/src/dsl/temporalOperator.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/executor/CPUExecutor.cpp
+++ b/src/executor/CPUExecutor.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/executor/GPUExecutor.cpp
+++ b/src/executor/GPUExecutor.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/executor/serialExecutor.cpp
+++ b/src/executor/serialExecutor.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/finiteVolume/cellCentred/auxiliary/coNum.cpp
+++ b/src/finiteVolume/cellCentred/auxiliary/coNum.cpp
@@ -38,7 +38,7 @@ std::pair<scalar, scalar> computeCoNum(const SurfaceField<scalar>& faceFlux, con
     parallelFor(
         exec,
         {0, nInternalFaces},
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             scalar flux = Kokkos::sqrt(surfFaceFlux[i] * surfFaceFlux[i]);
             Kokkos::atomic_add(&volPhi[surfOwner[i]], flux);
             Kokkos::atomic_add(&volPhi[surfNeighbour[i]], flux);
@@ -49,7 +49,7 @@ std::pair<scalar, scalar> computeCoNum(const SurfaceField<scalar>& faceFlux, con
     parallelFor(
         exec,
         {nInternalFaces, faceFlux.size()},
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             auto own = surfFaceCells[i - nInternalFaces];
             scalar flux = Kokkos::sqrt(surfFaceFlux[i] * surfFaceFlux[i]);
             Kokkos::atomic_add(&volPhi[own], flux);
@@ -64,7 +64,7 @@ std::pair<scalar, scalar> computeCoNum(const SurfaceField<scalar>& faceFlux, con
     parallelReduce(
         exec,
         {0, mesh.nCells()},
-        KOKKOS_LAMBDA(const localIdx celli, NeoN::scalar& lmax) {
+        NEON_LAMBDA(const localIdx celli, NeoN::scalar& lmax) {
             NeoN::scalar val = (volPhi[celli] / surfV[celli]);
             if (val > lmax) lmax = val;
         },
@@ -76,7 +76,7 @@ std::pair<scalar, scalar> computeCoNum(const SurfaceField<scalar>& faceFlux, con
     parallelReduce(
         exec,
         {0, mesh.nCells()},
-        KOKKOS_LAMBDA(const localIdx celli, scalar& lsum) { lsum += volPhi[celli]; },
+        NEON_LAMBDA(const localIdx celli, scalar& lsum) { lsum += volPhi[celli]; },
         sumPhi
     );
 
@@ -85,7 +85,7 @@ std::pair<scalar, scalar> computeCoNum(const SurfaceField<scalar>& faceFlux, con
     parallelReduce(
         exec,
         {0, mesh.nCells()},
-        KOKKOS_LAMBDA(const localIdx celli, scalar& lsum) { lsum += surfV[celli]; },
+        NEON_LAMBDA(const localIdx celli, scalar& lsum) { lsum += surfV[celli]; },
         sumVol
     );
 

--- a/src/finiteVolume/cellCentred/auxiliary/coNum.cpp
+++ b/src/finiteVolume/cellCentred/auxiliary/coNum.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/finiteVolume/cellCentred/boundary/boundary.cpp
+++ b/src/finiteVolume/cellCentred/boundary/boundary.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
+++ b/src/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
+++ b/src/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
@@ -35,7 +35,7 @@ void computeFaceNormalGrad(
     NeoN::parallelFor(
         exec,
         {0, nInternalFaces},
-        KOKKOS_LAMBDA(const localIdx facei) {
+        NEON_LAMBDA(const localIdx facei) {
             phif[facei] = nonOrthDeltaCoeffs[facei] * (phi[neighbour[facei]] - phi[owner[facei]]);
         },
         "computeFaceNormalGradInternal"
@@ -44,7 +44,7 @@ void computeFaceNormalGrad(
     NeoN::parallelFor(
         exec,
         {nInternalFaces, phif.size()},
-        KOKKOS_LAMBDA(const localIdx facei) {
+        NEON_LAMBDA(const localIdx facei) {
             auto faceBCI = facei - nInternalFaces;
             auto own = surfFaceCells[faceBCI];
 

--- a/src/finiteVolume/cellCentred/fields/volumeField.cpp
+++ b/src/finiteVolume/cellCentred/fields/volumeField.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 NeoN authors
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -31,7 +31,7 @@ void computeLinearInterpolation(
     NeoN::parallelFor(
         exec,
         {0, dstS.size()},
-        KOKKOS_LAMBDA(const localIdx facei) {
+        NEON_LAMBDA(const localIdx facei) {
             if (facei < nInternalFaces)
             {
                 auto own = ownerS[facei];

--- a/src/finiteVolume/cellCentred/interpolation/upwind.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/upwind.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/finiteVolume/cellCentred/interpolation/upwind.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/upwind.cpp
@@ -33,7 +33,7 @@ void computeUpwindInterpolation(
     parallelFor(
         exec,
         {0, dstS.size()},
-        KOKKOS_LAMBDA(const localIdx facei) {
+        NEON_LAMBDA(const localIdx facei) {
             if (facei < nInternalFaces)
             {
                 if (fluxS[facei] >= 0)
@@ -77,7 +77,7 @@ void computeUpwindInterpolationWeights(
     parallelFor(
         exec,
         {0, weights.size()},
-        KOKKOS_LAMBDA(const localIdx facei) {
+        NEON_LAMBDA(const localIdx facei) {
             if (facei < nInternalFaces)
             {
                 weightS[facei] = fluxS[facei] >= 0 ? 1 : 0;

--- a/src/finiteVolume/cellCentred/operators/ddtOperator.cpp
+++ b/src/finiteVolume/cellCentred/operators/ddtOperator.cpp
@@ -30,7 +30,7 @@ void DdtOperator<ValueType>::explicitOperation(Vector<ValueType>& source, scalar
     parallelFor(
         source.exec(),
         source.range(),
-        KOKKOS_LAMBDA(const localIdx celli) {
+        NEON_LAMBDA(const localIdx celli) {
             sourceView[celli] += dtInver * (field[celli] - oldVector[celli]) * vol[celli];
         },
         "ddtOpertator::explicitOperation"
@@ -53,7 +53,7 @@ void DdtOperator<ValueType>::bdf1Kernel(
     parallelFor(
         ls.exec(),
         {0, oldVector.size()},
-        KOKKOS_LAMBDA(const localIdx celli) {
+        NEON_LAMBDA(const localIdx celli) {
             const auto idx = matrix.rowOffs[celli] + diagOffs[celli];
             const auto commonCoef = operatorScaling[celli] * vol[celli];
             matrix.values[idx] += commonCoef * a0a1 * one<ValueType>();

--- a/src/finiteVolume/cellCentred/operators/ddtOperator.cpp
+++ b/src/finiteVolume/cellCentred/operators/ddtOperator.cpp
@@ -83,7 +83,7 @@ void DdtOperator<ValueType>::bdf2Kernel(
     parallelFor(
         ls.exec(),
         {0, oldVector.size()},
-        KOKKOS_LAMBDA(const localIdx celli) {
+        NEON_LAMBDA(const localIdx celli) {
             const auto idx = matrix.rowOffs[celli] + diagOffs[celli];
             const auto commonCoef = operatorScaling[celli] * vol[celli];
             matrix.values[idx] += commonCoef * a0 * one<ValueType>();

--- a/src/finiteVolume/cellCentred/operators/expression.cpp
+++ b/src/finiteVolume/cellCentred/operators/expression.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
@@ -71,7 +71,7 @@ void computeDiv(
         parallelFor(
             exec,
             {0, nInternalFaces},
-            KOKKOS_LAMBDA(const localIdx i) {
+            NEON_LAMBDA(const localIdx i) {
                 ValueType flux = faceFlux[i] * phiF[i];
                 Kokkos::atomic_add(&res[owner[i]], flux);
                 Kokkos::atomic_sub(&res[neighbour[i]], flux);
@@ -82,7 +82,7 @@ void computeDiv(
         parallelFor(
             exec,
             {nInternalFaces, nInternalFaces + nBoundaryFaces},
-            KOKKOS_LAMBDA(const localIdx i) {
+            NEON_LAMBDA(const localIdx i) {
                 auto own = faceCells[i - nInternalFaces];
                 ValueType valueOwn = faceFlux[i] * phiF[i];
                 Kokkos::atomic_add(&res[own], valueOwn);
@@ -93,9 +93,7 @@ void computeDiv(
         parallelFor(
             exec,
             {0, nCells},
-            KOKKOS_LAMBDA(const localIdx celli) {
-                res[celli] *= operatorScaling[celli] / v[celli];
-            },
+            NEON_LAMBDA(const localIdx celli) { res[celli] *= operatorScaling[celli] / v[celli]; },
             "normalizeFluxes"
         );
     }
@@ -184,7 +182,7 @@ void computeDivImp(
     parallelFor(
         exec,
         {0, nInternalFaces},
-        KOKKOS_LAMBDA(const localIdx facei) {
+        NEON_LAMBDA(const localIdx facei) {
             auto flux = faceFluxV[facei];
             auto weight = weightsV[facei];
             auto value = zero<ValueType>();
@@ -235,7 +233,7 @@ void computeDivImp(
     parallelFor(
         exec,
         {nInternalFaces, faceFluxV.size()},
-        KOKKOS_LAMBDA(const localIdx facei) {
+        NEON_LAMBDA(const localIdx facei) {
             auto bcfacei = facei - nInternalFaces;
             auto flux = bweights[bcfacei] * faceFluxV[facei];
 

--- a/src/finiteVolume/cellCentred/operators/gaussGreenGrad.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenGrad.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/finiteVolume/cellCentred/operators/gaussGreenGrad.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenGrad.cpp
@@ -48,7 +48,7 @@ void computeGrad(
     parallelFor(
         exec,
         {0, nInternalFaces},
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             Vec3 flux = faceAreaS[i] * surfPhif[i];
             Kokkos::atomic_add(&surfGradPhi[surfOwner[i]], flux);
             Kokkos::atomic_sub(&surfGradPhi[surfNeighbour[i]], flux);
@@ -59,7 +59,7 @@ void computeGrad(
     parallelFor(
         exec,
         {nInternalFaces, surfPhif.size()},
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             auto own = surfFaceCells[i - nInternalFaces];
             Vec3 valueOwn = faceAreaS[i] * surfPhif[i];
             Kokkos::atomic_add(&surfGradPhi[own], valueOwn);
@@ -70,7 +70,7 @@ void computeGrad(
     parallelFor(
         exec,
         {0, mesh.nCells()},
-        KOKKOS_LAMBDA(const localIdx celli) {
+        NEON_LAMBDA(const localIdx celli) {
             surfGradPhi[celli] *= operatorScaling[celli] / surfV[celli];
         },
         "computeGradCells"

--- a/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
@@ -34,7 +34,7 @@ void computeLaplacianExp(
     parallelFor(
         exec,
         {0, nInternalFaces},
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             ValueType flux = faceArea[i] * fnGrad[i];
             Kokkos::atomic_add(&result[owner[i]], flux);
             Kokkos::atomic_sub(&result[neighbour[i]], flux);
@@ -45,7 +45,7 @@ void computeLaplacianExp(
     parallelFor(
         exec,
         {nInternalFaces, fnGrad.size()},
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             auto own = surfFaceCells[i - nInternalFaces];
             ValueType valueOwn = faceArea[i] * fnGrad[i];
             Kokkos::atomic_add(&result[own], valueOwn);
@@ -56,9 +56,7 @@ void computeLaplacianExp(
     parallelFor(
         exec,
         {0, mesh.nCells()},
-        KOKKOS_LAMBDA(const localIdx celli) {
-            result[celli] *= operatorScaling[celli] / vol[celli];
-        },
+        NEON_LAMBDA(const localIdx celli) { result[celli] *= operatorScaling[celli] / vol[celli]; },
         "computeLaplacianExplicitCells"
     );
 }
@@ -110,7 +108,7 @@ void computeLaplacianImpl(
     parallelFor(
         exec,
         {0, nInternalFaces},
-        KOKKOS_LAMBDA(const localIdx facei) {
+        NEON_LAMBDA(const localIdx facei) {
             auto flux = deltaCoeffs[facei] * sGamma[facei] * magFaceArea[facei];
 
             auto own = owner[facei];
@@ -156,7 +154,7 @@ void computeLaplacianImpl(
     parallelFor(
         exec,
         {nInternalFaces, sGamma.size()},
-        KOKKOS_LAMBDA(const localIdx facei) {
+        NEON_LAMBDA(const localIdx facei) {
             auto bcfacei = facei - nInternalFaces;
             auto flux = sGamma[facei] * magFaceArea[facei];
 

--- a/src/finiteVolume/cellCentred/operators/sourceTerm.cpp
+++ b/src/finiteVolume/cellCentred/operators/sourceTerm.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/finiteVolume/cellCentred/operators/sourceTerm.cpp
+++ b/src/finiteVolume/cellCentred/operators/sourceTerm.cpp
@@ -29,7 +29,7 @@ void SourceTerm<ValueType>::explicitOperation(Vector<ValueType>& source) const
     NeoN::parallelFor(
         source.exec(),
         source.range(),
-        KOKKOS_LAMBDA(const localIdx celli) {
+        NEON_LAMBDA(const localIdx celli) {
             sourceView[celli] += operatorScaling[celli] * coeff[celli] * fieldView[celli];
         },
         "sourceTerm::explicitOperation"
@@ -48,7 +48,7 @@ void SourceTerm<ValueType>::implicitOperation(la::LinearSystem<ValueType, localI
     NeoN::parallelFor(
         ls.exec(),
         {0, coeff.size()},
-        KOKKOS_LAMBDA(const localIdx celli) {
+        NEON_LAMBDA(const localIdx celli) {
             localIdx idx = matrix.rowOffs[celli] + diagOffs[celli];
             matrix.values[idx] +=
                 operatorScaling[celli] * coeff[celli] * vol[celli] * one<ValueType>();

--- a/src/finiteVolume/cellCentred/operators/surfaceIntegrate.cpp
+++ b/src/finiteVolume/cellCentred/operators/surfaceIntegrate.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/finiteVolume/cellCentred/operators/surfaceIntegrate.cpp
+++ b/src/finiteVolume/cellCentred/operators/surfaceIntegrate.cpp
@@ -26,7 +26,7 @@ void surfaceIntegrate(
     parallelFor(
         exec,
         {0, nInternalFaces},
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             Kokkos::atomic_add(&res[static_cast<size_t>(owner[i])], flux[i]);
             Kokkos::atomic_sub(&res[static_cast<size_t>(neighbour[i])], flux[i]);
         },
@@ -36,7 +36,7 @@ void surfaceIntegrate(
     parallelFor(
         exec,
         {nInternalFaces, nInternalFaces + nBoundaryFaces},
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             auto own = faceCells[i - nInternalFaces];
             Kokkos::atomic_add(&res[own], flux[i]);
         },
@@ -46,7 +46,7 @@ void surfaceIntegrate(
     parallelFor(
         exec,
         {0, nCells},
-        KOKKOS_LAMBDA(const localIdx celli) { res[celli] *= operatorScaling[celli] / v[celli]; },
+        NEON_LAMBDA(const localIdx celli) { res[celli] *= operatorScaling[celli] / v[celli]; },
         "surfaceIntegrateInternalCells"
     );
 }

--- a/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
@@ -28,7 +28,7 @@ void BasicGeometryScheme::updateWeights(const Executor& exec, SurfaceField<scala
     parallelFor(
         exec,
         {0, nInternalFaces},
-        KOKKOS_LAMBDA(const localIdx facei) {
+        NEON_LAMBDA(const localIdx facei) {
             scalar sfdOwn = std::abs(sf[facei] & (cf[facei] - c[owner[facei]]));
             scalar sfdNei = std::abs(sf[facei] & (c[neighbour[facei]] - cf[facei]));
 
@@ -47,7 +47,7 @@ void BasicGeometryScheme::updateWeights(const Executor& exec, SurfaceField<scala
     parallelFor(
         exec,
         {nInternalFaces, weightS.size()},
-        KOKKOS_LAMBDA(const localIdx facei) {
+        NEON_LAMBDA(const localIdx facei) {
             const auto bcfacei = facei - nInternalFaces;
             weightS[facei] = 1.0;
             weightB[bcfacei] = 1.0;
@@ -71,7 +71,7 @@ void BasicGeometryScheme::updateDeltaCoeffs(
     parallelFor(
         exec,
         {0, mesh_.nInternalFaces()},
-        KOKKOS_LAMBDA(const localIdx facei) {
+        NEON_LAMBDA(const localIdx facei) {
             Vec3 cellToCellDist = cellCentre[neighbour[facei]] - cellCentre[owner[facei]];
             deltaCoeff[facei] = 1.0 / mag(cellToCellDist);
         },
@@ -83,7 +83,7 @@ void BasicGeometryScheme::updateDeltaCoeffs(
     parallelFor(
         exec,
         {nInternalFaces, deltaCoeff.size()},
-        KOKKOS_LAMBDA(const localIdx facei) {
+        NEON_LAMBDA(const localIdx facei) {
             auto own = surfFaceCells[facei - nInternalFaces];
             Vec3 cellToCellDist = cf[facei] - cellCentre[own];
 
@@ -113,7 +113,7 @@ void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
     parallelFor(
         exec,
         {0, nInternalFaces},
-        KOKKOS_LAMBDA(const localIdx facei) {
+        NEON_LAMBDA(const localIdx facei) {
             Vec3 cellToCellDist = cellCentre[neighbour[facei]] - cellCentre[owner[facei]];
             Vec3 faceNormal = 1 / faceArea[facei] * faceAreaVec3[facei];
 
@@ -128,7 +128,7 @@ void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
     parallelFor(
         exec,
         {nInternalFaces, nonOrthDeltaCoeff.size()},
-        KOKKOS_LAMBDA(const localIdx facei) {
+        NEON_LAMBDA(const localIdx facei) {
             auto own = surfFaceCells[facei - nInternalFaces];
             Vec3 cellToCellDist = cf[facei] - cellCentre[own];
             Vec3 faceNormal = 1 / faceArea[facei] * faceAreaVec3[facei];

--- a/src/finiteVolume/cellCentred/stencil/cellToFaceStencil.cpp
+++ b/src/finiteVolume/cellCentred/stencil/cellToFaceStencil.cpp
@@ -25,7 +25,7 @@ SegmentedVector<localIdx, localIdx> CellToFaceStencil::computeStencil() const
     parallelFor(
         exec,
         {0, nInternalFaces},
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             Kokkos::atomic_inc(&nFacesPerCellView[static_cast<size_t>(faceOwner[i])]);
             Kokkos::atomic_inc(&nFacesPerCellView[static_cast<size_t>(faceNeighbour[i])]);
         },
@@ -35,7 +35,7 @@ SegmentedVector<localIdx, localIdx> CellToFaceStencil::computeStencil() const
     parallelFor(
         exec,
         {0, boundaryFaceCells.size()},
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             Kokkos::atomic_inc(&nFacesPerCellView[boundaryFaceCells[i]]);
         },
         "countFacesPerCellBoundary"
@@ -49,7 +49,7 @@ SegmentedVector<localIdx, localIdx> CellToFaceStencil::computeStencil() const
     parallelFor(
         exec,
         {0, nInternalFaces},
-        KOKKOS_LAMBDA(const localIdx facei) {
+        NEON_LAMBDA(const localIdx facei) {
             localIdx owner = faceOwner[facei];
             localIdx neighbour = faceNeighbour[facei];
 
@@ -67,7 +67,7 @@ SegmentedVector<localIdx, localIdx> CellToFaceStencil::computeStencil() const
     parallelFor(
         exec,
         {nInternalFaces, nInternalFaces + boundaryFaceCells.size()},
-        KOKKOS_LAMBDA(const localIdx facei) {
+        NEON_LAMBDA(const localIdx facei) {
             localIdx owner = boundaryFaceCells[facei - nInternalFaces];
             localIdx segIdxOwn = Kokkos::atomic_fetch_add(&nFacesPerCellView[owner], 1);
             localIdx startSegOwn = segment[owner];

--- a/src/finiteVolume/cellCentred/stencil/cellToFaceStencil.cpp
+++ b/src/finiteVolume/cellCentred/stencil/cellToFaceStencil.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/finiteVolume/cellCentred/stencil/geometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/geometryScheme.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/linearAlgebra/ginkgo.cpp
+++ b/src/linearAlgebra/ginkgo.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 NeoN authors
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/linearAlgebra/sparsityPattern.cpp
+++ b/src/linearAlgebra/sparsityPattern.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/linearAlgebra/sparsityPattern.cpp
+++ b/src/linearAlgebra/sparsityPattern.cpp
@@ -47,7 +47,7 @@ void updateSparsityPatternSerial(const UnstructuredMesh& mesh, SparsityPattern& 
     parallelFor(
         SerialExecutor {},
         {0, nInternalFaces},
-        KOKKOS_LAMBDA(const localIdx facei) {
+        NEON_LAMBDA(const localIdx facei) {
             // hit on performance on serial
             auto own = faceOwnHV[facei];
             auto nei = faceNeiHV[facei];
@@ -70,7 +70,7 @@ void updateSparsityPatternSerial(const UnstructuredMesh& mesh, SparsityPattern& 
     parallelFor(
         SerialExecutor {},
         {0, nInternalFaces},
-        KOKKOS_LAMBDA(const localIdx facei) {
+        NEON_LAMBDA(const localIdx facei) {
             auto nei = faceNeiHV[facei];
             auto own = faceOwnHV[facei];
 
@@ -90,7 +90,7 @@ void updateSparsityPatternSerial(const UnstructuredMesh& mesh, SparsityPattern& 
 
     map(
         nFacesPerCellH,
-        KOKKOS_LAMBDA(const localIdx celli) {
+        NEON_LAMBDA(const localIdx celli) {
             auto nFaces = nFacesPerCellHV[celli];
             diagOffsetHV[celli] = static_cast<uint8_t>(nFaces);
             colIdxHV[rowOffsHV[celli] + nFaces] = celli;
@@ -102,7 +102,7 @@ void updateSparsityPatternSerial(const UnstructuredMesh& mesh, SparsityPattern& 
     parallelFor(
         SerialExecutor {},
         {0, nInternalFaces},
-        KOKKOS_LAMBDA(const localIdx facei) {
+        NEON_LAMBDA(const localIdx facei) {
             auto nei = faceNeiHV[facei];
             auto own = faceOwnHV[facei];
 
@@ -146,7 +146,7 @@ void updateSparsityPatternParallel(const UnstructuredMesh& mesh, SparsityPattern
     parallelFor(
         exec,
         {0, nInternalFaces},
-        KOKKOS_LAMBDA(const localIdx facei) {
+        NEON_LAMBDA(const localIdx facei) {
             // hit on performance on serial
             auto owner = faceOwner[facei];
             auto neighbour = faceNeiV[facei];
@@ -167,7 +167,7 @@ void updateSparsityPatternParallel(const UnstructuredMesh& mesh, SparsityPattern
     parallelFor(
         exec,
         {0, nInternalFaces},
-        KOKKOS_LAMBDA(const localIdx facei) {
+        NEON_LAMBDA(const localIdx facei) {
             auto neighbour = faceNeiV[facei];
             auto owner = faceOwner[facei];
 
@@ -186,7 +186,7 @@ void updateSparsityPatternParallel(const UnstructuredMesh& mesh, SparsityPattern
 
     map(
         nFacesPerCell,
-        KOKKOS_LAMBDA(const localIdx celli) {
+        NEON_LAMBDA(const localIdx celli) {
             auto nFaces = nFacesPerCellView[celli];
             diagOffsetView[celli] = static_cast<uint8_t>(nFaces);
             colIdxV[rowOffs[celli] + nFaces] = celli;
@@ -198,7 +198,7 @@ void updateSparsityPatternParallel(const UnstructuredMesh& mesh, SparsityPattern
     parallelFor(
         exec,
         {0, nInternalFaces},
-        KOKKOS_LAMBDA(const localIdx facei) {
+        NEON_LAMBDA(const localIdx facei) {
             auto neighbour = faceNeiV[facei];
             auto owner = faceOwner[facei];
 

--- a/src/linearAlgebra/utilities.cpp
+++ b/src/linearAlgebra/utilities.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/linearAlgebra/utilities.cpp
+++ b/src/linearAlgebra/utilities.cpp
@@ -26,7 +26,7 @@ Vector<localIdx> unpackColIdx(
     NeoN::parallelFor(
         exec,
         {0, unpackedRowOffs.size() - 1},
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             const auto j {rowV[i]};        // new row start
             const auto l {oldRowV[i / 3]}; // original row start
             const auto length {rowV[i + 1] - rowV[i]};
@@ -55,7 +55,7 @@ Vector<scalar> unpackVecValues(const Vector<Vec3>& in)
     NeoN::parallelFor(
         exec,
         {0, in.size()},
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             localIdx j = 3 * i;
             outV[j + 0] = inV[i][0];
             outV[j + 1] = inV[i][1];
@@ -81,7 +81,7 @@ Vector<scalar> unpackMtxValues(
     NeoN::parallelFor(
         exec,
         {0, rowOffs.size() - 1},
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             const auto length {rowV[i + 1] - rowV[i]};
             for (auto k = 0; k < length; k++)
             {
@@ -111,7 +111,7 @@ Vector<localIdx> unpackRowOffs(const Vector<localIdx>& in)
     NeoN::parallelFor(
         exec,
         {0, in.size() - 1},
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             localIdx j = 3 * i;
             const auto val = inV[i + 1] - inV[i];
             lengthV[j + 0] = val;
@@ -129,7 +129,7 @@ Vector<localIdx> unpackRowOffs(const Vector<localIdx>& in)
     NeoN::parallelScan(
         exec,
         {1, length.size() + 1},
-        KOKKOS_LAMBDA(const NeoN::localIdx i, NeoN::localIdx& update, const bool final) {
+        NEON_LAMBDA(const NeoN::localIdx i, NeoN::localIdx& update, const bool final) {
             update += lengthV[i - 1];
             if (final)
             {
@@ -150,7 +150,7 @@ void packVecValues(const Vector<scalar>& in, Vector<Vec3>& out)
     NeoN::parallelFor(
         exec,
         {0, out.size()},
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             localIdx j = 3 * i;
             outV[i][0] = inV[j + 0];
             outV[i][1] = inV[j + 1];
@@ -173,7 +173,7 @@ void computeResidual(
     NeoN::parallelFor(
         resV.exec(),
         {0, resV.size()},
-        KOKKOS_LAMBDA(const localIdx rowi) {
+        NEON_LAMBDA(const localIdx rowi) {
             auto rowStart = rowOffs[rowi];
             auto rowEnd = rowOffs[rowi + 1];
             scalar sum = 0.0;

--- a/src/mesh/unstructured/boundaryMesh.cpp
+++ b/src/mesh/unstructured/boundaryMesh.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/mesh/unstructured/communicator.cpp
+++ b/src/mesh/unstructured/communicator.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/mesh/unstructured/unstructuredMesh.cpp
+++ b/src/mesh/unstructured/unstructuredMesh.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/mesh/unstructured/unstructuredMesh.cpp
+++ b/src/mesh/unstructured/unstructuredMesh.cpp
@@ -128,7 +128,7 @@ UnstructuredMesh create1DUniformMesh(const Executor exec, const localIdx nCells)
     parallelFor(
         exec,
         {0, nCells - 1},
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             meshPointsView[i][0] = leftBoundaryX + static_cast<scalar>(i + 1) * meshSpacing;
         },
         "computeMeshPoints"
@@ -141,7 +141,7 @@ UnstructuredMesh create1DUniformMesh(const Executor exec, const localIdx nCells)
     parallelFor(
         exec,
         {0, nCells},
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             cellCentersView[i][0] = 0.5 * meshSpacing + meshSpacing * static_cast<scalar>(i);
         },
         "computeCellCenters"
@@ -169,7 +169,7 @@ UnstructuredMesh create1DUniformMesh(const Executor exec, const localIdx nCells)
     parallelFor(
         exec,
         {0, nCells - 1},
-        KOKKOS_LAMBDA(const localIdx i) {
+        NEON_LAMBDA(const localIdx i) {
             faceOwnerView[i] = i;
             faceNeighborView[i] = i + 1;
         },

--- a/src/timeIntegration/rungeKutta.cpp
+++ b/src/timeIntegration/rungeKutta.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/timeIntegration/timeIntegration.cpp
+++ b/src/timeIntegration/timeIntegration.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/test/catch2/catch2_common.hpp
+++ b/test/catch2/catch2_common.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 NeoN authors
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/catch2/executorGenerator.hpp
+++ b/test/catch2/executorGenerator.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/catch2/mpiGlobals.cpp
+++ b/test/catch2/mpiGlobals.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/catch2/mpiGlobals.hpp
+++ b/test/catch2/mpiGlobals.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/catch2/mpiReporter.cpp
+++ b/test/catch2/mpiReporter.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/catch2/mpiReporter.hpp
+++ b/test/catch2/mpiReporter.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/catch2/mpiSerialization.cpp
+++ b/test/catch2/mpiSerialization.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/catch2/mpiSerialization.hpp
+++ b/test/catch2/mpiSerialization.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/catch2/test_main.cpp
+++ b/test/catch2/test_main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/catch2/test_main_mpi.cpp
+++ b/test/catch2/test_main_mpi.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/test/core/array.cpp
+++ b/test/core/array.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/core/database/CMakeLists.txt
+++ b/test/core/database/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/test/core/database/collection.cpp
+++ b/test/core/database/collection.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/core/database/customTestCollection.hpp
+++ b/test/core/database/customTestCollection.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/core/database/database.cpp
+++ b/test/core/database/database.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/core/database/document.cpp
+++ b/test/core/database/document.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/core/database/fieldCollection.cpp
+++ b/test/core/database/fieldCollection.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/core/dictionary.cpp
+++ b/test/core/dictionary.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/core/executor.cpp
+++ b/test/core/executor.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/core/input.cpp
+++ b/test/core/input.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/core/mpi/CMakeLists.txt
+++ b/test/core/mpi/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/test/core/mpi/fullDuplexCommBuffer.cpp
+++ b/test/core/mpi/fullDuplexCommBuffer.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/core/mpi/halfDuplexCommBuffer.cpp
+++ b/test/core/mpi/halfDuplexCommBuffer.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/core/mpi/operators.cpp
+++ b/test/core/mpi/operators.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/core/parallelAlgorithms.cpp
+++ b/test/core/parallelAlgorithms.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/core/parallelAlgorithms.cpp
+++ b/test/core/parallelAlgorithms.cpp
@@ -25,7 +25,7 @@ TEST_CASE("parallelFor")
         auto viewB = fieldB.view();
         NeoN::fill(fieldB, 1.0);
         NeoN::parallelFor(
-            exec, {0, 5}, KOKKOS_LAMBDA(const NeoN::localIdx i) { viewA[i] = viewB[i] + 2.0; }
+            exec, {0, 5}, NEON_LAMBDA(const NeoN::localIdx i) { viewA[i] = viewB[i] + 2.0; }
         );
         auto hostA = fieldA.copyToHost();
         for (auto value : hostA.view())
@@ -45,9 +45,7 @@ TEST_CASE("parallelFor")
         NeoN::parallelFor(
             exec,
             {0, 5},
-            KOKKOS_LAMBDA(const NeoN::localIdx i) {
-                viewA[i] = viewB[i] + NeoN::Vec3(2.0, 2.0, 2.0);
-            }
+            NEON_LAMBDA(const NeoN::localIdx i) { viewA[i] = viewB[i] + NeoN::Vec3(2.0, 2.0, 2.0); }
         );
         auto hostA = fieldA.copyToHost();
         for (auto value : hostA.view())
@@ -64,7 +62,7 @@ TEST_CASE("parallelFor")
         auto viewB = fieldB.view();
         NeoN::fill(fieldB, 1.0);
         NeoN::parallelFor(
-            fieldA, KOKKOS_LAMBDA(const NeoN::localIdx i) { return viewB[i] + 2.0; }
+            fieldA, NEON_LAMBDA(const NeoN::localIdx i) { return viewB[i] + 2.0; }
         );
         auto hostA = fieldA.copyToHost();
         for (auto value : hostA.view())
@@ -90,7 +88,7 @@ TEST_CASE("parallelReduce")
         NeoN::parallelReduce(
             exec,
             {0, 5},
-            KOKKOS_LAMBDA(const NeoN::localIdx i, double& lsum) { lsum += viewB[i]; },
+            NEON_LAMBDA(const NeoN::localIdx i, double& lsum) { lsum += viewB[i]; },
             sum
         );
 
@@ -109,7 +107,7 @@ TEST_CASE("parallelReduce")
         NeoN::parallelReduce(
             exec,
             {0, 5},
-            KOKKOS_LAMBDA(const NeoN::localIdx i, NeoN::scalar& lmax) {
+            NEON_LAMBDA(const NeoN::localIdx i, NeoN::scalar& lmax) {
                 if (lmax < viewB[i]) lmax = viewB[i];
             },
             reducer
@@ -127,7 +125,7 @@ TEST_CASE("parallelReduce")
         NeoN::fill(fieldB, 1.0);
         NeoN::scalar sum = 0.0;
         NeoN::parallelReduce(
-            fieldA, KOKKOS_LAMBDA(const NeoN::localIdx i, double& lsum) { lsum += viewB[i]; }, sum
+            fieldA, NEON_LAMBDA(const NeoN::localIdx i, double& lsum) { lsum += viewB[i]; }, sum
         );
 
         REQUIRE(sum == 5.0);
@@ -144,7 +142,7 @@ TEST_CASE("parallelReduce")
         Kokkos::Max<NeoN::scalar> reducer(max);
         NeoN::parallelReduce(
             fieldA,
-            KOKKOS_LAMBDA(const NeoN::localIdx i, NeoN::scalar& lmax) {
+            NEON_LAMBDA(const NeoN::localIdx i, NeoN::scalar& lmax) {
                 if (lmax < viewB[i]) lmax = viewB[i];
             },
             reducer
@@ -168,7 +166,7 @@ TEST_CASE("parallelScan")
         NeoN::parallelScan(
             exec,
             {1, segView.size()},
-            KOKKOS_LAMBDA(const NeoN::localIdx i, NeoN::localIdx& update, const bool final) {
+            NEON_LAMBDA(const NeoN::localIdx i, NeoN::localIdx& update, const bool final) {
                 update += intView[i - 1];
                 if (final)
                 {
@@ -204,7 +202,7 @@ TEST_CASE("parallelScan")
         NeoN::parallelScan(
             exec,
             {1, segView.size()},
-            KOKKOS_LAMBDA(const NeoN::localIdx i, NeoN::localIdx& update, const bool final) {
+            NEON_LAMBDA(const NeoN::localIdx i, NeoN::localIdx& update, const bool final) {
                 update += intView[i - 1];
                 if (final)
                 {

--- a/test/core/primitives/CMakeLists.txt
+++ b/test/core/primitives/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/test/core/primitives/scalar.cpp
+++ b/test/core/primitives/scalar.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/core/primitives/vec3.cpp
+++ b/test/core/primitives/vec3.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/core/runTimeSelectionFactory.cpp
+++ b/test/core/runTimeSelectionFactory.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/core/segmentedVector.cpp
+++ b/test/core/segmentedVector.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/core/segmentedVector.cpp
+++ b/test/core/segmentedVector.cpp
@@ -57,7 +57,7 @@ TEST_CASE("segmentedVector")
             parallelFor(
                 exec,
                 {0, segVector.numSegments()},
-                KOKKOS_LAMBDA(const NeoN::localIdx segI) {
+                NEON_LAMBDA(const NeoN::localIdx segI) {
                     // check if it works with bounds
                     auto [bStart, bEnd] = segView.bounds(segI);
                     auto bVals = valueView.subview(bStart, bEnd - bStart);
@@ -126,7 +126,7 @@ TEST_CASE("segmentedVector")
             parallelFor(
                 exec,
                 {0, segVector.numSegments()},
-                KOKKOS_LAMBDA(const NeoN::localIdx segI) {
+                NEON_LAMBDA(const NeoN::localIdx segI) {
                     // fill values
                     auto vals = segView.view(segI);
                     for (auto& val : vals)

--- a/test/core/tokenList.cpp
+++ b/test/core/tokenList.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/core/vector/CMakeLists.txt
+++ b/test/core/vector/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 NeoN authors
+# SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/test/core/vector/vector.cpp
+++ b/test/core/vector/vector.cpp
@@ -250,7 +250,7 @@ TEST_CASE("Vector Operations")
         REQUIRE(equal(a, 20.0));
 
         auto sB = b.view();
-        a.apply(KOKKOS_LAMBDA(const NeoN::localIdx i) { return 2 * sB[i]; });
+        a.apply(NEON_LAMBDA(const NeoN::localIdx i) { return 2 * sB[i]; });
         REQUIRE(equal(a, 20.0));
     }
 }
@@ -271,7 +271,7 @@ TEST_CASE("getViews")
     REQUIRE(hostC.view()[0] == 3.0);
 
     NeoN::parallelFor(
-        a, KOKKOS_LAMBDA(const NeoN::localIdx i) { return viewB[i] + viewC[i]; }
+        a, NEON_LAMBDA(const NeoN::localIdx i) { return viewB[i] + viewC[i]; }
     );
 
     auto hostD = a.copyToHost();

--- a/test/core/vector/vector.cpp
+++ b/test/core/vector/vector.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/core/view.cpp
+++ b/test/core/view.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/core/view.cpp
+++ b/test/core/view.cpp
@@ -23,7 +23,7 @@ TEST_CASE("parallelFor")
     auto fieldNFView = NeoN::View(fieldStdView);
 
     NeoN::parallelFor(
-        exec, {0, 5}, KOKKOS_LAMBDA(const NeoN::localIdx i) { fieldNFView[i] *= 2.0; }
+        exec, {0, 5}, NEON_LAMBDA(const NeoN::localIdx i) { fieldNFView[i] *= 2.0; }
     );
     REQUIRE(fieldNFView.failureIndex == 0);
 
@@ -33,7 +33,7 @@ TEST_CASE("parallelFor")
 #ifndef _MSC_VER
     fieldNFView.abortOnFail = false;
     NeoN::parallelFor(
-        exec, {5, 6}, KOKKOS_LAMBDA(const localIdx i) { fieldNFView[i] *= 2.0; }
+        exec, {5, 6}, NEON_LAMBDA(const localIdx i) { fieldNFView[i] *= 2.0; }
     );
     REQUIRE(fieldNFView.failureIndex == 5);
 #endif

--- a/test/dsl/CMakeLists.txt
+++ b/test/dsl/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/test/dsl/coeff.cpp
+++ b/test/dsl/coeff.cpp
@@ -61,7 +61,7 @@ TEST_CASE("Coeff")
             Coeff coeff = fieldB; // is a view with uniform value 1.0
             {
                 NeoN::parallelFor(
-                    fieldA, KOKKOS_LAMBDA(const NeoN::localIdx i) { return coeff[i] + 2.0; }
+                    fieldA, NEON_LAMBDA(const NeoN::localIdx i) { return coeff[i] + 2.0; }
                 );
             };
             auto hostVectorA = fieldA.copyToHost();
@@ -76,7 +76,7 @@ TEST_CASE("Coeff")
             Coeff coeff = Coeff(2.0);
             {
                 NeoN::parallelFor(
-                    fieldA, KOKKOS_LAMBDA(const NeoN::localIdx i) { return coeff[i] + 2.0; }
+                    fieldA, NEON_LAMBDA(const NeoN::localIdx i) { return coeff[i] + 2.0; }
                 );
             };
             auto hostVectorA = fieldA.copyToHost();
@@ -91,7 +91,7 @@ TEST_CASE("Coeff")
             Coeff coeff {-5.0, fieldB};
             {
                 NeoN::parallelFor(
-                    fieldA, KOKKOS_LAMBDA(const NeoN::localIdx i) { return coeff[i] + 2.0; }
+                    fieldA, NEON_LAMBDA(const NeoN::localIdx i) { return coeff[i] + 2.0; }
                 );
             };
             auto hostVectorA = fieldA.copyToHost();

--- a/test/dsl/coeff.cpp
+++ b/test/dsl/coeff.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/dsl/common.hpp
+++ b/test/dsl/common.hpp
@@ -167,7 +167,7 @@ public:
         NeoN::parallelFor(
             source.exec(),
             source.range(),
-            KOKKOS_LAMBDA(const localIdx i) { sourceView[i] += coeff[i] * fieldView[i]; }
+            NEON_LAMBDA(const localIdx i) { sourceView[i] += coeff[i] * fieldView[i]; }
         );
     }
 
@@ -182,14 +182,14 @@ public:
         NeoN::parallelFor(
             this->exec(),
             {0, values.size()},
-            KOKKOS_LAMBDA(const localIdx i) { values[i] += coeff[i] * fieldView[i]; }
+            NEON_LAMBDA(const localIdx i) { values[i] += coeff[i] * fieldView[i]; }
         );
 
         // update rhs
         NeoN::parallelFor(
             this->exec(),
             ls.rhs().range(),
-            KOKKOS_LAMBDA(const localIdx i) { rhs[i] += coeff[i] * fieldView[i]; }
+            NEON_LAMBDA(const localIdx i) { rhs[i] += coeff[i] * fieldView[i]; }
         );
     }
 
@@ -228,7 +228,7 @@ public:
         NeoN::parallelFor(
             source.exec(),
             source.range(),
-            KOKKOS_LAMBDA(const localIdx i) { sourceView[i] += coeff[i] * fieldView[i]; }
+            NEON_LAMBDA(const localIdx i) { sourceView[i] += coeff[i] * fieldView[i]; }
         );
     }
 
@@ -244,14 +244,14 @@ public:
         NeoN::parallelFor(
             this->exec(),
             {0, values.size()},
-            KOKKOS_LAMBDA(const localIdx i) { values[i] += coeff[i] * fieldView[i]; }
+            NEON_LAMBDA(const localIdx i) { values[i] += coeff[i] * fieldView[i]; }
         );
 
         // update rhs
         NeoN::parallelFor(
             this->exec(),
             ls.rhs().range(),
-            KOKKOS_LAMBDA(const localIdx i) { rhs[i] += coeff[i] * fieldView[i]; }
+            NEON_LAMBDA(const localIdx i) { rhs[i] += coeff[i] * fieldView[i]; }
         );
     }
 

--- a/test/dsl/expression.cpp
+++ b/test/dsl/expression.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/dsl/spatialOperator.cpp
+++ b/test/dsl/spatialOperator.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/dsl/temporalOperator.cpp
+++ b/test/dsl/temporalOperator.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/fields/CMakeLists.txt
+++ b/test/fields/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/test/fields/field.cpp
+++ b/test/fields/field.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/finiteVolume/CMakeLists.txt
+++ b/test/finiteVolume/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/test/finiteVolume/cellCentred/auxiliary/CMakeLists.txt
+++ b/test/finiteVolume/cellCentred/auxiliary/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/test/finiteVolume/cellCentred/auxiliary/coNum.cpp
+++ b/test/finiteVolume/cellCentred/auxiliary/coNum.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 NeoN authors
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/finiteVolume/cellCentred/boundary/CMakeLists.txt
+++ b/test/finiteVolume/cellCentred/boundary/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/test/finiteVolume/cellCentred/boundary/surface/CMakeLists.txt
+++ b/test/finiteVolume/cellCentred/boundary/surface/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/test/finiteVolume/cellCentred/boundary/surface/surfFixedValue.cpp
+++ b/test/finiteVolume/cellCentred/boundary/surface/surfFixedValue.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/finiteVolume/cellCentred/boundary/surface/surfSymmetry.cpp
+++ b/test/finiteVolume/cellCentred/boundary/surface/surfSymmetry.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/finiteVolume/cellCentred/boundary/volume/CMakeLists.txt
+++ b/test/finiteVolume/cellCentred/boundary/volume/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/test/finiteVolume/cellCentred/boundary/volume/volFixedGradient.cpp
+++ b/test/finiteVolume/cellCentred/boundary/volume/volFixedGradient.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/finiteVolume/cellCentred/boundary/volume/volFixedValue.cpp
+++ b/test/finiteVolume/cellCentred/boundary/volume/volFixedValue.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/finiteVolume/cellCentred/boundary/volume/volSymmetry.cpp
+++ b/test/finiteVolume/cellCentred/boundary/volume/volSymmetry.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/finiteVolume/cellCentred/faceNormalGradient/CMakeLists.txt
+++ b/test/finiteVolume/cellCentred/faceNormalGradient/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/test/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
+++ b/test/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
@@ -31,7 +31,7 @@ TEMPLATE_TEST_CASE("uncorrected", "[template]", NeoN::scalar, NeoN::Vec3)
     fvcc::VolumeField<TestType> phi(exec, "phi", mesh, volumeBCs);
     NeoN::parallelFor(
         phi.internalVector(),
-        KOKKOS_LAMBDA(const NeoN::localIdx i) { return scalar(i + 1) * one<TestType>(); }
+        NEON_LAMBDA(const NeoN::localIdx i) { return scalar(i + 1) * one<TestType>(); }
     );
     phi.boundaryData().value() =
         NeoN::Vector<TestType>(exec, {0.5 * one<TestType>(), 10.5 * one<TestType>()});

--- a/test/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
+++ b/test/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/finiteVolume/cellCentred/fields/CMakeLists.txt
+++ b/test/finiteVolume/cellCentred/fields/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/test/finiteVolume/cellCentred/fields/surfaceField.cpp
+++ b/test/finiteVolume/cellCentred/fields/surfaceField.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/finiteVolume/cellCentred/fields/volumeField.cpp
+++ b/test/finiteVolume/cellCentred/fields/volumeField.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/finiteVolume/cellCentred/interpolation/CMakeLists.txt
+++ b/test/finiteVolume/cellCentred/interpolation/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/test/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/test/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/finiteVolume/cellCentred/interpolation/surfaceInterpolation.cpp
+++ b/test/finiteVolume/cellCentred/interpolation/surfaceInterpolation.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/finiteVolume/cellCentred/interpolation/upwind.cpp
+++ b/test/finiteVolume/cellCentred/interpolation/upwind.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 NeoN authors
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/finiteVolume/cellCentred/operator/CMakeLists.txt
+++ b/test/finiteVolume/cellCentred/operator/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/test/finiteVolume/cellCentred/operator/common_operator.hpp
+++ b/test/finiteVolume/cellCentred/operator/common_operator.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 NeoN authors
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/finiteVolume/cellCentred/operator/common_operator.hpp
+++ b/test/finiteVolume/cellCentred/operator/common_operator.hpp
@@ -24,7 +24,7 @@ auto setup_operator_test(const UnstructuredMesh& mesh)
     parallelFor(
         exec,
         {mesh.nCells() - 1, mesh.nCells()},
-        KOKKOS_LAMBDA(const localIdx i) { boundFaceFlux[i] = -1.0; }
+        NEON_LAMBDA(const localIdx i) { boundFaceFlux[i] = -1.0; }
     );
 
     auto volumeBCs = fvcc::createCalculatedBCs<fvcc::VolumeBoundary<TestType>>(mesh);

--- a/test/finiteVolume/cellCentred/operator/gaussGreenDiv.cpp
+++ b/test/finiteVolume/cellCentred/operator/gaussGreenDiv.cpp
@@ -32,7 +32,7 @@ TEMPLATE_TEST_CASE("DivOperator", "[template]", NeoN::scalar, NeoN::Vec3)
     parallelFor(
         exec,
         {mesh.nCells() - 1, mesh.nCells()},
-        KOKKOS_LAMBDA(const localIdx i) { boundFaceFlux[i] = -1.0; }
+        NEON_LAMBDA(const localIdx i) { boundFaceFlux[i] = -1.0; }
     );
 
     auto volumeBCs = fvcc::createCalculatedBCs<fvcc::VolumeBoundary<TestType>>(mesh);

--- a/test/finiteVolume/cellCentred/operator/gaussGreenDiv.cpp
+++ b/test/finiteVolume/cellCentred/operator/gaussGreenDiv.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/finiteVolume/cellCentred/operator/laplacianOperator.cpp
+++ b/test/finiteVolume/cellCentred/operator/laplacianOperator.cpp
@@ -57,7 +57,7 @@ TEMPLATE_TEST_CASE("laplacianOperator fixedValue", "[template]", scalar, Vec3)
         auto phi = fvcc::VolumeField<TestType>(exec, "phi", mesh, bcs);
         parallelFor(
             phi.internalVector(),
-            KOKKOS_LAMBDA(const localIdx i) { return scalar(i + 1) * one<TestType>(); }
+            NEON_LAMBDA(const localIdx i) { return scalar(i + 1) * one<TestType>(); }
         );
         phi.correctBoundaryConditions();
 

--- a/test/finiteVolume/cellCentred/operator/laplacianOperator.cpp
+++ b/test/finiteVolume/cellCentred/operator/laplacianOperator.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/finiteVolume/cellCentred/operator/sourceTerm.cpp
+++ b/test/finiteVolume/cellCentred/operator/sourceTerm.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/linearAlgebra/CMakeLists.txt
+++ b/test/linearAlgebra/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/test/linearAlgebra/CSRMatrix.cpp
+++ b/test/linearAlgebra/CSRMatrix.cpp
@@ -70,7 +70,7 @@ TEMPLATE_TEST_CASE("CSRMatrix", "[template]", NeoN::scalar)
         parallelFor(
             exec,
             {0, 1},
-            KOKKOS_LAMBDA(const NeoN::localIdx) {
+            NEON_LAMBDA(const NeoN::localIdx) {
                 checkSparseView[0] = csrView.entry(0, 0);
                 checkSparseView[1] = csrView.entry(1, 1);
                 checkSparseView[2] = csrView.entry(1, 2);
@@ -91,7 +91,7 @@ TEMPLATE_TEST_CASE("CSRMatrix", "[template]", NeoN::scalar)
         parallelFor(
             exec,
             {0, 1},
-            KOKKOS_LAMBDA(const NeoN::localIdx) {
+            NEON_LAMBDA(const NeoN::localIdx) {
                 checkDenseView[0] = denseView.entry(0, 0);
                 checkDenseView[1] = denseView.entry(0, 1);
                 checkDenseView[2] = denseView.entry(0, 2);
@@ -122,7 +122,7 @@ TEMPLATE_TEST_CASE("CSRMatrix", "[template]", NeoN::scalar)
         parallelFor(
             exec,
             {0, 1},
-            KOKKOS_LAMBDA(const NeoN::localIdx) {
+            NEON_LAMBDA(const NeoN::localIdx) {
                 csrView.entry(0, 0) = -1.0;
                 csrView.entry(1, 1) = -5.0;
                 csrView.entry(1, 2) = -6.0;
@@ -142,7 +142,7 @@ TEMPLATE_TEST_CASE("CSRMatrix", "[template]", NeoN::scalar)
         parallelFor(
             exec,
             {0, 1},
-            KOKKOS_LAMBDA(const NeoN::localIdx) {
+            NEON_LAMBDA(const NeoN::localIdx) {
                 denseView.entry(0, 0) = -1.0;
                 denseView.entry(0, 1) = -2.0;
                 denseView.entry(0, 2) = -3.0;
@@ -177,7 +177,7 @@ TEMPLATE_TEST_CASE("CSRMatrix", "[template]", NeoN::scalar)
         parallelFor(
             exec,
             {0, 1},
-            KOKKOS_LAMBDA(const NeoN::localIdx) {
+            NEON_LAMBDA(const NeoN::localIdx) {
                 checkSparseView[0] = csrView.entry(0);
                 checkSparseView[1] = csrView.entry(1);
                 checkSparseView[2] = csrView.entry(2);
@@ -197,7 +197,7 @@ TEMPLATE_TEST_CASE("CSRMatrix", "[template]", NeoN::scalar)
         parallelFor(
             exec,
             {0, 1},
-            KOKKOS_LAMBDA(const NeoN::localIdx) {
+            NEON_LAMBDA(const NeoN::localIdx) {
                 checkDenseView[0] = denseView.entry(0);
                 checkDenseView[1] = denseView.entry(1);
                 checkDenseView[2] = denseView.entry(2);
@@ -228,7 +228,7 @@ TEMPLATE_TEST_CASE("CSRMatrix", "[template]", NeoN::scalar)
         parallelFor(
             exec,
             {0, 1},
-            KOKKOS_LAMBDA(const NeoN::localIdx) {
+            NEON_LAMBDA(const NeoN::localIdx) {
                 csrView.entry(0) = -1.0;
                 csrView.entry(1) = -5.0;
                 csrView.entry(2) = -6.0;
@@ -249,7 +249,7 @@ TEMPLATE_TEST_CASE("CSRMatrix", "[template]", NeoN::scalar)
         parallelFor(
             exec,
             {0, 1},
-            KOKKOS_LAMBDA(const NeoN::localIdx) {
+            NEON_LAMBDA(const NeoN::localIdx) {
                 denseView.entry(0) = -1.0;
                 denseView.entry(1) = -2.0;
                 denseView.entry(2) = -3.0;
@@ -325,7 +325,7 @@ TEMPLATE_TEST_CASE("CSRMatrix", "[template]", NeoN::Vec3)
         parallelFor(
             exec,
             {0, 1},
-            KOKKOS_LAMBDA(const NeoN::localIdx) {
+            NEON_LAMBDA(const NeoN::localIdx) {
                 checkSparseView[0] = csrView.entry(0, 0);
                 checkSparseView[1] = csrView.entry(1, 1);
                 checkSparseView[2] = csrView.entry(1, 2);

--- a/test/linearAlgebra/CSRMatrix.cpp
+++ b/test/linearAlgebra/CSRMatrix.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/linearAlgebra/ginkgo.cpp
+++ b/test/linearAlgebra/ginkgo.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 NeoN authors
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/linearAlgebra/linearAlgebra.cpp
+++ b/test/linearAlgebra/linearAlgebra.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/linearAlgebra/linearSystem.cpp
+++ b/test/linearAlgebra/linearSystem.cpp
@@ -90,14 +90,14 @@ TEMPLATE_TEST_CASE("LinearSystem", "[template]", NeoN::scalar)
         parallelFor(
             exec,
             {0, lsView.matrix.values.size()},
-            KOKKOS_LAMBDA(const localIdx i) { lsView.matrix.values[i] = -lsView.matrix.values[i]; }
+            NEON_LAMBDA(const localIdx i) { lsView.matrix.values[i] = -lsView.matrix.values[i]; }
         );
 
         // Modify values.
         parallelFor(
             exec,
             {0, lsView.rhs.size()},
-            KOKKOS_LAMBDA(const localIdx i) { lsView.rhs[i] = -lsView.rhs[i]; }
+            NEON_LAMBDA(const localIdx i) { lsView.rhs[i] = -lsView.rhs[i]; }
         );
 
         // Check modification.

--- a/test/linearAlgebra/linearSystem.cpp
+++ b/test/linearAlgebra/linearSystem.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/linearAlgebra/petsc.cpp
+++ b/test/linearAlgebra/petsc.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/linearAlgebra/sparsityPattern.cpp
+++ b/test/linearAlgebra/sparsityPattern.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/linearAlgebra/utilities.cpp
+++ b/test/linearAlgebra/utilities.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/mesh/CMakeLists.txt
+++ b/test/mesh/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/test/mesh/unstructured/CMakeLists.txt
+++ b/test/mesh/unstructured/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/test/mesh/unstructured/communicator.cpp
+++ b/test/mesh/unstructured/communicator.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/mesh/unstructured/unstructuredMesh.cpp
+++ b/test/mesh/unstructured/unstructuredMesh.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 - 2025 NeoN authors
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/test/timeIntegration/CMakeLists.txt
+++ b/test/timeIntegration/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 NeoN authors
+# SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 #
 # SPDX-License-Identifier: Unlicense
 

--- a/test/timeIntegration/ddtFluxCorr.cpp
+++ b/test/timeIntegration/ddtFluxCorr.cpp
@@ -103,7 +103,7 @@ TEST_CASE("timeIntegration: ddtPhiCorr on single-cell mesh", "[timeIntegration][
             NeoN::parallelFor(
                 exec,
                 {size_t(0), mesh.nFaces()},
-                KOKKOS_LAMBDA(const NeoN::localIdx i) { flux0V[i] = (sfV[i] & uf0V[i]); }
+                NEON_LAMBDA(const NeoN::localIdx i) { flux0V[i] = (sfV[i] & uf0V[i]); }
             );
 
             flux.internalVector() = flux0.internalVector();

--- a/test/timeIntegration/rungeKutta.cpp
+++ b/test/timeIntegration/rungeKutta.cpp
@@ -44,7 +44,7 @@ public:
         NeoN::parallelFor(
             source.exec(),
             source.range(),
-            KOKKOS_LAMBDA(const localIdx i) { sourceView[i] -= fieldData[i] * fieldData[i]; }
+            NEON_LAMBDA(const localIdx i) { sourceView[i] -= fieldData[i] * fieldData[i]; }
         );
     }
 


### PR DESCRIPTION
Third party libaries should not need to rely on implementation details. Thus in this PR a `NEON_LAMBDA` is added. For now it just forwards to `KOKKOS_LAMBDA` if `NEON_WITH_KOKKOS` is selected. Same for `Kokkos::atomic_add` and `Kokkos::atomic_sub`.
