### PR TITLE
Add benchmarks on Intel CI & Update AMD benchmark config

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -120,3 +120,9 @@ benchmark-neon-amd:
     - .gpu-amd
     - .rules-neon-benchmarking
     - .benchmark
+
+benchmark-neon-intel:
+  extends:
+    - .gpu-intel
+    - .rules-neon-benchmarking
+    - .benchmark

--- a/benchmarks/catch_main.hpp
+++ b/benchmarks/catch_main.hpp
@@ -26,5 +26,5 @@ int main(int argc, char* argv[])
 
     int result = session.run();
 
-    return result;
+    std::_Exit(result); // Note: Fix for bench_allocator failure on Intel GPU
 }

--- a/benchmarks/catch_main.hpp
+++ b/benchmarks/catch_main.hpp
@@ -26,5 +26,5 @@ int main(int argc, char* argv[])
 
     int result = session.run();
 
-    std::_Exit(result); // Note: Fix for bench_allocator failure on Intel GPU
+    std::_Exit(result); // Note: Fix for bench_allocator failure
 }

--- a/ci/lrz-gitlab/benchmark.sh
+++ b/ci/lrz-gitlab/benchmark.sh
@@ -34,6 +34,8 @@ collect_system_info() {
             nvidia-smi
         elif [[ "$1" == "amd" ]]; then
             rocm-smi --showproductname --showvbios
+        elif [[ "$1" == "intel" ]]; then
+            SYCL_UR_TRACE=1 sycl-ls
         else
             echo "No GPU selected"
         fi
@@ -47,7 +49,7 @@ collect_system_info() {
         g++ --version || clang++ --version || echo "No C++ compiler found"
         echo ""
         echo "CUDA/ROCm compiler:"
-        nvcc --version 2>/dev/null || hipcc --version 2>/dev/null || echo "No GPU compiler available"
+        nvcc --version 2>/dev/null || hipcc --version 2>/dev/null || icpx --version 2>/dev/null  || echo "No GPU compiler available"
     } > "${RESULTS_DIR}/system-info.log"
 }
 
@@ -74,12 +76,11 @@ build_and_benchmark() {
             -DKokkos_ARCH_AMD_GFX90A=ON \
             -DNeoN_WITH_THREADS=OFF
     elif [[ "$GPU_VENDOR" == "intel" ]]; then
-        export ONEAPI_DEVICE_SELECTOR=level_zero:gpu
-
         cmake --preset $PRESET \
             -DCMAKE_CXX_COMPILER=icpx \
             -DCMAKE_CXX_FLAGS="-Wno-deprecated-declarations -Wno-sycl-2020-compat" \
             -DKokkos_ENABLE_SYCL=ON \
+            -DKokkos_ARCH_INTEL_PVC=ON \
             -DNeoN_WITH_THREADS=OFF \
             -DNeoN_BUILD_BENCHMARKS=ON \
             -DCMAKE_BUILD_TYPE="release"

--- a/ci/lrz-gitlab/benchmark.sh
+++ b/ci/lrz-gitlab/benchmark.sh
@@ -35,7 +35,8 @@ collect_system_info() {
         elif [[ "$1" == "amd" ]]; then
             rocm-smi --showproductname --showvbios
         elif [[ "$1" == "intel" ]]; then
-            SYCL_UR_TRACE=1 sycl-ls
+            SYCL_PI_TRACE=1
+            sycl-ls
         else
             echo "No GPU selected"
         fi
@@ -67,11 +68,16 @@ build_and_benchmark() {
         cmake --preset $PRESET -DCMAKE_CUDA_ARCHITECTURES=90 -DNeoN_WITH_THREADS=OFF
     elif [[ "$GPU_VENDOR" == "amd" ]]; then
         # Set up environment
-        export PATH=/opt/rocm/bin:$PATH
-        export HIPCC_CXX=/usr/bin/g++
-
+        export CXX_COMPILER_PATH="$(which g++)"
+        export CXX_SOURCE="${CXX_COMPILER_PATH%/*/*}"
+        export CXX_LIBDIR="${CXX_SOURCE}/lib64"
+        export LD_LIBRARY_PATH=${CXX_LIBDIR}:${LD_LIBRARY_PATH}
         cmake --preset $PRESET \
-            -DCMAKE_CXX_COMPILER=hipcc \
+            -DCMAKE_PREFIX_PATH=/opt/rocm \
+            -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang \
+            -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ \
+            -DCMAKE_CXX_FLAGS="--gcc-toolchain=${CXX_SOURCE}" \
+            -DCMAKE_EXE_LINKER_FLAGS="-L${CXX_LIBDIR}" \
             -DCMAKE_HIP_ARCHITECTURES=gfx90a \
             -DKokkos_ARCH_AMD_GFX90A=ON \
             -DNeoN_WITH_THREADS=OFF
@@ -82,7 +88,6 @@ build_and_benchmark() {
             -DKokkos_ENABLE_SYCL=ON \
             -DKokkos_ARCH_INTEL_PVC=ON \
             -DNeoN_WITH_THREADS=OFF \
-            -DNeoN_BUILD_BENCHMARKS=ON \
             -DCMAKE_BUILD_TYPE="release"
     else
         cmake --preset $PRESET -DNeoN_WITH_THREADS=OFF

--- a/ci/lrz-gitlab/benchmark.sh
+++ b/ci/lrz-gitlab/benchmark.sh
@@ -73,6 +73,16 @@ build_and_benchmark() {
             -DCMAKE_HIP_ARCHITECTURES=gfx90a \
             -DKokkos_ARCH_AMD_GFX90A=ON \
             -DNeoN_WITH_THREADS=OFF
+    elif [[ "$GPU_VENDOR" == "intel" ]]; then
+        export ONEAPI_DEVICE_SELECTOR=level_zero:gpu
+
+        cmake --preset $PRESET \
+            -DCMAKE_CXX_COMPILER=icpx \
+            -DCMAKE_CXX_FLAGS="-Wno-deprecated-declarations -Wno-sycl-2020-compat" \
+            -DKokkos_ENABLE_SYCL=ON \
+            -DNeoN_WITH_THREADS=OFF \
+            -DNeoN_BUILD_BENCHMARKS=ON \
+            -DCMAKE_BUILD_TYPE="release"
     else
         cmake --preset $PRESET -DNeoN_WITH_THREADS=OFF
     fi

--- a/ci/lrz-gitlab/benchmark.sh
+++ b/ci/lrz-gitlab/benchmark.sh
@@ -36,7 +36,7 @@ collect_system_info() {
             rocm-smi --showproductname --showvbios
         elif [[ "$1" == "intel" ]]; then
             SYCL_PI_TRACE=1
-            sycl-ls
+            sycl-ls 2>/dev/null | grep '^\[level_zero:gpu\]'
         else
             echo "No GPU selected"
         fi

--- a/ci/lrz-gitlab/benchmark.sh
+++ b/ci/lrz-gitlab/benchmark.sh
@@ -127,8 +127,8 @@ collect_system_info "${GPU_VENDOR}"
 # Current branch
 build_and_benchmark "$(git rev-parse --abbrev-ref HEAD)" "${RESULTS_DIR}"
 
-# Main branch
-build_and_benchmark "main" "${RESULTS_DIR}/main"
+# Develop branch
+build_and_benchmark "develop" "${RESULTS_DIR}/develop"
 
 # Push results
 push_results

--- a/ci/lrz-gitlab/build-and-test.sh
+++ b/ci/lrz-gitlab/build-and-test.sh
@@ -56,9 +56,7 @@ elif [ "$GPU_VENDOR" == "amd" ]; then
     ctest --preset develop -E bench --output-on-failure
 
 elif [ "$GPU_VENDOR" == "intel" ]; then
-    if ! sycl-ls --ignore-device-selectors 2>/dev/null | grep -qi intel; then
-        echo "No Intel GPU found or Level Zero runtime not available"
-    fi
+    SYCL_UR_TRACE=1 sycl-ls
 
     # Compiler info (non-fatal)
     icpx --version 2>/dev/null | head -1 || echo "icpx not found"
@@ -68,11 +66,11 @@ elif [ "$GPU_VENDOR" == "intel" ]; then
         -DCMAKE_CXX_COMPILER=icpx \
         -DCMAKE_CXX_FLAGS="-Wno-deprecated-declarations -Wno-sycl-2020-compat" \
         -DKokkos_ENABLE_SYCL=ON \
+        -DKokkos_ARCH_INTEL_PVC=ON \
         -DNeoN_WITH_THREADS=OFF \
         -DNeoN_BUILD_BENCHMARKS=ON \
         -DCMAKE_BUILD_TYPE="release"
     cmake --build --preset develop
-    export ONEAPI_DEVICE_SELECTOR=level_zero:gpu
     ctest --preset develop -E bench --output-on-failure
 
 else

--- a/ci/lrz-gitlab/build-and-test.sh
+++ b/ci/lrz-gitlab/build-and-test.sh
@@ -56,7 +56,8 @@ elif [ "$GPU_VENDOR" == "amd" ]; then
     ctest --preset develop -E bench --output-on-failure
 
 elif [ "$GPU_VENDOR" == "intel" ]; then
-    SYCL_UR_TRACE=1 sycl-ls
+    SYCL_PI_TRACE=1
+    sycl-ls
 
     # Compiler info (non-fatal)
     icpx --version 2>/dev/null | head -1 || echo "icpx not found"
@@ -68,8 +69,8 @@ elif [ "$GPU_VENDOR" == "intel" ]; then
         -DKokkos_ENABLE_SYCL=ON \
         -DKokkos_ARCH_INTEL_PVC=ON \
         -DNeoN_WITH_THREADS=OFF \
-        -DNeoN_BUILD_BENCHMARKS=ON \
-        -DCMAKE_BUILD_TYPE="release"
+        -DCMAKE_BUILD_TYPE="release" \
+        -DNeoN_BUILD_BENCHMARKS=ON
     cmake --build --preset develop
     ctest --preset develop -E bench --output-on-failure
 

--- a/ci/lrz-gitlab/build-and-test.sh
+++ b/ci/lrz-gitlab/build-and-test.sh
@@ -57,7 +57,7 @@ elif [ "$GPU_VENDOR" == "amd" ]; then
 
 elif [ "$GPU_VENDOR" == "intel" ]; then
     SYCL_PI_TRACE=1
-    sycl-ls
+    sycl-ls 2>/dev/null | grep '^\[level_zero:gpu\]'
 
     # Compiler info (non-fatal)
     icpx --version 2>/dev/null | head -1 || echo "icpx not found"


### PR DESCRIPTION
This PR 
- Adds the benchmark trigger for the Intel CI.
- Updates benchmark config on AMD CI.
- Fix `bench_allocator` failure in the current develop branch.

Close #450 
