### PR TITLE
Addition of multiple features required for SA-DDES turbulence model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add experimental umpire support [#455](https://github.com/exasim-project/NeoN/pull/455)
 - Add python bindings via nanobind [#382](https://github.com/exasim-project/NeoN/pull/382)
 - Correct the Ginkgo version to 2.0.0 (unreleased) [#493](https://github.com/exasim-project/NeoN/pull/493)
+- Add tensor and symmTensor primitives, Su type sourceTerm and passing of fields to BCs [#428](https://github.com/exasim-project/NeoN/pull/428)
 
 ### Misc
 - Bump Ginkgo to 1.11 and Kokkos 4.7.01 [#409](https://github.com/exasim-project/NeoN/pull/409)

--- a/_typos.toml
+++ b/_typos.toml
@@ -7,3 +7,5 @@ extend-exclude = ["third_party/*", "doc/Doxyfile.in"]
 
 [default.extend-words]
 nd = "nd"
+ilda = "ilda"
+tilda = "tilda"

--- a/include/NeoN/core/macros.hpp
+++ b/include/NeoN/core/macros.hpp
@@ -5,6 +5,8 @@
 #pragma once
 
 #include "NeoN/core/primitives/vec3.hpp"
+#include "NeoN/core/primitives/tensor.hpp"
+#include "NeoN/core/primitives/symmTensor.hpp"
 
 /* @brief given a c macro the macro gets called for all regularly used integer types
  * this is used to instantiate templates for our container types
@@ -29,4 +31,6 @@
  */
 #define NN_FOR_ALL_VALUE_TYPES(_macro)                                                             \
     NN_FOR_ALL_SCALAR_TYPES(_macro);                                                               \
-    _macro(Vec3)
+    _macro(Vec3);                                                                                  \
+    _macro(Tensor);                                                                                \
+    _macro(SymmTensor)

--- a/include/NeoN/core/primitives/symmTensor.hpp
+++ b/include/NeoN/core/primitives/symmTensor.hpp
@@ -1,0 +1,289 @@
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <Kokkos_Core.hpp> // IWYU pragma: keep
+
+#include "NeoN/core/primitives/scalar.hpp"
+#include "NeoN/core/primitives/vec3.hpp"
+#include "NeoN/core/primitives/tensor.hpp"
+#include "NeoN/core/primitives/traits.hpp"
+
+
+namespace NeoN
+{
+
+
+/**
+ * @class SymmTensor
+ * @brief A class for the representation of a symmetric 3x3 tensor
+ * @ingroup primitives
+ *
+ * Upper-triangle storage order: [xx, xy, xz, yy, yz, zz]
+ * i.e. data_[0]=xx, data_[1]=xy, data_[2]=xz, data_[3]=yy, data_[4]=yz, data_[5]=zz.
+ */
+class SymmTensor
+{
+public:
+
+    KOKKOS_INLINE_FUNCTION
+    SymmTensor()
+    {
+        for (int k = 0; k < 6; ++k)
+        {
+            data_[k] = 0.0;
+        }
+    }
+
+    /** @brief Construct scalar-times-identity symmetric tensor */
+    KOKKOS_INLINE_FUNCTION
+    explicit SymmTensor(const scalar diag)
+    {
+        data_[0] = diag; // xx
+        data_[1] = 0.0;  // xy
+        data_[2] = 0.0;  // xz
+        data_[3] = diag; // yy
+        data_[4] = 0.0;  // yz
+        data_[5] = diag; // zz
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    SymmTensor(scalar xx, scalar xy, scalar xz, scalar yy, scalar yz, scalar zz)
+    {
+        data_[0] = xx;
+        data_[1] = xy;
+        data_[2] = xz;
+        data_[3] = yy;
+        data_[4] = yz;
+        data_[5] = zz;
+    }
+
+    KOKKOS_INLINE_FUNCTION scalar* data() { return data_; }
+    KOKKOS_INLINE_FUNCTION const scalar* data() const { return data_; }
+
+    KOKKOS_INLINE_FUNCTION constexpr size_t size() const { return 6; }
+
+    /** @brief Component access — maps (i,j) to the stored upper-triangle */
+    KOKKOS_INLINE_FUNCTION
+    scalar operator()(const size_t i, const size_t j) const
+    {
+        // index map: (0,0)->0, (0,1)->1, (0,2)->2, (1,1)->3, (1,2)->4, (2,2)->5
+        // symmetric: (1,0)->(0,1), (2,0)->(0,2), (2,1)->(1,2)
+        static constexpr int lut[3][3] = {{0, 1, 2}, {1, 3, 4}, {2, 4, 5}};
+        return data_[lut[i][j]];
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    scalar& operator()(const size_t i, const size_t j)
+    {
+        static constexpr int lut[3][3] = {{0, 1, 2}, {1, 3, 4}, {2, 4, 5}};
+        return data_[lut[i][j]];
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    bool operator==(const SymmTensor& rhs) const
+    {
+        for (int k = 0; k < 6; ++k)
+        {
+            if (data_[k] != rhs.data_[k]) return false;
+        }
+        return true;
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    SymmTensor operator+(const SymmTensor& rhs) const
+    {
+        SymmTensor res;
+        for (int k = 0; k < 6; ++k)
+        {
+            res.data_[k] = data_[k] + rhs.data_[k];
+        }
+        return res;
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    SymmTensor& operator+=(const SymmTensor& rhs)
+    {
+        for (int k = 0; k < 6; ++k)
+        {
+            data_[k] += rhs.data_[k];
+        }
+        return *this;
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    SymmTensor operator-(const SymmTensor& rhs) const
+    {
+        SymmTensor res;
+        for (int k = 0; k < 6; ++k)
+        {
+            res.data_[k] = data_[k] - rhs.data_[k];
+        }
+        return res;
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    SymmTensor& operator-=(const SymmTensor& rhs)
+    {
+        for (int k = 0; k < 6; ++k)
+        {
+            data_[k] -= rhs.data_[k];
+        }
+        return *this;
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    SymmTensor operator*(const scalar s) const
+    {
+        SymmTensor res;
+        for (int k = 0; k < 6; ++k)
+        {
+            res.data_[k] = data_[k] * s;
+        }
+        return res;
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    SymmTensor& operator*=(const scalar s)
+    {
+        for (int k = 0; k < 6; ++k)
+        {
+            data_[k] *= s;
+        }
+        return *this;
+    }
+
+    /** @brief Trace: xx + yy + zz */
+    KOKKOS_INLINE_FUNCTION
+    scalar trace() const { return data_[0] + data_[3] + data_[5]; }
+
+    /** @brief Deviatoric part: S - (1/3)*tr(S)*I */
+    KOKKOS_INLINE_FUNCTION
+    SymmTensor dev() const
+    {
+        const scalar tr3 = trace() / scalar(3);
+        return SymmTensor(
+            data_[0] - tr3, data_[1], data_[2], data_[3] - tr3, data_[4], data_[5] - tr3
+        );
+    }
+
+    /** @brief dev2: S - (2/3)*tr(S)*I  (used in viscous stress) */
+    KOKKOS_INLINE_FUNCTION
+    SymmTensor dev2() const
+    {
+        const scalar tr23 = scalar(2.0 / 3.0) * trace();
+        return SymmTensor(
+            data_[0] - tr23, data_[1], data_[2], data_[3] - tr23, data_[4], data_[5] - tr23
+        );
+    }
+
+private:
+
+    scalar data_[6];
+};
+
+
+KOKKOS_INLINE_FUNCTION
+SymmTensor operator*(const scalar s, const SymmTensor& st) { return st * s; }
+
+/** @brief Symmetric matrix-vector product S·v */
+KOKKOS_INLINE_FUNCTION
+Vec3 operator&(const SymmTensor& s, const Vec3& v)
+{
+    return Vec3(
+        s(0, 0) * v[0] + s(0, 1) * v[1] + s(0, 2) * v[2],
+        s(1, 0) * v[0] + s(1, 1) * v[1] + s(1, 2) * v[2],
+        s(2, 0) * v[0] + s(2, 1) * v[1] + s(2, 2) * v[2]
+    );
+}
+
+/** @brief Frobenius norm */
+KOKKOS_INLINE_FUNCTION
+scalar mag(const SymmTensor& s)
+{
+    // off-diagonal entries appear twice
+    return sqrt(
+        s(0, 0) * s(0, 0) + s(1, 1) * s(1, 1) + s(2, 2) * s(2, 2)
+        + scalar(2) * (s(0, 1) * s(0, 1) + s(0, 2) * s(0, 2) + s(1, 2) * s(1, 2))
+    );
+}
+
+/** @brief Frobenius norm squared */
+KOKKOS_INLINE_FUNCTION
+scalar magSqr(const SymmTensor& s)
+{
+    return s(0, 0) * s(0, 0) + s(1, 1) * s(1, 1) + s(2, 2) * s(2, 2)
+         + scalar(2) * (s(0, 1) * s(0, 1) + s(0, 2) * s(0, 2) + s(1, 2) * s(1, 2));
+}
+
+/** @brief Symmetric part of a full tensor: ½(T + T^T) */
+KOKKOS_INLINE_FUNCTION
+SymmTensor symm(const Tensor& t)
+{
+    return SymmTensor(
+        t(0, 0),
+        scalar(0.5) * (t(0, 1) + t(1, 0)),
+        scalar(0.5) * (t(0, 2) + t(2, 0)),
+        t(1, 1),
+        scalar(0.5) * (t(1, 2) + t(2, 1)),
+        t(2, 2)
+    );
+}
+
+/** @brief T + T^T (= 2*symm(T)) as a full tensor */
+KOKKOS_INLINE_FUNCTION
+Tensor twoSymm(const Tensor& t)
+{
+    return Tensor(
+        scalar(2) * t(0, 0),
+        t(0, 1) + t(1, 0),
+        t(0, 2) + t(2, 0),
+        t(1, 0) + t(0, 1),
+        scalar(2) * t(1, 1),
+        t(1, 2) + t(2, 1),
+        t(2, 0) + t(0, 2),
+        t(2, 1) + t(1, 2),
+        scalar(2) * t(2, 2)
+    );
+}
+
+/** @brief T + T^T - (2/3)*tr(T)*I — used for viscous stress */
+KOKKOS_INLINE_FUNCTION
+SymmTensor devTwoSymm(const Tensor& t)
+{
+    const scalar sph = (scalar(2) / scalar(3)) * (t(0, 0) + t(1, 1) + t(2, 2));
+    return SymmTensor(
+        scalar(2) * t(0, 0) - sph,
+        t(0, 1) + t(1, 0),
+        t(0, 2) + t(2, 0),
+        scalar(2) * t(1, 1) - sph,
+        t(1, 2) + t(2, 1),
+        scalar(2) * t(2, 2) - sph
+    );
+}
+
+std::ostream& operator<<(std::ostream& out, const SymmTensor& s);
+
+
+template<>
+KOKKOS_INLINE_FUNCTION SymmTensor zero<SymmTensor>()
+{
+    return SymmTensor(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+}
+
+template<>
+KOKKOS_INLINE_FUNCTION SymmTensor one<SymmTensor>()
+{
+    return SymmTensor(scalar(1));
+}
+
+template<>
+KOKKOS_INLINE_FUNCTION SymmTensor inv<SymmTensor>(SymmTensor)
+{
+    return SymmTensor(scalar(1));
+}
+
+
+} // namespace NeoN

--- a/include/NeoN/core/primitives/tensor.hpp
+++ b/include/NeoN/core/primitives/tensor.hpp
@@ -1,7 +1,251 @@
-// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
 //
 // SPDX-License-Identifier: MIT
 
 #pragma once
 
-#include "scalar.hpp"
+#include <Kokkos_Core.hpp> // IWYU pragma: keep
+
+#include "NeoN/core/primitives/scalar.hpp"
+#include "NeoN/core/primitives/vec3.hpp"
+#include "NeoN/core/primitives/traits.hpp"
+
+
+namespace NeoN
+{
+
+
+/**
+ * @class Tensor
+ * @brief A class for the representation of a 3x3 tensor
+ * @ingroup primitives
+ *
+ * Row-major storage: component (i,j) is at data_[3*i+j].
+ */
+class Tensor
+{
+public:
+
+    KOKKOS_INLINE_FUNCTION
+    Tensor()
+    {
+        for (int k = 0; k < 9; ++k)
+        {
+            data_[k] = 0.0;
+        }
+    }
+
+    /** @brief Construct scalar-times-identity tensor */
+    KOKKOS_INLINE_FUNCTION
+    explicit Tensor(const scalar diag)
+    {
+        for (int k = 0; k < 9; ++k)
+        {
+            data_[k] = 0.0;
+        }
+        data_[0] = diag;
+        data_[4] = diag;
+        data_[8] = diag;
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    Tensor(
+        scalar t00,
+        scalar t01,
+        scalar t02,
+        scalar t10,
+        scalar t11,
+        scalar t12,
+        scalar t20,
+        scalar t21,
+        scalar t22
+    )
+    {
+        data_[0] = t00;
+        data_[1] = t01;
+        data_[2] = t02;
+        data_[3] = t10;
+        data_[4] = t11;
+        data_[5] = t12;
+        data_[6] = t20;
+        data_[7] = t21;
+        data_[8] = t22;
+    }
+
+    KOKKOS_INLINE_FUNCTION scalar* data() { return data_; }
+    KOKKOS_INLINE_FUNCTION const scalar* data() const { return data_; }
+
+    constexpr size_t size() const { return 9; }
+
+    KOKKOS_INLINE_FUNCTION
+    scalar& operator()(const size_t i, const size_t j) { return data_[3 * i + j]; }
+
+    KOKKOS_INLINE_FUNCTION
+    scalar operator()(const size_t i, const size_t j) const { return data_[3 * i + j]; }
+
+    KOKKOS_INLINE_FUNCTION
+    bool operator==(const Tensor& rhs) const
+    {
+        for (int k = 0; k < 9; ++k)
+        {
+            if (data_[k] != rhs.data_[k]) return false;
+        }
+        return true;
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    Tensor operator+(const Tensor& rhs) const
+    {
+        Tensor res;
+        for (int k = 0; k < 9; ++k)
+        {
+            res.data_[k] = data_[k] + rhs.data_[k];
+        }
+        return res;
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    Tensor& operator+=(const Tensor& rhs)
+    {
+        for (int k = 0; k < 9; ++k)
+        {
+            data_[k] += rhs.data_[k];
+        }
+        return *this;
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    Tensor operator-(const Tensor& rhs) const
+    {
+        Tensor res;
+        for (int k = 0; k < 9; ++k)
+        {
+            res.data_[k] = data_[k] - rhs.data_[k];
+        }
+        return res;
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    Tensor& operator-=(const Tensor& rhs)
+    {
+        for (int k = 0; k < 9; ++k)
+        {
+            data_[k] -= rhs.data_[k];
+        }
+        return *this;
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    Tensor operator*(const scalar s) const
+    {
+        Tensor res;
+        for (int k = 0; k < 9; ++k)
+        {
+            res.data_[k] = data_[k] * s;
+        }
+        return res;
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    Tensor& operator*=(const scalar s)
+    {
+        for (int k = 0; k < 9; ++k)
+        {
+            data_[k] *= s;
+        }
+        return *this;
+    }
+
+    /** @brief Trace: sum of diagonal components */
+    KOKKOS_INLINE_FUNCTION
+    scalar trace() const { return data_[0] + data_[4] + data_[8]; }
+
+    /** @brief Transpose */
+    KOKKOS_INLINE_FUNCTION
+    Tensor T() const
+    {
+        return Tensor(
+            data_[0], data_[3], data_[6], data_[1], data_[4], data_[7], data_[2], data_[5], data_[8]
+        );
+    }
+
+private:
+
+    scalar data_[9];
+};
+
+
+KOKKOS_INLINE_FUNCTION
+Tensor operator*(const scalar s, const Tensor& t) { return t * s; }
+
+/** @brief Matrix-vector product T·v */
+KOKKOS_INLINE_FUNCTION
+Vec3 operator&(const Tensor& t, const Vec3& v)
+{
+    return Vec3(
+        t(0, 0) * v[0] + t(0, 1) * v[1] + t(0, 2) * v[2],
+        t(1, 0) * v[0] + t(1, 1) * v[1] + t(1, 2) * v[2],
+        t(2, 0) * v[0] + t(2, 1) * v[1] + t(2, 2) * v[2]
+    );
+}
+
+/** @brief Row-vector times matrix v·T */
+KOKKOS_INLINE_FUNCTION
+Vec3 operator&(const Vec3& v, const Tensor& t)
+{
+    return Vec3(
+        v[0] * t(0, 0) + v[1] * t(1, 0) + v[2] * t(2, 0),
+        v[0] * t(0, 1) + v[1] * t(1, 1) + v[2] * t(2, 1),
+        v[0] * t(0, 2) + v[1] * t(1, 2) + v[2] * t(2, 2)
+    );
+}
+
+/** @brief Frobenius norm */
+KOKKOS_INLINE_FUNCTION
+scalar mag(const Tensor& t)
+{
+    scalar s = 0;
+    for (int k = 0; k < 9; ++k)
+    {
+        s += t.data()[k] * t.data()[k];
+    }
+    return sqrt(s);
+}
+
+/** @brief Frobenius norm squared */
+KOKKOS_INLINE_FUNCTION
+scalar magSqr(const Tensor& t)
+{
+    scalar s = 0;
+    const scalar* d = t.data();
+    for (int k = 0; k < 9; ++k)
+    {
+        s += d[k] * d[k];
+    }
+    return s;
+}
+
+std::ostream& operator<<(std::ostream& out, const Tensor& t);
+
+
+template<>
+KOKKOS_INLINE_FUNCTION Tensor zero<Tensor>()
+{
+    return Tensor(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+}
+
+template<>
+KOKKOS_INLINE_FUNCTION Tensor one<Tensor>()
+{
+    return Tensor(scalar(1));
+}
+
+template<>
+KOKKOS_INLINE_FUNCTION Tensor inv<Tensor>(Tensor)
+{
+    // Placeholder — matrix inverse not needed for field arithmetic
+    return Tensor(scalar(1));
+}
+
+
+} // namespace NeoN

--- a/include/NeoN/core/primitives/tensor.hpp
+++ b/include/NeoN/core/primitives/tensor.hpp
@@ -162,7 +162,7 @@ public:
 
     /** @brief Transpose */
     KOKKOS_INLINE_FUNCTION
-    Tensor T() const
+    Tensor T() const // NOLINT
     {
         return Tensor(
             data_[0], data_[3], data_[6], data_[1], data_[4], data_[7], data_[2], data_[5], data_[8]

--- a/include/NeoN/dsl/explicit.hpp
+++ b/include/NeoN/dsl/explicit.hpp
@@ -9,7 +9,7 @@
 #include "NeoN/dsl/spatialOperator.hpp"
 #include "NeoN/dsl/temporalOperator.hpp"
 #include "NeoN/dsl/ddt.hpp"
-
+#include "NeoN/finiteVolume/cellCentred/fields/surfaceField.hpp"
 // TODO: decouple from fvcc
 #include "NeoN/finiteVolume/cellCentred/fields/volumeField.hpp"
 #include "NeoN/finiteVolume/cellCentred/operators/ddtOperator.hpp"
@@ -58,5 +58,11 @@ laplacian(const fvcc::SurfaceField<scalar>& gamma, fvcc::VolumeField<ValueType>&
 }
 
 SpatialOperator<Vec3> grad(const fvcc::VolumeField<scalar>& phi);
+
+template<typename ValueType>
+SpatialOperator<ValueType> source(fvcc::VolumeField<ValueType>& coeff)
+{
+    return SpatialOperator<ValueType>(fvcc::SourceTerm(dsl::Operator::Type::Explicit, coeff));
+}
 
 } // namespace NeoN

--- a/include/NeoN/finiteVolume/cellCentred/boundary.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary.hpp
@@ -5,6 +5,8 @@
 #pragma once
 
 #include "NeoN/core/dictionary.hpp"
+#include "NeoN/core/primitives/tensor.hpp"
+#include "NeoN/core/primitives/symmTensor.hpp"
 #include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
 
 #include "boundary/volume/empty.hpp"
@@ -62,6 +64,8 @@ namespace fvcc = finiteVolume::cellCentred;
 
 template class fvcc::VolumeBoundaryFactory<scalar>;
 template class fvcc::VolumeBoundaryFactory<Vec3>;
+template class fvcc::VolumeBoundaryFactory<Tensor>;
+template class fvcc::VolumeBoundaryFactory<SymmTensor>;
 
 template class fvcc::volumeBoundary::FixedValue<scalar>;
 template class fvcc::volumeBoundary::FixedValue<Vec3>;
@@ -71,6 +75,8 @@ template class fvcc::volumeBoundary::FixedGradient<Vec3>;
 
 template class fvcc::volumeBoundary::Calculated<scalar>;
 template class fvcc::volumeBoundary::Calculated<Vec3>;
+template class fvcc::volumeBoundary::Calculated<Tensor>;
+template class fvcc::volumeBoundary::Calculated<SymmTensor>;
 
 template class fvcc::volumeBoundary::Extrapolated<scalar>;
 template class fvcc::volumeBoundary::Extrapolated<Vec3>;
@@ -83,12 +89,16 @@ template class fvcc::volumeBoundary::Symmetry<Vec3>;
 
 template class fvcc::SurfaceBoundaryFactory<scalar>;
 template class fvcc::SurfaceBoundaryFactory<Vec3>;
+template class fvcc::SurfaceBoundaryFactory<Tensor>;
+template class fvcc::SurfaceBoundaryFactory<SymmTensor>;
 
 template class fvcc::surfaceBoundary::FixedValue<scalar>;
 template class fvcc::surfaceBoundary::FixedValue<Vec3>;
 
 template class fvcc::surfaceBoundary::Calculated<scalar>;
 template class fvcc::surfaceBoundary::Calculated<Vec3>;
+template class fvcc::surfaceBoundary::Calculated<Tensor>;
+template class fvcc::surfaceBoundary::Calculated<SymmTensor>;
 
 template class fvcc::surfaceBoundary::Empty<scalar>;
 template class fvcc::surfaceBoundary::Empty<Vec3>;

--- a/include/NeoN/finiteVolume/cellCentred/boundary/boundaryContext.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/boundaryContext.hpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+
+#include "NeoN/core/primitives/scalar.hpp"
+#include "NeoN/core/primitives/vec3.hpp"
+#include "NeoN/core/primitives/tensor.hpp"
+
+namespace NeoN::finiteVolume::cellCentred
+{
+
+template<typename ValueType>
+class VolumeField;
+
+/**
+ * @class BoundaryContext
+ * @brief Carries named field references for wall-function boundary conditions.
+ *
+ * Wall functions that need auxiliary fields (U, nu, nearWallDist, omega, k …)
+ * look up what they need by name instead of accepting a fixed argument list.
+ * All fields are stored as non-owning const pointers; the caller is responsible
+ * for ensuring the lifetime of the referenced fields exceeds the context.
+ */
+class BoundaryContext
+{
+public:
+
+    void insert(std::string name, const VolumeField<scalar>& f);
+    void insert(std::string name, const VolumeField<Vec3>& f);
+    void insert(std::string name, const VolumeField<Tensor>& f);
+
+    const VolumeField<scalar>& scalar(const std::string& name) const;
+    const VolumeField<Vec3>& vector(const std::string& name) const;
+    const VolumeField<Tensor>& tensor(const std::string& name) const;
+
+    bool hasScalar(const std::string& name) const noexcept;
+    bool hasVector(const std::string& name) const noexcept;
+    bool hasTensor(const std::string& name) const noexcept;
+
+private:
+
+    std::unordered_map<std::string, const VolumeField<NeoN::scalar>*> scalarFields_;
+    std::unordered_map<std::string, const VolumeField<Vec3>*> vectorFields_;
+    std::unordered_map<std::string, const VolumeField<Tensor>*> tensorFields_;
+};
+
+} // namespace NeoN::finiteVolume::cellCentred

--- a/include/NeoN/finiteVolume/cellCentred/boundary/boundaryContext.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/boundaryContext.hpp
@@ -35,9 +35,9 @@ public:
     void insert(std::string name, const VolumeField<Vec3>& f);
     void insert(std::string name, const VolumeField<Tensor>& f);
 
-    const VolumeField<scalar>& scalar(const std::string& name) const;
-    const VolumeField<Vec3>& vector(const std::string& name) const;
-    const VolumeField<Tensor>& tensor(const std::string& name) const;
+    const VolumeField<scalar>& scalarFieldPtr(const std::string& name) const;
+    const VolumeField<Vec3>& vectorFieldPtr(const std::string& name) const;
+    const VolumeField<Tensor>& tensorFieldPtr(const std::string& name) const;
 
     bool hasScalar(const std::string& name) const noexcept;
     bool hasVector(const std::string& name) const noexcept;

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/calculated.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/calculated.hpp
@@ -19,6 +19,8 @@ class Calculated : public VolumeBoundaryFactory<ValueType>::template Register<Ca
 
 public:
 
+    using Base::correctBoundaryCondition;
+
     using CalculatedType = Calculated<ValueType>;
 
     Calculated(const UnstructuredMesh& mesh, const Dictionary& dict, localIdx patchID)

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/empty.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/empty.hpp
@@ -19,6 +19,8 @@ class Empty : public VolumeBoundaryFactory<ValueType>::template Register<Empty<V
 
 public:
 
+    using Base::correctBoundaryCondition;
+
     Empty(const UnstructuredMesh& mesh, const Dictionary& dict, localIdx patchID)
         : Base(mesh, dict, patchID, {.assignable = true, .fixesValue = false})
     {}

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/extrapolated.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/extrapolated.hpp
@@ -62,6 +62,8 @@ class Extrapolated :
 
 public:
 
+    using Base::correctBoundaryCondition;
+
     using ExtrapolatedType = Extrapolated<ValueType>;
 
     Extrapolated(const UnstructuredMesh& mesh, const Dictionary& dict, localIdx patchID)

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedGradient.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedGradient.hpp
@@ -63,6 +63,8 @@ class FixedGradient :
 
 public:
 
+    using Base::correctBoundaryCondition;
+
     using FixedGradientType = FixedGradient<ValueType>;
 
     FixedGradient(const UnstructuredMesh& mesh, const Dictionary& dict, localIdx patchID)

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedValue.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedValue.hpp
@@ -53,6 +53,8 @@ class FixedValue : public VolumeBoundaryFactory<ValueType>::template Register<Fi
 
 public:
 
+    using Base::correctBoundaryCondition;
+
     FixedValue(const UnstructuredMesh& mesh, const Dictionary& dict, localIdx patchID)
         : Base(mesh, dict, patchID, {.assignable = false, .fixesValue = true}),
           fixedValue_(dict.get<ValueType>("fixedValue"))

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/symmetry.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/symmetry.hpp
@@ -110,6 +110,8 @@ class Symmetry : public VolumeBoundaryFactory<ValueType>::template Register<Symm
 
 public:
 
+    using Base::correctBoundaryCondition;
+
     using SymmetryType = Symmetry<ValueType>;
 
     Symmetry(const UnstructuredMesh& mesh, const Dictionary& dict, localIdx patchID)

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp
@@ -14,6 +14,11 @@
 namespace NeoN::finiteVolume::cellCentred
 {
 
+template<typename ValueType>
+class VolumeField;
+
+class BoundaryContext;
+
 /* collects attributes of a boundary for simple queries
  *
  */
@@ -45,6 +50,11 @@ public:
     virtual ~VolumeBoundaryFactory() = default;
 
     virtual void correctBoundaryCondition(Field<ValueType>& domainVector) = 0;
+
+    virtual void correctBoundaryCondition(Field<ValueType>& domainVector, const BoundaryContext&)
+    {
+        correctBoundaryCondition(domainVector);
+    }
 
     virtual std::unique_ptr<VolumeBoundaryFactory> clone() const = 0;
 
@@ -85,6 +95,12 @@ public:
     virtual void correctBoundaryCondition(Field<ValueType>& domainVector)
     {
         boundaryCorrectionStrategy_->correctBoundaryCondition(domainVector);
+    }
+
+    virtual void
+    correctBoundaryCondition(Field<ValueType>& domainVector, const BoundaryContext& ctx)
+    {
+        boundaryCorrectionStrategy_->correctBoundaryCondition(domainVector, ctx);
     }
 
     const BoundaryAttributes attributes() const

--- a/include/NeoN/finiteVolume/cellCentred/fields/surfaceField.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/fields/surfaceField.hpp
@@ -164,6 +164,7 @@ operator*(const SurfaceField<scalar>& lhs, const SurfaceField<scalar>& rhs)
     result.boundaryData().value() *= rhs.boundaryData().value();
     return result;
 }
+
 inline SurfaceField<scalar>
 operator+(const SurfaceField<scalar>& lhs, const SurfaceField<scalar>& rhs)
 {

--- a/include/NeoN/finiteVolume/cellCentred/fields/volumeField.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/fields/volumeField.hpp
@@ -7,6 +7,7 @@
 #include "NeoN/core/database/database.hpp"
 #include "NeoN/finiteVolume/cellCentred/fields/domain.hpp"
 #include "NeoN/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp"
+#include "NeoN/finiteVolume/cellCentred/boundary/boundaryContext.hpp"
 #include "NeoN/core/database/fieldDatabase.hpp"
 
 #include <vector>
@@ -121,6 +122,8 @@ public:
      */
     void correctBoundaryConditions();
 
+    void correctBoundaryConditions(const BoundaryContext& ctx);
+
     std::vector<VolumeBoundary<ValueType>> boundaryConditions() const
     {
         return boundaryConditions_;
@@ -131,5 +134,4 @@ private:
     std::vector<VolumeBoundary<ValueType>> boundaryConditions_; // The vector of boundary conditions
     std::optional<Database*> db_; // The optional pointer to the database
 };
-
 } // namespace NeoN

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "NeoN/core/executor/executor.hpp"
+#include "NeoN/core/primitives/tensor.hpp"
 #include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
 #include "NeoN/finiteVolume/cellCentred/operators/gradOperator.hpp"
 #include "NeoN/finiteVolume/cellCentred/fields/volumeField.hpp"
@@ -49,14 +50,14 @@ public:
     /* @brief compute grad
      *
      * @param phi [in] - field for which the gradient is computed
-     * @param operatorScaling [in] - scales operator by a coefficient
      * @param gradPhi [in,out] - resulting gradient field
+     * @param operatorScaling [in] - scales operator by a coefficient
      */
-    virtual void
-    grad(const VolumeField<scalar>& phi, const dsl::Coeff coeff, VolumeField<Vec3>& in) const
-    {
-        grad(phi, coeff, in.internalVector());
-    }
+    virtual void grad(
+        const VolumeField<scalar>& phi,
+        VolumeField<Vec3>& gradPhi,
+        const dsl::Coeff operatorScaling = dsl::Coeff {}
+    ) const;
 
     /* @brief compute explicit gradient operator and return result
      *
@@ -68,6 +69,15 @@ public:
         const VolumeField<scalar>& phi, const dsl::Coeff operatorScaling = dsl::Coeff {}
     ) const override;
 
+    void gradTensor(
+        const VolumeField<Vec3>& u,
+        VolumeField<Tensor>& gradU,
+        const dsl::Coeff operatorScaling = dsl::Coeff {}
+    ) const;
+
+    VolumeField<Tensor>
+    gradTensor(const VolumeField<Vec3>& u, const dsl::Coeff operatorScaling = dsl::Coeff {}) const;
+
     virtual std::unique_ptr<GradOperatorFactory<Vec3>> clone() const override
     {
         NF_ERROR_EXIT("Not implemented");
@@ -76,6 +86,7 @@ public:
 private:
 
     SurfaceInterpolation<scalar> surfaceInterpolation_;
+    SurfaceInterpolation<Vec3> surfaceInterpolationVec_;
 };
 
 } // namespace NeoN

--- a/include/NeoN/finiteVolume/cellCentred/operators/sourceTerm.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/sourceTerm.hpp
@@ -24,11 +24,15 @@ public:
 
     using VectorValueType = ValueType;
 
+    // Sp: source += scaling * coefficients * field  (implicit or explicit)
     SourceTerm(
         dsl::Operator::Type termType,
         const VolumeField<scalar>& coefficients,
         const VolumeField<ValueType>& field
     );
+
+    // Su: source += scaling * coefficients  (explicit only)
+    SourceTerm(dsl::Operator::Type termType, VolumeField<ValueType>& coefficients);
 
     ~SourceTerm();
 
@@ -42,8 +46,9 @@ public:
 
 private:
 
-    const VolumeField<scalar>& coefficients_;
+    // Non-null for Sp mode. Null for Su mode (field_ from mixin IS the coefficient).
+    const VolumeField<scalar>* spCoeff_;
 };
 
 
-} // namespace NeoN
+} // namespace NeoN::finiteVolume::cellCentred

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,8 @@ endif()
 target_sources(
   NeoN
   PRIVATE "core/primitives/vec3.cpp"
+          "core/primitives/tensor.cpp"
+          "core/primitives/symmTensor.cpp"
           "core/time.cpp"
           "core/vector/vector.cpp"
           "core/vector/vectorFreeFunctions.cpp"
@@ -46,6 +48,7 @@ target_sources(
           "finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp"
           "finiteVolume/cellCentred/stencil/cellToFaceStencil.cpp"
           "finiteVolume/cellCentred/boundary/boundary.cpp"
+          "finiteVolume/cellCentred/boundary/boundaryContext.cpp"
           "finiteVolume/cellCentred/operators/ddtOperator.cpp"
           "finiteVolume/cellCentred/fields/volumeField.cpp"
           "finiteVolume/cellCentred/operators/gaussGreenGrad.cpp"

--- a/src/bindings/dsl.cpp
+++ b/src/bindings/dsl.cpp
@@ -172,7 +172,12 @@ void registerDSL(nb::module_& m)
     exp_m.def("laplacian", &dsl::exp::laplacian<scalar>);
     exp_m.def("laplacian", &dsl::exp::laplacian<Vec3>);
     exp_m.def("grad", &dsl::exp::grad);
-    exp_m.def("source", &dsl::exp::source<scalar>);
+    exp_m.def("source", [](ScalarVolField& coeff) { return dsl::exp::source<scalar>(coeff); });
+    exp_m.def(
+        "source",
+        [](const ScalarVolField& coeff, const ScalarVolField& phi)
+        { return dsl::exp::source<scalar>(coeff, phi); }
+    );
 
     // solve
     m.def(

--- a/src/bindings/inputs.cpp
+++ b/src/bindings/inputs.cpp
@@ -32,7 +32,9 @@ void registerInputs(nb::module_& m)
             {
                 new (&self) NeoN::TokenList();
                 for (const auto& s : strings)
+                {
                     self.insert(std::any(s));
+                }
             },
             "strings"_a,
             "Create a TokenList from a Python list of strings (e.g. TokenList(['linear']))"

--- a/src/bindings/volumeField.cpp
+++ b/src/bindings/volumeField.cpp
@@ -125,7 +125,9 @@ void registerVolumeField(nb::module_& m)
         .def("size", &fvcc::VolumeField<NeoN::scalar>::size, "Get the field size")
         .def(
             "correct_boundary_conditions",
-            &fvcc::VolumeField<NeoN::scalar>::correctBoundaryConditions,
+            static_cast<void (fvcc::VolumeField<NeoN::scalar>::*)()>(
+                &fvcc::VolumeField<NeoN::scalar>::correctBoundaryConditions
+            ),
             "Apply boundary conditions"
         )
         .def("has_database", &fvcc::VolumeField<NeoN::scalar>::hasDatabase)
@@ -211,7 +213,11 @@ void registerVolumeField(nb::module_& m)
         .def("exec", &fvcc::VolumeField<NeoN::Vec3>::exec, nb::rv_policy::reference_internal)
         .def("size", &fvcc::VolumeField<NeoN::Vec3>::size)
         .def(
-            "correct_boundary_conditions", &fvcc::VolumeField<NeoN::Vec3>::correctBoundaryConditions
+            "correct_boundary_conditions",
+            static_cast<void (fvcc::VolumeField<NeoN::Vec3>::*)()>(
+                &fvcc::VolumeField<NeoN::Vec3>::correctBoundaryConditions
+            ),
+            "Apply boundary conditions"
         )
         .def("has_database", &fvcc::VolumeField<NeoN::Vec3>::hasDatabase)
         .def_rw("name", &fvcc::VolumeField<NeoN::Vec3>::name)

--- a/src/core/primitives/symmTensor.cpp
+++ b/src/core/primitives/symmTensor.cpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#include "NeoN/core/primitives/symmTensor.hpp"
+
+
+namespace NeoN
+{
+
+std::ostream& operator<<(std::ostream& os, const SymmTensor& s)
+{
+    os << "((" << s(0, 0) << " " << s(0, 1) << " " << s(0, 2) << ") (" << s(1, 0) << " " << s(1, 1)
+       << " " << s(1, 2) << ") (" << s(2, 0) << " " << s(2, 1) << " " << s(2, 2) << "))";
+    return os;
+}
+
+} // namespace NeoN

--- a/src/core/primitives/tensor.cpp
+++ b/src/core/primitives/tensor.cpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#include "NeoN/core/primitives/tensor.hpp"
+
+
+namespace NeoN
+{
+
+std::ostream& operator<<(std::ostream& os, const Tensor& t)
+{
+    os << "((" << t(0, 0) << " " << t(0, 1) << " " << t(0, 2) << ") (" << t(1, 0) << " " << t(1, 1)
+       << " " << t(1, 2) << ") (" << t(2, 0) << " " << t(2, 1) << " " << t(2, 2) << "))";
+    return os;
+}
+
+} // namespace NeoN

--- a/src/core/vector/vectorFreeFunctions.cpp
+++ b/src/core/vector/vectorFreeFunctions.cpp
@@ -7,6 +7,8 @@
 #include "NeoN/core/primitives/label.hpp"
 #include "NeoN/core/parallelAlgorithms.hpp"
 #include "NeoN/core/primitives/scalar.hpp"
+#include "NeoN/core/primitives/tensor.hpp"
+#include "NeoN/core/primitives/symmTensor.hpp"
 #include "NeoN/core/vector/vector.hpp"
 #include "NeoN/core/macros.hpp"
 #include "NeoN/core/view.hpp"
@@ -20,7 +22,7 @@ template<typename ValueType>
 void scalarMul(Vector<ValueType>& vect, const scalar value)
     requires requires(ValueType a, scalar b) { a* b; }
 {
-    if constexpr (std::is_same_v<ValueType, Vec3>)
+    if constexpr (std::is_same_v<ValueType, Vec3> || std::is_same_v<ValueType, Tensor> || std::is_same_v<ValueType, SymmTensor>)
     {
         auto viewA = vect.view();
         parallelFor(
@@ -153,6 +155,7 @@ template void setComponent<0>(const Vector<scalar>&, Vector<Vec3>&);
 template void setComponent<1>(const Vector<scalar>&, Vector<Vec3>&);
 template void setComponent<2>(const Vector<scalar>&, Vector<Vec3>&);
 
+
 // operator instantiation
 #define NN_VECTOR_OPERATOR_INSTANTIATION(Type)                                                     \
     /* free function operator with additional requirements  */                                     \
@@ -178,5 +181,16 @@ NN_FOR_ALL_INTEGER_TYPES(NN_VECTOR_OPERATOR_INSTANTIATION);
 NN_VECTOR_OPERATOR_INSTANTIATION(float);
 NN_VECTOR_OPERATOR_INSTANTIATION(double);
 NN_VECTOR_OPERATOR_INSTANTIATION_VEC3(Vec3);
+
+// Tensor types support +/-/scalarMul but not element-wise mul(Tensor,Tensor)
+#define NN_VECTOR_OPERATOR_INSTANTIATION_TENSOR(Type)                                              \
+    template void scalarMul<Type>(Vector<Type>&, const scalar);                                    \
+    template void add<Type>(Vector<Type>&, const std::type_identity_t<Type>&);                     \
+    template void add<Type>(Vector<Type>&, const Vector<std::type_identity_t<Type>>&);             \
+    template void sub<Type>(Vector<Type>&, const std::type_identity_t<Type>&);                     \
+    template void sub<Type>(Vector<Type>&, const Vector<std::type_identity_t<Type>>&);
+
+NN_VECTOR_OPERATOR_INSTANTIATION_TENSOR(Tensor);
+NN_VECTOR_OPERATOR_INSTANTIATION_TENSOR(SymmTensor);
 
 } // namespace NeoN

--- a/src/dsl/explicit.cpp
+++ b/src/dsl/explicit.cpp
@@ -20,4 +20,5 @@ SpatialOperator<NeoN::Vec3> grad(const fvcc::VolumeField<NeoN::scalar>& phi)
     );
 }
 
+
 } // namespace NeoN

--- a/src/finiteVolume/cellCentred/boundary/boundaryContext.cpp
+++ b/src/finiteVolume/cellCentred/boundary/boundaryContext.cpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#include "NeoN/finiteVolume/cellCentred/boundary/boundaryContext.hpp"
+#include "NeoN/finiteVolume/cellCentred/fields/volumeField.hpp"
+
+namespace NeoN::finiteVolume::cellCentred
+{
+
+void BoundaryContext::insert(std::string name, const VolumeField<NeoN::scalar>& f)
+{
+    scalarFields_.emplace(std::move(name), &f);
+}
+
+void BoundaryContext::insert(std::string name, const VolumeField<Vec3>& f)
+{
+    vectorFields_.emplace(std::move(name), &f);
+}
+
+void BoundaryContext::insert(std::string name, const VolumeField<Tensor>& f)
+{
+    tensorFields_.emplace(std::move(name), &f);
+}
+
+const VolumeField<NeoN::scalar>& BoundaryContext::scalar(const std::string& name) const
+{
+    return *scalarFields_.at(name);
+}
+
+const VolumeField<Vec3>& BoundaryContext::vector(const std::string& name) const
+{
+    return *vectorFields_.at(name);
+}
+
+const VolumeField<Tensor>& BoundaryContext::tensor(const std::string& name) const
+{
+    return *tensorFields_.at(name);
+}
+
+bool BoundaryContext::hasScalar(const std::string& name) const noexcept
+{
+    return scalarFields_.count(name) > 0;
+}
+
+bool BoundaryContext::hasVector(const std::string& name) const noexcept
+{
+    return vectorFields_.count(name) > 0;
+}
+
+bool BoundaryContext::hasTensor(const std::string& name) const noexcept
+{
+    return tensorFields_.count(name) > 0;
+}
+
+} // namespace NeoN::finiteVolume::cellCentred

--- a/src/finiteVolume/cellCentred/boundary/boundaryContext.cpp
+++ b/src/finiteVolume/cellCentred/boundary/boundaryContext.cpp
@@ -23,17 +23,17 @@ void BoundaryContext::insert(std::string name, const VolumeField<Tensor>& f)
     tensorFields_.emplace(std::move(name), &f);
 }
 
-const VolumeField<NeoN::scalar>& BoundaryContext::scalar(const std::string& name) const
+const VolumeField<NeoN::scalar>& BoundaryContext::scalarFieldPtr(const std::string& name) const
 {
     return *scalarFields_.at(name);
 }
 
-const VolumeField<Vec3>& BoundaryContext::vector(const std::string& name) const
+const VolumeField<Vec3>& BoundaryContext::vectorFieldPtr(const std::string& name) const
 {
     return *vectorFields_.at(name);
 }
 
-const VolumeField<Tensor>& BoundaryContext::tensor(const std::string& name) const
+const VolumeField<Tensor>& BoundaryContext::tensorFieldPtr(const std::string& name) const
 {
     return *tensorFields_.at(name);
 }

--- a/src/finiteVolume/cellCentred/fields/volumeField.cpp
+++ b/src/finiteVolume/cellCentred/fields/volumeField.cpp
@@ -98,6 +98,15 @@ void VolumeField<ValueType>::correctBoundaryConditions()
     }
 }
 
+template<typename ValueType>
+void VolumeField<ValueType>::correctBoundaryConditions(const BoundaryContext& ctx)
+{
+    for (auto& boundaryCondition : boundaryConditions_)
+    {
+        boundaryCondition.correctBoundaryCondition(this->field_, ctx);
+    }
+}
+
 #define NN_DECLARE_FIELD(TYPENAME) template class VolumeField<TYPENAME>
 
 NN_FOR_ALL_VALUE_TYPES(NN_DECLARE_FIELD);

--- a/src/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -6,6 +6,8 @@
 
 #include "NeoN/finiteVolume/cellCentred/interpolation/linear.hpp"
 #include "NeoN/core/parallelAlgorithms.hpp"
+#include "NeoN/core/primitives/tensor.hpp"
+#include "NeoN/core/primitives/symmTensor.hpp"
 
 namespace NeoN::finiteVolume::cellCentred
 {
@@ -53,6 +55,8 @@ void computeLinearInterpolation(
 
 NF_DECLARE_COMPUTE_IMP_LIN_INT(scalar);
 NF_DECLARE_COMPUTE_IMP_LIN_INT(Vec3);
+NF_DECLARE_COMPUTE_IMP_LIN_INT(Tensor);
+NF_DECLARE_COMPUTE_IMP_LIN_INT(SymmTensor);
 
 // template class Linear<scalar>;
 // template class Linear<Vec3>;

--- a/src/finiteVolume/cellCentred/operators/gaussGreenGrad.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenGrad.cpp
@@ -6,6 +6,7 @@
 #include "NeoN/finiteVolume/cellCentred/interpolation/linear.hpp"
 #include "NeoN/core/containerFreeFunctions.hpp"
 #include "NeoN/core/parallelAlgorithms.hpp"
+#include "NeoN/core/primitives/tensor.hpp"
 
 namespace NeoN::finiteVolume::cellCentred
 {
@@ -77,10 +78,98 @@ void computeGrad(
     );
 }
 
+void computeBoundaryGrad(
+    const VolumeField<scalar>& phi, VolumeField<Vec3>& gradPhi, const dsl::Coeff operatorScaling
+)
+{
+    const UnstructuredMesh& mesh = phi.mesh();
+    const auto exec = gradPhi.exec();
+    const auto boundaryConditions = phi.boundaryConditions();
+
+    auto gradInternal = gradPhi.internalVector().view();
+    auto gradBoundary = gradPhi.boundaryData().value().view();
+    const auto
+        [phiInternal, phiBoundaryValue, phiBoundaryRefGrad, faceCells, deltaCoeffs, normals] =
+            views(
+                phi.internalVector(),
+                phi.boundaryData().value(),
+                phi.boundaryData().refGrad(),
+                mesh.boundaryMesh().faceCells(),
+                mesh.boundaryMesh().deltaCoeffs(),
+                mesh.boundaryMesh().nf()
+            );
+
+    for (localIdx patchID = 0; patchID < mesh.nBoundaries(); ++patchID)
+    {
+        const auto attrs = boundaryConditions[patchID].attributes();
+        const auto [start, end] = phi.boundaryData().range(patchID);
+
+        if (start == end)
+        {
+            continue;
+        }
+
+        if (attrs.fixesValue)
+        {
+            parallelFor(
+                exec,
+                {start, end},
+                NEON_LAMBDA(const localIdx i) {
+                    const auto owner = faceCells[i];
+
+                    // Extrapolate internal gradient
+                    Vec3 g = gradInternal[owner];
+
+                    // Compute snGrad
+                    const scalar snGrad =
+                        (phiBoundaryValue[i] - phiInternal[owner]) * deltaCoeffs[i];
+                    const Vec3 n = normals[i];
+
+                    // Normal reconstruction
+                    const scalar nDotG = n[0] * g[0] + n[1] * g[1] + n[2] * g[2];
+
+                    g += n * (snGrad - nDotG);
+
+                    gradBoundary[i] = g;
+                },
+                "computeGradBoundaryFixedValue"
+            );
+        }
+        else
+        {
+            parallelFor(
+                exec,
+                {start, end},
+                NEON_LAMBDA(const localIdx i) {
+                    const auto owner = faceCells[i];
+
+                    // Extrapolate internal gradient
+                    Vec3 g = gradInternal[owner];
+
+                    const Vec3 n = normals[i];
+
+                    // snGrad from BC
+                    const scalar snGrad = phiBoundaryRefGrad[i];
+
+                    // 2) Normal reconstruction
+                    const scalar nDotG = n[0] * g[0] + n[1] * g[1] + n[2] * g[2];
+
+                    g += n * (snGrad - nDotG);
+
+                    gradBoundary[i] = g;
+                },
+                "computeGradBoundaryRefGrad"
+            );
+        }
+    }
+}
+
 GaussGreenGrad::GaussGreenGrad(const Executor& exec, const UnstructuredMesh& mesh)
-    : Base(exec, mesh), surfaceInterpolation_(
-                            exec, mesh, std::make_unique<Linear<scalar>>(exec, mesh, Dictionary())
-                        ) {};
+    : Base(exec, mesh),
+      surfaceInterpolation_(exec, mesh, std::make_unique<Linear<scalar>>(exec, mesh, Dictionary())),
+      surfaceInterpolationVec_(
+          exec, mesh, std::make_unique<Linear<Vec3>>(exec, mesh, Dictionary())
+      ) {};
 
 
 void GaussGreenGrad::grad(
@@ -90,6 +179,16 @@ void GaussGreenGrad::grad(
     computeGrad(phi, surfaceInterpolation_, gradPhi, operatorScaling);
 };
 
+void GaussGreenGrad::grad(
+    const VolumeField<scalar>& phi, VolumeField<Vec3>& gradPhi, const dsl::Coeff operatorScaling
+) const
+{
+    fill(gradPhi.internalVector(), zero<Vec3>());
+
+    computeGrad(phi, surfaceInterpolation_, gradPhi.internalVector(), operatorScaling);
+    computeBoundaryGrad(phi, gradPhi, operatorScaling);
+}
+
 VolumeField<Vec3>
 GaussGreenGrad::grad(const VolumeField<scalar>& phi, const dsl::Coeff operatorScaling) const
 {
@@ -97,7 +196,181 @@ GaussGreenGrad::grad(const VolumeField<scalar>& phi, const dsl::Coeff operatorSc
     VolumeField<Vec3> gradPhi = VolumeField<Vec3>(phi.exec(), "gradPhi", phi.mesh(), gradBCs);
     fill(gradPhi.internalVector(), zero<Vec3>());
     computeGrad(phi, surfaceInterpolation_, gradPhi.internalVector(), operatorScaling);
+    computeBoundaryGrad(phi, gradPhi, operatorScaling);
     return gradPhi;
+}
+
+// ---- Tensor gradient implementation ----------------------------------------
+
+KOKKOS_INLINE_FUNCTION
+void atomicAddTensor(Tensor* target, int row, int col, scalar value)
+{
+    Kokkos::atomic_add(&(*target)(row, col), value);
+}
+
+KOKKOS_INLINE_FUNCTION
+void atomicSubTensor(Tensor* target, int row, int col, scalar value)
+{
+    Kokkos::atomic_sub(&(*target)(row, col), value);
+}
+
+void computeGradTensor(
+    const VolumeField<Vec3>& u,
+    const SurfaceInterpolation<Vec3>& surfInterpVec,
+    Vector<Tensor>& gradU,
+    const dsl::Coeff operatorScaling
+)
+{
+    const UnstructuredMesh& mesh = u.mesh();
+    const auto exec = gradU.exec();
+
+    SurfaceField<Vec3> uf(exec, "Uf", mesh, createCalculatedBCs<SurfaceBoundary<Vec3>>(mesh));
+    surfInterpVec.interpolate(u, uf);
+
+    auto gT = gradU.view();
+
+    const auto [UfAll, owner, nei, SfAll, V, bFaceCells] = views(
+        uf.internalVector(),
+        mesh.faceOwner(),
+        mesh.faceNeighbour(),
+        mesh.faceAreas(),
+        mesh.cellVolumes(),
+        mesh.boundaryMesh().faceCells()
+    );
+
+    const localIdx nInt = mesh.nInternalFaces();
+    const localIdx nBnd = mesh.boundaryMesh().offset().back();
+    const localIdx nFaces = nInt + nBnd;
+
+    parallelFor(
+        exec,
+        {0, nInt},
+        NEON_LAMBDA(const localIdx f) {
+            const Vec3 sf = SfAll[f];
+            const Vec3 uf = UfAll[f];
+            const auto o = owner[f];
+            const auto n = nei[f];
+            // gradU(row,col) += Sf[col] * U[row]  (Gauss-Green)
+            for (int row = 0; row < 3; ++row)
+            {
+                for (int col = 0; col < 3; ++col)
+                {
+                    const scalar c = sf[col] * uf[row];
+                    atomicAddTensor(&gT[o], row, col, c);
+                    atomicSubTensor(&gT[n], row, col, c);
+                }
+            }
+        },
+        "computeGradTensorInternal"
+    );
+
+    parallelFor(
+        exec,
+        {nInt, nFaces},
+        NEON_LAMBDA(const localIdx f) {
+            const localIdx bi = f - nInt;
+            const auto o = bFaceCells[bi];
+            const Vec3 sf = SfAll[f];
+            const Vec3 uf = UfAll[f];
+            for (int row = 0; row < 3; ++row)
+            {
+                for (int col = 0; col < 3; ++col)
+                {
+                    atomicAddTensor(&gT[o], row, col, sf[col] * uf[row]);
+                }
+            }
+        },
+        "computeGradTensorBoundary"
+    );
+
+    parallelFor(
+        exec,
+        {0, mesh.nCells()},
+        NEON_LAMBDA(const localIdx c) {
+            const scalar s = operatorScaling[c] / V[c];
+            gT[c] *= s;
+        },
+        "computeGradTensorCells"
+    );
+}
+
+void computeBoundaryGradTensor(const VolumeField<Vec3>& u, VolumeField<Tensor>& gradU)
+{
+    const auto& mesh = u.mesh();
+    const auto exec = u.exec();
+    const auto& offsets = mesh.boundaryMesh().offset();
+
+    const auto bcs = u.boundaryConditions();
+
+    auto gTInt = gradU.internalVector().view();
+    auto gTB = gradU.boundaryData().value().view();
+
+    const auto [UInt, UB, URefGradB, faceCells, deltaCoeffs, nHat] = views(
+        u.internalVector(),
+        u.boundaryData().value(),
+        u.boundaryData().refGrad(),
+        mesh.boundaryMesh().faceCells(),
+        mesh.boundaryMesh().deltaCoeffs(),
+        mesh.boundaryMesh().nf()
+    );
+
+    for (localIdx patchID = 0; patchID < static_cast<localIdx>(offsets.size() - 1); ++patchID)
+    {
+        const localIdx start = offsets[patchID];
+        const localIdx end = offsets[patchID + 1];
+        if (start == end) continue;
+
+        const auto attrs = bcs[patchID].attributes();
+
+        parallelFor(
+            exec,
+            {static_cast<size_t>(start), static_cast<size_t>(end)},
+            NEON_LAMBDA(const localIdx i) {
+                const auto owner = faceCells[i];
+                const Vec3 n = nHat[i];
+                Tensor g = gTInt[owner];
+
+                Vec3 snGrad;
+                if (attrs.fixesValue) snGrad = (UB[i] - UInt[owner]) * deltaCoeffs[i];
+                else
+                    snGrad = URefGradB[i];
+
+                // Reconstruct each row: g(row,:) += n * (snGrad[row] - n · g(row,:))
+                for (int row = 0; row < 3; ++row)
+                {
+                    const Vec3 gRow(g(row, 0), g(row, 1), g(row, 2));
+                    const scalar nDotG = n[0] * gRow[0] + n[1] * gRow[1] + n[2] * gRow[2];
+                    const Vec3 corrected = gRow + n * (snGrad[row] - nDotG);
+                    g(row, 0) = corrected[0];
+                    g(row, 1) = corrected[1];
+                    g(row, 2) = corrected[2];
+                }
+                gTB[i] = g;
+            },
+            "computeGradTensorBoundaryReconstruct"
+        );
+    }
+}
+
+void GaussGreenGrad::gradTensor(
+    const VolumeField<Vec3>& u, VolumeField<Tensor>& gradU, const dsl::Coeff operatorScaling
+) const
+{
+    fill(gradU.internalVector(), zero<Tensor>());
+    computeGradTensor(u, surfaceInterpolationVec_, gradU.internalVector(), operatorScaling);
+    computeBoundaryGradTensor(u, gradU);
+}
+
+VolumeField<Tensor>
+GaussGreenGrad::gradTensor(const VolumeField<Vec3>& u, const dsl::Coeff operatorScaling) const
+{
+    auto calcBC = createCalculatedBCs<VolumeBoundary<Tensor>>(u.mesh());
+    VolumeField<Tensor> gradU(u.exec(), "gradU", u.mesh(), calcBC);
+    fill(gradU.internalVector(), zero<Tensor>());
+
+    computeGradTensor(u, surfaceInterpolationVec_, gradU.internalVector(), operatorScaling);
+    computeBoundaryGradTensor(u, gradU);
+    return gradU;
 }
 
 } // namespace NeoN

--- a/src/finiteVolume/cellCentred/operators/sourceTerm.cpp
+++ b/src/finiteVolume/cellCentred/operators/sourceTerm.cpp
@@ -19,31 +19,62 @@ SourceTerm<ValueType>::SourceTerm(
     const VolumeField<ValueType>& field
 )
     : dsl::OperatorMixin<VolumeField<ValueType>>(field.exec(), dsl::Coeff {1.0}, field, termType),
-      coefficients_(coefficients) {};
+      spCoeff_(&coefficients) {};
+
+template<typename ValueType>
+SourceTerm<ValueType>::SourceTerm(
+    dsl::Operator::Type termType, VolumeField<ValueType>& coefficients
+)
+    : dsl::OperatorMixin<VolumeField<ValueType>>(
+        coefficients.exec(), dsl::Coeff {1.0}, coefficients, termType
+    ),
+      spCoeff_(nullptr) {};
 
 template<typename ValueType>
 void SourceTerm<ValueType>::explicitOperation(Vector<ValueType>& source) const
 {
     auto operatorScaling = this->getCoefficient();
-    auto [sourceView, fieldView, coeff] =
-        views(source, this->field_.internalVector(), coefficients_.internalVector());
-    NeoN::parallelFor(
-        source.exec(),
-        source.range(),
-        NEON_LAMBDA(const localIdx celli) {
-            sourceView[celli] += operatorScaling[celli] * coeff[celli] * fieldView[celli];
-        },
-        "sourceTerm::explicitOperation"
-    );
+    if (spCoeff_)
+    {
+        // Sp: source += scaling * spCoeff * field
+        auto [sourceView, fieldView, coeff] =
+            views(source, this->field_.internalVector(), spCoeff_->internalVector());
+        NeoN::parallelFor(
+            source.exec(),
+            source.range(),
+            NEON_LAMBDA(const localIdx celli) {
+                sourceView[celli] += operatorScaling[celli] * coeff[celli] * fieldView[celli];
+            },
+            "Sp::explicitOperation"
+        );
+    }
+    else
+    {
+        // Su: source += scaling * coeff  (field_ IS the coefficient for Su)
+        auto [sourceView, coeff] = views(source, this->field_.internalVector());
+        NeoN::parallelFor(
+            source.exec(),
+            source.range(),
+            NEON_LAMBDA(const localIdx celli) {
+                sourceView[celli] += operatorScaling[celli] * coeff[celli];
+            },
+            "Su::explicitOperation"
+        );
+    }
 }
 
 template<typename ValueType>
 void SourceTerm<ValueType>::implicitOperation(la::LinearSystem<ValueType>& ls) const
 {
+    if (!spCoeff_)
+    {
+        NF_ERROR_EXIT("Not implemented");
+    }
+    // Sp implicit: diagonal += scaling * spCoeff * volume
     const auto matIt = ls.faceToMatrixAddress();
     const auto operatorScaling = this->getCoefficient();
-    const auto vol = coefficients_.mesh().cellVolumes().view();
-    const auto [diagOffs, coeff] = views(matIt->diagOffset(), coefficients_.internalVector());
+    const auto vol = spCoeff_->mesh().cellVolumes().view();
+    const auto [diagOffs, coeff] = views(matIt->diagOffset(), spCoeff_->internalVector());
     auto values = ls.matrix().values().view();
     auto [colIdx, rowOffs] = ls.matrix().sparsity()->view();
 
@@ -54,7 +85,7 @@ void SourceTerm<ValueType>::implicitOperation(la::LinearSystem<ValueType>& ls) c
             localIdx idx = rowOffs[celli] + diagOffs[celli];
             values[idx] += operatorScaling[celli] * coeff[celli] * vol[celli] * one<ValueType>();
         },
-        "sourceTerm::implicitOperation"
+        "Sp::implicitOperation"
     );
 }
 

--- a/test/core/primitives/CMakeLists.txt
+++ b/test/core/primitives/CMakeLists.txt
@@ -4,3 +4,5 @@
 
 neon_unit_test(scalar)
 neon_unit_test(vec3)
+neon_unit_test(tensor)
+neon_unit_test(symmTensor)

--- a/test/core/primitives/symmTensor.cpp
+++ b/test/core/primitives/symmTensor.cpp
@@ -1,0 +1,270 @@
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#define CATCH_CONFIG_RUNNER
+#include <catch2/catch_session.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "NeoN/NeoN.hpp"
+
+using NeoN::scalar;
+using NeoN::SymmTensor;
+using NeoN::Tensor;
+using NeoN::Vec3;
+
+TEST_CASE("SymmTensor - Constructors")
+{
+    SECTION("Default constructor zeros all components")
+    {
+        SymmTensor s;
+        for (size_t i = 0; i < 3; ++i)
+        {
+            for (size_t j = 0; j < 3; ++j)
+            {
+                REQUIRE(s(i, j) == 0.0);
+            }
+        }
+    }
+
+    SECTION("Diagonal constructor produces scalar * I")
+    {
+        SymmTensor s(3.0);
+        REQUIRE(s(0, 0) == 3.0);
+        REQUIRE(s(1, 1) == 3.0);
+        REQUIRE(s(2, 2) == 3.0);
+        REQUIRE(s(0, 1) == 0.0);
+        REQUIRE(s(0, 2) == 0.0);
+        REQUIRE(s(1, 2) == 0.0);
+    }
+
+    SECTION("6-component constructor - upper-triangle storage")
+    {
+        SymmTensor s(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+        // diagonal
+        REQUIRE(s(0, 0) == 1.0); // xx
+        REQUIRE(s(1, 1) == 4.0); // yy
+        REQUIRE(s(2, 2) == 6.0); // zz
+        // off-diagonal and symmetry
+        REQUIRE(s(0, 1) == 2.0); // xy
+        REQUIRE(s(1, 0) == 2.0); // yx == xy
+        REQUIRE(s(0, 2) == 3.0); // xz
+        REQUIRE(s(2, 0) == 3.0); // zx == xz
+        REQUIRE(s(1, 2) == 5.0); // yz
+        REQUIRE(s(2, 1) == 5.0); // zy == yz
+    }
+}
+
+TEST_CASE("SymmTensor - Size")
+{
+    SymmTensor s;
+    REQUIRE(s.size() == 6);
+}
+
+TEST_CASE("SymmTensor - Equality")
+{
+    SymmTensor a(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+    SymmTensor b(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+    SymmTensor c(6.0, 5.0, 4.0, 3.0, 2.0, 1.0);
+
+    REQUIRE(a == b);
+    REQUIRE(!(a == c));
+}
+
+TEST_CASE("SymmTensor - Arithmetic")
+{
+    SymmTensor a(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+    SymmTensor b(6.0, 5.0, 4.0, 3.0, 2.0, 1.0);
+    SymmTensor sum(7.0, 7.0, 7.0, 7.0, 7.0, 7.0);
+    SymmTensor zero(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+
+    SECTION("Addition")
+    {
+        REQUIRE(a + b == sum);
+        SymmTensor c = a;
+        c += b;
+        REQUIRE(c == sum);
+    }
+
+    SECTION("Subtraction")
+    {
+        REQUIRE(a - a == zero);
+        SymmTensor c = a;
+        c -= a;
+        REQUIRE(c == zero);
+    }
+
+    SECTION("Scalar multiplication")
+    {
+        SymmTensor doubled(2.0, 4.0, 6.0, 8.0, 10.0, 12.0);
+        REQUIRE(a * 2.0 == doubled);
+        REQUIRE(2.0 * a == doubled);
+        SymmTensor c = a;
+        c *= 2.0;
+        REQUIRE(c == doubled);
+    }
+}
+
+TEST_CASE("SymmTensor - Trace")
+{
+    SymmTensor s(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+    REQUIRE(s.trace() == 1.0 + 4.0 + 6.0); // xx + yy + zz
+
+    SymmTensor identity(1.0);
+    REQUIRE(identity.trace() == 3.0);
+}
+
+TEST_CASE("SymmTensor - Deviatoric parts")
+{
+    SECTION("dev() = S - (1/3)*tr(S)*I")
+    {
+        SymmTensor s(3.0, 1.0, 2.0, 6.0, 4.0, 9.0);
+        scalar tr = s.trace(); // 3 + 6 + 9 = 18
+        scalar tr3 = tr / 3.0; // 6
+        SymmTensor d = s.dev();
+
+        REQUIRE_THAT(d(0, 0), Catch::Matchers::WithinRel(3.0 - tr3));
+        REQUIRE_THAT(d(1, 1), Catch::Matchers::WithinRel(6.0 - tr3));
+        REQUIRE_THAT(d(2, 2), Catch::Matchers::WithinRel(9.0 - tr3));
+        REQUIRE(d(0, 1) == s(0, 1)); // off-diagonal unchanged
+        REQUIRE(d(0, 2) == s(0, 2));
+        REQUIRE(d(1, 2) == s(1, 2));
+
+        // deviatoric is traceless
+        REQUIRE_THAT(d.trace(), Catch::Matchers::WithinAbs(0.0, 1e-12));
+    }
+
+    SECTION("dev2() = S - (2/3)*tr(S)*I")
+    {
+        SymmTensor s(3.0, 1.0, 2.0, 6.0, 4.0, 9.0);
+        scalar tr = s.trace();        // 18
+        scalar tr23 = 2.0 / 3.0 * tr; // 12
+        SymmTensor d2 = s.dev2();
+
+        REQUIRE_THAT(d2(0, 0), Catch::Matchers::WithinRel(3.0 - tr23));
+        REQUIRE_THAT(d2(1, 1), Catch::Matchers::WithinRel(6.0 - tr23));
+        REQUIRE_THAT(d2(2, 2), Catch::Matchers::WithinRel(9.0 - tr23));
+        REQUIRE(d2(0, 1) == s(0, 1));
+        REQUIRE(d2(0, 2) == s(0, 2));
+        REQUIRE(d2(1, 2) == s(1, 2));
+    }
+}
+
+TEST_CASE("SymmTensor - Matrix-vector product S·v")
+{
+    SymmTensor identity(1.0);
+    Vec3 v(1.0, 2.0, 3.0);
+    Vec3 result = identity & v;
+    REQUIRE(result[0] == 1.0);
+    REQUIRE(result[1] == 2.0);
+    REQUIRE(result[2] == 3.0);
+
+    SymmTensor s(2.0, 0.0, 0.0, 3.0, 0.0, 4.0);
+    Vec3 scaled = s & v;
+    REQUIRE(scaled[0] == 2.0);
+    REQUIRE(scaled[1] == 6.0);
+    REQUIRE(scaled[2] == 12.0);
+
+    SymmTensor shear(0.0, 1.0, 0.0, 0.0, 0.0, 0.0);
+    Vec3 sheared = shear & v;
+    REQUIRE(sheared[0] == v[1]);
+    REQUIRE(sheared[1] == v[0]);
+    REQUIRE(sheared[2] == 0.0);
+}
+
+TEST_CASE("SymmTensor - Norms")
+{
+    SECTION("Identity tensor")
+    {
+        SymmTensor identity(1.0);
+        REQUIRE_THAT(NeoN::mag(identity), Catch::Matchers::WithinRel(std::sqrt(3.0)));
+        REQUIRE_THAT(NeoN::magSqr(identity), Catch::Matchers::WithinRel(3.0));
+    }
+
+    SECTION("Pure shear - off-diagonal counts twice")
+    {
+        SymmTensor shear(0.0, 1.0, 0.0, 0.0, 0.0, 0.0); // only xy = yx = 1
+        // Frobenius norm squared = xy^2 + yx^2 = 2
+        REQUIRE_THAT(NeoN::magSqr(shear), Catch::Matchers::WithinRel(2.0));
+        REQUIRE_THAT(NeoN::mag(shear), Catch::Matchers::WithinRel(std::sqrt(2.0)));
+    }
+
+    SECTION("Known tensor")
+    {
+        SymmTensor s(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+        // magSqr = 1^2 + 4^2 + 6^2 + 2*(2^2 + 3^2 + 5^2) = 1+16+36 + 2*(4+9+25) = 53 + 76 = 129
+        scalar expected = 1.0 + 16.0 + 36.0 + 2.0 * (4.0 + 9.0 + 25.0);
+        REQUIRE_THAT(NeoN::magSqr(s), Catch::Matchers::WithinRel(expected));
+    }
+}
+
+TEST_CASE("SymmTensor - symm and twoSymm")
+{
+    SECTION("symm(T) extracts symmetric part of a full tensor")
+    {
+        Tensor t(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+        SymmTensor s = NeoN::symm(t);
+        REQUIRE(s(0, 0) == 1.0);
+        REQUIRE(s(1, 1) == 5.0);
+        REQUIRE(s(2, 2) == 9.0);
+        REQUIRE_THAT(s(0, 1), Catch::Matchers::WithinRel(0.5 * (2.0 + 4.0)));
+        REQUIRE_THAT(s(0, 2), Catch::Matchers::WithinRel(0.5 * (3.0 + 7.0)));
+        REQUIRE_THAT(s(1, 2), Catch::Matchers::WithinRel(0.5 * (6.0 + 8.0)));
+        REQUIRE(s(1, 0) == s(0, 1));
+        REQUIRE(s(2, 0) == s(0, 2));
+        REQUIRE(s(2, 1) == s(1, 2));
+    }
+
+    SECTION("symm of symmetric tensor is identity operation")
+    {
+        Tensor t(1.0, 2.0, 3.0, 2.0, 5.0, 6.0, 3.0, 6.0, 9.0);
+        SymmTensor s = NeoN::symm(t);
+        REQUIRE(s(0, 0) == 1.0);
+        REQUIRE(s(0, 1) == 2.0);
+        REQUIRE(s(0, 2) == 3.0);
+        REQUIRE(s(1, 1) == 5.0);
+        REQUIRE(s(1, 2) == 6.0);
+        REQUIRE(s(2, 2) == 9.0);
+    }
+
+    SECTION("twoSymm(T) == T + T^T")
+    {
+        Tensor t(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+        Tensor ts = NeoN::twoSymm(t);
+        REQUIRE(ts(0, 0) == 2.0 * t(0, 0));
+        REQUIRE(ts(1, 1) == 2.0 * t(1, 1));
+        REQUIRE(ts(2, 2) == 2.0 * t(2, 2));
+        REQUIRE_THAT(ts(0, 1), Catch::Matchers::WithinRel(t(0, 1) + t(1, 0)));
+        REQUIRE_THAT(ts(1, 0), Catch::Matchers::WithinRel(t(1, 0) + t(0, 1)));
+        REQUIRE(ts(0, 1) == ts(1, 0));
+        REQUIRE(ts(0, 2) == ts(2, 0));
+        REQUIRE(ts(1, 2) == ts(2, 1));
+    }
+}
+
+TEST_CASE("SymmTensor - Traits")
+{
+    SECTION("zero<SymmTensor>")
+    {
+        SymmTensor z = NeoN::zero<SymmTensor>();
+        for (size_t i = 0; i < 3; ++i)
+        {
+            for (size_t j = 0; j < 3; ++j)
+            {
+                REQUIRE(z(i, j) == 0.0);
+            }
+        }
+    }
+
+    SECTION("one<SymmTensor> is identity")
+    {
+        SymmTensor id = NeoN::one<SymmTensor>();
+        REQUIRE(id(0, 0) == 1.0);
+        REQUIRE(id(1, 1) == 1.0);
+        REQUIRE(id(2, 2) == 1.0);
+        REQUIRE(id(0, 1) == 0.0);
+        REQUIRE(id(0, 2) == 0.0);
+        REQUIRE(id(1, 2) == 0.0);
+    }
+}

--- a/test/core/primitives/tensor.cpp
+++ b/test/core/primitives/tensor.cpp
@@ -176,9 +176,9 @@ TEST_CASE("Tensor - Norms")
     REQUIRE_THAT(NeoN::magSqr(identity), Catch::Matchers::WithinRel(3.0));
 
     Tensor t(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
-    scalar expected_sqr = 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81;
-    REQUIRE_THAT(NeoN::magSqr(t), Catch::Matchers::WithinRel(expected_sqr));
-    REQUIRE_THAT(NeoN::mag(t), Catch::Matchers::WithinRel(std::sqrt(expected_sqr)));
+    scalar expectedSqr = 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81;
+    REQUIRE_THAT(NeoN::magSqr(t), Catch::Matchers::WithinRel(expectedSqr));
+    REQUIRE_THAT(NeoN::mag(t), Catch::Matchers::WithinRel(std::sqrt(expectedSqr)));
 }
 
 TEST_CASE("Tensor - Traits")

--- a/test/core/primitives/tensor.cpp
+++ b/test/core/primitives/tensor.cpp
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#define CATCH_CONFIG_RUNNER
+#include <catch2/catch_session.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "NeoN/NeoN.hpp"
+
+using NeoN::scalar;
+using NeoN::Tensor;
+using NeoN::Vec3;
+
+TEST_CASE("Tensor - Constructors")
+{
+    SECTION("Default constructor zeros all components")
+    {
+        Tensor t;
+        for (size_t i = 0; i < 3; ++i)
+        {
+            for (size_t j = 0; j < 3; ++j)
+            {
+                REQUIRE(t(i, j) == 0.0);
+            }
+        }
+    }
+
+    SECTION("Diagonal constructor produces scalar * I")
+    {
+        Tensor t(3.0);
+        REQUIRE(t(0, 0) == 3.0);
+        REQUIRE(t(1, 1) == 3.0);
+        REQUIRE(t(2, 2) == 3.0);
+        REQUIRE(t(0, 1) == 0.0);
+        REQUIRE(t(0, 2) == 0.0);
+        REQUIRE(t(1, 0) == 0.0);
+        REQUIRE(t(1, 2) == 0.0);
+        REQUIRE(t(2, 0) == 0.0);
+        REQUIRE(t(2, 1) == 0.0);
+    }
+
+    SECTION("Full component constructor - row-major layout")
+    {
+        Tensor t(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+        REQUIRE(t(0, 0) == 1.0);
+        REQUIRE(t(0, 1) == 2.0);
+        REQUIRE(t(0, 2) == 3.0);
+        REQUIRE(t(1, 0) == 4.0);
+        REQUIRE(t(1, 1) == 5.0);
+        REQUIRE(t(1, 2) == 6.0);
+        REQUIRE(t(2, 0) == 7.0);
+        REQUIRE(t(2, 1) == 8.0);
+        REQUIRE(t(2, 2) == 9.0);
+    }
+}
+
+TEST_CASE("Tensor - Size")
+{
+    Tensor t;
+    REQUIRE(t.size() == 9);
+}
+
+TEST_CASE("Tensor - Equality")
+{
+    Tensor a(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+    Tensor b(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+    Tensor c(9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0);
+
+    REQUIRE(a == b);
+    REQUIRE(!(a == c));
+}
+
+TEST_CASE("Tensor - Arithmetic")
+{
+    Tensor a(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+    Tensor b(9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0);
+    Tensor sum(10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0);
+    Tensor zero(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+
+    SECTION("Addition")
+    {
+        REQUIRE(a + b == sum);
+        Tensor c = a;
+        c += b;
+        REQUIRE(c == sum);
+    }
+
+    SECTION("Subtraction")
+    {
+        REQUIRE(a - a == zero);
+        Tensor c = a;
+        c -= a;
+        REQUIRE(c == zero);
+    }
+
+    SECTION("Scalar multiplication")
+    {
+        Tensor doubled(2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0, 18.0);
+        REQUIRE(a * 2.0 == doubled);
+        REQUIRE(2.0 * a == doubled);
+        Tensor c = a;
+        c *= 2.0;
+        REQUIRE(c == doubled);
+    }
+}
+
+TEST_CASE("Tensor - Trace")
+{
+    Tensor t(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+    REQUIRE(t.trace() == 1.0 + 5.0 + 9.0);
+
+    Tensor identity(1.0);
+    REQUIRE(identity.trace() == 3.0);
+}
+
+TEST_CASE("Tensor - Transpose")
+{
+    Tensor a(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+    Tensor at = a.T();
+
+    for (size_t i = 0; i < 3; ++i)
+    {
+        for (size_t j = 0; j < 3; ++j)
+        {
+            REQUIRE(at(i, j) == a(j, i));
+        }
+    }
+
+    Tensor symmetric(1.0, 2.0, 3.0, 2.0, 5.0, 6.0, 3.0, 6.0, 9.0);
+    REQUIRE(symmetric.T() == symmetric);
+}
+
+TEST_CASE("Tensor - Matrix-vector products")
+{
+    Tensor t(1.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 3.0);
+    Vec3 v(1.0, 2.0, 3.0);
+
+    SECTION("T·v")
+    {
+        Vec3 result = t & v;
+        REQUIRE(result[0] == 1.0);
+        REQUIRE(result[1] == 4.0);
+        REQUIRE(result[2] == 9.0);
+    }
+
+    SECTION("v·T")
+    {
+        Vec3 result = v & t;
+        REQUIRE(result[0] == 1.0);
+        REQUIRE(result[1] == 4.0);
+        REQUIRE(result[2] == 9.0);
+    }
+
+    SECTION("General asymmetric tensor")
+    {
+        Tensor g(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+        Vec3 u(1.0, 0.0, 0.0);
+        Vec3 row0 = g & u;
+        REQUIRE(row0[0] == 1.0);
+        REQUIRE(row0[1] == 4.0);
+        REQUIRE(row0[2] == 7.0);
+
+        Vec3 col0 = u & g;
+        REQUIRE(col0[0] == 1.0);
+        REQUIRE(col0[1] == 2.0);
+        REQUIRE(col0[2] == 3.0);
+    }
+}
+
+TEST_CASE("Tensor - Norms")
+{
+    Tensor identity(1.0);
+    REQUIRE_THAT(NeoN::mag(identity), Catch::Matchers::WithinRel(std::sqrt(3.0)));
+    REQUIRE_THAT(NeoN::magSqr(identity), Catch::Matchers::WithinRel(3.0));
+
+    Tensor t(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0);
+    scalar expected_sqr = 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81;
+    REQUIRE_THAT(NeoN::magSqr(t), Catch::Matchers::WithinRel(expected_sqr));
+    REQUIRE_THAT(NeoN::mag(t), Catch::Matchers::WithinRel(std::sqrt(expected_sqr)));
+}
+
+TEST_CASE("Tensor - Traits")
+{
+    SECTION("zero<Tensor>")
+    {
+        Tensor z = NeoN::zero<Tensor>();
+        for (size_t i = 0; i < 3; ++i)
+        {
+            for (size_t j = 0; j < 3; ++j)
+            {
+                REQUIRE(z(i, j) == 0.0);
+            }
+        }
+    }
+
+    SECTION("one<Tensor> is identity")
+    {
+        Tensor id = NeoN::one<Tensor>();
+        REQUIRE(id(0, 0) == 1.0);
+        REQUIRE(id(1, 1) == 1.0);
+        REQUIRE(id(2, 2) == 1.0);
+        REQUIRE(id(0, 1) == 0.0);
+        REQUIRE(id(0, 2) == 0.0);
+        REQUIRE(id(1, 0) == 0.0);
+        REQUIRE(id(1, 2) == 0.0);
+        REQUIRE(id(2, 0) == 0.0);
+        REQUIRE(id(2, 1) == 0.0);
+    }
+}

--- a/test/finiteVolume/cellCentred/boundary/surface/surfSymmetry.cpp
+++ b/test/finiteVolume/cellCentred/boundary/surface/surfSymmetry.cpp
@@ -88,7 +88,9 @@ TEST_CASE("symmetry_surface")
                 const auto vExpected = intV - nV * (intV & nV); // half-symmetry
 
                 for (auto d = 0u; d < 3; ++d)
+                {
                     REQUIRE(boundaryValueV[d] == Approx(vExpected[d]));
+                }
             }
 
             for (auto& boundaryValueV : valuesH.view(boundary->range()))
@@ -101,7 +103,9 @@ TEST_CASE("symmetry_surface")
                 const auto vExpected = intV - nV * (intV & nV);
 
                 for (auto d = 0u; d < 3; ++d)
+                {
                     REQUIRE(boundaryValueV[d] == Approx(vExpected[d]));
+                }
             }
         }
     }

--- a/test/finiteVolume/cellCentred/boundary/volume/volSymmetry.cpp
+++ b/test/finiteVolume/cellCentred/boundary/volume/volSymmetry.cpp
@@ -96,13 +96,17 @@ TEST_CASE("symmetry_volume")
                 const auto vExpected = intV - nV * (intV & nV); // half-symmetry
 
                 for (auto d = 0u; d < 3; ++d)
+                {
                     REQUIRE(boundaryValueV[d] == Approx(vExpected[d]));
+                }
             }
 
             for (auto& gradValueV : refGradH.view(boundary->range()))
             {
                 for (auto d = 0u; d < 3; ++d)
+                {
                     REQUIRE(gradValueV[d] == Approx(0.0));
+                }
             }
         }
     }

--- a/test/finiteVolume/cellCentred/operator/sourceTerm.cpp
+++ b/test/finiteVolume/cellCentred/operator/sourceTerm.cpp
@@ -68,4 +68,28 @@ TEMPLATE_TEST_CASE("SourceTerm", "[template]", NeoN::scalar, NeoN::Vec3)
     }
 }
 
+TEMPLATE_TEST_CASE("SourceTerm Su constructor", "[template]", NeoN::scalar, NeoN::Vec3)
+{
+    auto [execName, exec] = GENERATE(allAvailableExecutor());
+
+    auto mesh = createSingleCellMesh(exec);
+
+    auto coeffBCs = fvcc::createCalculatedBCs<fvcc::VolumeBoundary<TestType>>(mesh);
+    fvcc::VolumeField<TestType> coeff(exec, "coeff", mesh, coeffBCs);
+    fill(coeff.internalVector(), 5 * one<TestType>());
+    fill(coeff.boundaryData().value(), zero<TestType>());
+    coeff.correctBoundaryConditions();
+
+    SECTION("explicit Su" + execName)
+    {
+        fvcc::SourceTerm<TestType> sTerm(Operator::Type::Explicit, coeff);
+
+        auto source = Vector<TestType>(exec, coeff.size(), zero<TestType>());
+        sTerm.explicitOperation(source);
+
+        auto exp = std::vector<TestType>(static_cast<size_t>(coeff.size()), 5 * one<TestType>());
+        REQUIRE_THAT(exp, IsEqualTo(source, EqualInt()));
+    }
+}
+
 }


### PR DESCRIPTION
# Implementation of turbulence model
This PR implements features required to run the SpalartAllmarasDDES turbulence model which is implemented in NeoFOAM PR [233](https://github.com/exasim-project/NeoFOAM/pull/233) It consists of the following components:
## Generally required for turbulence models
1. Tensor and symmTensor primitives 
2. New `Su` type overload of source operator `source` (the available implementation before was only a `Sp` type source term that multiplies by the transport variable) to be able to add source terms that do not linearly depend on the turbulence transport variable
3. Functionality to pass generic fields to correctBoundaryConditions
