### PR TITLE
Bump kokkos to 5.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Bump Ginkgo to 1.11 and Kokkos 4.7.01 [#409](https://github.com/exasim-project/NeoN/pull/409)
 - Remove stencilDataBase [#416](https://github.com/exasim-project/NeoN/pull/416)
 - Added backward ddtScheme and scheme selection mechanism [#419](https://github.com/exasim-project/NeoN/pull/419)
+- Bump Kokkos to 5.0.2 [#476](https://github.com/exasim-project/NeoN/pull/476)
 
 # Version 0.2.0 (2025/12/03)
 ## Features

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ NeoN has the following requirements
 
 *  _cmake > 3.22_
 *  _gcc >= 10_ or  _clang >= 16_
-*  _Kokkos 4.3.0_
+*  _Kokkos 5.0.2_
 
 For GPU support
 * NVIDIA: CUDA _12+_

--- a/cmake/Versions.cmake
+++ b/cmake/Versions.cmake
@@ -5,7 +5,7 @@
 # Centralized version management for all third-party dependencies in NeoN
 
 set(NeoN_KOKKOS_CHECKOUT_VERSION
-    "4.7.01"
+    "5.0.2"
     CACHE STRING "Use specific version of Kokkos")
 mark_as_advanced(NeoN_KOKKOS_CHECKOUT_VERSION)
 

--- a/test/dsl/expression.cpp
+++ b/test/dsl/expression.cpp
@@ -42,14 +42,14 @@ TEMPLATE_TEST_CASE("Expression", "[template]", NeoN::scalar, NeoN::Vec3)
             )
         );
 
-        auto call_failing = [&]()
+        auto callFailing = [&]()
         {
             return expr
                 .template getOperator<dsl::SpatialOperator<TestType>, Operator::Type::Explicit>(
                     "Dummy2"
                 );
         };
-        REQUIRE_THROWS_AS(call_failing(), std::runtime_error);
+        REQUIRE_THROWS_AS(callFailing(), std::runtime_error);
 
         REQUIRE_NOTHROW(expr.template dropOperator<Operator::Type::Explicit>("Dummy"));
         REQUIRE_FALSE(expr.template hasOperator<Operator::Type::Explicit>("Dummy"));


### PR DESCRIPTION
- Bump Kokkos version to 5.0.2. 
- Performance improvement is expected.
- Test for exasim-project/NeoFOAM#259
