### PR TITLE
feat: mesh connectivity reconstruction internals

### DIFF
--- a/include/NeoN/mesh/unstructured/io/connectivity/cellReconstruction.hpp
+++ b/include/NeoN/mesh/unstructured/io/connectivity/cellReconstruction.hpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "NeoN/mesh/unstructured/io/connectivity/types.hpp"
+
+namespace NeoN::io
+{
+
+/// Reconstruct cell-to-node connectivity from face topology.
+///
+/// Collects faces per cell via faceOwner/faceNeighbour, builds unique
+/// node set, determines element type from face/node counts.
+/// Runs on the host (copies inputs); results are placed on exec.
+CellConnectivity rebuildCellConnectivity(
+    const Executor& exec,
+    const Vector<localIdx>& faceOwner,
+    const Vector<localIdx>& faceNeighbour,
+    const SegmentedVector<localIdx, localIdx>& faceNodes,
+    localIdx nCells,
+    localIdx nInternalFaces,
+    localIdx nFaces
+);
+
+/// Reconstruct per-cell info including face-node lists from face topology.
+///
+/// Like rebuildCellConnectivity but also stores cellFaceNodes per cell,
+/// needed by node ordering functions and writers. Always host-side.
+std::vector<CellInfo> rebuildCellInfo(
+    const Vector<localIdx>& faceOwner,
+    const Vector<localIdx>& faceNeighbour,
+    const SegmentedVector<localIdx, localIdx>& faceNodes,
+    localIdx nCells,
+    localIdx nInternalFaces,
+    localIdx nFaces
+);
+
+} // namespace NeoN::io

--- a/include/NeoN/mesh/unstructured/io/connectivity/faceTopology.hpp
+++ b/include/NeoN/mesh/unstructured/io/connectivity/faceTopology.hpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "NeoN/mesh/unstructured/io/connectivity/types.hpp"
+
+namespace NeoN::io
+{
+
+/// Build face topology from cell-to-node connectivity.
+///
+/// Each cell's faces are identified using element-type face templates,
+/// then deduplicated using canonical (sorted) face keys. Shared faces
+/// become internal faces; unshared faces become boundary faces.
+/// The deduplication runs on the host; results are copied to exec.
+FaceTopology buildFaceTopology(const Executor& exec, const CellConnectivity& connectivity);
+
+} // namespace NeoN::io

--- a/include/NeoN/mesh/unstructured/io/connectivity/nodeOrdering.hpp
+++ b/include/NeoN/mesh/unstructured/io/connectivity/nodeOrdering.hpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "NeoN/mesh/unstructured/io/connectivity/types.hpp"
+
+namespace NeoN::io
+{
+
+/// Order quad nodes: returns [n0, n1, n2, n3] in connected edge order (0-based).
+std::vector<localIdx> orderQuadNodes(const CellInfo& cell);
+
+/// Order tet nodes: returns [base0, base1, base2, apex] (0-based).
+std::vector<localIdx> orderTetNodes(const CellInfo& cell);
+
+/// Order hex nodes: returns [bottom0..3, top0..3] (0-based).
+std::vector<localIdx> orderHexNodes(const CellInfo& cell);
+
+/// Order pyramid nodes: returns [base0..3, apex] (0-based).
+std::vector<localIdx> orderPyramidNodes(const CellInfo& cell);
+
+/// Order wedge/prism nodes: returns [bottom0..2, top0..2] (0-based).
+std::vector<localIdx> orderWedgeNodes(const CellInfo& cell);
+
+} // namespace NeoN::io

--- a/include/NeoN/mesh/unstructured/io/connectivity/types.hpp
+++ b/include/NeoN/mesh/unstructured/io/connectivity/types.hpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "NeoN/core/executor/executor.hpp"
+#include "NeoN/core/primitives/label.hpp"
+#include "NeoN/core/primitives/scalar.hpp"
+#include "NeoN/core/primitives/vec3.hpp"
+#include "NeoN/core/segmentedVector.hpp"
+#include "NeoN/core/vector/vector.hpp"
+
+#include <vector>
+
+namespace NeoN::io
+{
+
+/// Cell connectivity: cell-to-node mapping and element type per cell.
+struct CellConnectivity
+{
+    SegmentedVector<localIdx, localIdx> cellToNodes; // on exec
+    Vector<int32_t> cellTypes;                       // VTK cell type IDs (10=TET, 12=HEX, etc.)
+    localIdx nCells {};
+};
+
+
+/// Per-cell info with face-node lists for node ordering.
+/// Host-side only: used during IO write path (node ordering, sequential graph traversal).
+struct CellInfo
+{
+    std::vector<localIdx> nodeIds;                    // unique node IDs for this cell
+    std::vector<std::vector<localIdx>> cellFaceNodes; // nodes of each face of this cell
+    int cellType {};                                  // VTK cell type ID
+};
+
+
+/// Face topology: owner/neighbour, face-to-node, internal/boundary split.
+struct FaceTopology
+{
+    Vector<localIdx> faceOwner;                    // on exec (all faces)
+    Vector<localIdx> faceNeighbour;                // on exec (internal faces only)
+    SegmentedVector<localIdx, localIdx> faceNodes; // on exec
+    localIdx nInternalFaces {};
+    localIdx nBoundaryFaces {};
+};
+
+} // namespace NeoN::io

--- a/include/NeoN/mesh/unstructured/io/connectivity/vtkExtraction.hpp
+++ b/include/NeoN/mesh/unstructured/io/connectivity/vtkExtraction.hpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "NeoN/mesh/unstructured/io/connectivity/types.hpp"
+
+class vtkUnstructuredGrid;
+
+namespace NeoN::io
+{
+
+/// Extract cell connectivity from a VTK unstructured grid.
+/// Results are placed on exec (default: SerialExecutor).
+CellConnectivity
+extractCellConnectivity(vtkUnstructuredGrid* grid, const Executor& exec = SerialExecutor {});
+
+} // namespace NeoN::io

--- a/include/NeoN/mesh/unstructured/io/meshConnectivity.hpp
+++ b/include/NeoN/mesh/unstructured/io/meshConnectivity.hpp
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "NeoN/mesh/unstructured/io/connectivity/types.hpp"
+#include "NeoN/mesh/unstructured/io/connectivity/faceTopology.hpp"
+#include "NeoN/mesh/unstructured/io/connectivity/cellReconstruction.hpp"
+#include "NeoN/mesh/unstructured/io/connectivity/nodeOrdering.hpp"
+#include "NeoN/mesh/unstructured/io/connectivity/vtkExtraction.hpp"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,6 +78,23 @@ target_link_libraries(NeoN PUBLIC NeoN_public_api)
 if(NeoN_ENABLE_MPI_SUPPORT)
   target_link_libraries(NeoN PUBLIC MPI::MPI_CXX)
 endif()
+if(NeoN_WITH_VTK)
+  target_sources(
+    NeoN
+    PRIVATE "mesh/unstructured/io/connectivity/faceTopology.cpp"
+            "mesh/unstructured/io/connectivity/cellReconstruction.cpp"
+            "mesh/unstructured/io/connectivity/nodeOrdering.cpp"
+            "mesh/unstructured/io/connectivity/vtkExtraction.cpp")
+  target_link_libraries(
+    NeoN
+    PUBLIC VTK::CommonCore
+           VTK::CommonDataModel
+           VTK::IOXML
+           VTK::IOCGNSReader
+           VTK::IOHDF
+           VTK::cgns
+           VTK::FiltersCore)
+endif()
 if(WIN32)
   set_target_properties(
     NeoN

--- a/src/mesh/unstructured/io/connectivity/cellReconstruction.cpp
+++ b/src/mesh/unstructured/io/connectivity/cellReconstruction.cpp
@@ -1,0 +1,204 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#include "NeoN/mesh/unstructured/io/connectivity/cellReconstruction.hpp"
+#include "detail.hpp"
+
+#include <algorithm>
+#include <set>
+#include <vector>
+
+
+namespace NeoN::io
+{
+
+CellConnectivity rebuildCellConnectivity(
+    const Executor& exec,
+    const Vector<localIdx>& faceOwner,
+    const Vector<localIdx>& faceNeighbour,
+    const SegmentedVector<localIdx, localIdx>& faceNodes,
+    localIdx nCells,
+    localIdx nInternalFaces,
+    localIdx nFaces
+)
+{
+    // VTK cell type constants
+    constexpr int VTK_QUAD_TYPE = 9;
+    constexpr int VTK_TETRA_TYPE = 10;
+    constexpr int VTK_HEXAHEDRON_TYPE = 12;
+    constexpr int VTK_WEDGE_TYPE = 13;
+    constexpr int VTK_PYRAMID_TYPE = 14;
+
+    // Copy to host for sequential algorithm
+    auto hostOwner = faceOwner.copyToHost();
+    auto hostNeighbour = faceNeighbour.copyToHost();
+    auto hostFaceNodes = faceNodes.copyToHost();
+
+    auto owView = hostOwner.view();
+    auto neiView = hostNeighbour.view();
+    auto fnView = hostFaceNodes.view();
+
+    // Collect faces per cell
+    std::vector<std::vector<localIdx>> cellFaces(static_cast<std::size_t>(nCells));
+    for (localIdx f = 0; f < nFaces; ++f)
+    {
+        auto oi = static_cast<std::size_t>(owView[f]);
+        cellFaces[oi].push_back(f);
+        if (f < nInternalFaces)
+        {
+            auto ni = static_cast<std::size_t>(neiView[f]);
+            cellFaces[ni].push_back(f);
+        }
+    }
+
+    std::vector<std::vector<localIdx>> hostCellToNodes(static_cast<std::size_t>(nCells));
+    std::vector<int32_t> hostCellTypes(static_cast<std::size_t>(nCells));
+
+    for (localIdx c = 0; c < nCells; ++c)
+    {
+        auto ci = static_cast<std::size_t>(c);
+
+        std::set<localIdx> nodeSet;
+        std::size_t maxNodesPerFace = 0;
+        for (localIdx f : cellFaces[ci])
+        {
+            auto [start, end] = fnView.bounds(f);
+            maxNodesPerFace = std::max(maxNodesPerFace, static_cast<std::size_t>(end - start));
+            for (auto n = start; n < end; ++n)
+            {
+                nodeSet.insert(fnView.values[n]);
+            }
+        }
+        hostCellToNodes[ci].assign(nodeSet.begin(), nodeSet.end());
+
+        localIdx nCellFaces = static_cast<localIdx>(cellFaces[ci].size());
+        localIdx nCellNodes = static_cast<localIdx>(nodeSet.size());
+
+        if (maxNodesPerFace <= 2) hostCellTypes[ci] = VTK_QUAD_TYPE;
+        else if (nCellFaces == 4 && nCellNodes == 4)
+            hostCellTypes[ci] = VTK_TETRA_TYPE;
+        else if (nCellFaces == 6 && nCellNodes == 8)
+            hostCellTypes[ci] = VTK_HEXAHEDRON_TYPE;
+        else if (nCellFaces == 5 && nCellNodes == 6)
+            hostCellTypes[ci] = VTK_WEDGE_TYPE;
+        else if (nCellFaces == 5 && nCellNodes == 5)
+            hostCellTypes[ci] = VTK_PYRAMID_TYPE;
+        else if (nCellNodes == 4)
+            hostCellTypes[ci] = VTK_TETRA_TYPE;
+        else if (nCellNodes == 8)
+            hostCellTypes[ci] = VTK_HEXAHEDRON_TYPE;
+        else
+            hostCellTypes[ci] = VTK_TETRA_TYPE;
+    }
+
+    // Pack into NeoN types: flatten cellToNodes into SegmentedVector
+    std::vector<localIdx> cellNodeValues;
+    std::vector<localIdx> cellNodeSizes;
+    for (const auto& nodes : hostCellToNodes)
+    {
+        cellNodeSizes.push_back(static_cast<localIdx>(nodes.size()));
+        cellNodeValues.insert(cellNodeValues.end(), nodes.begin(), nodes.end());
+    }
+
+    SerialExecutor serial;
+
+    return CellConnectivity {
+        detail::makeSegmentedVector(cellNodeValues, cellNodeSizes, exec),
+        Vector<int32_t>(serial, hostCellTypes).copyToExecutor(exec),
+        nCells
+    };
+}
+
+
+std::vector<CellInfo> rebuildCellInfo(
+    const Vector<localIdx>& faceOwner,
+    const Vector<localIdx>& faceNeighbour,
+    const SegmentedVector<localIdx, localIdx>& faceNodes,
+    localIdx nCells,
+    localIdx nInternalFaces,
+    localIdx nFaces
+)
+{
+    // VTK cell type constants
+    constexpr int VTK_QUAD_TYPE = 9;
+    constexpr int VTK_TETRA_TYPE = 10;
+    constexpr int VTK_HEXAHEDRON_TYPE = 12;
+    constexpr int VTK_WEDGE_TYPE = 13;
+    constexpr int VTK_PYRAMID_TYPE = 14;
+
+    // Copy to host for sequential algorithm
+    auto hostOwner = faceOwner.copyToHost();
+    auto hostNeighbour = faceNeighbour.copyToHost();
+    auto hostFaceNodes = faceNodes.copyToHost();
+
+    auto owView = hostOwner.view();
+    auto neiView = hostNeighbour.view();
+    auto fnView = hostFaceNodes.view();
+
+    // Collect faces per cell
+    std::vector<std::vector<localIdx>> cellFaces(static_cast<std::size_t>(nCells));
+    for (localIdx f = 0; f < nFaces; ++f)
+    {
+        auto oi = static_cast<std::size_t>(owView[f]);
+        cellFaces[oi].push_back(f);
+        if (f < nInternalFaces)
+        {
+            auto ni = static_cast<std::size_t>(neiView[f]);
+            cellFaces[ni].push_back(f);
+        }
+    }
+
+    std::vector<CellInfo> cells(static_cast<std::size_t>(nCells));
+
+    for (localIdx c = 0; c < nCells; ++c)
+    {
+        auto ci = static_cast<std::size_t>(c);
+        auto& cell = cells[ci];
+
+        std::set<localIdx> nodeSet;
+        for (localIdx f : cellFaces[ci])
+        {
+            auto [start, end] = fnView.bounds(f);
+            std::vector<localIdx> faceNodeVec;
+            faceNodeVec.reserve(static_cast<std::size_t>(end - start));
+            for (auto n = start; n < end; ++n)
+            {
+                faceNodeVec.push_back(fnView.values[n]);
+                nodeSet.insert(fnView.values[n]);
+            }
+            cell.cellFaceNodes.push_back(std::move(faceNodeVec));
+        }
+        cell.nodeIds.assign(nodeSet.begin(), nodeSet.end());
+
+        localIdx nCellFaces = static_cast<localIdx>(cell.cellFaceNodes.size());
+        localIdx nCellNodes = static_cast<localIdx>(cell.nodeIds.size());
+
+        std::size_t maxNodesPerFace = 0;
+        for (const auto& fn : cell.cellFaceNodes)
+        {
+            maxNodesPerFace = std::max(maxNodesPerFace, fn.size());
+        }
+
+        if (maxNodesPerFace <= 2) cell.cellType = VTK_QUAD_TYPE;
+        else if (nCellFaces == 4 && nCellNodes == 4)
+            cell.cellType = VTK_TETRA_TYPE;
+        else if (nCellFaces == 6 && nCellNodes == 8)
+            cell.cellType = VTK_HEXAHEDRON_TYPE;
+        else if (nCellFaces == 5 && nCellNodes == 6)
+            cell.cellType = VTK_WEDGE_TYPE;
+        else if (nCellFaces == 5 && nCellNodes == 5)
+            cell.cellType = VTK_PYRAMID_TYPE;
+        else if (nCellNodes == 4)
+            cell.cellType = VTK_TETRA_TYPE;
+        else if (nCellNodes == 8)
+            cell.cellType = VTK_HEXAHEDRON_TYPE;
+        else
+            cell.cellType = VTK_TETRA_TYPE;
+    }
+
+    return cells;
+}
+
+
+} // namespace NeoN::io

--- a/src/mesh/unstructured/io/connectivity/detail.hpp
+++ b/src/mesh/unstructured/io/connectivity/detail.hpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "NeoN/core/executor/executor.hpp"
+#include "NeoN/core/primitives/label.hpp"
+#include "NeoN/core/segmentedVector.hpp"
+#include "NeoN/core/vector/vector.hpp"
+
+#include <vector>
+
+namespace NeoN::io::detail
+{
+
+// Build a SegmentedVector from flat values and their per-segment sizes (on exec).
+inline SegmentedVector<localIdx, localIdx> makeSegmentedVector(
+    const std::vector<localIdx>& flatValues,
+    const std::vector<localIdx>& sizes,
+    const Executor& exec
+)
+{
+    SerialExecutor serial;
+
+    std::vector<localIdx> offsets;
+    offsets.reserve(sizes.size() + 1);
+    offsets.push_back(0);
+    for (localIdx sz : sizes)
+    {
+        offsets.push_back(offsets.back() + sz);
+    }
+
+    return SegmentedVector<localIdx, localIdx>(
+        Vector<localIdx>(serial, flatValues).copyToExecutor(exec),
+        Vector<localIdx>(serial, offsets).copyToExecutor(exec)
+    );
+}
+
+} // namespace NeoN::io::detail

--- a/src/mesh/unstructured/io/connectivity/faceTopology.cpp
+++ b/src/mesh/unstructured/io/connectivity/faceTopology.cpp
@@ -1,0 +1,271 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#include "NeoN/mesh/unstructured/io/connectivity/faceTopology.hpp"
+#include "detail.hpp"
+
+#include <algorithm>
+#include <unordered_map>
+#include <vector>
+
+
+namespace NeoN::io
+{
+
+namespace
+{
+
+// Face templates for each VTK element type (local node indices per face)
+using FaceTemplate = std::vector<std::vector<int>>;
+
+FaceTemplate tetFaces() { return {{0, 2, 1}, {0, 1, 3}, {1, 2, 3}, {0, 3, 2}}; }
+
+FaceTemplate hexFaces()
+{
+    return {{0, 3, 2, 1}, {4, 5, 6, 7}, {0, 1, 5, 4}, {2, 3, 7, 6}, {0, 4, 7, 3}, {1, 2, 6, 5}};
+}
+
+FaceTemplate wedgeFaces()
+{
+    return {{0, 2, 1}, {3, 4, 5}, {0, 1, 4, 3}, {1, 2, 5, 4}, {0, 3, 5, 2}};
+}
+
+FaceTemplate pyramidFaces() { return {{0, 3, 2, 1}, {0, 1, 4}, {1, 2, 4}, {2, 3, 4}, {0, 4, 3}}; }
+
+
+// Canonical face key: sorted node indices
+using FaceKey = std::vector<localIdx>;
+
+FaceKey makeFaceKey(const std::vector<localIdx>& faceNodeIds)
+{
+    FaceKey key(faceNodeIds);
+    std::sort(key.begin(), key.end());
+    return key;
+}
+
+struct FaceKeyHash
+{
+    std::size_t operator()(const FaceKey& key) const
+    {
+        std::size_t seed = key.size();
+        for (auto& v : key)
+        {
+            seed ^= static_cast<std::size_t>(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        }
+        return seed;
+    }
+};
+
+struct FaceData
+{
+    localIdx owner {-1};
+    localIdx neighbour {-1};
+    std::vector<localIdx> nodes;
+};
+
+
+const FaceTemplate& faceTemplateForType(int vtkCellType)
+{
+    // VTK cell type constants
+    constexpr int VTK_TETRA_TYPE = 10;
+    constexpr int VTK_HEXAHEDRON_TYPE = 12;
+    constexpr int VTK_WEDGE_TYPE = 13;
+    constexpr int VTK_PYRAMID_TYPE = 14;
+
+    static const FaceTemplate tetFacesTmpl = tetFaces();
+    static const FaceTemplate hexFacesTmpl = hexFaces();
+    static const FaceTemplate wedgeFacesTmpl = wedgeFaces();
+    static const FaceTemplate pyramidFacesTmpl = pyramidFaces();
+    static const FaceTemplate empty;
+
+    switch (vtkCellType)
+    {
+    case VTK_TETRA_TYPE:
+        return tetFacesTmpl;
+    case VTK_HEXAHEDRON_TYPE:
+        return hexFacesTmpl;
+    case VTK_WEDGE_TYPE:
+        return wedgeFacesTmpl;
+    case VTK_PYRAMID_TYPE:
+        return pyramidFacesTmpl;
+    default:
+        return empty;
+    }
+}
+
+using FaceMap = std::unordered_map<FaceKey, FaceData, FaceKeyHash>;
+
+FaceMap deduplicateFaces(
+    SegmentedVectorView<localIdx, localIdx> fnView, View<int32_t> ctView, localIdx nCells
+)
+{
+    FaceMap faceMap;
+
+    for (localIdx cellId = 0; cellId < nCells; ++cellId)
+    {
+        int cellType = static_cast<int>(ctView[cellId]);
+
+        auto [start, end] = fnView.bounds(cellId);
+        std::vector<localIdx> cellNodes;
+        cellNodes.reserve(static_cast<std::size_t>(end - start));
+        for (localIdx n = start; n < end; ++n)
+        {
+            cellNodes.push_back(fnView.values[n]);
+        }
+
+        const auto& faces = faceTemplateForType(cellType);
+        if (faces.empty()) continue;
+
+        for (const auto& faceLocalNodes : faces)
+        {
+            std::vector<localIdx> faceGlobalNodes;
+            faceGlobalNodes.reserve(faceLocalNodes.size());
+            for (int localNode : faceLocalNodes)
+            {
+                faceGlobalNodes.push_back(cellNodes[static_cast<std::size_t>(localNode)]);
+            }
+
+            FaceKey key = makeFaceKey(faceGlobalNodes);
+            auto it = faceMap.find(key);
+            if (it == faceMap.end())
+            {
+                FaceData fd;
+                fd.owner = cellId;
+                fd.nodes = faceGlobalNodes;
+                faceMap[key] = fd;
+            }
+            else
+            {
+                it->second.neighbour = cellId;
+            }
+        }
+    }
+
+    return faceMap;
+}
+
+std::pair<std::vector<FaceData>, std::vector<FaceData>> partitionAndSortFaces(FaceMap faceMap)
+{
+    std::vector<FaceData> internalFaces;
+    std::vector<FaceData> boundaryFaces;
+
+    for (auto& [key, fd] : faceMap)
+    {
+        if (fd.neighbour >= 0)
+        {
+            if (fd.owner > fd.neighbour)
+            {
+                std::swap(fd.owner, fd.neighbour);
+                std::reverse(fd.nodes.begin(), fd.nodes.end());
+            }
+            internalFaces.push_back(fd);
+        }
+        else
+        {
+            boundaryFaces.push_back(fd);
+        }
+    }
+
+    std::sort(
+        internalFaces.begin(),
+        internalFaces.end(),
+        [](const FaceData& a, const FaceData& b)
+        {
+            if (a.owner != b.owner) return a.owner < b.owner;
+            return a.neighbour < b.neighbour;
+        }
+    );
+
+    std::sort(
+        boundaryFaces.begin(),
+        boundaryFaces.end(),
+        [](const FaceData& a, const FaceData& b) { return a.owner < b.owner; }
+    );
+
+    return {internalFaces, boundaryFaces};
+}
+
+struct FaceArrays
+{
+    std::vector<localIdx> ownerData;
+    std::vector<localIdx> neighbourData;
+    std::vector<localIdx> faceNodesValues;
+    std::vector<localIdx> faceNodesSizes;
+    localIdx nInternal;
+    localIdx nBoundary;
+};
+
+FaceArrays packFaceArrays(
+    const std::vector<FaceData>& internalFaces, const std::vector<FaceData>& boundaryFaces
+)
+{
+    localIdx nInternal = static_cast<localIdx>(internalFaces.size());
+    localIdx nBoundary = static_cast<localIdx>(boundaryFaces.size());
+    localIdx nFaces = nInternal + nBoundary;
+
+    std::vector<localIdx> ownerData(static_cast<std::size_t>(nFaces));
+    std::vector<localIdx> neighbourData(static_cast<std::size_t>(nInternal));
+    std::vector<localIdx> faceNodesValues;
+    std::vector<localIdx> faceNodesSizes;
+
+    for (localIdx i = 0; i < nInternal; ++i)
+    {
+        auto idx = static_cast<std::size_t>(i);
+        ownerData[idx] = internalFaces[idx].owner;
+        neighbourData[idx] = internalFaces[idx].neighbour;
+        faceNodesSizes.push_back(static_cast<localIdx>(internalFaces[idx].nodes.size()));
+        faceNodesValues.insert(
+            faceNodesValues.end(), internalFaces[idx].nodes.begin(), internalFaces[idx].nodes.end()
+        );
+    }
+
+    for (localIdx i = 0; i < nBoundary; ++i)
+    {
+        auto idx = static_cast<std::size_t>(i);
+        ownerData[static_cast<std::size_t>(nInternal + i)] = boundaryFaces[idx].owner;
+        faceNodesSizes.push_back(static_cast<localIdx>(boundaryFaces[idx].nodes.size()));
+        faceNodesValues.insert(
+            faceNodesValues.end(), boundaryFaces[idx].nodes.begin(), boundaryFaces[idx].nodes.end()
+        );
+    }
+
+    return FaceArrays {
+        std::move(ownerData),
+        std::move(neighbourData),
+        std::move(faceNodesValues),
+        std::move(faceNodesSizes),
+        nInternal,
+        nBoundary
+    };
+}
+
+} // anonymous namespace
+
+
+FaceTopology buildFaceTopology(const Executor& exec, const CellConnectivity& connectivity)
+{
+    // Step 1: bring connectivity to host for the sequential deduplication algorithm
+    auto hostCellToNodes = connectivity.cellToNodes.copyToHost();
+    auto hostCellTypes = connectivity.cellTypes.copyToHost();
+
+    // Steps 2-4: deduplicate, partition, pack
+    auto faceMap =
+        deduplicateFaces(hostCellToNodes.view(), hostCellTypes.view(), connectivity.nCells);
+    auto [internalFaces, boundaryFaces] = partitionAndSortFaces(std::move(faceMap));
+    auto arrays = packFaceArrays(internalFaces, boundaryFaces);
+
+    // Step 5: build NeoN types on SerialExecutor, then copy to exec
+    SerialExecutor serial;
+
+    return FaceTopology {
+        Vector<localIdx>(serial, arrays.ownerData).copyToExecutor(exec),
+        Vector<localIdx>(serial, arrays.neighbourData).copyToExecutor(exec),
+        detail::makeSegmentedVector(arrays.faceNodesValues, arrays.faceNodesSizes, exec),
+        arrays.nInternal,
+        arrays.nBoundary
+    };
+}
+
+
+} // namespace NeoN::io

--- a/src/mesh/unstructured/io/connectivity/nodeOrdering.cpp
+++ b/src/mesh/unstructured/io/connectivity/nodeOrdering.cpp
@@ -1,0 +1,221 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#include "NeoN/mesh/unstructured/io/connectivity/nodeOrdering.hpp"
+
+#include <map>
+#include <set>
+#include <vector>
+
+
+namespace NeoN::io
+{
+
+std::vector<localIdx> orderQuadNodes(const CellInfo& cell)
+{
+    // Chain edges to get nodes in connected order around the quad.
+    // Each edge (face) has 2 nodes. Start from first edge and follow connectivity.
+    auto& edges = cell.cellFaceNodes;
+    std::vector<localIdx> ordered;
+    ordered.reserve(4);
+
+    // Start with the first edge
+    ordered.push_back(edges[0][0]);
+    ordered.push_back(edges[0][1]);
+
+    // Build adjacency: for each node, which edges contain it
+    std::map<localIdx, std::vector<std::size_t>> nodeToEdges;
+    for (std::size_t ei = 0; ei < edges.size(); ++ei)
+    {
+        for (localIdx n : edges[ei])
+        {
+            nodeToEdges[n].push_back(ei);
+        }
+    }
+
+    std::set<std::size_t> usedEdges;
+    usedEdges.insert(0);
+
+    // Follow the chain: last node of ordered → find next unused edge containing it
+    for (int step = 0; step < 2; ++step)
+    {
+        localIdx lastNode = ordered.back();
+        for (std::size_t ei : nodeToEdges[lastNode])
+        {
+            if (usedEdges.count(ei)) continue;
+            usedEdges.insert(ei);
+            // Add the other node of this edge
+            localIdx other = (edges[ei][0] == lastNode) ? edges[ei][1] : edges[ei][0];
+            ordered.push_back(other);
+            break;
+        }
+    }
+
+    return ordered;
+}
+
+
+std::vector<localIdx> orderTetNodes(const CellInfo& cell)
+{
+    // Take first face as base (n0, n1, n2), remaining node is apex
+    auto& baseFace = cell.cellFaceNodes[0];
+    std::set<localIdx> baseNodes(baseFace.begin(), baseFace.end());
+    localIdx apex = -1;
+    for (localIdx n : cell.nodeIds)
+    {
+        if (baseNodes.find(n) == baseNodes.end())
+        {
+            apex = n;
+            break;
+        }
+    }
+    return {baseFace[0], baseFace[1], baseFace[2], apex};
+}
+
+
+std::vector<localIdx> orderHexNodes(const CellInfo& cell)
+{
+    auto& faces = cell.cellFaceNodes;
+    auto& bottom = faces[0];
+    std::set<localIdx> bottomSet(bottom.begin(), bottom.end());
+
+    // Find top face (shares no nodes with bottom)
+    std::size_t topIdx = 1;
+    for (std::size_t fi = 1; fi < faces.size(); ++fi)
+    {
+        bool sharesNode = false;
+        for (localIdx n : faces[fi])
+        {
+            if (bottomSet.count(n))
+            {
+                sharesNode = true;
+                break;
+            }
+        }
+        if (!sharesNode)
+        {
+            topIdx = fi;
+            break;
+        }
+    }
+    std::set<localIdx> topSet(faces[topIdx].begin(), faces[topIdx].end());
+
+    // Build vertical edge map from side faces
+    std::map<localIdx, localIdx> bottomToTop;
+    for (std::size_t fi = 0; fi < faces.size(); ++fi)
+    {
+        if (fi == 0 || fi == topIdx) continue;
+        auto& sideFace = faces[fi];
+        auto sz = sideFace.size();
+        for (std::size_t i = 0; i < sz; ++i)
+        {
+            localIdx a = sideFace[i];
+            localIdx b = sideFace[(i + 1) % sz];
+            bool aBot = bottomSet.count(a) > 0;
+            bool bBot = bottomSet.count(b) > 0;
+            bool aTop = topSet.count(a) > 0;
+            bool bTop = topSet.count(b) > 0;
+            if (aBot && bTop) bottomToTop[a] = b;
+            else if (bBot && aTop)
+                bottomToTop[b] = a;
+        }
+    }
+
+    std::vector<localIdx> nodes(8);
+    for (int i = 0; i < 4; ++i)
+    {
+        auto bi = static_cast<std::size_t>(i);
+        nodes[bi] = bottom[bi];
+        auto it = bottomToTop.find(bottom[bi]);
+        if (it != bottomToTop.end())
+        {
+            nodes[bi + 4] = it->second;
+        }
+    }
+    return nodes;
+}
+
+
+std::vector<localIdx> orderPyramidNodes(const CellInfo& cell)
+{
+    auto& faces = cell.cellFaceNodes;
+    std::size_t baseIdx = 0;
+    for (std::size_t fi = 0; fi < faces.size(); ++fi)
+    {
+        if (faces[fi].size() == 4)
+        {
+            baseIdx = fi;
+            break;
+        }
+    }
+    auto& base = faces[baseIdx];
+    std::set<localIdx> baseSet(base.begin(), base.end());
+
+    localIdx apex = -1;
+    for (localIdx n : cell.nodeIds)
+    {
+        if (baseSet.find(n) == baseSet.end())
+        {
+            apex = n;
+            break;
+        }
+    }
+
+    return {base[0], base[1], base[2], base[3], apex};
+}
+
+
+std::vector<localIdx> orderWedgeNodes(const CellInfo& cell)
+{
+    auto& faces = cell.cellFaceNodes;
+    std::vector<std::size_t> triFaces;
+    for (std::size_t fi = 0; fi < faces.size(); ++fi)
+    {
+        if (faces[fi].size() == 3)
+        {
+            triFaces.push_back(fi);
+        }
+    }
+
+    auto& bottom = faces[triFaces[0]];
+    std::set<localIdx> bottomSet(bottom.begin(), bottom.end());
+    std::set<localIdx> topSet(faces[triFaces[1]].begin(), faces[triFaces[1]].end());
+
+    // Build vertical edge map from quad side faces
+    std::map<localIdx, localIdx> bottomToTop;
+    for (std::size_t fi = 0; fi < faces.size(); ++fi)
+    {
+        if (faces[fi].size() != 4) continue;
+        auto& sideFace = faces[fi];
+        auto sz = sideFace.size();
+        for (std::size_t i = 0; i < sz; ++i)
+        {
+            localIdx a = sideFace[i];
+            localIdx b = sideFace[(i + 1) % sz];
+            bool aBot = bottomSet.count(a) > 0;
+            bool bBot = bottomSet.count(b) > 0;
+            bool aTop = topSet.count(a) > 0;
+            bool bTop = topSet.count(b) > 0;
+            if (aBot && bTop) bottomToTop[a] = b;
+            else if (bBot && aTop)
+                bottomToTop[b] = a;
+        }
+    }
+
+    std::vector<localIdx> nodes(6);
+    for (int i = 0; i < 3; ++i)
+    {
+        auto bi = static_cast<std::size_t>(i);
+        nodes[bi] = bottom[bi];
+        auto it = bottomToTop.find(bottom[bi]);
+        if (it != bottomToTop.end())
+        {
+            nodes[bi + 3] = it->second;
+        }
+    }
+    return nodes;
+}
+
+
+} // namespace NeoN::io

--- a/src/mesh/unstructured/io/connectivity/vtkExtraction.cpp
+++ b/src/mesh/unstructured/io/connectivity/vtkExtraction.cpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#include "NeoN/mesh/unstructured/io/connectivity/vtkExtraction.hpp"
+#include "detail.hpp"
+
+#include <vtkCellIterator.h>
+#include <vtkCellType.h>
+#include <vtkIdList.h>
+#include <vtkUnstructuredGrid.h>
+
+#include <vector>
+
+
+namespace NeoN::io
+{
+
+CellConnectivity extractCellConnectivity(vtkUnstructuredGrid* grid, const Executor& exec)
+{
+    std::vector<std::vector<localIdx>> hostCellToNodes;
+    std::vector<int32_t> hostCellTypes;
+
+    auto* iter = grid->NewCellIterator();
+    for (iter->InitTraversal(); !iter->IsDoneWithTraversal(); iter->GoToNextCell())
+    {
+        int cellType = iter->GetCellType();
+
+        // Only process 3D cells
+        if (cellType != VTK_TETRA && cellType != VTK_HEXAHEDRON && cellType != VTK_WEDGE
+            && cellType != VTK_PYRAMID)
+        {
+            continue;
+        }
+
+        vtkIdList* ptIds = iter->GetPointIds();
+        std::vector<localIdx> nodes;
+        nodes.reserve(static_cast<std::size_t>(ptIds->GetNumberOfIds()));
+        for (vtkIdType i = 0; i < ptIds->GetNumberOfIds(); ++i)
+        {
+            nodes.push_back(static_cast<localIdx>(ptIds->GetId(i)));
+        }
+
+        hostCellToNodes.push_back(std::move(nodes));
+        hostCellTypes.push_back(static_cast<int32_t>(cellType));
+    }
+    iter->Delete();
+
+    localIdx nCells = static_cast<localIdx>(hostCellToNodes.size());
+
+    std::vector<localIdx> cellNodeValues;
+    std::vector<localIdx> cellNodeSizes;
+    for (const auto& nodes : hostCellToNodes)
+    {
+        cellNodeSizes.push_back(static_cast<localIdx>(nodes.size()));
+        cellNodeValues.insert(cellNodeValues.end(), nodes.begin(), nodes.end());
+    }
+
+    return CellConnectivity {
+        detail::makeSegmentedVector(cellNodeValues, cellNodeSizes, exec),
+        Vector<int32_t>(SerialExecutor {}, hostCellTypes).copyToExecutor(exec),
+        nCells
+    };
+}
+
+
+} // namespace NeoN::io

--- a/test/mesh/unstructured/CMakeLists.txt
+++ b/test/mesh/unstructured/CMakeLists.txt
@@ -7,3 +7,5 @@ if(NeoN_ENABLE_MPI_SUPPORT)
 endif()
 
 neon_unit_test(unstructuredMesh)
+
+add_subdirectory(io)

--- a/test/mesh/unstructured/io/CMakeLists.txt
+++ b/test/mesh/unstructured/io/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+#
+# SPDX-License-Identifier: Unlicense
+
+if(NeoN_WITH_VTK)
+  neon_unit_test(meshConnectivity)
+endif()

--- a/test/mesh/unstructured/io/meshConnectivity.cpp
+++ b/test/mesh/unstructured/io/meshConnectivity.cpp
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#define CATCH_CONFIG_RUNNER
+#include "catch2_common.hpp"
+
+#include "NeoN/mesh/unstructured/io/meshConnectivity.hpp"
+
+#include <set>
+
+
+namespace
+{
+
+// Helper: build a single-tet CellConnectivity on the given executor.
+// Nodes 0,1,2,3 — VTK type 10 (VTK_TETRA).
+NeoN::io::CellConnectivity makeTetConn(const NeoN::Executor& exec)
+{
+    std::vector<NeoN::localIdx> values = {0, 1, 2, 3};
+    std::vector<NeoN::localIdx> offsets = {0, 4}; // one segment [0,4)
+    NeoN::Vector<NeoN::localIdx> valVec(exec, values);
+    NeoN::Vector<NeoN::localIdx> offVec(exec, offsets);
+
+    return NeoN::io::CellConnectivity {
+        NeoN::SegmentedVector<NeoN::localIdx, NeoN::localIdx>(valVec, offVec),
+        NeoN::Vector<int32_t>(exec, std::vector<int32_t> {10}),
+        1
+    };
+}
+
+} // anonymous namespace
+
+
+TEST_CASE("CellConnectivity uses NeoN SegmentedVector and Vector types")
+{
+    NeoN::SerialExecutor exec;
+    auto conn = makeTetConn(exec);
+
+    REQUIRE(conn.nCells == 1);
+    REQUIRE(conn.cellTypes.size() == 1);
+    REQUIRE(conn.cellToNodes.numSegments() == 1);
+}
+
+
+TEST_CASE("buildFaceTopology takes Executor and returns NeoN FaceTopology")
+{
+    NeoN::SerialExecutor exec;
+    auto conn = makeTetConn(exec);
+    auto topo = NeoN::io::buildFaceTopology(exec, conn);
+
+    REQUIRE(topo.nInternalFaces == 0);
+    REQUIRE(topo.nBoundaryFaces == 4);
+    REQUIRE(topo.faceOwner.size() == 4);
+    REQUIRE(topo.faceNeighbour.size() == 0);
+    REQUIRE(topo.faceNodes.numSegments() == 4);
+}
+
+
+TEST_CASE("rebuildCellConnectivity takes NeoN types as input and output")
+{
+    NeoN::SerialExecutor exec;
+    auto conn = makeTetConn(exec);
+    auto topo = NeoN::io::buildFaceTopology(exec, conn);
+
+    NeoN::localIdx nFaces = topo.nInternalFaces + topo.nBoundaryFaces;
+    auto rebuilt = NeoN::io::rebuildCellConnectivity(
+        exec, topo.faceOwner, topo.faceNeighbour, topo.faceNodes, 1, topo.nInternalFaces, nFaces
+    );
+
+    REQUIRE(rebuilt.nCells == 1);
+    auto hostTypes = rebuilt.cellTypes.copyToHost();
+    REQUIRE(hostTypes.view()[0] == 10);
+}
+
+
+TEST_CASE("rebuildCellInfo takes NeoN types")
+{
+    NeoN::SerialExecutor exec;
+    auto conn = makeTetConn(exec);
+    auto topo = NeoN::io::buildFaceTopology(exec, conn);
+
+    NeoN::localIdx nFaces = topo.nInternalFaces + topo.nBoundaryFaces;
+    auto cells = NeoN::io::rebuildCellInfo(
+        topo.faceOwner, topo.faceNeighbour, topo.faceNodes, 1, topo.nInternalFaces, nFaces
+    );
+
+    REQUIRE(cells.size() == 1);
+    REQUIRE(cells[0].cellType == 10);
+    REQUIRE(cells[0].nodeIds.size() == 4);
+    REQUIRE(cells[0].cellFaceNodes.size() == 4);
+}
+
+
+TEST_CASE("node ordering functions work with CellInfo from NeoN-typed topology")
+{
+    NeoN::SerialExecutor exec;
+    auto conn = makeTetConn(exec);
+    auto topo = NeoN::io::buildFaceTopology(exec, conn);
+
+    NeoN::localIdx nFaces = topo.nInternalFaces + topo.nBoundaryFaces;
+    auto cells = NeoN::io::rebuildCellInfo(
+        topo.faceOwner, topo.faceNeighbour, topo.faceNodes, 1, topo.nInternalFaces, nFaces
+    );
+
+    auto ordered = NeoN::io::orderTetNodes(cells[0]);
+    REQUIRE(ordered.size() == 4);
+
+    std::set<NeoN::localIdx> nodeSet(ordered.begin(), ordered.end());
+    REQUIRE(nodeSet == std::set<NeoN::localIdx>({0, 1, 2, 3}));
+}

--- a/test/mesh/unstructured/io/testHelpers.hpp
+++ b/test/mesh/unstructured/io/testHelpers.hpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "NeoN/mesh/unstructured/io/meshConnectivity.hpp"
+
+#include <vector>
+
+namespace NeoN::test
+{
+
+/// Build a CellConnectivity with NeoN types from host vectors.
+inline io::CellConnectivity makeCellConn(
+    const Executor& exec, std::vector<std::vector<localIdx>> cells, std::vector<int32_t> types
+)
+{
+    SerialExecutor serial;
+    std::vector<localIdx> values, offsets;
+    offsets.push_back(0);
+    for (auto& c : cells)
+    {
+        values.insert(values.end(), c.begin(), c.end());
+        offsets.push_back(static_cast<localIdx>(offsets.back() + static_cast<localIdx>(c.size())));
+    }
+    return io::CellConnectivity {
+        SegmentedVector<localIdx, localIdx>(
+            Vector<localIdx>(serial, values).copyToExecutor(exec),
+            Vector<localIdx>(serial, offsets).copyToExecutor(exec)
+        ),
+        Vector<int32_t>(serial, types).copyToExecutor(exec),
+        static_cast<localIdx>(cells.size())
+    };
+}
+
+} // namespace NeoN::test


### PR DESCRIPTION
Adds face topology, cell reconstruction, node reordering, and VTK cell extraction algorithms. Hash-map dedup runs on host and results are copied to the executor. No IO format dependency — pure algorithmic layer.

Guarded by NeoN_WITH_VTK; links VTK modules required for type definitions.
