### PR TITLE
Use NVIDIA GPUs other than H100 for CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,8 +4,8 @@
 
 # Available GPUs and corresponding Docker images
 .use-nvidia-gpu:
-  tags: ["nvidia-h100-gpus"]
-  image: chihtaw/cuda-openfoam-ginkgo:12.8.1-v2412-arch_90
+  tags: ["nvidia-gpus"]
+  image: chihtaw/cuda-openfoam-ginkgo:12.8.1-v2412-arch_89
 
 .use-amd-gpu:
   tags: ["amd-gpus"]

--- a/ci/lrz-gitlab/build-and-test.sh
+++ b/ci/lrz-gitlab/build-and-test.sh
@@ -28,7 +28,7 @@ if [ "$GPU_TYPE" == "nvidia" ]; then
 
     echo "=== Configuring, building, and testing NeoN on NVIDIA ==="
     cmake --preset develop \
-        -DCMAKE_CUDA_ARCHITECTURES=89 \
+        -DCMAKE_CUDA_ARCHITECTURES=90 \
         -DNeoN_WITH_THREADS=OFF \
         -DNeoN_BUILD_BENCHMARKS=ON
     cmake --build --preset develop
@@ -37,7 +37,6 @@ if [ "$GPU_TYPE" == "nvidia" ]; then
 elif [ "$GPU_TYPE" == "amd" ]; then
     # Set up environment
     export PATH=/opt/rocm/bin:$PATH
-    export HIPCC_CXX=/usr/bin/g++
 
     echo "=== AMD GPU and compiler driver info ==="
     rocminfo | grep "AMD"

--- a/ci/lrz-gitlab/build-and-test.sh
+++ b/ci/lrz-gitlab/build-and-test.sh
@@ -28,7 +28,7 @@ if [ "$GPU_TYPE" == "nvidia" ]; then
 
     echo "=== Configuring, building, and testing NeoN on NVIDIA ==="
     cmake --preset develop \
-        -DCMAKE_CUDA_ARCHITECTURES=90 \
+        -DCMAKE_CUDA_ARCHITECTURES=89 \
         -DNeoN_WITH_THREADS=OFF \
         -DNeoN_BUILD_BENCHMARKS=ON
     cmake --build --preset develop


### PR DESCRIPTION
# Motivation
Use another compute node of TUM COMA cluster: `gpu-nvidia` which contains NVIDIA L40S GPUs.