### PR TITLE
Reduce mesh memory footprint

### DIFF
--- a/include/NeoN/finiteVolume/cellCentred/stencil/geometryScheme.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/stencil/geometryScheme.hpp
@@ -77,6 +77,8 @@ public:
 
     void update();
 
+    void reset() const;
+
     std::string name() const;
 
     // add selection mechanism via dictionary later

--- a/include/NeoN/finiteVolume/cellCentred/stencil/geometryScheme.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/stencil/geometryScheme.hpp
@@ -35,7 +35,13 @@ public:
 };
 
 /* @class GeometryScheme
- * @brief Implements a method to compute deltaCoeffs
+ * @brief Implements access to compute deltaCoeffs, weights, and nonOrthDeltaCoeffs
+ *
+ * Where:
+ *  - deltaCoeff: inverse owner to neighbour cell centre distance
+ *  - weight: the distance of the cell centre to face normalized by the distance to the neighbour
+ * cell
+ *  - nonOrthDeltaCoeff: faceNormal * cellToCellDist
  */
 class GeometryScheme
 {

--- a/include/NeoN/mesh/unstructured/unstructuredMesh.hpp
+++ b/include/NeoN/mesh/unstructured/unstructuredMesh.hpp
@@ -34,6 +34,44 @@ public:
     /**
      * @brief Constructor for the UnstructuredMesh class.
      *
+     * @param exec
+     * @param points The field of mesh points.
+     * @param cellVolumes The field of cell volumes in the mesh.
+     * @param cellCentres The field of cell centres in the mesh.
+     * @param faceAreas The field of area face normals.
+     * @param faceCentres The field of face centres.
+     * @param magFaceAreas The field of magnitudes of face areas.
+     * @param faceOwner The field of face owner cells.
+     * @param faceNeighbour The field of face neighbour cells.
+     * @param nCells The number of cells in the mesh.
+     * @param nInternalFaces The number of internal faces in the mesh.
+     * @param nBoundaryFaces The number of boundary faces in the mesh.
+     * @param nBoundaries The number of boundaries in the mesh.
+     * @param nFaces The number of faces in the mesh.
+     * @param boundaryMesh The boundary mesh.
+     */
+    UnstructuredMesh(
+        Executor exec,
+        vectorVector points,
+        scalarVector cellVolumes,
+        vectorVector cellCentres,
+        vectorVector faceAreas,
+        vectorVector faceCentres,
+        scalarVector magFaceAreas,
+        labelVector faceOwner,
+        labelVector faceNeighbour,
+        localIdx nCells,
+        localIdx nInternalFaces,
+        localIdx nBoundaryFaces,
+        localIdx nBoundaries,
+        localIdx nFaces,
+        BoundaryMesh boundaryMesh
+    );
+
+    /**
+     * @brief Constructor for the UnstructuredMesh class.
+     * @note executor is determined from faceOwner
+     *
      * @param points The field of mesh points.
      * @param cellVolumes The field of cell volumes in the mesh.
      * @param cellCentres The field of cell centres in the mesh.

--- a/include/NeoN/mesh/unstructured/unstructuredMesh.hpp
+++ b/include/NeoN/mesh/unstructured/unstructuredMesh.hpp
@@ -72,6 +72,7 @@ public:
      * @return The field of mesh points.
      */
     const vectorVector& points() const;
+    vectorVector& points();
 
     /**
      * @brief Get the field of cell volumes in the mesh.
@@ -79,6 +80,7 @@ public:
      * @return The field of cell volumes in the mesh.
      */
     const scalarVector& cellVolumes() const;
+    scalarVector& cellVolumes();
 
     /**
      * @brief Get the field of cell centres in the mesh.
@@ -86,6 +88,7 @@ public:
      * @return The field of cell centres in the mesh.
      */
     const vectorVector& cellCentres() const;
+    vectorVector& cellCentres();
 
     /**
      * @brief Get the field of face centres.
@@ -93,6 +96,7 @@ public:
      * @return The field of face centres.
      */
     const vectorVector& faceCentres() const;
+    vectorVector& faceCentres();
 
     /**
      * @brief Get the field of area face normals.
@@ -100,6 +104,7 @@ public:
      * @return The field of area face normals.
      */
     const vectorVector& faceAreas() const;
+    vectorVector& faceAreas();
 
     /**
      * @brief Get the field of magnitudes of face areas.
@@ -107,6 +112,7 @@ public:
      * @return The field of magnitudes of face areas.
      */
     const scalarVector& magFaceAreas() const;
+    scalarVector& magFaceAreas();
 
     /**
      * @brief Get the field of face owner cells.
@@ -114,6 +120,7 @@ public:
      * @return The field of face owner cells.
      */
     const labelVector& faceOwner() const;
+    labelVector& faceOwner();
 
     /**
      * @brief Get the field of face neighbour cells.
@@ -121,6 +128,7 @@ public:
      * @return The field of face neighbour cells.
      */
     const labelVector& faceNeighbour() const;
+    labelVector& faceNeighbour();
 
     /**
      * @brief Get the number of cells in the mesh.

--- a/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
@@ -116,10 +116,7 @@ void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
         NEON_LAMBDA(const localIdx facei) {
             Vec3 cellToCellDist = cellCentre[neighbour[facei]] - cellCentre[owner[facei]];
             Vec3 faceNormal = 1 / faceArea[facei] * faceAreaVec3[facei];
-
             scalar orthoDist = faceNormal & cellToCellDist;
-
-
             nonOrthDeltaCoeff[facei] = 1.0 / std::max(orthoDist, 0.05 * mag(cellToCellDist));
         },
         "basicGeometricScheme::updateNonOrthDeltaCoeffsInternal"
@@ -132,10 +129,7 @@ void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
             auto own = surfFaceCells[facei - nInternalFaces];
             Vec3 cellToCellDist = cf[facei] - cellCentre[own];
             Vec3 faceNormal = 1 / faceArea[facei] * faceAreaVec3[facei];
-
             scalar orthoDist = faceNormal & cellToCellDist;
-
-
             nonOrthDeltaCoeff[facei] = 1.0 / std::max(orthoDist, 0.05 * mag(cellToCellDist));
         },
         "basicGeometricScheme::updateNonOrthDeltaCoeffsBoundary"

--- a/src/finiteVolume/cellCentred/stencil/geometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/geometryScheme.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
+#include "NeoN/core/logging.hpp"
 #include "NeoN/finiteVolume/cellCentred/stencil/geometryScheme.hpp"
 #include "NeoN/finiteVolume/cellCentred/stencil/basicGeometryScheme.hpp"
 #include "NeoN/finiteVolume/cellCentred/boundary.hpp"
@@ -104,17 +105,31 @@ std::string GeometryScheme::name() const { return std::string("GeometryScheme");
 
 void GeometryScheme::update()
 {
-    std::visit(
-        [&](const auto& exec)
-        {
-            kernel_->updateWeights(exec, weights_);
-            kernel_->updateDeltaCoeffs(exec, deltaCoeffs_);
-            kernel_->updateNonOrthDeltaCoeffs(exec, nonOrthDeltaCoeffs_);
-            // kernel_->updateNonOrthCorrectionVec3s(exec, nonOrthCorrectionVec3s_);
-        },
-        exec_
-    );
+    if (mesh_.faceCentres().size() > 0)
+    {
+        std::visit(
+            [&](const auto& exec)
+            {
+                kernel_->updateWeights(exec, weights_);
+                kernel_->updateDeltaCoeffs(exec, deltaCoeffs_);
+                kernel_->updateNonOrthDeltaCoeffs(exec, nonOrthDeltaCoeffs_);
+                // kernel_->updateNonOrthCorrectionVec3s(exec, nonOrthCorrectionVec3s_);
+            },
+            exec_
+        );
+        reset();
+    }
 }
+
+void GeometryScheme::reset() const
+{
+    // TODO this needs a better approach
+    // ideally faceCentres are some kind of hostViewVector
+    Logging::warn("resetting face and cell centres");
+    const_cast<UnstructuredMesh&>(mesh_).faceCentres().resize(0);
+    const_cast<UnstructuredMesh&>(mesh_).cellCentres().resize(0);
+}
+
 
 const SurfaceField<scalar>& GeometryScheme::weights() const { return weights_; }
 

--- a/src/mesh/unstructured/unstructuredMesh.cpp
+++ b/src/mesh/unstructured/unstructuredMesh.cpp
@@ -9,6 +9,29 @@
 
 namespace NeoN
 {
+UnstructuredMesh::UnstructuredMesh(
+    Executor exec,
+    vectorVector points,
+    scalarVector cellVolumes,
+    vectorVector cellCentres,
+    vectorVector faceAreas,
+    vectorVector faceCentres,
+    scalarVector magFaceAreas,
+    labelVector faceOwner,
+    labelVector faceNeighbour,
+    localIdx nCells,
+    localIdx nInternalFaces,
+    localIdx nBoundaryFaces,
+    localIdx nBoundaries,
+    localIdx nFaces,
+    BoundaryMesh boundaryMesh
+)
+    : exec_(exec), points_(points), cellVolumes_(cellVolumes), cellCentres_(cellCentres),
+      faceAreas_(faceAreas), faceCentres_(faceCentres), magFaceAreas_(magFaceAreas),
+      faceOwner_(faceOwner), faceNeighbour_(faceNeighbour), nCells_(nCells),
+      nInternalFaces_(nInternalFaces), nBoundaryFaces_(nBoundaryFaces), nBoundaries_(nBoundaries),
+      nFaces_(nFaces), boundaryMesh_(boundaryMesh), stencilDataBase_()
+{}
 
 UnstructuredMesh::UnstructuredMesh(
     vectorVector points,
@@ -26,11 +49,23 @@ UnstructuredMesh::UnstructuredMesh(
     localIdx nFaces,
     BoundaryMesh boundaryMesh
 )
-    : exec_(points.exec()), points_(points), cellVolumes_(cellVolumes), cellCentres_(cellCentres),
-      faceAreas_(faceAreas), faceCentres_(faceCentres), magFaceAreas_(magFaceAreas),
-      faceOwner_(faceOwner), faceNeighbour_(faceNeighbour), nCells_(nCells),
-      nInternalFaces_(nInternalFaces), nBoundaryFaces_(nBoundaryFaces), nBoundaries_(nBoundaries),
-      nFaces_(nFaces), boundaryMesh_(boundaryMesh), stencilDataBase_()
+    : UnstructuredMesh(
+        faceOwner.exec(),
+        points,
+        cellVolumes,
+        cellCentres,
+        faceAreas,
+        faceCentres,
+        magFaceAreas,
+        faceOwner,
+        faceNeighbour,
+        nCells,
+        nInternalFaces,
+        nBoundaryFaces,
+        nBoundaries,
+        nFaces,
+        boundaryMesh
+    )
 {}
 
 

--- a/src/mesh/unstructured/unstructuredMesh.cpp
+++ b/src/mesh/unstructured/unstructuredMesh.cpp
@@ -36,19 +36,35 @@ UnstructuredMesh::UnstructuredMesh(
 
 const vectorVector& UnstructuredMesh::points() const { return points_; }
 
+vectorVector& UnstructuredMesh::points() { return points_; }
+
 const scalarVector& UnstructuredMesh::cellVolumes() const { return cellVolumes_; }
+
+scalarVector& UnstructuredMesh::cellVolumes() { return cellVolumes_; }
 
 const vectorVector& UnstructuredMesh::cellCentres() const { return cellCentres_; }
 
+vectorVector& UnstructuredMesh::cellCentres() { return cellCentres_; }
+
 const vectorVector& UnstructuredMesh::faceCentres() const { return faceCentres_; }
+
+vectorVector& UnstructuredMesh::faceCentres() { return faceCentres_; }
 
 const vectorVector& UnstructuredMesh::faceAreas() const { return faceAreas_; }
 
+vectorVector& UnstructuredMesh::faceAreas() { return faceAreas_; }
+
 const scalarVector& UnstructuredMesh::magFaceAreas() const { return magFaceAreas_; }
+
+scalarVector& UnstructuredMesh::magFaceAreas() { return magFaceAreas_; }
 
 const labelVector& UnstructuredMesh::faceOwner() const { return faceOwner_; }
 
+labelVector& UnstructuredMesh::faceOwner() { return faceOwner_; }
+
 const labelVector& UnstructuredMesh::faceNeighbour() const { return faceNeighbour_; }
+
+labelVector& UnstructuredMesh::faceNeighbour() { return faceNeighbour_; }
 
 localIdx UnstructuredMesh::nCells() const { return nCells_; }
 


### PR DESCRIPTION
Minor changes to allow reducing the mesh memory footprint.

- add non const accessors to unstructuredMesh 
- dont use points executor as default for mesh. 