### PR TITLE
Add Mesh Iteration Strategies for Cell Based Assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Version 0.3.0 (unreleased)
 ## Features
 - Add corrected and limited-corrected face-normal gradient schemes [#514](https://github.com/exasim-project/NeoN/pull/514)
+- Add experimental support for cell based assembly strategies [#471](https://github.com/exasim-project/NeoN/pull/471)
 - Add experimental support for COO and CSR Matrices [#486](https://github.com/exasim-project/NeoN/pull/486)
 - Add experimental umpire support [#455](https://github.com/exasim-project/NeoN/pull/455)
 - Add python bindings via nanobind [#382](https://github.com/exasim-project/NeoN/pull/382)

--- a/include/NeoN/core/copyTo.hpp
+++ b/include/NeoN/core/copyTo.hpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "NeoN/core/executor/executor.hpp"
+
+namespace NeoN
+{
+
+/**
+ * @class SupportsCopyTo
+ * @brief MixinClass signaling copyTo is supported
+ *
+ *  Requires copyToExecutor to be implemented, provides a copyToHost for free
+ */
+template<typename HostType>
+class SupportsCopyTo
+{
+
+public:
+
+    virtual ~SupportsCopyTo() = default;
+
+    [[nodiscard]] virtual HostType copyToExecutor(Executor exec) const = 0;
+
+    [[nodiscard]] HostType copyToHost() const { return copyToExecutor(SerialExecutor()); }
+};
+
+}

--- a/include/NeoN/core/segmentedVector.hpp
+++ b/include/NeoN/core/segmentedVector.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "NeoN/core/view.hpp"
+#include "NeoN/core/copyTo.hpp"
 #include "NeoN/core/parallelAlgorithms.hpp"
 #include "NeoN/core/primitives/label.hpp"
 #include "NeoN/core/vector/vector.hpp"
@@ -127,7 +128,7 @@ public:
  * @ingroup Vectors
  */
 template<typename ValueType, typename IndexType>
-class SegmentedVector
+class SegmentedVector : public SupportsCopyTo<SegmentedVector<ValueType, IndexType>>
 {
 public:
 
@@ -186,14 +187,11 @@ public:
      */
     localIdx numSegments() const { return segments_.size() - 1; }
 
-    /**
-     * @brief Returns a copy of the segmentedVector on the host
-     * @return copy of the segmentedVector on the host
-     */
-    SegmentedVector<ValueType, IndexType> copyToHost() const
+    [[nodiscard]] SegmentedVector<ValueType, IndexType> copyToExecutor(Executor exec) const override
     {
-        SegmentedVector<ValueType, IndexType> result(values_.copyToHost(), segments_.copyToHost());
-        return result;
+        return SegmentedVector<ValueType, IndexType>(
+            values_.copyToExecutor(exec), segments_.copyToExecutor(exec)
+        );
     }
 
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp
@@ -9,6 +9,7 @@
 #include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
 #include "NeoN/finiteVolume/cellCentred/operators/divOperator.hpp"
 #include "NeoN/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp"
+#include "NeoN/linearAlgebra/meshIterationStrategies.hpp"
 
 namespace NeoN::finiteVolume::cellCentred
 {
@@ -106,7 +107,8 @@ public:
         const VolumeField<ValueType>& phi,
         const dsl::Coeff operatorScaling) const override
     {
-        if (dynamic_cast<const CellBased*>(ls.getMeshIterator()) != nullptr)
+        if (dynamic_cast<const la::CellBasedIterator*>(ls.getMeshIterator()->get().get())
+            != nullptr)
         {
             NF_ERROR_EXIT("CellBased iteration not implemented");
         }

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp
@@ -106,9 +106,9 @@ public:
         const VolumeField<ValueType>& phi,
         const dsl::Coeff operatorScaling) const override
     {
-        if (ls.getMeshIterator()->name() == "CellBased")
+        if (dynamic_cast<const CellBased*>(ls.getMeshIterator()) != nullptr)
         {
-            NF_ERROR_EXIT("Cellbased iteration not implemented");
+            NF_ERROR_EXIT("CellBased iteration not implemented");
         }
         const auto weights = surfaceInterpolation_.weight(faceFlux, phi);
         computeDivIntImp(ls, faceFlux, phi, weights, operatorScaling);

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp
@@ -106,6 +106,10 @@ public:
         const VolumeField<ValueType>& phi,
         const dsl::Coeff operatorScaling) const override
     {
+        if (ls.getMeshIterator()->name() == "CellBased")
+        {
+            NF_ERROR_EXIT("Cellbased iteration not implemented");
+        }
         const auto weights = surfaceInterpolation_.weight(faceFlux, phi);
         computeDivIntImp(ls, faceFlux, phi, weights, operatorScaling);
         computeDivBoundImp(ls, faceFlux, phi, weights, operatorScaling);

--- a/include/NeoN/finiteVolume/cellCentred/stencil/cellToFaceStencil.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/stencil/cellToFaceStencil.hpp
@@ -17,7 +17,11 @@ public:
 
     CellToFaceStencil(const UnstructuredMesh& mesh);
 
-    SegmentedVector<localIdx, localIdx> computeStencil() const;
+    /** @brief computes the internal mesh stencil
+     *
+     * Ie for each cell the faceIdxs of the internal faceIdxs are stored in order
+     */
+    SegmentedVector<localIdx, localIdx> computeInternalStencil() const;
 
 private:
 

--- a/include/NeoN/linearAlgebra/cooSparsityPattern.hpp
+++ b/include/NeoN/linearAlgebra/cooSparsityPattern.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "NeoN/core/copyTo.hpp"
 #include "NeoN/core/vector/vector.hpp"
 #include "NeoN/linearAlgebra/sparsityView.hpp"
 #include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
@@ -19,7 +20,7 @@ namespace NeoN::la
  * of sparsity patterns from a given unstructured mesh
  */
 template<typename IndexType>
-class CooSparsityPattern
+class CooSparsityPattern : public NeoN::SupportsCopyTo<CooSparsityPattern<IndexType>>
 {
 
     void validate() const;
@@ -33,22 +34,12 @@ public:
 
     CooSparsityPattern(Vector<IndexType>&& colIdx, Vector<IndexType>&& rowIdxs, Dimensions dim);
 
-    [[nodiscard]] CooSparsityPattern copyToHost() const
-    {
-        return CooSparsityPattern<IndexType>(
-            colIdxs_.copyToExecutor(SerialExecutor()),
-            rowIdxs_.copyToExecutor(SerialExecutor()),
-            dimensions_
-        );
-    }
-
-    [[nodiscard]] CooSparsityPattern copyToExecutor(Executor dstExec) const
+    [[nodiscard]] CooSparsityPattern copyToExecutor(Executor dstExec) const override
     {
         return CooSparsityPattern<IndexType>(
             colIdxs_.copyToExecutor(dstExec), rowIdxs_.copyToExecutor(dstExec), dimensions_
         );
     }
-
 
     ~CooSparsityPattern() = default;
 

--- a/include/NeoN/linearAlgebra/csrSparsityPattern.hpp
+++ b/include/NeoN/linearAlgebra/csrSparsityPattern.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "NeoN/core/copyTo.hpp"
 #include "NeoN/core/vector/vector.hpp"
 #include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
 #include "NeoN/linearAlgebra/sparsityView.hpp"
@@ -18,7 +19,7 @@ namespace NeoN::la
  * of sparsity patterns from a given unstructured mesh
  */
 template<typename IndexType>
-class CsrSparsityPattern
+class CsrSparsityPattern : public NeoN::SupportsCopyTo<CsrSparsityPattern<IndexType>>
 {
 
     void validate() const;
@@ -32,22 +33,12 @@ public:
 
     CsrSparsityPattern(Vector<IndexType>&& colIdx, Vector<IndexType>&& rowOffs, Dimensions dim);
 
-    [[nodiscard]] CsrSparsityPattern copyToHost() const
-    {
-        return CsrSparsityPattern<IndexType>(
-            colIdxs_.copyToExecutor(SerialExecutor()),
-            rowOffs_.copyToExecutor(SerialExecutor()),
-            dimensions_
-        );
-    }
-
-    [[nodiscard]] CsrSparsityPattern copyToExecutor(Executor dstExec) const
+    [[nodiscard]] CsrSparsityPattern copyToExecutor(Executor dstExec) const override
     {
         return CsrSparsityPattern<IndexType>(
             colIdxs_.copyToExecutor(dstExec), rowOffs_.copyToExecutor(dstExec), dimensions_
         );
     }
-
 
     ~CsrSparsityPattern() = default;
 

--- a/include/NeoN/linearAlgebra/faceToMatrixAddress.hpp
+++ b/include/NeoN/linearAlgebra/faceToMatrixAddress.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "NeoN/core/array.hpp"
+#include "NeoN/core/copyTo.hpp"
 #include "NeoN/linearAlgebra/cooSparsityPattern.hpp"
 #include "NeoN/linearAlgebra/csrSparsityPattern.hpp"
 #include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
@@ -70,7 +71,7 @@ struct FaceToMatrixView
  * the Matrix, not by this class; this class only borrows a view of the row offsets.
  *
  */
-class FaceToMatrixAddress
+class FaceToMatrixAddress : public NeoN::SupportsCopyTo<FaceToMatrixAddress>
 {
     void validate() const;
 
@@ -112,7 +113,7 @@ public:
     FaceToMatrixAddress(const FaceToMatrixAddress& mi);
 
 
-    FaceToMatrixAddress copyToExecutor(Executor dstExec) const
+    [[nodiscard]] FaceToMatrixAddress copyToExecutor(Executor dstExec) const override
     {
         return {
             ownerOffset_.copyToExecutor(dstExec),

--- a/include/NeoN/linearAlgebra/linearSystem.hpp
+++ b/include/NeoN/linearAlgebra/linearSystem.hpp
@@ -9,6 +9,7 @@
 #include "NeoN/linearAlgebra/matrix.hpp"
 #include "NeoN/linearAlgebra/cooSparsityPattern.hpp"
 #include "NeoN/linearAlgebra/csrSparsityPattern.hpp"
+#include "NeoN/linearAlgebra/meshIterationStrategies.hpp"
 #include "NeoN/linearAlgebra/faceToMatrixAddress.hpp"
 
 #include <string>
@@ -64,11 +65,13 @@ class LinearSystem
     {
         NF_ASSERT(matrix_.exec() == rhs_.exec(), "Executors are not the same");
         NF_ASSERT(matrix_.nRows() == rhs_.size(), "Matrix and RHS size mismatch");
+        NF_ASSERT(meshIteratorContext_ != nullptr, "");
         // NF_ASSERT(
         //     boundaryMatrix_.nRows() == boundaryRhs_.size(), "BMatrix.nRows() !=
         //     boundaryRHS.size()"
         // );
     }
+
 
 public:
 
@@ -78,17 +81,22 @@ public:
         const SystemMatrixType& matrix,
         const Vector<ValueType>& rhs,
         const BoundaryMatrixType& boundaryMatrix,
-        const Vector<ValueType>& boundaryRhs
+        const Vector<ValueType>& boundaryRhs,
+        std::shared_ptr<MeshIterationStrategy> strategy = std::make_shared<FaceBasedIterator>()
     )
-        : matrix_(matrix), rhs_(rhs), boundaryMatrix_(boundaryMatrix), boundaryRhs_(boundaryRhs)
+        : matrix_(matrix), rhs_(rhs), boundaryMatrix_(boundaryMatrix), boundaryRhs_(boundaryRhs),
+          meshIteratorContext_(std::make_shared<MeshIteratorContext>())
     {
+        meshIteratorContext_->setStrategy(strategy);
         validate();
     }
 
     LinearSystem(const LinearSystem& ls)
         : matrix_(ls.matrix_), rhs_(ls.rhs_), boundaryMatrix_(ls.boundaryMatrix_),
-          boundaryRhs_(ls.boundaryRhs_)
-    {}
+          boundaryRhs_(ls.boundaryRhs_), meshIteratorContext_(ls.meshIteratorContext_)
+    {
+        validate();
+    }
 
     ~LinearSystem() = default;
 
@@ -161,6 +169,8 @@ public:
         return {matrix_.view(), rhs_.view(), boundaryMatrix_.view(), boundaryRhs_.view()};
     }
 
+    std::shared_ptr<MeshIteratorContext> getMeshIterator() { return meshIteratorContext_; }
+
     const Executor& exec() const { return matrix_.exec(); }
 
 private:
@@ -176,6 +186,8 @@ private:
     Vector<ValueType> boundaryRhs_;
 
     Dictionary auxiliaryCoefficients_;
+
+    std::shared_ptr<MeshIteratorContext> meshIteratorContext_ = nullptr;
 };
 
 /*@brief helper function that creates a zero initialised linear system based on a given mesh
@@ -184,21 +196,22 @@ template<
     typename ValueType,
     typename SystemMatrixType = CSRMatrix<ValueType, localIdx>,
     typename BoundaryMatrixType = COOMatrix<ValueType, localIdx>>
-LinearSystem<ValueType, SystemMatrixType, BoundaryMatrixType>
-createEmptyLinearSystem(const UnstructuredMesh& mesh)
+LinearSystem<ValueType, SystemMatrixType, BoundaryMatrixType> createEmptyLinearSystem(
+    const UnstructuredMesh& mesh,
+    std::shared_ptr<MeshIterationStrategy> strategy = std::make_shared<FaceBasedIterator>()
+)
 {
-    auto [systemSp, ftma] =
+    auto [sp, mi] =
         createSparsityPatternFaceToMatrixAddress<typename SystemMatrixType::MatrixSparsityType>(mesh
         );
     auto bSp =
-        createBoundarySparsityPattern<typename BoundaryMatrixType::MatrixSparsityType>(mesh, *ftma);
+        createBoundarySparsityPattern<typename BoundaryMatrixType::MatrixSparsityType>(mesh, *mi);
     return {
-        SystemMatrixType(
-            Vector<ValueType>(systemSp->exec(), systemSp->nnz(), zero<ValueType>()), systemSp, ftma
-        ),
-        Vector<ValueType>(systemSp->exec(), systemSp->rows(), zero<ValueType>()),
+        SystemMatrixType(Vector<ValueType>(sp->exec(), sp->nnz(), zero<ValueType>()), sp, mi),
+        Vector<ValueType>(sp->exec(), sp->rows(), zero<ValueType>()),
         BoundaryMatrixType(Vector<ValueType>(bSp->exec(), bSp->nnz(), zero<ValueType>()), bSp),
-        Vector<ValueType>(bSp->exec(), bSp->nnz(), zero<ValueType>())
+        Vector<ValueType>(bSp->exec(), bSp->nnz(), zero<ValueType>()),
+        strategy
     };
 }
 

--- a/include/NeoN/linearAlgebra/linearSystem.hpp
+++ b/include/NeoN/linearAlgebra/linearSystem.hpp
@@ -65,7 +65,14 @@ class LinearSystem
     {
         NF_ASSERT(matrix_.exec() == rhs_.exec(), "Executors are not the same");
         NF_ASSERT(matrix_.nRows() == rhs_.size(), "Matrix and RHS size mismatch");
-        NF_ASSERT(meshIteratorContext_ != nullptr, "");
+        NF_ASSERT(
+            meshIteratorContext_ != nullptr,
+            "Mesh iterator context must be set before validating the linear system"
+        );
+        NF_ASSERT(
+            meshIteratorContext_->get() != nullptr,
+            "Mesh iterator strategy must be set before validating the linear system"
+        );
         // NF_ASSERT(
         //     boundaryMatrix_.nRows() == boundaryRhs_.size(), "BMatrix.nRows() !=
         //     boundaryRHS.size()"

--- a/include/NeoN/linearAlgebra/linearSystem.hpp
+++ b/include/NeoN/linearAlgebra/linearSystem.hpp
@@ -6,6 +6,7 @@
 
 #include "NeoN/core/vector/vector.hpp"
 #include "NeoN/core/dictionary.hpp"
+#include "NeoN/core/copyTo.hpp"
 #include "NeoN/linearAlgebra/matrix.hpp"
 #include "NeoN/linearAlgebra/cooSparsityPattern.hpp"
 #include "NeoN/linearAlgebra/csrSparsityPattern.hpp"
@@ -58,7 +59,8 @@ template<
     typename ValueType,
     typename SystemMatrixType = CSRMatrix<ValueType, localIdx>,
     typename BoundaryMatrixType = COOMatrix<ValueType, localIdx>>
-class LinearSystem
+class LinearSystem :
+    public NeoN::SupportsCopyTo<LinearSystem<ValueType, SystemMatrixType, BoundaryMatrixType>>
 {
 
     void validate()
@@ -123,13 +125,14 @@ public:
 
     [[nodiscard]] const Vector<ValueType>& boundaryRhs() const { return boundaryRhs_; }
 
-    [[nodiscard]] LinearSystem<ValueType, SystemMatrixType, BoundaryMatrixType> copyToHost() const
+    [[nodiscard]] LinearSystem<ValueType, SystemMatrixType, BoundaryMatrixType>
+    copyToExecutor(Executor exec) const override
     {
         return {
-            matrix_.copyToHost(),
-            rhs_.copyToHost(),
-            boundaryMatrix_.copyToHost(),
-            boundaryRhs_.copyToHost()
+            matrix_.copyToExecutor(exec),
+            rhs_.copyToExecutor(exec),
+            boundaryMatrix_.copyToExecutor(exec),
+            boundaryRhs_.copyToExecutor(exec)
         };
     }
 

--- a/include/NeoN/linearAlgebra/matrix.hpp
+++ b/include/NeoN/linearAlgebra/matrix.hpp
@@ -67,7 +67,7 @@ struct MatrixView
  * @tparam IndexType The index type of the rows and columns.
  */
 template<typename ValueType, typename SparsityType>
-class Matrix
+class Matrix : public NeoN::SupportsCopyTo<Matrix<ValueType, SparsityType>>
 {
 
     void validate()
@@ -192,21 +192,7 @@ public:
      * @param dstExec The destination executor.
      * @return A copy of the matrix on the destination executor.
      */
-    [[nodiscard]] Matrix<ValueType, SparsityType> copyToExecutor(Executor dstExec) const
-    {
-        if (dstExec == values_.exec())
-        {
-            return *this;
-        }
-        return {
-            values_.copyToExecutor(dstExec),
-            std::make_shared<const SparsityType>(this->sparsityPattern_->copyToExecutor(dstExec)),
-            (faceToMatrixAddress_) ? std::make_shared<const FaceToMatrixAddress>(
-                this->faceToMatrixAddress_->copyToExecutor(dstExec)
-            )
-                                   : nullptr
-        };
-    }
+    [[nodiscard]] Matrix<ValueType, SparsityType> copyToExecutor(Executor dstExec) const override;
 
     /**
      * @brief Get a reference to column indices vector.
@@ -220,28 +206,6 @@ public:
     [[nodiscard]] std::shared_ptr<const FaceToMatrixAddress> faceToMatrixAddress() const
     {
         return faceToMatrixAddress_;
-    }
-
-    /**
-     * @brief Copy the matrix to the host.
-     * @return A copy of the matrix on the host.
-     */
-    [[nodiscard]] Matrix<ValueType, SparsityType> copyToHost() const
-    {
-        if constexpr (std::is_same_v<typename SparsityType::SparsityIndexType, localIdx>)
-        {
-            if (faceToMatrixAddress_)
-            {
-                auto hostSp = std::make_shared<const SparsityType>(sparsityPattern_->copyToHost());
-                auto hostFtma = std::make_shared<const FaceToMatrixAddress>(
-                    faceToMatrixAddress_->ownerOffset().copyToHost(),
-                    faceToMatrixAddress_->neighbourOffset().copyToHost(),
-                    faceToMatrixAddress_->diagOffset().copyToHost()
-                );
-                return {values_.copyToHost(), hostSp, hostFtma};
-            }
-        }
-        return copyToExecutor(SerialExecutor());
     }
 
     /**

--- a/include/NeoN/linearAlgebra/meshIterationStrategies.hpp
+++ b/include/NeoN/linearAlgebra/meshIterationStrategies.hpp
@@ -4,6 +4,10 @@
 
 #pragma once
 
+#include <cstddef>
+#include <memory>
+#include <string>
+
 #include "NeoN/core/segmentedVector.hpp"
 
 #include "NeoN/linearAlgebra/csrSparsityPattern.hpp"

--- a/include/NeoN/linearAlgebra/meshIterationStrategies.hpp
+++ b/include/NeoN/linearAlgebra/meshIterationStrategies.hpp
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "NeoN/core/segmentedVector.hpp"
+
+#include "NeoN/linearAlgebra/csrSparsityPattern.hpp"
+#include "NeoN/linearAlgebra/cooSparsityPattern.hpp"
+#include "NeoN/linearAlgebra/faceToMatrixAddress.hpp"
+#include "NeoN/finiteVolume/cellCentred/stencil/cellToFaceStencil.hpp"
+
+namespace NeoN::la
+{
+
+/** @brief Abstract base class defining the interface for mesh iteration strategies.
+ *
+ * Concrete strategies (e.g. FaceBasedIterator, CellBasedIterator) differ in how they
+ * traverse the mesh when assembling linear-system contributions.
+ */
+class MeshIterationStrategy
+{
+
+protected:
+public:
+
+    /** @brief Returns the strategy name. */
+    virtual std::string name() const = 0;
+
+    /** @brief Returns the number of iteration elements (cells or faces). */
+    virtual size_t size() const = 0;
+
+    virtual ~MeshIterationStrategy() {}
+};
+
+/** @brief Holds and exposes the active MeshIterationStrategy.
+ *
+ * Acts as a strategy context: callers set one concrete strategy and then query
+ * it uniformly through @ref get and @ref name without knowing the concrete type.
+ */
+class MeshIteratorContext
+{
+
+    std::shared_ptr<MeshIterationStrategy> strategy {};
+
+public:
+
+    /** @brief Replaces the active strategy. */
+    void setStrategy(std::shared_ptr<MeshIterationStrategy> strategy_);
+
+    /** @brief Returns the active strategy, or nullptr if none has been set. */
+    std::shared_ptr<MeshIterationStrategy> get() const;
+
+    /** @brief Returns the name of the active strategy, or an empty string if none is set. */
+    std::string name() const;
+};
+
+
+/** @brief Iteration strategy that traverses internal faces.
+ *
+ * Used when assembling operator contributions face-by-face, visiting each
+ * internal face once and scattering to the owner and neighbour cells.
+ */
+class FaceBasedIterator : public MeshIterationStrategy
+{
+
+public:
+
+    std::string name() const override { return "FaceBased"; }
+
+    size_t size() const override { return 0; }
+
+    ~FaceBasedIterator() override {}
+};
+
+
+/** @brief Iteration strategy that traverses cells and their face stencils.
+ *
+ * Pre-computes a cell-centric connectivity table (@ref CellBasedData) so that
+ * each cell can independently gather all face contributions during assembly,
+ * which is better suited for GPU-parallel execution than the face-based approach.
+ */
+class CellBasedIterator : public MeshIterationStrategy
+{
+
+
+public:
+
+    CellBasedIterator();
+
+    /** @brief Pre-computed connectivity required for cell-based assembly.
+     *
+     * All arrays are indexed by the flat position within @ref cellFaces, i.e.
+     * for cell @c c the relevant slice runs from @c cellFaces.offset(c) to
+     * @c cellFaces.offset(c+1).
+     */
+    struct CellBasedData
+    {
+        localIdx size; ///< Number of cells.
+
+        /** @brief Cell-to-face stencil; segments correspond to cells, values are face indices. */
+        SegmentedVector<localIdx, localIdx> cellFaces;
+
+        /** @brief For each stencil entry: the cell on the other side of the face. */
+        Vector<localIdx> faceNeighbour;
+
+        // TODO scalar is unreasonable large here
+        /** @brief Sign of the face contribution: +1 if this cell owns the face, -1 otherwise. */
+        Vector<scalar> faceSign;
+
+        /** @brief Flat index into the CSR matrix values array for each stencil entry. */
+        Vector<localIdx> matrixColumnIdx;
+    };
+
+    std::string name() const override;
+
+    size_t size() const override;
+
+    ~CellBasedIterator() override {}
+
+    /** @brief Returns the pre-computed connectivity data, or nullptr if not yet initialised. */
+    std::shared_ptr<CellBasedData> getCellBasedData();
+
+    /** @brief Computes and stores the cell-based connectivity data.
+     *
+     * @tparam SparsityType      Sparsity pattern type (e.g. CsrSparsityPattern,
+     * CooSparsityPattern).
+     * @param mesh               The mesh providing owner/neighbour topology.
+     * @param sparsityPattern    Sparsity pattern of the linear system.
+     * @param faceToMatrixAddress Mapping from faces to matrix row offsets.
+     */
+    template<typename SparsityType>
+    void setComputeCellBasedData(
+        const UnstructuredMesh& mesh,
+        std::shared_ptr<const SparsityType> sparsityPattern,
+        std::shared_ptr<const la::FaceToMatrixAddress> faceToMatrixAddress
+    );
+
+    /** @brief Builds and returns cell-based connectivity data without storing it.
+     *
+     * Launches a parallel kernel that, for every cell, iterates over its face
+     * stencil and records the neighbour cell, the face sign, and the matrix
+     * column index for each face.
+     *
+     * @tparam SparsityType      Sparsity pattern type (e.g. CsrSparsityPattern,
+     * CooSparsityPattern).
+     * @param mesh               The mesh providing owner/neighbour topology.
+     * @param sparsityPattern    Sparsity pattern of the linear system.
+     * @param faceToMatrixAddress Mapping from faces to matrix row offsets.
+     * @return Shared pointer to the newly allocated CellBasedData.
+     */
+    template<typename SparsityType>
+    std::shared_ptr<CellBasedData> computeCellBasedData(
+        const UnstructuredMesh& mesh,
+        std::shared_ptr<const SparsityType> sparsityPattern,
+        const std::shared_ptr<const la::FaceToMatrixAddress> faceToMatrixAddress
+    );
+
+    std::shared_ptr<CellBasedData> cellBasedIteratorData_;
+};
+
+}

--- a/include/NeoN/linearAlgebra/meshIterationStrategies.hpp
+++ b/include/NeoN/linearAlgebra/meshIterationStrategies.hpp
@@ -51,7 +51,7 @@ class MeshIteratorContext
 public:
 
     /** @brief Replaces the active strategy. */
-    void setStrategy(std::shared_ptr<MeshIterationStrategy> strategy_);
+    void setStrategy(std::shared_ptr<MeshIterationStrategy> strategy);
 
     /** @brief Returns the active strategy, or nullptr if none has been set. */
     std::shared_ptr<MeshIterationStrategy> get() const;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,7 @@ target_sources(
           "linearAlgebra/faceToMatrixAddress.cpp"
           "linearAlgebra/cooSparsityPattern.cpp"
           "linearAlgebra/csrSparsityPattern.cpp"
+          "linearAlgebra/meshIterationStrategies.cpp"
           "mesh/unstructured/boundaryMesh.cpp"
           "mesh/unstructured/unstructuredMesh.cpp"
           "mesh/unstructured/uniformMeshDataGenerator.cpp"

--- a/src/finiteVolume/cellCentred/stencil/cellToFaceStencil.cpp
+++ b/src/finiteVolume/cellCentred/stencil/cellToFaceStencil.cpp
@@ -14,8 +14,7 @@ SegmentedVector<localIdx, localIdx> CellToFaceStencil::computeInternalStencil() 
 {
     const auto exec = mesh_.exec();
     const auto nCells = mesh_.nCells();
-    const auto [faceOwners, faceNeighbors] =
-        views(mesh_.faceOwners(), mesh_.faceNeighbors());
+    const auto [faceOwners, faceNeighbors] = views(mesh_.faceOwners(), mesh_.faceNeighbors());
 
     const auto nInternalFaces = mesh_.nInternalFaces();
 

--- a/src/finiteVolume/cellCentred/stencil/cellToFaceStencil.cpp
+++ b/src/finiteVolume/cellCentred/stencil/cellToFaceStencil.cpp
@@ -18,30 +18,36 @@ SegmentedVector<localIdx, localIdx> CellToFaceStencil::computeInternalStencil() 
 
     const auto nInternalFaces = mesh_.nInternalFaces();
 
-    Vector<localIdx> nFacesPerCell(exec, nCells, 0);
+    const SerialExecutor serialExec;
+    Vector<localIdx> nFacesPerCell(serialExec, nCells, 0);
     View<localIdx> nFacesPerCellView = nFacesPerCell.view();
 
+    auto hostFaceOwners = mesh_.faceOwners().copyToHost();
+    auto hostFaceNeighbors = mesh_.faceNeighbors().copyToHost();
+    const auto [hostFaceOwnersView, hostFaceNeighborsView] =
+        views(hostFaceOwners, hostFaceNeighbors);
+
     parallelFor(
-        exec,
+        serialExec,
         {0, nInternalFaces},
         NEON_LAMBDA(const localIdx i) {
-            Kokkos::atomic_inc(&nFacesPerCellView[faceOwners[i]]);
-            Kokkos::atomic_inc(&nFacesPerCellView[faceNeighbors[i]]);
+            Kokkos::atomic_inc(&nFacesPerCellView[hostFaceOwnersView[i]]);
+            Kokkos::atomic_inc(&nFacesPerCellView[hostFaceNeighborsView[i]]);
         },
         "countFacesPerCellInternal"
     );
 
-    SegmentedVector<localIdx, localIdx> stencil(nFacesPerCell); // guessed
+    SegmentedVector<localIdx, localIdx> stencil(nFacesPerCell);
     auto [stencilValues, segment] = stencil.views();
 
     fill(nFacesPerCell, 0); // reset nFacesPerCell
 
     parallelFor(
-        exec,
+        serialExec,
         {0, nInternalFaces},
         NEON_LAMBDA(const localIdx facei) {
-            localIdx owner = faceOwners[facei];
-            localIdx neigh = faceNeighbors[facei];
+            localIdx owner = hostFaceOwnersView[facei];
+            localIdx neigh = hostFaceNeighborsView[facei];
 
             const auto segIdxOwn = Kokkos::atomic_fetch_inc(&nFacesPerCellView[owner]);
             const auto segIdxNei = Kokkos::atomic_fetch_inc(&nFacesPerCellView[neigh]);
@@ -55,7 +61,7 @@ SegmentedVector<localIdx, localIdx> CellToFaceStencil::computeInternalStencil() 
         "computeStencilInternal"
     );
 
-    return stencil;
+    return stencil.copyToExecutor(exec);
 }
 
 } // namespace NeoN::finiteVolume::cellCentred

--- a/src/finiteVolume/cellCentred/stencil/cellToFaceStencil.cpp
+++ b/src/finiteVolume/cellCentred/stencil/cellToFaceStencil.cpp
@@ -10,12 +10,12 @@ namespace NeoN::finiteVolume::cellCentred
 
 CellToFaceStencil::CellToFaceStencil(const UnstructuredMesh& mesh) : mesh_(mesh) {}
 
-SegmentedVector<localIdx, localIdx> CellToFaceStencil::computeStencil() const
+SegmentedVector<localIdx, localIdx> CellToFaceStencil::computeInternalStencil() const
 {
     const auto exec = mesh_.exec();
     const auto nCells = mesh_.nCells();
-    const auto [faceOwners, faceNeighbors, boundaryFaceOwners] =
-        views(mesh_.faceOwners(), mesh_.faceNeighbors(), mesh_.boundaryMesh().faceOwners());
+    const auto [faceOwners, faceNeighbors] =
+        views(mesh_.faceOwners(), mesh_.faceNeighbors());
 
     const auto nInternalFaces = mesh_.nInternalFaces();
 
@@ -32,15 +32,6 @@ SegmentedVector<localIdx, localIdx> CellToFaceStencil::computeStencil() const
         "countFacesPerCellInternal"
     );
 
-    parallelFor(
-        exec,
-        {0, boundaryFaceOwners.size()},
-        NEON_LAMBDA(const localIdx i) {
-            Kokkos::atomic_inc(&nFacesPerCellView[boundaryFaceOwners[i]]);
-        },
-        "countFacesPerCellBoundary"
-    );
-
     SegmentedVector<localIdx, localIdx> stencil(nFacesPerCell); // guessed
     auto [stencilValues, segment] = stencil.views();
 
@@ -53,27 +44,16 @@ SegmentedVector<localIdx, localIdx> CellToFaceStencil::computeStencil() const
             localIdx owner = faceOwners[facei];
             localIdx neighbour = faceNeighbors[facei];
 
-            localIdx segIdxOwn = Kokkos::atomic_fetch_add(&nFacesPerCellView[owner], 1);
-            localIdx segIdxNei = Kokkos::atomic_fetch_add(&nFacesPerCellView[neighbour], 1);
+            const auto segIdxOwn = Kokkos::atomic_fetch_inc(&nFacesPerCellView[owner]);
+            const auto segIdxNei = Kokkos::atomic_fetch_inc(&nFacesPerCellView[neighbour]);
 
-            auto startSegOwn = segment[owner];
-            auto startSegNei = segment[neighbour];
-            Kokkos::atomic_store(&stencilValues[startSegOwn + segIdxOwn], facei);
-            Kokkos::atomic_store(&stencilValues[startSegNei + segIdxNei], facei);
+            auto segOwn = segment[owner] + segIdxOwn;
+            auto segNei = segment[neighbour] + segIdxNei;
+
+            stencilValues[segOwn] = facei;
+            stencilValues[segNei] = facei;
         },
         "computeStencilInternal"
-    );
-
-    parallelFor(
-        exec,
-        {nInternalFaces, nInternalFaces + boundaryFaceOwners.size()},
-        NEON_LAMBDA(const localIdx facei) {
-            localIdx owner = boundaryFaceOwners[facei - nInternalFaces];
-            localIdx segIdxOwn = Kokkos::atomic_fetch_add(&nFacesPerCellView[owner], 1);
-            localIdx startSegOwn = segment[owner];
-            Kokkos::atomic_store(&stencilValues[startSegOwn + segIdxOwn], facei);
-        },
-        "computeStencilBound"
     );
 
     return stencil;

--- a/src/finiteVolume/cellCentred/stencil/cellToFaceStencil.cpp
+++ b/src/finiteVolume/cellCentred/stencil/cellToFaceStencil.cpp
@@ -41,13 +41,13 @@ SegmentedVector<localIdx, localIdx> CellToFaceStencil::computeInternalStencil() 
         {0, nInternalFaces},
         NEON_LAMBDA(const localIdx facei) {
             localIdx owner = faceOwners[facei];
-            localIdx neighbour = faceNeighbors[facei];
+            localIdx neigh = faceNeighbors[facei];
 
             const auto segIdxOwn = Kokkos::atomic_fetch_inc(&nFacesPerCellView[owner]);
             const auto segIdxNei = Kokkos::atomic_fetch_inc(&nFacesPerCellView[neighbour]);
 
             auto segOwn = segment[owner] + segIdxOwn;
-            auto segNei = segment[neighbour] + segIdxNei;
+            auto segNei = segment[neigh] + segIdxNei;
 
             stencilValues[segOwn] = facei;
             stencilValues[segNei] = facei;

--- a/src/finiteVolume/cellCentred/stencil/cellToFaceStencil.cpp
+++ b/src/finiteVolume/cellCentred/stencil/cellToFaceStencil.cpp
@@ -44,7 +44,7 @@ SegmentedVector<localIdx, localIdx> CellToFaceStencil::computeInternalStencil() 
             localIdx neigh = faceNeighbors[facei];
 
             const auto segIdxOwn = Kokkos::atomic_fetch_inc(&nFacesPerCellView[owner]);
-            const auto segIdxNei = Kokkos::atomic_fetch_inc(&nFacesPerCellView[neighbour]);
+            const auto segIdxNei = Kokkos::atomic_fetch_inc(&nFacesPerCellView[neigh]);
 
             auto segOwn = segment[owner] + segIdxOwn;
             auto segNei = segment[neigh] + segIdxNei;

--- a/src/linearAlgebra/matrix.cpp
+++ b/src/linearAlgebra/matrix.cpp
@@ -37,6 +37,25 @@ Vector<ValueType> Matrix<ValueType, SparsityType>::diag() const
 }
 
 
+template<typename ValueType, typename SparsityType>
+Matrix<ValueType, SparsityType> Matrix<ValueType, SparsityType>::copyToExecutor(Executor dstExec
+) const
+{
+    if (dstExec == values_.exec())
+    {
+        return *this;
+    }
+    return {
+        values_.copyToExecutor(dstExec),
+        std::make_shared<const SparsityType>(this->sparsityPattern_->copyToExecutor(dstExec)),
+        (faceToMatrixAddress_) ? std::make_shared<const FaceToMatrixAddress>(
+            this->faceToMatrixAddress_->copyToExecutor(dstExec)
+        )
+                               : nullptr
+    };
+}
+
+
 // Free functions
 
 template<typename ValueType, typename IndexType>
@@ -246,12 +265,13 @@ void scaledInverseDiag(
     );
 }
 
-#define NN_DECLARE_CSRMATRIX(VALUETYPE, INTEGERTYPE)                                               \
+#define NN_DECLARE_MATRIX(VALUETYPE, INTEGERTYPE)                                                  \
     template class Matrix<VALUETYPE, la::CsrSparsityPattern<INTEGERTYPE>>;                         \
+    template class Matrix<VALUETYPE, la::CooSparsityPattern<INTEGERTYPE>>;                         \
     template Vector<VALUETYPE>                                                                     \
     upper<VALUETYPE, INTEGERTYPE>(const CSRMatrix<VALUETYPE, INTEGERTYPE>&)
 
-NN_DECLARE_CSRMATRIX(scalar, localIdx);
-NN_DECLARE_CSRMATRIX(Vec3, int);
+NN_DECLARE_MATRIX(scalar, localIdx);
+NN_DECLARE_MATRIX(Vec3, localIdx);
 
 }

--- a/src/linearAlgebra/meshIterationStrategies.cpp
+++ b/src/linearAlgebra/meshIterationStrategies.cpp
@@ -10,9 +10,9 @@ namespace NeoN::la
 
 // MeshIteratorContext
 
-void MeshIteratorContext::setStrategy(std::shared_ptr<MeshIterationStrategy> strategy_)
+void MeshIteratorContext::setStrategy(std::shared_ptr<MeshIterationStrategy> strategyIn)
 {
-    strategy = std::move(strategy_);
+    strategy = std::move(strategyIn);
 }
 
 std::shared_ptr<MeshIterationStrategy> MeshIteratorContext::get() const

--- a/src/linearAlgebra/meshIterationStrategies.cpp
+++ b/src/linearAlgebra/meshIterationStrategies.cpp
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#include "NeoN/core/macros.hpp"
+#include "NeoN/linearAlgebra/meshIterationStrategies.hpp"
+
+namespace NeoN::la
+{
+
+// MeshIteratorContext
+
+void MeshIteratorContext::setStrategy(std::shared_ptr<MeshIterationStrategy> strategy_)
+{
+    strategy = std::move(strategy_);
+}
+
+std::shared_ptr<MeshIterationStrategy> MeshIteratorContext::get() const
+{
+    if (strategy)
+    {
+        return strategy;
+    }
+    return nullptr;
+}
+
+std::string MeshIteratorContext::name() const
+{
+    if (strategy)
+    {
+        return strategy->name();
+    }
+    return "";
+}
+
+// CellBasedIterator
+
+CellBasedIterator::CellBasedIterator() : cellBasedIteratorData_(nullptr) {}
+
+std::string CellBasedIterator::name() const { return "CellBased"; }
+
+size_t CellBasedIterator::size() const { return static_cast<size_t>(cellBasedIteratorData_->size); }
+
+std::shared_ptr<CellBasedIterator::CellBasedData> CellBasedIterator::getCellBasedData()
+{
+    return cellBasedIteratorData_;
+}
+
+template<typename SparsityType>
+void CellBasedIterator::setComputeCellBasedData(
+    const UnstructuredMesh& mesh,
+    std::shared_ptr<const SparsityType> sparsityPattern,
+    std::shared_ptr<const la::FaceToMatrixAddress> faceToMatrixAddress
+)
+{
+    cellBasedIteratorData_ = computeCellBasedData(mesh, sparsityPattern, faceToMatrixAddress);
+}
+
+template<typename SparsityType>
+std::shared_ptr<CellBasedIterator::CellBasedData> CellBasedIterator::computeCellBasedData(
+    const UnstructuredMesh& mesh,
+    std::shared_ptr<const SparsityType> sparsityPattern,
+    const std::shared_ptr<const la::FaceToMatrixAddress> faceToMatrixAddress
+)
+{
+    // Count faces per cell (owner and neighbour contributions)
+    auto exec = mesh.exec();
+    auto cellToFaceStencil = finiteVolume::cellCentred::CellToFaceStencil(mesh);
+    auto cellFaces = cellToFaceStencil.computeInternalStencil();
+    auto owner = mesh.faceOwners();
+    auto neighbour = mesh.faceNeighbors();
+
+    // Pre-compute face neighbour, sign, and matrix column indices
+    const auto totalFaceConnections = cellFaces.size();
+    Vector<localIdx> faceNeighbour(exec, totalFaceConnections);
+    Vector<scalar> faceSign(exec, totalFaceConnections);
+    Vector<localIdx> matrixColumnIdx(exec, totalFaceConnections);
+
+    const auto [diagOffs, ownOffs, neiOffs] = views(
+        faceToMatrixAddress->diagOffset(),
+        faceToMatrixAddress->ownerOffset(),
+        faceToMatrixAddress->neighbourOffset()
+    );
+
+    const auto [ownerV, neighbourV] = views(owner, neighbour);
+    const auto [matrixRowOffs] = views(sparsityPattern->rowOffs());
+
+    auto [faceNeighbourV, faceSignV, matrixColumnIdxV] =
+        views(faceNeighbour, faceSign, matrixColumnIdx);
+
+    auto [cellFacesValues, cellFacesSegments] = cellFaces.views();
+
+    parallelFor(
+        exec,
+        {0, mesh.nCells()},
+        NEON_LAMBDA(const localIdx celli) {
+            const auto faces = cellFacesSegments[celli + 1] - cellFacesSegments[celli];
+            const auto startIdx = cellFacesSegments[celli];
+
+            for (localIdx i = 0; i < faces; ++i)
+            {
+                const auto faceIdx = cellFacesValues[startIdx + i];
+                const auto own = ownerV[faceIdx];
+                const auto nei = neighbourV[faceIdx];
+
+                const auto isOwner = (own == celli);
+                const auto neiCell = isOwner ? nei : own;
+
+                faceNeighbourV[startIdx + i] = neiCell;
+                faceSignV[startIdx + i] = isOwner ? 1.0 : -1.0;
+
+                // Compute matrix column index
+                const auto rowStart = matrixRowOffs[celli];
+                if (isOwner)
+                {
+                    matrixColumnIdxV[startIdx + i] = rowStart + ownOffs[faceIdx];
+                }
+                else
+                {
+                    matrixColumnIdxV[startIdx + i] = rowStart + neiOffs[faceIdx];
+                }
+            }
+        },
+        "computeFaceData"
+    );
+
+    return std::make_shared<CellBasedData>(
+        mesh.nCells(), cellFaces, faceNeighbour, faceSign, matrixColumnIdx
+    );
+}
+
+template void CellBasedIterator::setComputeCellBasedData<CsrSparsityPattern<
+    localIdx>>(const UnstructuredMesh&, std::shared_ptr<const CsrSparsityPattern<localIdx>>, std::shared_ptr<const FaceToMatrixAddress>);
+
+template void CellBasedIterator::setComputeCellBasedData<CooSparsityPattern<
+    localIdx>>(const UnstructuredMesh&, std::shared_ptr<const CooSparsityPattern<localIdx>>, std::shared_ptr<const FaceToMatrixAddress>);
+
+template std::shared_ptr<CellBasedIterator::CellBasedData>
+CellBasedIterator::computeCellBasedData<CsrSparsityPattern<
+    localIdx>>(const UnstructuredMesh&, std::shared_ptr<const CsrSparsityPattern<localIdx>>, const std::shared_ptr<const FaceToMatrixAddress>);
+
+template std::shared_ptr<CellBasedIterator::CellBasedData>
+CellBasedIterator::computeCellBasedData<CooSparsityPattern<
+    localIdx>>(const UnstructuredMesh&, std::shared_ptr<const CooSparsityPattern<localIdx>>, const std::shared_ptr<const FaceToMatrixAddress>);
+
+}

--- a/src/linearAlgebra/meshIterationStrategies.cpp
+++ b/src/linearAlgebra/meshIterationStrategies.cpp
@@ -66,18 +66,17 @@ std::shared_ptr<CellBasedIterator::CellBasedData> CellBasedIterator::computeCell
     // Count faces per cell (owner and neighbour contributions)
     auto exec = mesh.exec();
     auto cellToFaceStencil = finiteVolume::cellCentred::CellToFaceStencil(mesh);
-    auto cellFaces = cellToFaceStencil.computeInternalStencil();
+    auto cellInternalFaces = cellToFaceStencil.computeInternalStencil();
     auto owner = mesh.faceOwners();
     auto neighbour = mesh.faceNeighbors();
 
     // Pre-compute face neighbour, sign, and matrix column indices
-    const auto totalFaceConnections = cellFaces.size();
-    Vector<localIdx> faceNeighbour(exec, totalFaceConnections);
-    Vector<scalar> faceSign(exec, totalFaceConnections);
-    Vector<localIdx> matrixColumnIdx(exec, totalFaceConnections);
+    const auto ninternalFaceConnections = cellInternalFaces.size();
+    Vector<localIdx> iFaceNeighbours(exec, ninternalFaceConnections);
+    Vector<scalar> iFaceSigns(exec, ninternalFaceConnections);
+    Vector<localIdx> matrixColumnIdx(exec, ninternalFaceConnections);
 
-    const auto [diagOffs, ownOffs, neiOffs] = views(
-        faceToMatrixAddress->diagOffset(),
+    const auto [ownOffs, neiOffs] = views(
         faceToMatrixAddress->ownerOffset(),
         faceToMatrixAddress->neighbourOffset()
     );
@@ -85,8 +84,8 @@ std::shared_ptr<CellBasedIterator::CellBasedData> CellBasedIterator::computeCell
     const auto [ownerV, neighbourV] = views(owner, neighbour);
     const auto [matrixRowOffs] = views(sparsityPattern->rowOffs());
 
-    auto [faceNeighbourV, faceSignV, matrixColumnIdxV] =
-        views(faceNeighbour, faceSign, matrixColumnIdx);
+    auto [iFaceNeighboursV, iFaceSignsV, matrixColumnIdxV] =
+        views(iFaceNeighbours, iFaceSigns, matrixColumnIdx);
 
     auto [cellFacesValues, cellFacesSegments] = cellFaces.views();
 
@@ -106,8 +105,8 @@ std::shared_ptr<CellBasedIterator::CellBasedData> CellBasedIterator::computeCell
                 const auto isOwner = (own == celli);
                 const auto neiCell = isOwner ? nei : own;
 
-                faceNeighbourV[startIdx + i] = neiCell;
-                faceSignV[startIdx + i] = isOwner ? 1.0 : -1.0;
+                iFaceNeighboursV[startIdx + i] = neiCell;
+                iFaceSignsV[startIdx + i] = isOwner ? 1.0 : -1.0;
 
                 // Compute matrix column index
                 const auto rowStart = matrixRowOffs[celli];

--- a/src/linearAlgebra/meshIterationStrategies.cpp
+++ b/src/linearAlgebra/meshIterationStrategies.cpp
@@ -76,10 +76,8 @@ std::shared_ptr<CellBasedIterator::CellBasedData> CellBasedIterator::computeCell
     Vector<scalar> iFaceSigns(exec, ninternalFaceConnections);
     Vector<localIdx> matrixColumnIdx(exec, ninternalFaceConnections);
 
-    const auto [ownOffs, neiOffs] = views(
-        faceToMatrixAddress->ownerOffset(),
-        faceToMatrixAddress->neighbourOffset()
-    );
+    const auto [ownOffs, neiOffs] =
+        views(faceToMatrixAddress->ownerOffset(), faceToMatrixAddress->neighbourOffset());
 
     const auto [ownerV, neighbourV] = views(owner, neighbour);
     const auto [matrixRowOffs] = views(sparsityPattern->rowOffs());
@@ -87,7 +85,7 @@ std::shared_ptr<CellBasedIterator::CellBasedData> CellBasedIterator::computeCell
     auto [iFaceNeighboursV, iFaceSignsV, matrixColumnIdxV] =
         views(iFaceNeighbours, iFaceSigns, matrixColumnIdx);
 
-    auto [cellFacesValues, cellFacesSegments] = cellFaces.views();
+    auto [cellFacesValues, cellFacesSegments] = cellInternalFaces.views();
 
     parallelFor(
         exec,
@@ -124,7 +122,7 @@ std::shared_ptr<CellBasedIterator::CellBasedData> CellBasedIterator::computeCell
     );
 
     return std::make_shared<CellBasedData>(
-        mesh.nCells(), cellFaces, faceNeighbour, faceSign, matrixColumnIdx
+        mesh.nCells(), cellInternalFaces, iFaceNeighbours, iFaceSigns, matrixColumnIdx
     );
 }
 

--- a/test/linearAlgebra/CMakeLists.txt
+++ b/test/linearAlgebra/CMakeLists.txt
@@ -8,6 +8,7 @@ neon_unit_test(cooSparsityPattern)
 neon_unit_test(csrSparsityPattern)
 neon_unit_test(faceToMatrixAddress)
 neon_unit_test(utilities)
+neon_unit_test(matrixIterator)
 
 # the following tests currently require Ginkgo
 if(NeoN_WITH_GINKGO)

--- a/test/linearAlgebra/matrixIterator.cpp
+++ b/test/linearAlgebra/matrixIterator.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
+                            // a custom main
+#include <string>
+
+#include "catch2_common.hpp"
+
+#include "NeoN/NeoN.hpp"
+
+using NeoN::scalar;
+using NeoN::localIdx;
+using NeoN::Vector;
+using NeoN::la::LinearSystem;
+using NeoN::la::CSRMatrix;
+
+TEMPLATE_TEST_CASE("matrixIterator", "[template]", NeoN::scalar)
+{
+    auto [execName, exec] = GENERATE(allAvailableExecutor());
+
+    Vector<scalar> values(exec, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0});
+    Vector<localIdx> colIdx(exec, {0, 1, 2, 0, 1, 2, 0, 1, 2});
+    Vector<localIdx> rowOffs(exec, {0, 3, 6, 9});
+    CSRMatrix<scalar, localIdx> csrMatrix(values, colIdx, rowOffs, {3, 3});
+
+    SECTION("Construct with MeshCellIterator " + execName)
+    {
+        auto nCells = 5;
+        auto mesh = create1DUniformMesh(exec, nCells);
+        auto [sp, mi] = NeoN::la::createSparsityPatternFaceToMatrixAddress<
+            NeoN::la::CsrSparsityPattern<NeoN::localIdx>>(mesh);
+        auto cellIterator = std::make_shared<NeoN::la::CellBasedIterator>();
+        cellIterator->setComputeCellBasedData(mesh, sp, mi);
+
+        auto cellBasedData = cellIterator->getCellBasedData();
+
+        auto cellFacesIdx = cellBasedData->cellFaces.values().copyToHost();
+        auto cellFacesOffsets = cellBasedData->cellFaces.segments().copyToHost();
+        auto faceNeighbour = cellBasedData->faceNeighbour.copyToHost();
+        auto faceSign = cellBasedData->faceSign.copyToHost();
+        auto matrixColumnIdx = cellBasedData->matrixColumnIdx.copyToHost();
+
+        // [ | 0 | |  1  | |   2 | |   3 | |  4 | ]
+        auto expFaceCellIdx =
+            NeoN::Vector<localIdx>(NeoN::SerialExecutor(), {0, 0, 1, 1, 2, 2, 3, 3});
+        auto expFaceOffsets = NeoN::Vector<localIdx>(NeoN::SerialExecutor(), {0, 1, 3, 5, 7, 8});
+        auto expFaceNeighbour =
+            NeoN::Vector<localIdx>(NeoN::SerialExecutor(), {1, 0, 2, 1, 3, 2, 4, 3});
+        auto expFaceSign =
+            NeoN::Vector<scalar>(NeoN::SerialExecutor(), {1, -1, 1, -1, 1, -1, 1, -1});
+        auto expMatrixColumnIdx =
+            NeoN::Vector<localIdx>(NeoN::SerialExecutor(), {1, 2, 4, 5, 7, 8, 10, 11});
+
+        REQUIRE_THAT(faceSign, Equals(expFaceSign, Approx {1e-10}));
+        REQUIRE_THAT(faceNeighbour, Equals(expFaceNeighbour, EqualInt {}));
+        REQUIRE_THAT(cellFacesOffsets, Equals(expFaceOffsets, EqualInt {}));
+        REQUIRE_THAT(cellFacesIdx, Equals(expFaceCellIdx, EqualInt {}));
+        REQUIRE_THAT(matrixColumnIdx, Equals(expMatrixColumnIdx, EqualInt {}));
+    }
+
+    SECTION("Can construct linearSystem with MeshCellIterator " + execName)
+    {
+        auto nCells = 5;
+        auto mesh = create1DUniformMesh(exec, nCells);
+        auto cellIterator = std::make_shared<NeoN::la::CellBasedIterator>();
+        auto ls = createEmptyLinearSystem<TestType>(mesh, cellIterator);
+
+        REQUIRE(ls.getMeshIterator()->name() == "CellBased");
+    }
+}


### PR DESCRIPTION
# Motivation

This PR adds a selectable `meshIterationStrategty` to linearySystem. The purpose is to enable dispatching to different operator implementations based on the selected strategy.