### PR TITLE
Update Intel docker-image with pre-installed ginkgo

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@
 
 .use-intel-gpu:
   tags: ["intel-gpus"]
-  image: dheerajraghunathan/oneapi-openfoam:2025.3-v2412-arch_pvc
+  image: dheerajraghunathan/oneapi-openfoam-ginkgo:2025.3-v2412-arch_pvc
 
 # Common configuration for all build and test jobs
 .build-and-test-neon-common:


### PR DESCRIPTION
This PR updates the docker image for intel. Ginkgo 1.11.0 is pre-installed.