### PR TITLE
Add corrected and limitedCorrected faceNormalGradient schemes

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -13,7 +13,7 @@ SPDX-License-Identifier = "MIT"
 
 [[annotations]]
 path = [
-    "CMakePresets.json", ".clang-format", ".clang-tidy", ".pre-commit-config.yaml", "spack.yaml", "REUSE.toml", "scripts/san_ignores.txt", "CITATION.cff"
+    "CMakePresets.json", ".clang-format", ".clang-tidy", ".pre-commit-config.yaml", "spack.yaml", "REUSE.toml", "scripts/san_ignores.txt", "CITATION.cff", "CLAUDE.md"
 ]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2023 - 2024 NeoN authors"

--- a/include/NeoN/finiteVolume/cellCentred/boundary/surface/fixedValue.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/surface/fixedValue.hpp
@@ -19,16 +19,11 @@ namespace detail
 // from a __device__ function is not allowed
 template<typename ValueType>
 void setFixedValue(
-    Field<ValueType>& domainVector,
-    const UnstructuredMesh& mesh,
-    std::pair<size_t, size_t> range,
-    ValueType fixedValue
+    Field<ValueType>& domainVector, std::pair<size_t, size_t> range, ValueType fixedValue
 )
 {
     auto refValue = domainVector.boundaryData().refValue().view();
     auto value = domainVector.boundaryData().value().view();
-    auto internalValues = domainVector.internalVector().view();
-    auto nInternalFaces = mesh.nInternalFaces();
 
     NeoN::parallelFor(
         domainVector.exec(),
@@ -36,7 +31,6 @@ void setFixedValue(
         NEON_LAMBDA(const localIdx i) {
             refValue[i] = fixedValue;
             value[i] = fixedValue;
-            internalValues[nInternalFaces + i] = fixedValue;
         },
         "setFixedValueSurface"
     );
@@ -52,12 +46,12 @@ class FixedValue :
 public:
 
     FixedValue(const UnstructuredMesh& mesh, const Dictionary& dict, localIdx patchID)
-        : Base(mesh, dict, patchID), mesh_(mesh), fixedValue_(dict.get<ValueType>("fixedValue"))
+        : Base(mesh, dict, patchID), fixedValue_(dict.get<ValueType>("fixedValue"))
     {}
 
     virtual void correctBoundaryCondition(Field<ValueType>& domainVector) override
     {
-        detail::setFixedValue(domainVector, mesh_, this->range(), fixedValue_);
+        detail::setFixedValue(domainVector, this->range(), fixedValue_);
     }
 
     static std::string name() { return "fixedValue"; }
@@ -73,7 +67,6 @@ public:
 
 private:
 
-    const UnstructuredMesh& mesh_;
     ValueType fixedValue_;
 };
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary/surface/symmetry.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/surface/symmetry.hpp
@@ -15,42 +15,35 @@ namespace NeoN::finiteVolume::cellCentred::surfaceBoundary
 {
 namespace detail
 {
-// Scalar specialization --------------------------------------------------------
+// Scalar specialization: zero flux at the symmetry plane
 inline void applySymmetry(
-    Field<scalar>& domainVector, const UnstructuredMesh& mesh, std::pair<size_t, size_t> range
+    Field<scalar>& domainVector,
+    [[maybe_unused]] const UnstructuredMesh&,
+    std::pair<size_t, size_t> range
 )
 {
-    auto [refValueV, valueV, internalValuesV, faceCellsV] = views(
-        domainVector.boundaryData().refValue(),
-        domainVector.boundaryData().value(),
-        domainVector.internalVector(),
-        mesh.boundaryMesh().faceCells()
-    );
+    auto [refValueV, valueV] =
+        views(domainVector.boundaryData().refValue(), domainVector.boundaryData().value());
 
     NeoN::parallelFor(
         domainVector.exec(),
         range,
         NEON_LAMBDA(const localIdx i) {
-            const localIdx owner = faceCellsV[i];
-            const scalar v = internalValuesV[owner];
-
-            refValueV[i] = v;
-            valueV[i] = v;
+            refValueV[i] = 0;
+            valueV[i] = 0;
         },
         "computeSymmetryBoundaryScalar"
     );
 }
 
-// Vec3 specialization ----------------------------------------------------------
+// Vec3 specialization: zero the normal component of the existing face value
 inline void applySymmetry(
     Field<Vec3>& domainVector, const UnstructuredMesh& mesh, std::pair<size_t, size_t> range
 )
 {
-    auto [refValueV, valueV, internalValuesV, faceCellsV, nHatV] = views(
+    auto [refValueV, valueV, nHatV] = views(
         domainVector.boundaryData().refValue(),
         domainVector.boundaryData().value(),
-        domainVector.internalVector(),
-        mesh.boundaryMesh().faceCells(),
         mesh.boundaryMesh().nf()
     );
 
@@ -58,12 +51,10 @@ inline void applySymmetry(
         domainVector.exec(),
         range,
         NEON_LAMBDA(const localIdx i) {
-            const localIdx owner = faceCellsV[i];
             const Vec3 n = nHatV[i];
-
-            Vec3 v = internalValuesV[owner];
-            const scalar vn = v & n; // dot product
-            const auto vtan = v - n * vn;
+            const Vec3 v = valueV[i];
+            const scalar vn = v & n;
+            const Vec3 vtan = v - n * vn;
 
             refValueV[i] = vtan;
             valueV[i] = vtan;

--- a/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/corrected.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/corrected.hpp
@@ -27,6 +27,13 @@ void computeCorrectedFaceNormalGrad(
 );
 
 template<typename ValueType>
+void computeCorrectionTerm(
+    const VolumeField<ValueType>& volField,
+    const std::shared_ptr<GeometryScheme> geometryScheme,
+    SurfaceField<ValueType>& corrField
+);
+
+template<typename ValueType>
 class Corrected :
     public FaceNormalGradientFactory<ValueType>::template Register<Corrected<ValueType>>
 {
@@ -59,6 +66,15 @@ public:
     virtual const SurfaceField<scalar>& deltaCoeffs() const override
     {
         return geometryScheme_->nonOrthDeltaCoeffs();
+    }
+
+    bool hasImplicitCorrection() const override { return true; }
+
+    virtual void implicitCorrection(
+        const VolumeField<ValueType>& phi, SurfaceField<ValueType>& corrField
+    ) const override
+    {
+        computeCorrectionTerm(phi, geometryScheme_, corrField);
     }
 
     std::unique_ptr<FaceNormalGradientFactory<ValueType>> clone() const override

--- a/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/corrected.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/corrected.hpp
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "NeoN/core/executor/executor.hpp"
+#include "NeoN/finiteVolume/cellCentred/faceNormalGradient/faceNormalGradient.hpp"
+#include "NeoN/finiteVolume/cellCentred/fields/volumeField.hpp"
+#include "NeoN/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp"
+#include "NeoN/finiteVolume/cellCentred/stencil/geometryScheme.hpp"
+#include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
+
+#include <Kokkos_Core.hpp>
+
+#include <functional>
+
+
+namespace NeoN::finiteVolume::cellCentred
+{
+
+template<typename ValueType>
+void computeCorrectedFaceNormalGrad(
+    const VolumeField<ValueType>& volField,
+    const std::shared_ptr<GeometryScheme> geometryScheme,
+    SurfaceField<ValueType>& surfaceField
+);
+
+template<typename ValueType>
+class Corrected :
+    public FaceNormalGradientFactory<ValueType>::template Register<Corrected<ValueType>>
+{
+    using Base = FaceNormalGradientFactory<ValueType>::template Register<Corrected<ValueType>>;
+
+public:
+
+    Corrected(const Executor& exec, const UnstructuredMesh& mesh, Input)
+        : Base(exec, mesh), geometryScheme_(GeometryScheme::readOrCreate(mesh)) {};
+
+    Corrected(const Executor& exec, const UnstructuredMesh& mesh)
+        : Base(exec, mesh), geometryScheme_(GeometryScheme::readOrCreate(mesh)) {};
+
+    static std::string name() { return "corrected"; }
+
+    static std::string doc()
+    {
+        return "Corrected face normal gradient with explicit non-orthogonality correction";
+    }
+
+    static std::string schema() { return "none"; }
+
+    virtual void faceNormalGrad(
+        const VolumeField<ValueType>& volField, SurfaceField<ValueType>& surfaceField
+    ) const override
+    {
+        computeCorrectedFaceNormalGrad(volField, geometryScheme_, surfaceField);
+    }
+
+    virtual const SurfaceField<scalar>& deltaCoeffs() const override
+    {
+        return geometryScheme_->nonOrthDeltaCoeffs();
+    }
+
+    std::unique_ptr<FaceNormalGradientFactory<ValueType>> clone() const override
+    {
+        return std::make_unique<Corrected>(*this);
+    }
+
+private:
+
+    const std::shared_ptr<GeometryScheme> geometryScheme_;
+};
+
+// instantiate the template class
+template class Corrected<scalar>;
+template class Corrected<Vec3>;
+
+} // namespace NeoN

--- a/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/faceNormalGradient.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/faceNormalGradient.hpp
@@ -8,6 +8,7 @@
 
 #include <Kokkos_Core.hpp>
 
+#include "NeoN/core/containerFreeFunctions.hpp"
 #include "NeoN/core/executor/executor.hpp"
 #include "NeoN/core/input.hpp"
 #include "NeoN/core/runtimeSelectionFactory.hpp"
@@ -54,6 +55,20 @@ public:
 
     virtual const SurfaceField<scalar>& deltaCoeffs() const = 0;
 
+    // Returns true when this scheme contributes a non-zero explicit correction
+    // term to the implicit Laplacian RHS (i.e. corrected and limitedCorrected).
+    virtual bool hasImplicitCorrection() const { return false; }
+
+    // Fills corrField.internalVector() with the per-face correction term:
+    //   corrected        → corrVec[f] · interpGrad[f]
+    //   limitedCorrected → limiter[f] * corrVec[f] · interpGrad[f]
+    // Default (uncorrected): fills internal vector with zeros.
+    virtual void
+    implicitCorrection(const VolumeField<ValueType>& phi, SurfaceField<ValueType>& corrField) const
+    {
+        NeoN::fill(corrField.internalVector(), zero<ValueType>());
+    }
+
     // Pure virtual function for cloning
     virtual std::unique_ptr<FaceNormalGradientFactory<ValueType>> clone() const = 0;
 
@@ -98,6 +113,13 @@ public:
 
     const SurfaceField<scalar>& deltaCoeffs() const { return faceNormalGradKernel_->deltaCoeffs(); }
 
+    bool hasImplicitCorrection() const { return faceNormalGradKernel_->hasImplicitCorrection(); }
+
+    void
+    implicitCorrection(const VolumeField<ValueType>& phi, SurfaceField<ValueType>& corrField) const
+    {
+        faceNormalGradKernel_->implicitCorrection(phi, corrField);
+    }
 
     SurfaceField<ValueType> faceNormalGrad(const VolumeField<ValueType>& volVector) const
     {

--- a/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/limitedCorrected.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/limitedCorrected.hpp
@@ -29,6 +29,14 @@ void computeLimitedCorrectedFaceNormalGrad(
 );
 
 template<typename ValueType>
+void computeLimitedCorrectionTerm(
+    const VolumeField<ValueType>& volField,
+    const std::shared_ptr<GeometryScheme> geometryScheme,
+    scalar limitCoeff,
+    SurfaceField<ValueType>& corrField
+);
+
+template<typename ValueType>
 class LimitedCorrected :
     public FaceNormalGradientFactory<ValueType>::template Register<LimitedCorrected<ValueType>>
 {
@@ -66,6 +74,15 @@ public:
     virtual const SurfaceField<scalar>& deltaCoeffs() const override
     {
         return geometryScheme_->nonOrthDeltaCoeffs();
+    }
+
+    bool hasImplicitCorrection() const override { return true; }
+
+    virtual void implicitCorrection(
+        const VolumeField<ValueType>& phi, SurfaceField<ValueType>& corrField
+    ) const override
+    {
+        computeLimitedCorrectionTerm(phi, geometryScheme_, limitCoeff_, corrField);
     }
 
     std::unique_ptr<FaceNormalGradientFactory<ValueType>> clone() const override

--- a/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/limitedCorrected.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/limitedCorrected.hpp
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "NeoN/core/executor/executor.hpp"
+#include "NeoN/core/input.hpp"
+#include "NeoN/finiteVolume/cellCentred/faceNormalGradient/faceNormalGradient.hpp"
+#include "NeoN/finiteVolume/cellCentred/fields/volumeField.hpp"
+#include "NeoN/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp"
+#include "NeoN/finiteVolume/cellCentred/stencil/geometryScheme.hpp"
+#include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
+
+#include <Kokkos_Core.hpp>
+
+#include <functional>
+
+
+namespace NeoN::finiteVolume::cellCentred
+{
+
+template<typename ValueType>
+void computeLimitedCorrectedFaceNormalGrad(
+    const VolumeField<ValueType>& volField,
+    const std::shared_ptr<GeometryScheme> geometryScheme,
+    scalar limitCoeff,
+    SurfaceField<ValueType>& surfaceField
+);
+
+template<typename ValueType>
+class LimitedCorrected :
+    public FaceNormalGradientFactory<ValueType>::template Register<LimitedCorrected<ValueType>>
+{
+    using Base =
+        FaceNormalGradientFactory<ValueType>::template Register<LimitedCorrected<ValueType>>;
+
+    static constexpr scalar defaultLimitCoeff = 0.333;
+
+public:
+
+    LimitedCorrected(const Executor& exec, const UnstructuredMesh& mesh, const Input& inputs)
+        : Base(exec, mesh), geometryScheme_(GeometryScheme::readOrCreate(mesh)),
+          limitCoeff_(readLimitCoeff(inputs)) {};
+
+    LimitedCorrected(const Executor& exec, const UnstructuredMesh& mesh)
+        : Base(exec, mesh), geometryScheme_(GeometryScheme::readOrCreate(mesh)),
+          limitCoeff_(defaultLimitCoeff) {};
+
+    static std::string name() { return "limitedCorrected"; }
+
+    static std::string doc()
+    {
+        return "Limited corrected face normal gradient with bounded non-orthogonality correction";
+    }
+
+    static std::string schema() { return "none"; }
+
+    virtual void faceNormalGrad(
+        const VolumeField<ValueType>& volField, SurfaceField<ValueType>& surfaceField
+    ) const override
+    {
+        computeLimitedCorrectedFaceNormalGrad(volField, geometryScheme_, limitCoeff_, surfaceField);
+    }
+
+    virtual const SurfaceField<scalar>& deltaCoeffs() const override
+    {
+        return geometryScheme_->nonOrthDeltaCoeffs();
+    }
+
+    std::unique_ptr<FaceNormalGradientFactory<ValueType>> clone() const override
+    {
+        return std::make_unique<LimitedCorrected>(*this);
+    }
+
+private:
+
+    static scalar readLimitCoeff(const Input& inputs)
+    {
+        if (std::holds_alternative<NeoN::Dictionary>(inputs))
+        {
+            const auto& dict = std::get<NeoN::Dictionary>(inputs);
+            if (dict.contains("limitCoeff"))
+            {
+                return dict.get<scalar>("limitCoeff");
+            }
+            return defaultLimitCoeff;
+        }
+        // TokenList: coefficient follows the scheme name (already consumed by factory)
+        auto& tl = std::get<NeoN::TokenList>(inputs);
+        return tl.next<scalar>();
+    }
+
+    const std::shared_ptr<GeometryScheme> geometryScheme_;
+    scalar limitCoeff_;
+};
+
+// instantiate the template class
+template class LimitedCorrected<scalar>;
+template class LimitedCorrected<Vec3>;
+
+} // namespace NeoN

--- a/include/NeoN/finiteVolume/cellCentred/fields/surfaceField.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/fields/surfaceField.hpp
@@ -49,9 +49,7 @@ public:
             exec,
             fieldName,
             mesh,
-            Field<ValueType>(
-                exec, mesh.nInternalFaces() + mesh.nBoundaryFaces(), mesh.boundaryMesh().offset()
-            )
+            Field<ValueType>(exec, mesh.nInternalFaces(), mesh.boundaryMesh().offset())
         ),
           FieldDatabaseMixin(), boundaryConditions_(boundaryConditions)
     {}

--- a/include/NeoN/finiteVolume/cellCentred/operators/ddtFluxCorr.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/ddtFluxCorr.hpp
@@ -40,26 +40,49 @@ inline void ddtFluxCorrBDF1Kernel(
     scalar dt
 )
 {
-    auto [outV, flux0V, uf0V, SfV] = views(
-        fluxCorr.internalVector(), flux0.internalVector(), uf0.internalVector(), mesh.faceAreas()
-    );
-
     const scalar a1 = scalar(1) / dt;
-    const auto n = outV.size();
+    const auto nInternalFaces = mesh.nInternalFaces();
+    const auto nBoundaryFaces = mesh.nBoundaryFaces();
 
-    parallelFor(
-        exec,
-        {size_t(0), n},
-        NEON_LAMBDA(const localIdx i) {
-            const auto d = (SfV[i] & uf0V[i]);
-            const auto corr = flux0V[i] - d;
+    // Internal faces
+    {
+        auto [outV, flux0V, uf0V, SfV] = views(
+            fluxCorr.internalVector(),
+            flux0.internalVector(),
+            uf0.internalVector(),
+            mesh.faceAreas()
+        );
+        parallelFor(
+            exec,
+            {size_t(0), static_cast<size_t>(nInternalFaces)},
+            NEON_LAMBDA(const localIdx i) {
+                const auto d = (SfV[i] & uf0V[i]);
+                const auto corr = flux0V[i] - d;
+                const scalar limiter = ddtFluxCorrLimiter(mag(flux0V[i]), mag(corr));
+                outV[i] = limiter * a1 * corr;
+            },
+            "ddtFluxCorr::BDF1::internal"
+        );
+    }
 
-            const scalar limiter = ddtFluxCorrLimiter(mag(flux0V[i]), mag(corr));
-
-            outV[i] = limiter * a1 * corr;
-        },
-        "ddtFluxCorr::BDF1"
-    );
+    // Boundary faces
+    {
+        auto outBV = fluxCorr.boundaryData().value().view();
+        auto flux0BV = flux0.boundaryData().value().view();
+        auto uf0BV = uf0.boundaryData().value().view();
+        auto SfV = mesh.faceAreas().view();
+        parallelFor(
+            exec,
+            {size_t(0), static_cast<size_t>(nBoundaryFaces)},
+            NEON_LAMBDA(const localIdx bfi) {
+                const auto d = (SfV[nInternalFaces + bfi] & uf0BV[bfi]);
+                const auto corr = flux0BV[bfi] - d;
+                const scalar limiter = ddtFluxCorrLimiter(mag(flux0BV[bfi]), mag(corr));
+                outBV[bfi] = limiter * a1 * corr;
+            },
+            "ddtFluxCorr::BDF1::boundary"
+        );
+    }
 }
 
 // ------------------------------------------------------------------
@@ -76,36 +99,66 @@ inline void ddtFluxCorrBDF2Kernel(
     scalar dt
 )
 {
-    auto [outV, flux0V, flux00V, uf0V, uf00V, SfV] = views(
-        fluxCorr.internalVector(),
-        flux0.internalVector(),
-        flux00.internalVector(),
-        uf0.internalVector(),
-        uf00.internalVector(),
-        mesh.faceAreas()
-    );
-
     const scalar a1 = 2.0 / dt;
     const scalar a2 = -0.5 / dt;
-    const auto n = outV.size();
+    const auto nInternalFaces = mesh.nInternalFaces();
+    const auto nBoundaryFaces = mesh.nBoundaryFaces();
 
-    parallelFor(
-        exec,
-        {size_t(0), n},
-        NEON_LAMBDA(const localIdx i) {
-            const auto d1 = (SfV[i] & uf0V[i]);
-            const auto corr1 = flux0V[i] - d1;
+    // Internal faces
+    {
+        auto [outV, flux0V, flux00V, uf0V, uf00V, SfV] = views(
+            fluxCorr.internalVector(),
+            flux0.internalVector(),
+            flux00.internalVector(),
+            uf0.internalVector(),
+            uf00.internalVector(),
+            mesh.faceAreas()
+        );
+        parallelFor(
+            exec,
+            {size_t(0), static_cast<size_t>(nInternalFaces)},
+            NEON_LAMBDA(const localIdx i) {
+                const auto d1 = (SfV[i] & uf0V[i]);
+                const auto corr1 = flux0V[i] - d1;
 
-            const auto d2 = (SfV[i] & uf00V[i]);
-            const auto corr2 = flux00V[i] - d2;
+                const auto d2 = (SfV[i] & uf00V[i]);
+                const auto corr2 = flux00V[i] - d2;
 
-            const scalar limiter1 = ddtFluxCorrLimiter(mag(flux0V[i]), mag(corr1));
-            const scalar limiter2 = ddtFluxCorrLimiter(mag(flux00V[i]), mag(corr2));
+                const scalar limiter1 = ddtFluxCorrLimiter(mag(flux0V[i]), mag(corr1));
+                const scalar limiter2 = ddtFluxCorrLimiter(mag(flux00V[i]), mag(corr2));
 
-            outV[i] = limiter1 * a1 * corr1 + limiter2 * a2 * corr2;
-        },
-        "ddtFluxCorr::BDF2"
-    );
+                outV[i] = limiter1 * a1 * corr1 + limiter2 * a2 * corr2;
+            },
+            "ddtFluxCorr::BDF2::internal"
+        );
+    }
+
+    // Boundary faces
+    {
+        auto outBV = fluxCorr.boundaryData().value().view();
+        auto flux0BV = flux0.boundaryData().value().view();
+        auto flux00BV = flux00.boundaryData().value().view();
+        auto uf0BV = uf0.boundaryData().value().view();
+        auto uf00BV = uf00.boundaryData().value().view();
+        auto SfV = mesh.faceAreas().view();
+        parallelFor(
+            exec,
+            {size_t(0), static_cast<size_t>(nBoundaryFaces)},
+            NEON_LAMBDA(const localIdx bfi) {
+                const auto d1 = (SfV[nInternalFaces + bfi] & uf0BV[bfi]);
+                const auto corr1 = flux0BV[bfi] - d1;
+
+                const auto d2 = (SfV[nInternalFaces + bfi] & uf00BV[bfi]);
+                const auto corr2 = flux00BV[bfi] - d2;
+
+                const scalar limiter1 = ddtFluxCorrLimiter(mag(flux0BV[bfi]), mag(corr1));
+                const scalar limiter2 = ddtFluxCorrLimiter(mag(flux00BV[bfi]), mag(corr2));
+
+                outBV[bfi] = limiter1 * a1 * corr1 + limiter2 * a2 * corr2;
+            },
+            "ddtFluxCorr::BDF2::boundary"
+        );
+    }
 }
 
 } // namespace detail

--- a/include/NeoN/finiteVolume/cellCentred/operators/surfaceIntegrate.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/surfaceIntegrate.hpp
@@ -22,6 +22,7 @@ void surfaceIntegrate(
     View<const int> owner,
     View<const int> faceCells,
     View<const ValueType> flux,
+    View<const ValueType> bFlux,
     View<const scalar> v,
     View<ValueType> res,
     const dsl::Coeff operatorScaling
@@ -61,6 +62,7 @@ public:
             mesh.faceOwner().view(),
             mesh.boundaryMesh().faceCells().view(),
             this->flux_.internalVector().view(),
+            this->flux_.boundaryData().value().view(),
             mesh.cellVolumes().view(),
             tmpsource.view(),
             operatorScaling

--- a/include/NeoN/finiteVolume/cellCentred/stencil/basicGeometryScheme.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/stencil/basicGeometryScheme.hpp
@@ -27,8 +27,9 @@ public:
     void updateNonOrthDeltaCoeffs(const Executor& exec, SurfaceField<scalar>& nonOrthDeltaCoeffs)
         override;
 
-    void
-    updateNonOrthDeltaCoeffs(const Executor& exec, SurfaceField<Vec3>& nonOrthDeltaCoeffs) override;
+    void updateNonOrthCorrectionVec3s(
+        const Executor& exec, SurfaceField<Vec3>& nonOrthCorrectionVec3s
+    ) override;
 
 
 private:

--- a/include/NeoN/finiteVolume/cellCentred/stencil/geometryScheme.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/stencil/geometryScheme.hpp
@@ -30,8 +30,9 @@ public:
     virtual void
     updateNonOrthDeltaCoeffs(const Executor& exec, SurfaceField<scalar>& nonOrthDeltaCoeffs) = 0;
 
-    virtual void
-    updateNonOrthDeltaCoeffs(const Executor& exec, SurfaceField<Vec3>& nonOrthDeltaCoeffs) = 0;
+    virtual void updateNonOrthCorrectionVec3s(
+        const Executor& exec, SurfaceField<Vec3>& nonOrthCorrectionVec3s
+    ) = 0;
 };
 
 /* @class GeometryScheme

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,6 +61,8 @@ target_sources(
           "finiteVolume/cellCentred/interpolation/linear.cpp"
           "finiteVolume/cellCentred/interpolation/upwind.cpp"
           "finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp"
+          "finiteVolume/cellCentred/faceNormalGradient/corrected.cpp"
+          "finiteVolume/cellCentred/faceNormalGradient/limitedCorrected.cpp"
           "finiteVolume/cellCentred/auxiliary/coNum.cpp"
           "timeIntegration/timeIntegration.cpp"
           "timeIntegration/rungeKutta.cpp")

--- a/src/bindings/coNum.cpp
+++ b/src/bindings/coNum.cpp
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "NeoN/core/vector/vector.hpp"
+#include "NeoN/core/parallelAlgorithms.hpp"
 #include "NeoN/finiteVolume/cellCentred/auxiliary/coNum.hpp"
 #include "NeoN/finiteVolume/cellCentred/boundary.hpp"
 #include "NeoN/finiteVolume/cellCentred/fields/surfaceField.hpp"
@@ -32,7 +33,9 @@ void registerCoNum(nb::module_& m)
            const NeoN::Vector<NeoN::scalar>& faceFlux,
            NeoN::scalar dt) -> std::pair<NeoN::scalar, NeoN::scalar>
         {
-            const auto expected = mesh.nInternalFaces() + mesh.nBoundaryFaces();
+            const auto nInt = mesh.nInternalFaces();
+            const auto nBnd = mesh.nBoundaryFaces();
+            const auto expected = nInt + nBnd;
             if (faceFlux.size() != expected)
             {
                 throw std::runtime_error(
@@ -43,7 +46,24 @@ void registerCoNum(nb::module_& m)
 
             auto bcs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<NeoN::scalar>>(mesh);
             fvcc::SurfaceField<NeoN::scalar> flux(faceFlux.exec(), "faceFlux", mesh, bcs);
-            flux.internalVector() = faceFlux;
+
+            // Split flat vector into internalVector (first nInt) and boundaryData (last nBnd)
+            auto flatV = faceFlux.view();
+            auto intV = flux.internalVector().view();
+            auto bndV = flux.boundaryData().value().view();
+            NeoN::parallelFor(
+                faceFlux.exec(),
+                {NeoN::localIdx(0), nInt},
+                NEON_LAMBDA(const NeoN::localIdx i) { intV[i] = flatV[i]; },
+                "coNum::splitInternal"
+            );
+            NeoN::parallelFor(
+                faceFlux.exec(),
+                {NeoN::localIdx(0), nBnd},
+                NEON_LAMBDA(const NeoN::localIdx bfi) { bndV[bfi] = flatV[nInt + bfi]; },
+                "coNum::splitBoundary"
+            );
+
             return fvcc::computeCoNum(flux, dt);
         },
         "mesh"_a,

--- a/src/bindings/coNum.cpp
+++ b/src/bindings/coNum.cpp
@@ -4,17 +4,9 @@
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/pair.h>
-#include <nanobind/stl/string.h>
 
-#include <stdexcept>
-#include <string>
-
-#include "NeoN/core/vector/vector.hpp"
-#include "NeoN/core/parallelAlgorithms.hpp"
 #include "NeoN/finiteVolume/cellCentred/auxiliary/coNum.hpp"
-#include "NeoN/finiteVolume/cellCentred/boundary.hpp"
 #include "NeoN/finiteVolume/cellCentred/fields/surfaceField.hpp"
-#include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
 #include "bindings.hpp"
 
 namespace nb = nanobind;
@@ -29,47 +21,11 @@ void registerCoNum(nb::module_& m)
 
     m.def(
         "compute_co_num",
-        [](const NeoN::UnstructuredMesh& mesh,
-           const NeoN::Vector<NeoN::scalar>& faceFlux,
-           NeoN::scalar dt) -> std::pair<NeoN::scalar, NeoN::scalar>
-        {
-            const auto nInt = mesh.nInternalFaces();
-            const auto nBnd = mesh.nBoundaryFaces();
-            const auto expected = nInt + nBnd;
-            if (faceFlux.size() != expected)
-            {
-                throw std::runtime_error(
-                    "face_flux size does not match mesh face count (" + std::to_string(expected)
-                    + ")"
-                );
-            }
-
-            auto bcs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<NeoN::scalar>>(mesh);
-            fvcc::SurfaceField<NeoN::scalar> flux(faceFlux.exec(), "faceFlux", mesh, bcs);
-
-            // Split flat vector into internalVector (first nInt) and boundaryData (last nBnd)
-            auto flatV = faceFlux.view();
-            auto intV = flux.internalVector().view();
-            auto bndV = flux.boundaryData().value().view();
-            NeoN::parallelFor(
-                faceFlux.exec(),
-                {NeoN::localIdx(0), nInt},
-                NEON_LAMBDA(const NeoN::localIdx i) { intV[i] = flatV[i]; },
-                "coNum::splitInternal"
-            );
-            NeoN::parallelFor(
-                faceFlux.exec(),
-                {NeoN::localIdx(0), nBnd},
-                NEON_LAMBDA(const NeoN::localIdx bfi) { bndV[bfi] = flatV[nInt + bfi]; },
-                "coNum::splitBoundary"
-            );
-
-            return fvcc::computeCoNum(flux, dt);
-        },
-        "mesh"_a,
+        [](const fvcc::SurfaceField<NeoN::scalar>& faceFlux, NeoN::scalar dt
+        ) -> std::pair<NeoN::scalar, NeoN::scalar> { return fvcc::computeCoNum(faceFlux, dt); },
         "face_flux"_a,
         "dt"_a,
-        "Compute the maximum Courant number from a face-flux vector."
+        "Compute (max, mean) Courant number from a scalar face-flux SurfaceField."
     );
 }
 

--- a/src/bindings/surfaceField.cpp
+++ b/src/bindings/surfaceField.cpp
@@ -111,6 +111,13 @@ void registerSurfaceField(nb::module_& m)
             "Get the internal vector"
         )
         .def(
+            "boundary_value",
+            [](fvcc::SurfaceField<NeoN::scalar>& self) -> NeoN::Vector<NeoN::scalar>&
+            { return self.boundaryData().value(); },
+            nb::rv_policy::reference_internal,
+            "Get the boundary-face value vector (size = mesh.n_boundary_faces())"
+        )
+        .def(
             "mesh",
             &fvcc::SurfaceField<NeoN::scalar>::mesh,
             nb::rv_policy::reference_internal,
@@ -212,6 +219,13 @@ void registerSurfaceField(nb::module_& m)
                 &fvcc::SurfaceField<NeoN::Vec3>::internalVector
             ),
             nb::rv_policy::reference_internal
+        )
+        .def(
+            "boundary_value",
+            [](fvcc::SurfaceField<NeoN::Vec3>& self) -> NeoN::Vector<NeoN::Vec3>&
+            { return self.boundaryData().value(); },
+            nb::rv_policy::reference_internal,
+            "Get the boundary-face value vector (size = mesh.n_boundary_faces())"
         )
         .def("mesh", &fvcc::SurfaceField<NeoN::Vec3>::mesh, nb::rv_policy::reference_internal)
         .def("exec", &fvcc::SurfaceField<NeoN::Vec3>::exec, nb::rv_policy::reference_internal)

--- a/src/finiteVolume/cellCentred/auxiliary/coNum.cpp
+++ b/src/finiteVolume/cellCentred/auxiliary/coNum.cpp
@@ -23,15 +23,17 @@ std::pair<scalar, scalar> computeCoNum(const SurfaceField<scalar>& faceFlux, con
     VolumeField<scalar> phi(exec, "phi", mesh, createCalculatedBCs<VolumeBoundary<scalar>>(mesh));
     fill(phi.internalVector(), 0.0);
 
-    const auto [surfFaceCells, volPhi, surfOwner, surfNeighbour, surfFaceFlux, surfV] = views(
+    const auto [surfFaceCells, volPhi, surfOwner, surfNeighbour, surfV] = views(
         mesh.boundaryMesh().faceCells(),
         phi.internalVector(),
         mesh.faceOwner(),
         mesh.faceNeighbour(),
-        faceFlux.internalVector(),
         mesh.cellVolumes()
     );
+    const auto surfFaceFlux = faceFlux.internalVector().view();
+    const auto bFaceFlux = faceFlux.boundaryData().value().view();
     auto nInternalFaces = mesh.nInternalFaces();
+    auto nBoundaryFaces = mesh.nBoundaryFaces();
 
     scalar maxCoNum = std::numeric_limits<scalar>::lowest();
     scalar meanCoNum = 0.0;
@@ -48,10 +50,10 @@ std::pair<scalar, scalar> computeCoNum(const SurfaceField<scalar>& faceFlux, con
 
     parallelFor(
         exec,
-        {nInternalFaces, faceFlux.size()},
-        NEON_LAMBDA(const localIdx i) {
-            auto own = surfFaceCells[i - nInternalFaces];
-            scalar flux = Kokkos::sqrt(surfFaceFlux[i] * surfFaceFlux[i]);
+        {0, nBoundaryFaces},
+        NEON_LAMBDA(const localIdx bfi) {
+            auto own = surfFaceCells[bfi];
+            scalar flux = Kokkos::sqrt(bFaceFlux[bfi] * bFaceFlux[bfi]);
             Kokkos::atomic_add(&volPhi[own], flux);
         },
         "computeCoNum::fluxBoundary"

--- a/src/finiteVolume/cellCentred/faceNormalGradient/corrected.cpp
+++ b/src/finiteVolume/cellCentred/faceNormalGradient/corrected.cpp
@@ -86,11 +86,64 @@ void computeCorrectedFaceNormalGrad(
     }
 }
 
+template<typename ValueType>
+void computeCorrectionTerm(
+    const VolumeField<ValueType>& volField,
+    const std::shared_ptr<GeometryScheme> geometryScheme,
+    SurfaceField<ValueType>& corrField
+)
+{
+    if constexpr (std::is_same_v<ValueType, scalar>)
+    {
+        const UnstructuredMesh& mesh = corrField.mesh();
+        const auto& exec = corrField.exec();
+
+        GaussGreenGrad gradScheme(exec, mesh);
+        VolumeField<Vec3> gradPhi = gradScheme.grad(volField);
+
+        const auto [owner, neighbour] = views(mesh.faceOwner(), mesh.faceNeighbour());
+
+        const auto [corrf, weights, corrVec] = views(
+            corrField.internalVector(),
+            geometryScheme->weights().internalVector(),
+            geometryScheme->nonOrthCorrectionVec3s().internalVector()
+        );
+
+        const auto gradPhiV = gradPhi.internalVector().view();
+        auto nInternalFaces = mesh.nInternalFaces();
+
+        NeoN::parallelFor(
+            exec,
+            {0, nInternalFaces},
+            NEON_LAMBDA(const localIdx facei) {
+                Vec3 interpGrad = weights[facei] * gradPhiV[owner[facei]]
+                                + (scalar(1) - weights[facei]) * gradPhiV[neighbour[facei]];
+                corrf[facei] = corrVec[facei] & interpGrad;
+            },
+            "computeCorrectionTermInternal"
+        );
+        // boundary correction is intentionally not written: the laplacian RHS update
+        // iterates only internal faces, so corrField.boundaryData() is never read.
+    }
+    else
+    {
+        NF_ERROR_EXIT("implicitCorrection for Vec3 fields is not implemented: "
+                      "requires tensor gradient support");
+    }
+}
+
 #define NF_DECLARE_COMPUTE_CORRECTED_FNG(TYPENAME)                                                 \
     template void computeCorrectedFaceNormalGrad<                                                  \
         TYPENAME>(const VolumeField<TYPENAME>&, const std::shared_ptr<GeometryScheme>, SurfaceField<TYPENAME>&)
 
 NF_DECLARE_COMPUTE_CORRECTED_FNG(scalar);
 NF_DECLARE_COMPUTE_CORRECTED_FNG(Vec3);
+
+#define NF_DECLARE_COMPUTE_CORRECTION_TERM(TYPENAME)                                               \
+    template void computeCorrectionTerm<                                                           \
+        TYPENAME>(const VolumeField<TYPENAME>&, const std::shared_ptr<GeometryScheme>, SurfaceField<TYPENAME>&)
+
+NF_DECLARE_COMPUTE_CORRECTION_TERM(scalar);
+NF_DECLARE_COMPUTE_CORRECTION_TERM(Vec3);
 
 } // namespace NeoN

--- a/src/finiteVolume/cellCentred/faceNormalGradient/corrected.cpp
+++ b/src/finiteVolume/cellCentred/faceNormalGradient/corrected.cpp
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#include <memory>
+#include <type_traits>
+
+#include "NeoN/core/error.hpp"
+#include "NeoN/finiteVolume/cellCentred/faceNormalGradient/corrected.hpp"
+
+namespace NeoN::finiteVolume::cellCentred
+{
+
+template<typename ValueType>
+void computeCorrectedFaceNormalGrad(
+    const VolumeField<ValueType>& volField,
+    const std::shared_ptr<GeometryScheme> geometryScheme,
+    SurfaceField<ValueType>& surfaceField
+)
+{
+    if constexpr (std::is_same_v<ValueType, scalar>)
+    {
+        const UnstructuredMesh& mesh = surfaceField.mesh();
+        const auto& exec = surfaceField.exec();
+
+        // Compute cell-centred gradient via Gauss-Green
+        GaussGreenGrad gradScheme(exec, mesh);
+        VolumeField<Vec3> gradPhi = gradScheme.grad(volField);
+
+        const auto [owner, neighbour, surfFaceCells] =
+            views(mesh.faceOwner(), mesh.faceNeighbour(), mesh.boundaryMesh().faceCells());
+
+        const auto
+            [phif,
+             phifB,
+             phi,
+             phiBCValue,
+             nonOrthDeltaCoeffs,
+             nonOrthDeltaCoeffsB,
+             weights,
+             corrVec] =
+                views(
+                    surfaceField.internalVector(),
+                    surfaceField.boundaryData().value(),
+                    volField.internalVector(),
+                    volField.boundaryData().value(),
+                    geometryScheme->nonOrthDeltaCoeffs().internalVector(),
+                    geometryScheme->nonOrthDeltaCoeffs().boundaryData().value(),
+                    geometryScheme->weights().internalVector(),
+                    geometryScheme->nonOrthCorrectionVec3s().internalVector()
+                );
+
+        const auto gradPhiV = gradPhi.internalVector().view();
+
+        auto nInternalFaces = mesh.nInternalFaces();
+        auto nBoundaryFaces = mesh.nBoundaryFaces();
+
+        NeoN::parallelFor(
+            exec,
+            {0, nInternalFaces},
+            NEON_LAMBDA(const localIdx facei) {
+                scalar ortho =
+                    nonOrthDeltaCoeffs[facei] * (phi[neighbour[facei]] - phi[owner[facei]]);
+                Vec3 interpGrad = weights[facei] * gradPhiV[owner[facei]]
+                                + (scalar(1) - weights[facei]) * gradPhiV[neighbour[facei]];
+                phif[facei] = ortho + (corrVec[facei] & interpGrad);
+            },
+            "computeCorrectedFaceNormalGradInternal"
+        );
+
+        // corrVec is zero at boundaries — boundary snGrad reduces to the uncorrected form.
+        NeoN::parallelFor(
+            exec,
+            {0, nBoundaryFaces},
+            NEON_LAMBDA(const localIdx bfi) {
+                auto own = surfFaceCells[bfi];
+                phifB[bfi] = nonOrthDeltaCoeffsB[bfi] * (phiBCValue[bfi] - phi[own]);
+            },
+            "computeCorrectedFaceNormalGradBoundary"
+        );
+    }
+    else
+    {
+        NF_ERROR_EXIT("corrected snGrad for Vec3 fields is not implemented: "
+                      "requires tensor gradient support");
+    }
+}
+
+#define NF_DECLARE_COMPUTE_CORRECTED_FNG(TYPENAME)                                                 \
+    template void computeCorrectedFaceNormalGrad<                                                  \
+        TYPENAME>(const VolumeField<TYPENAME>&, const std::shared_ptr<GeometryScheme>, SurfaceField<TYPENAME>&)
+
+NF_DECLARE_COMPUTE_CORRECTED_FNG(scalar);
+NF_DECLARE_COMPUTE_CORRECTED_FNG(Vec3);
+
+} // namespace NeoN

--- a/src/finiteVolume/cellCentred/faceNormalGradient/limitedCorrected.cpp
+++ b/src/finiteVolume/cellCentred/faceNormalGradient/limitedCorrected.cpp
@@ -106,4 +106,73 @@ void computeLimitedCorrectedFaceNormalGrad(
 NF_DECLARE_COMPUTE_LIMITED_CORRECTED_FNG(scalar);
 NF_DECLARE_COMPUTE_LIMITED_CORRECTED_FNG(Vec3);
 
+template<typename ValueType>
+void computeLimitedCorrectionTerm(
+    const VolumeField<ValueType>& volField,
+    const std::shared_ptr<GeometryScheme> geometryScheme,
+    scalar limitCoeff,
+    SurfaceField<ValueType>& corrField
+)
+{
+    if constexpr (std::is_same_v<ValueType, scalar>)
+    {
+        const UnstructuredMesh& mesh = corrField.mesh();
+        const auto& exec = corrField.exec();
+
+        GaussGreenGrad gradScheme(exec, mesh);
+        VolumeField<Vec3> gradPhi = gradScheme.grad(volField);
+
+        const auto [owner, neighbour] = views(mesh.faceOwner(), mesh.faceNeighbour());
+
+        const auto [corrf, phi, nonOrthDeltaCoeffs, weights, corrVec] = views(
+            corrField.internalVector(),
+            volField.internalVector(),
+            geometryScheme->nonOrthDeltaCoeffs().internalVector(),
+            geometryScheme->weights().internalVector(),
+            geometryScheme->nonOrthCorrectionVec3s().internalVector()
+        );
+
+        const auto gradPhiV = gradPhi.internalVector().view();
+        auto nInternalFaces = mesh.nInternalFaces();
+        const scalar lc = limitCoeff;
+        const scalar oneMinusLc = scalar(1) - lc;
+
+        NeoN::parallelFor(
+            exec,
+            {0, nInternalFaces},
+            NEON_LAMBDA(const localIdx facei) {
+                scalar ortho =
+                    nonOrthDeltaCoeffs[facei] * (phi[neighbour[facei]] - phi[owner[facei]]);
+                Vec3 interpGrad = weights[facei] * gradPhiV[owner[facei]]
+                                + (scalar(1) - weights[facei]) * gradPhiV[neighbour[facei]];
+                scalar corr = corrVec[facei] & interpGrad;
+
+                scalar absCorr = std::abs(corr);
+                scalar limiter =
+                    (absCorr > scalar(0)) ? std::min(
+                        lc * std::abs(ortho) / (oneMinusLc * absCorr + ROOTVSMALL), scalar(1)
+                    )
+                                          : scalar(1);
+
+                corrf[facei] = limiter * corr;
+            },
+            "computeLimitedCorrectionTermInternal"
+        );
+        // boundary correction is intentionally not written: the laplacian RHS update
+        // iterates only internal faces, so corrField.boundaryData() is never read.
+    }
+    else
+    {
+        NF_ERROR_EXIT("implicitCorrection for Vec3 fields is not implemented: "
+                      "requires tensor gradient support");
+    }
+}
+
+#define NF_DECLARE_COMPUTE_LIMITED_CORRECTION_TERM(TYPENAME)                                       \
+    template void computeLimitedCorrectionTerm<                                                    \
+        TYPENAME>(const VolumeField<TYPENAME>&, const std::shared_ptr<GeometryScheme>, scalar, SurfaceField<TYPENAME>&)
+
+NF_DECLARE_COMPUTE_LIMITED_CORRECTION_TERM(scalar);
+NF_DECLARE_COMPUTE_LIMITED_CORRECTION_TERM(Vec3);
+
 } // namespace NeoN

--- a/src/finiteVolume/cellCentred/faceNormalGradient/limitedCorrected.cpp
+++ b/src/finiteVolume/cellCentred/faceNormalGradient/limitedCorrected.cpp
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#include <memory>
+#include <type_traits>
+
+#include "NeoN/core/error.hpp"
+#include "NeoN/finiteVolume/cellCentred/faceNormalGradient/limitedCorrected.hpp"
+
+namespace NeoN::finiteVolume::cellCentred
+{
+
+template<typename ValueType>
+void computeLimitedCorrectedFaceNormalGrad(
+    const VolumeField<ValueType>& volField,
+    const std::shared_ptr<GeometryScheme> geometryScheme,
+    scalar limitCoeff,
+    SurfaceField<ValueType>& surfaceField
+)
+{
+    if constexpr (std::is_same_v<ValueType, scalar>)
+    {
+        const UnstructuredMesh& mesh = surfaceField.mesh();
+        const auto& exec = surfaceField.exec();
+
+        // Compute cell-centred gradient via Gauss-Green
+        GaussGreenGrad gradScheme(exec, mesh);
+        VolumeField<Vec3> gradPhi = gradScheme.grad(volField);
+
+        const auto [owner, neighbour, surfFaceCells] =
+            views(mesh.faceOwner(), mesh.faceNeighbour(), mesh.boundaryMesh().faceCells());
+
+        const auto
+            [phif,
+             phifB,
+             phi,
+             phiBCValue,
+             nonOrthDeltaCoeffs,
+             nonOrthDeltaCoeffsB,
+             weights,
+             corrVec] =
+                views(
+                    surfaceField.internalVector(),
+                    surfaceField.boundaryData().value(),
+                    volField.internalVector(),
+                    volField.boundaryData().value(),
+                    geometryScheme->nonOrthDeltaCoeffs().internalVector(),
+                    geometryScheme->nonOrthDeltaCoeffs().boundaryData().value(),
+                    geometryScheme->weights().internalVector(),
+                    geometryScheme->nonOrthCorrectionVec3s().internalVector()
+                );
+
+        const auto gradPhiV = gradPhi.internalVector().view();
+
+        auto nInternalFaces = mesh.nInternalFaces();
+        auto nBoundaryFaces = mesh.nBoundaryFaces();
+        const scalar lc = limitCoeff;
+        const scalar oneMinusLc = scalar(1) - lc;
+
+        NeoN::parallelFor(
+            exec,
+            {0, nInternalFaces},
+            NEON_LAMBDA(const localIdx facei) {
+                scalar ortho =
+                    nonOrthDeltaCoeffs[facei] * (phi[neighbour[facei]] - phi[owner[facei]]);
+                Vec3 interpGrad = weights[facei] * gradPhiV[owner[facei]]
+                                + (scalar(1) - weights[facei]) * gradPhiV[neighbour[facei]];
+                scalar corr = corrVec[facei] & interpGrad;
+
+                // Limiter: bounds the correction relative to the orthogonal part
+                scalar absCorr = std::abs(corr);
+                scalar limiter =
+                    (absCorr > scalar(0)) ? std::min(
+                        lc * std::abs(ortho) / (oneMinusLc * absCorr + ROOTVSMALL), scalar(1)
+                    )
+                                          : scalar(1);
+
+                phif[facei] = ortho + limiter * corr;
+            },
+            "computeLimitedCorrectedFaceNormalGradInternal"
+        );
+
+        // corrVec is zero at boundaries — boundary snGrad reduces to the uncorrected form.
+        NeoN::parallelFor(
+            exec,
+            {0, nBoundaryFaces},
+            NEON_LAMBDA(const localIdx bfi) {
+                auto own = surfFaceCells[bfi];
+                phifB[bfi] = nonOrthDeltaCoeffsB[bfi] * (phiBCValue[bfi] - phi[own]);
+            },
+            "computeLimitedCorrectedFaceNormalGradBoundary"
+        );
+    }
+    else
+    {
+        NF_ERROR_EXIT("limitedCorrected snGrad for Vec3 fields is not implemented: "
+                      "requires tensor gradient support");
+    }
+}
+
+#define NF_DECLARE_COMPUTE_LIMITED_CORRECTED_FNG(TYPENAME)                                         \
+    template void computeLimitedCorrectedFaceNormalGrad<                                           \
+        TYPENAME>(const VolumeField<TYPENAME>&, const std::shared_ptr<GeometryScheme>, scalar, SurfaceField<TYPENAME>&)
+
+NF_DECLARE_COMPUTE_LIMITED_CORRECTED_FNG(scalar);
+NF_DECLARE_COMPUTE_LIMITED_CORRECTED_FNG(Vec3);
+
+} // namespace NeoN

--- a/src/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
+++ b/src/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
@@ -22,15 +22,17 @@ void computeFaceNormalGrad(
     const auto [owner, neighbour, surfFaceCells] =
         views(mesh.faceOwner(), mesh.faceNeighbour(), mesh.boundaryMesh().faceCells());
 
-
-    const auto [phif, phi, phiBCValue, nonOrthDeltaCoeffs] = views(
+    const auto [phif, phifB, phi, phiBCValue, nonOrthDeltaCoeffs, nonOrthDeltaCoeffsB] = views(
         surfaceVector.internalVector(),
+        surfaceVector.boundaryData().value(),
         volVector.internalVector(),
         volVector.boundaryData().value(),
-        geometryScheme->nonOrthDeltaCoeffs().internalVector()
+        geometryScheme->nonOrthDeltaCoeffs().internalVector(),
+        geometryScheme->nonOrthDeltaCoeffs().boundaryData().value()
     );
 
     auto nInternalFaces = mesh.nInternalFaces();
+    auto nBoundaryFaces = mesh.nBoundaryFaces();
 
     NeoN::parallelFor(
         exec,
@@ -43,12 +45,10 @@ void computeFaceNormalGrad(
 
     NeoN::parallelFor(
         exec,
-        {nInternalFaces, phif.size()},
-        NEON_LAMBDA(const localIdx facei) {
-            auto faceBCI = facei - nInternalFaces;
-            auto own = surfFaceCells[faceBCI];
-
-            phif[facei] = nonOrthDeltaCoeffs[facei] * (phiBCValue[faceBCI] - phi[own]);
+        {0, nBoundaryFaces},
+        NEON_LAMBDA(const localIdx bfi) {
+            auto own = surfFaceCells[bfi];
+            phifB[bfi] = nonOrthDeltaCoeffsB[bfi] * (phiBCValue[bfi] - phi[own]);
         },
         "computeFaceNormalGradBoundary"
     );

--- a/src/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -21,31 +21,34 @@ void computeLinearInterpolation(
 {
     const auto exec = dst.exec();
     auto dstS = dst.internalVector().view();
-    const auto [srcS, weightS, ownerS, neighS, boundS] = views(
+    auto dstB = dst.boundaryData().value().view();
+    const auto [srcS, weightS, weightB, ownerS, neighS, boundS] = views(
         src.internalVector(),
         weights.internalVector(),
+        weights.boundaryData().value(),
         dst.mesh().faceOwner(),
         dst.mesh().faceNeighbour(),
         src.boundaryData().value()
     );
     auto nInternalFaces = dst.mesh().nInternalFaces();
+    auto nBoundaryFaces = dst.mesh().nBoundaryFaces();
 
     NeoN::parallelFor(
         exec,
-        {0, dstS.size()},
+        {0, nInternalFaces},
         NEON_LAMBDA(const localIdx facei) {
-            if (facei < nInternalFaces)
-            {
-                auto own = ownerS[facei];
-                auto nei = neighS[facei];
-                dstS[facei] = weightS[facei] * srcS[own] + (1 - weightS[facei]) * srcS[nei];
-            }
-            else
-            {
-                dstS[facei] = weightS[facei] * boundS[facei - nInternalFaces];
-            }
+            auto own = ownerS[facei];
+            auto nei = neighS[facei];
+            dstS[facei] = weightS[facei] * srcS[own] + (1 - weightS[facei]) * srcS[nei];
         },
-        "computeLinearInterpolation"
+        "computeLinearInterpolationInternal"
+    );
+
+    NeoN::parallelFor(
+        exec,
+        {0, nBoundaryFaces},
+        NEON_LAMBDA(const localIdx bfi) { dstB[bfi] = weightB[bfi] * boundS[bfi]; },
+        "computeLinearInterpolationBoundary"
     );
 }
 

--- a/src/finiteVolume/cellCentred/interpolation/upwind.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/upwind.cpp
@@ -20,39 +20,39 @@ void computeUpwindInterpolation(
 {
     const auto exec = dst.exec();
     auto dstS = dst.internalVector().view();
-    const auto [srcS, weightS, ownerS, neighS, boundS, fluxS] = views(
+    auto dstB = dst.boundaryData().value().view();
+    const auto [srcS, weightB, ownerS, neighS, boundS, fluxS] = views(
         src.internalVector(),
-        weights.internalVector(),
+        weights.boundaryData().value(),
         dst.mesh().faceOwner(),
         dst.mesh().faceNeighbour(),
         src.boundaryData().value(),
         flux.internalVector()
     );
     auto nInternalFaces = dst.mesh().nInternalFaces();
+    auto nBoundaryFaces = dst.mesh().nBoundaryFaces();
 
     parallelFor(
         exec,
-        {0, dstS.size()},
+        {0, nInternalFaces},
         NEON_LAMBDA(const localIdx facei) {
-            if (facei < nInternalFaces)
+            if (fluxS[facei] >= 0)
             {
-                if (fluxS[facei] >= 0)
-                {
-                    auto own = ownerS[facei];
-                    dstS[facei] = srcS[own];
-                }
-                else
-                {
-                    auto nei = neighS[facei];
-                    dstS[facei] = srcS[nei];
-                }
+                dstS[facei] = srcS[ownerS[facei]];
             }
             else
             {
-                dstS[facei] = weightS[facei] * boundS[facei - nInternalFaces];
+                dstS[facei] = srcS[neighS[facei]];
             }
         },
-        "computeUpwindInterpolation"
+        "computeUpwindInterpolationInternal"
+    );
+
+    parallelFor(
+        exec,
+        {0, nBoundaryFaces},
+        NEON_LAMBDA(const localIdx bfi) { dstB[bfi] = weightB[bfi] * boundS[bfi]; },
+        "computeUpwindInterpolationBoundary"
     );
 }
 
@@ -65,31 +65,23 @@ void computeUpwindInterpolationWeights(
 )
 {
     const auto exec = src.exec();
-    const auto [weightS, weightB, ownerS, neighS, fluxS] = views(
-        weights.internalVector(),
-        weights.boundaryData().value(),
-        src.mesh().faceOwner(),
-        src.mesh().faceNeighbour(),
-        flux.internalVector()
-    );
+    const auto [weightS, weightB, fluxS] =
+        views(weights.internalVector(), weights.boundaryData().value(), flux.internalVector());
     auto nInternalFaces = src.mesh().nInternalFaces();
+    auto nBoundaryFaces = src.mesh().nBoundaryFaces();
 
     parallelFor(
         exec,
-        {0, weights.size()},
-        NEON_LAMBDA(const localIdx facei) {
-            if (facei < nInternalFaces)
-            {
-                weightS[facei] = fluxS[facei] >= 0 ? 1 : 0;
-            }
-            else
-            {
-                auto bcfacei = facei - nInternalFaces;
-                weightB[bcfacei] = 1.0;
-                weightS[facei] = 1.0;
-            }
-        },
-        "computeUpwindInterpolation"
+        {0, nInternalFaces},
+        NEON_LAMBDA(const localIdx facei) { weightS[facei] = fluxS[facei] >= 0 ? 1 : 0; },
+        "computeUpwindWeightsInternal"
+    );
+
+    parallelFor(
+        exec,
+        {0, nBoundaryFaces},
+        NEON_LAMBDA(const localIdx bfi) { weightB[bfi] = 1.0; },
+        "computeUpwindWeightsBoundary"
     );
 }
 

--- a/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
@@ -36,7 +36,9 @@ void computeDiv(
     View<const localIdx> owner,
     View<const localIdx> faceCells,
     View<const scalar> faceFlux,
+    View<const scalar> bFaceFlux,
     View<const ValueType> phiF,
+    View<const ValueType> bPhiF,
     View<const scalar> v,
     View<ValueType> res,
     const dsl::Coeff operatorScaling
@@ -68,10 +70,10 @@ void computeDiv(
 
     parallelFor(
         exec,
-        {nInternalFaces, nInternalFaces + nBoundaryFaces},
-        NEON_LAMBDA(const localIdx i) {
-            auto own = faceCells[i - nInternalFaces];
-            ValueType valueOwn = faceFlux[i] * phiF[i];
+        {0, nBoundaryFaces},
+        NEON_LAMBDA(const localIdx bfi) {
+            auto own = faceCells[bfi];
+            ValueType valueOwn = bFaceFlux[bfi] * bPhiF[bfi];
             Kokkos::atomic_add(&res[own], valueOwn); // boundary face: F_f outward from owner
         },
         "sumFluxesBoundary"
@@ -116,11 +118,12 @@ void computeDivExp(
         mesh.faceOwner().view(),
         mesh.boundaryMesh().faceCells().view(),
         faceFlux.internalVector().view(),
+        faceFlux.boundaryData().value().view(),
         phif.internalVector().view(),
+        phif.boundaryData().value().view(),
         mesh.cellVolumes().view(),
         divPhi.view(),
         operatorScaling
-
     );
 }
 
@@ -148,8 +151,6 @@ void computeDivBoundImp(
     const auto exec = phi.exec();
     const auto& mesh = phi.mesh();
 
-    auto faceFluxV = faceFlux.internalVector().view();
-
     const auto ma = ls.faceToMatrixAddress()->view(ls.matrix().sparsity()->rowOffs().view());
 
     const auto [ownV, deltaCoeffs] =
@@ -157,7 +158,8 @@ void computeDivBoundImp(
 
     auto values = ls.matrix().values().view();
 
-    auto [bweights, refGradient, valueFraction, refValue] = views(
+    auto [bFaceFluxV, bweights, refGradient, valueFraction, refValue] = views(
+        faceFlux.boundaryData().value(),
         weights.boundaryData().value(),
         phi.boundaryData().refGrad(),
         phi.boundaryData().valueFraction(),
@@ -168,14 +170,11 @@ void computeDivBoundImp(
     auto bRhs = ls.boundaryRhs().view();
     auto bValues = ls.boundaryMatrix().values().view();
 
-    const auto nInternalFaces = mesh.nInternalFaces();
     const auto nBoundaryFaces = mesh.nBoundaryFaces();
-    auto totalFaces = nInternalFaces + nBoundaryFaces;
     parallelFor(
         exec,
-        {nInternalFaces, totalFaces},
-        NEON_LAMBDA(const localIdx facei) {
-            auto bfi = facei - nInternalFaces;
+        {0, nBoundaryFaces},
+        NEON_LAMBDA(const localIdx bfi) {
             auto ownRow = ownV[bfi];
 
             auto ownCoeff = operatorScaling[ownRow];
@@ -184,7 +183,7 @@ void computeDivBoundImp(
             auto refGradFrac = 1.0 - refValFrac;
 
             auto flux =
-                faceFluxV[facei] * -bweights[bfi] * ownCoeff * refGradFrac * one<ValueType>();
+                bFaceFluxV[bfi] * -bweights[bfi] * ownCoeff * refGradFrac * one<ValueType>();
 
             // since upper triangular value is "outside" of system matrix
             // it is stored separately in bMatrix
@@ -199,7 +198,7 @@ void computeDivBoundImp(
             // bweights converts the Dirichlet face value to a cell-to-face flux contribution;
             // the Neumann gradient correction (refGradient/δ) enters directly as a known increment.
             auto valueRhs =
-                (bweights[bfi] * faceFluxV[facei] * ownCoeff * (refValFrac * refValue[bfi]))
+                (bweights[bfi] * bFaceFluxV[bfi] * ownCoeff * (refValFrac * refValue[bfi]))
                 + refGradFrac * refGradient[bfi] * (1 / deltaCoeffs[bfi]);
             Kokkos::atomic_sub(&rhs[ownRow], valueRhs);
             bRhs[bfi] += valueRhs;

--- a/src/finiteVolume/cellCentred/operators/gaussGreenGrad.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenGrad.cpp
@@ -33,17 +33,18 @@ void computeGrad(
 
     auto surfGradPhi = out.view();
 
-    const auto [surfFaceCells, sBSf, surfPhif, surfOwner, surfNeighbour, faceAreaS, surfV] = views(
+    const auto [surfFaceCells, surfOwner, surfNeighbour, faceAreaS, surfV] = views(
         mesh.boundaryMesh().faceCells(),
-        mesh.boundaryMesh().sf(),
-        phif.internalVector(),
         mesh.faceOwner(),
         mesh.faceNeighbour(),
         mesh.faceAreas(),
         mesh.cellVolumes()
     );
+    const auto surfPhif = phif.internalVector().view();
+    const auto surfPhifB = phif.boundaryData().value().view();
 
     auto nInternalFaces = mesh.nInternalFaces();
+    auto nBoundaryFaces = mesh.nBoundaryFaces();
 
     // Green-Gauss gradient theorem: ∇φ_C = (1/V_C) * sum_f S_f * φ_f
     //
@@ -65,10 +66,10 @@ void computeGrad(
     // Boundary faces: only the owner cell is on this rank.
     parallelFor(
         exec,
-        {nInternalFaces, surfPhif.size()},
-        NEON_LAMBDA(const localIdx i) {
-            auto own = surfFaceCells[i - nInternalFaces];
-            Vec3 valueOwn = faceAreaS[i] * surfPhif[i]; // +S_f * φ_f (S_f outward from owner)
+        {0, nBoundaryFaces},
+        NEON_LAMBDA(const localIdx bfi) {
+            auto own = surfFaceCells[bfi];
+            Vec3 valueOwn = faceAreaS[nInternalFaces + bfi] * surfPhifB[bfi];
             Kokkos::atomic_add(&surfGradPhi[own], valueOwn);
         },
         "computeGradBoundary"
@@ -237,25 +238,25 @@ void computeGradTensor(
 
     auto gT = gradU.view();
 
-    const auto [UfAll, owner, nei, SfAll, V, bFaceCells] = views(
-        uf.internalVector(),
+    const auto [owner, nei, SfAll, V, bFaceCells] = views(
         mesh.faceOwner(),
         mesh.faceNeighbour(),
         mesh.faceAreas(),
         mesh.cellVolumes(),
         mesh.boundaryMesh().faceCells()
     );
+    const auto UfInt = uf.internalVector().view();
+    const auto UfBound = uf.boundaryData().value().view();
 
     const localIdx nInt = mesh.nInternalFaces();
-    const localIdx nBnd = mesh.boundaryMesh().offset().back();
-    const localIdx nFaces = nInt + nBnd;
+    const localIdx nBnd = mesh.nBoundaryFaces();
 
     parallelFor(
         exec,
         {0, nInt},
         NEON_LAMBDA(const localIdx f) {
             const Vec3 sf = SfAll[f];
-            const Vec3 faceU = UfAll[f];
+            const Vec3 faceU = UfInt[f];
             const auto o = owner[f];
             const auto n = nei[f];
             // gradU(row,col) += Sf[col] * U[row]  (Gauss-Green)
@@ -274,12 +275,11 @@ void computeGradTensor(
 
     parallelFor(
         exec,
-        {nInt, nFaces},
-        NEON_LAMBDA(const localIdx f) {
-            const localIdx bi = f - nInt;
+        {0, nBnd},
+        NEON_LAMBDA(const localIdx bi) {
             const auto o = bFaceCells[bi];
-            const Vec3 sf = SfAll[f];
-            const Vec3 faceU = UfAll[f];
+            const Vec3 sf = SfAll[nInt + bi];
+            const Vec3 faceU = UfBound[bi];
             for (size_t row = 0; row < 3; ++row)
             {
                 for (size_t col = 0; col < 3; ++col)

--- a/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
@@ -216,6 +216,35 @@ void computeLaplacianIntImpl(
         },
         "computeLocalLaplacianCoefficients"
     );
+
+    // Non-orthogonal correction (deferred correction) for corrected / limitedCorrected snGrad:
+    //   rhs[own] += corr[f] * γ_f * |S_f| * coeff[own]
+    //   rhs[nei] -= corr[f] * γ_f * |S_f| * coeff[nei]
+    // The correction is zero for uncorrected via the default implicitCorrection() implementation,
+    // so the if-guard skips unnecessary work and allocation.
+    if (faceNormalGradient.hasImplicitCorrection())
+    {
+        SurfaceField<ValueType> corrField(
+            exec, "snGradCorr", mesh, createCalculatedBCs<SurfaceBoundary<ValueType>>(mesh)
+        );
+        faceNormalGradient.implicitCorrection(phi, corrField);
+
+        const auto corrV = corrField.internalVector().view();
+        auto rhs = ls.rhs().view();
+
+        parallelFor(
+            exec,
+            {0, nInternalFaces},
+            NEON_LAMBDA(const localIdx facei) {
+                auto corrFlux = corrV[facei] * gammaV[facei] * magFaceArea[facei];
+                auto own = ownV[facei];
+                auto nei = neiV[facei];
+                Kokkos::atomic_add(&rhs[own], corrFlux * coeff[own]);
+                Kokkos::atomic_sub(&rhs[nei], corrFlux * coeff[nei]);
+            },
+            "computeLaplacianImplicitCorrection"
+        );
+    }
 }
 
 #define NN_DECLARE_COMPUTE_IMP_LAP(TYPENAME)                                                                                                                      \

--- a/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
@@ -27,8 +27,10 @@ void computeLaplacianExp(
 
     const auto [result, faceArea, fnGrad, vol] =
         views(lapPhi, mesh.magFaceAreas(), faceNormalGrad.internalVector(), mesh.cellVolumes());
+    const auto fnGradB = faceNormalGrad.boundaryData().value().view();
 
     auto nInternalFaces = mesh.nInternalFaces();
+    auto nBoundaryFaces = mesh.nBoundaryFaces();
 
     // Green-Gauss Laplacian: ∇·(γ∇φ)_C = (1/V_C) * sum_f γ_f * |S_f| * (∂φ/∂n)_f
     //
@@ -59,11 +61,10 @@ void computeLaplacianExp(
     // Boundary faces: only the owner cell is on this rank.
     parallelFor(
         exec,
-        {nInternalFaces, fnGrad.size()},
-        NEON_LAMBDA(const localIdx i) {
-            auto own = surfFaceCells[i - nInternalFaces];
-            ValueType valueOwn =
-                faceArea[i] * fnGrad[i]; // +|S_f| * fnGrad (S_f outward from owner)
+        {0, nBoundaryFaces},
+        NEON_LAMBDA(const localIdx bfi) {
+            auto own = surfFaceCells[bfi];
+            ValueType valueOwn = faceArea[nInternalFaces + bfi] * fnGradB[bfi];
             Kokkos::atomic_add(&result[own], valueOwn);
         },
         "computeLaplacianExplicitBoundary"
@@ -102,13 +103,11 @@ void computeLaplacianBoundImpl(
     const auto exec = phi.exec();
     const auto& mesh = phi.mesh();
 
-    auto gammaV = gamma.internalVector().view();
+    const auto [magFaceArea, surfFaceCells] =
+        views(mesh.magFaceAreas(), mesh.boundaryMesh().faceCells());
 
-    const auto [magFaceArea, surfFaceCells, deltaCoeffs] = views(
-        mesh.magFaceAreas(),
-        mesh.boundaryMesh().faceCells(),
-        faceNormalGradient.deltaCoeffs().internalVector()
-    );
+    const auto bGammaV = gamma.boundaryData().value().view();
+    const auto bDeltaCoeffs = faceNormalGradient.deltaCoeffs().boundaryData().value().view();
 
     const auto ma = ls.faceToMatrixAddress()->view(ls.matrix().sparsity()->rowOffs().view());
 
@@ -126,12 +125,10 @@ void computeLaplacianBoundImpl(
 
     const auto nInternalFaces = mesh.nInternalFaces();
     const auto nBoundaryFaces = mesh.nBoundaryFaces();
-    auto totalFaces = nInternalFaces + nBoundaryFaces;
     parallelFor(
         exec,
-        {nInternalFaces, totalFaces},
-        NEON_LAMBDA(const localIdx facei) {
-            auto bfi = facei - nInternalFaces;
+        {0, nBoundaryFaces},
+        NEON_LAMBDA(const localIdx bfi) {
             auto ownRow = surfFaceCells[bfi];
 
             auto ownRowCoeff = operatorScaling[ownRow];
@@ -139,9 +136,9 @@ void computeLaplacianBoundImpl(
             auto refValFrac = valueFraction[bfi];
             auto refGradFrac = 1.0 - refValFrac;
 
-            auto flux = gammaV[facei] * magFaceArea[facei];
+            auto flux = bGammaV[bfi] * magFaceArea[nInternalFaces + bfi];
             auto fluxContrib =
-                flux * ownRowCoeff * refValFrac * deltaCoeffs[facei] * one<ValueType>();
+                flux * ownRowCoeff * refValFrac * bDeltaCoeffs[bfi] * one<ValueType>();
 
             // since upper triangular value is "outside" of system matrix
             // it is stored separately in bMatrix
@@ -155,9 +152,9 @@ void computeLaplacianBoundImpl(
             // The implicit valFrac2 * φ_C term is handled via fluxContrib above.
             // bweights converts the Dirichlet face value to a cell-to-face flux contribution;
             // the Neumann gradient correction (refGradient/δ) enters directly as a known increment.
-            auto valueRhs = flux * ownRowCoeff
-                          * (refValFrac * deltaCoeffs[facei] * refValue[bfi]
-                             + refGradFrac * refGradient[bfi]);
+            auto valueRhs =
+                flux * ownRowCoeff
+                * (refValFrac * bDeltaCoeffs[bfi] * refValue[bfi] + refGradFrac * refGradient[bfi]);
             Kokkos::atomic_sub(&rhs[ownRow], valueRhs);
             bRhs[bfi] += valueRhs;
         },

--- a/src/finiteVolume/cellCentred/operators/surfaceIntegrate.cpp
+++ b/src/finiteVolume/cellCentred/operators/surfaceIntegrate.cpp
@@ -16,6 +16,7 @@ void surfaceIntegrate(
     View<const int> owner,
     View<const int> faceCells,
     View<const ValueType> flux,
+    View<const ValueType> bFlux,
     View<const scalar> v,
     View<ValueType> res,
     const dsl::Coeff operatorScaling
@@ -35,10 +36,10 @@ void surfaceIntegrate(
 
     parallelFor(
         exec,
-        {nInternalFaces, nInternalFaces + nBoundaryFaces},
-        NEON_LAMBDA(const localIdx i) {
-            auto own = faceCells[i - nInternalFaces];
-            Kokkos::atomic_add(&res[own], flux[i]);
+        {0, nBoundaryFaces},
+        NEON_LAMBDA(const localIdx bfi) {
+            auto own = faceCells[bfi];
+            Kokkos::atomic_add(&res[own], bFlux[bfi]);
         },
         "surfaceIntegrateBoundaryFaces"
     );
@@ -58,6 +59,7 @@ void surfaceIntegrate(
         View<const int>,                                                                           \
         View<const int>,                                                                           \
         View<const int>,                                                                           \
+        View<const TYPENAME>,                                                                      \
         View<const TYPENAME>,                                                                      \
         View<const scalar>,                                                                        \
         View<TYPENAME>,                                                                            \

--- a/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
@@ -135,11 +135,42 @@ void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
 }
 
 
-void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
-    [[maybe_unused]] const Executor& exec, [[maybe_unused]] SurfaceField<Vec3>& nonOrthDeltaCoeffs
+void BasicGeometryScheme::updateNonOrthCorrectionVec3s(
+    const Executor& exec, SurfaceField<Vec3>& nonOrthCorrectionVec3s
 )
 {
-    NF_ERROR_EXIT("Not implemented");
+    const auto [owner, neighbour, surfFaceCells] =
+        views(mesh_.faceOwner(), mesh_.faceNeighbour(), mesh_.boundaryMesh().faceCells());
+
+    const auto [cellCentre, faceAreaVec3, faceArea] =
+        views(mesh_.cellCentres(), mesh_.faceAreas(), mesh_.magFaceAreas());
+
+    const auto [corrVec, corrVecB] = views(
+        nonOrthCorrectionVec3s.internalVector(), nonOrthCorrectionVec3s.boundaryData().value()
+    );
+
+    const auto nInternalFaces = mesh_.nInternalFaces();
+    const auto nBoundaryFaces = mesh_.nBoundaryFaces();
+
+    parallelFor(
+        exec,
+        {0, nInternalFaces},
+        NEON_LAMBDA(const localIdx facei) {
+            Vec3 delta = cellCentre[neighbour[facei]] - cellCentre[owner[facei]];
+            Vec3 n = (1.0 / faceArea[facei]) * faceAreaVec3[facei];
+            scalar orthoDist = n & delta;
+            scalar nonOrthDeltaCoeff = 1.0 / std::max(orthoDist, scalar(0.05) * mag(delta));
+            corrVec[facei] = n - delta * nonOrthDeltaCoeff;
+        },
+        "basicGeometricScheme::updateNonOrthCorrectionVec3sInternal"
+    );
+
+    parallelFor(
+        exec,
+        {0, nBoundaryFaces},
+        NEON_LAMBDA(const localIdx bfi) { corrVecB[bfi] = zero<Vec3>(); },
+        "basicGeometricScheme::updateNonOrthCorrectionVec3sBoundary"
+    );
 }
 
 } // namespace NeoN

--- a/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
@@ -46,12 +46,8 @@ void BasicGeometryScheme::updateWeights(const Executor& exec, SurfaceField<scala
 
     parallelFor(
         exec,
-        {nInternalFaces, weightS.size()},
-        NEON_LAMBDA(const localIdx facei) {
-            const auto bcfacei = facei - nInternalFaces;
-            weightS[facei] = 1.0;
-            weightB[bcfacei] = 1.0;
-        },
+        {0, mesh_.nBoundaryFaces()},
+        NEON_LAMBDA(const localIdx bfi) { weightB[bfi] = 1.0; },
         "basicGeometricScheme::updateWeightsBoundary"
     );
 }
@@ -67,10 +63,13 @@ void BasicGeometryScheme::updateDeltaCoeffs(
     const auto [cf, cellCentre] = views(mesh_.faceCentres(), mesh_.cellCentres());
 
     auto deltaCoeff = deltaCoeffs.internalVector().view();
+    auto deltaCoeffB = deltaCoeffs.boundaryData().value().view();
+
+    const auto nInternalFaces = mesh_.nInternalFaces();
 
     parallelFor(
         exec,
-        {0, mesh_.nInternalFaces()},
+        {0, nInternalFaces},
         NEON_LAMBDA(const localIdx facei) {
             Vec3 cellToCellDist = cellCentre[neighbour[facei]] - cellCentre[owner[facei]];
             deltaCoeff[facei] = 1.0 / mag(cellToCellDist);
@@ -78,16 +77,13 @@ void BasicGeometryScheme::updateDeltaCoeffs(
         "basicGeometricScheme::updateDeltaCoeffsInternal"
     );
 
-    const auto nInternalFaces = mesh_.nInternalFaces();
-
     parallelFor(
         exec,
-        {nInternalFaces, deltaCoeff.size()},
-        NEON_LAMBDA(const localIdx facei) {
-            auto own = surfFaceCells[facei - nInternalFaces];
-            Vec3 cellToCellDist = cf[facei] - cellCentre[own];
-
-            deltaCoeff[facei] = 1.0 / mag(cellToCellDist);
+        {0, mesh_.nBoundaryFaces()},
+        NEON_LAMBDA(const localIdx bfi) {
+            auto own = surfFaceCells[bfi];
+            Vec3 cellToCellDist = cf[nInternalFaces + bfi] - cellCentre[own];
+            deltaCoeffB[bfi] = 1.0 / mag(cellToCellDist);
         },
         "basicGeometricScheme::updateDeltaCoeffsBoundary"
     );
@@ -106,6 +102,7 @@ void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
         views(mesh_.faceCentres(), mesh_.cellCentres(), mesh_.faceAreas(), mesh_.magFaceAreas());
 
     auto nonOrthDeltaCoeff = nonOrthDeltaCoeffs.internalVector().view();
+    auto nonOrthDeltaCoeffB = nonOrthDeltaCoeffs.boundaryData().value().view();
     fill(nonOrthDeltaCoeffs.internalVector(), 0.0);
 
     const auto nInternalFaces = mesh_.nInternalFaces();
@@ -124,13 +121,14 @@ void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
 
     parallelFor(
         exec,
-        {nInternalFaces, nonOrthDeltaCoeff.size()},
-        NEON_LAMBDA(const localIdx facei) {
-            auto own = surfFaceCells[facei - nInternalFaces];
-            Vec3 cellToCellDist = cf[facei] - cellCentre[own];
-            Vec3 faceNormal = 1 / faceArea[facei] * faceAreaVec3[facei];
+        {0, mesh_.nBoundaryFaces()},
+        NEON_LAMBDA(const localIdx bfi) {
+            auto own = surfFaceCells[bfi];
+            Vec3 cellToCellDist = cf[nInternalFaces + bfi] - cellCentre[own];
+            Vec3 faceNormal =
+                1 / faceArea[nInternalFaces + bfi] * faceAreaVec3[nInternalFaces + bfi];
             scalar orthoDist = faceNormal & cellToCellDist;
-            nonOrthDeltaCoeff[facei] = 1.0 / std::max(orthoDist, 0.05 * mag(cellToCellDist));
+            nonOrthDeltaCoeffB[bfi] = 1.0 / std::max(orthoDist, 0.05 * mag(cellToCellDist));
         },
         "basicGeometricScheme::updateNonOrthDeltaCoeffsBoundary"
     );

--- a/src/finiteVolume/cellCentred/stencil/geometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/geometryScheme.cpp
@@ -113,7 +113,7 @@ void GeometryScheme::update()
                 kernel_->updateWeights(exec, weights_);
                 kernel_->updateDeltaCoeffs(exec, deltaCoeffs_);
                 kernel_->updateNonOrthDeltaCoeffs(exec, nonOrthDeltaCoeffs_);
-                // kernel_->updateNonOrthCorrectionVec3s(exec, nonOrthCorrectionVec3s_);
+                kernel_->updateNonOrthCorrectionVec3s(exec, nonOrthCorrectionVec3s_);
             },
             exec_
         );

--- a/test/bindings/test_coNum.py
+++ b/test/bindings/test_coNum.py
@@ -9,10 +9,10 @@ def test_compute_co_num_on_uniform_mesh(executor):
     name, exec = executor
     mesh = neon.create_1d_uniform_mesh(exec, 4)
 
-    face_count = mesh.n_internal_faces() + mesh.n_boundary_faces()
-    face_flux = neon.ScalarVector(exec, face_count)
-    neon.fill(face_flux, 1.0)
+    face_flux = neon.ScalarSurfaceField(exec, "phi", mesh)
+    neon.fill(face_flux.internal_vector(), 1.0)
+    neon.fill(face_flux.boundary_value(), 1.0)
 
-    max_CoNum, mean_CoNum = neon.compute_co_num(mesh, face_flux, 0.01)
+    max_CoNum, mean_CoNum = neon.compute_co_num(face_flux, 0.01)
     assert abs(max_CoNum - 0.04) < 1.0e-12
     assert abs(mean_CoNum - 0.04) < 1.0e-12

--- a/test/bindings/test_surfaceField.py
+++ b/test/bindings/test_surfaceField.py
@@ -13,7 +13,7 @@ def test_scalar_surface_field_and_bcs(executor):
     assert len(bcs) == mesh.n_boundaries()
 
     field = neon.ScalarSurfaceField(exec, "phi", mesh)
-    assert field.size() == mesh.n_internal_faces() + mesh.n_boundary_faces()
+    assert field.size() == mesh.n_internal_faces()
 
     neon.fill(field.internal_vector(), 1.0)
     assert neon.equal(field.internal_vector(), 1.0)

--- a/test/bindings/test_surfaceInterpolation.py
+++ b/test/bindings/test_surfaceInterpolation.py
@@ -21,7 +21,7 @@ def test_surface_interpolation_scalar(executor):
     interp = neon.SurfaceInterpolationScalar(exec, mesh, token_list)
     surface = interp.interpolate(volume)
 
-    assert surface.size() == mesh.n_internal_faces() + mesh.n_boundary_faces()
+    assert surface.size() == mesh.n_internal_faces()
 
 
 def test_surface_interpolation_vector(executor):
@@ -40,4 +40,4 @@ def test_surface_interpolation_vector(executor):
     interp = neon.SurfaceInterpolationVec3(exec, mesh, token_list)
     surface = interp.interpolate(volume)
 
-    assert surface.size() == mesh.n_internal_faces() + mesh.n_boundary_faces()
+    assert surface.size() == mesh.n_internal_faces()

--- a/test/dsl/common.hpp
+++ b/test/dsl/common.hpp
@@ -110,9 +110,9 @@ struct CreateSurfaceVector
     {
         using SF = NeoN::finiteVolume::cellCentred::SurfaceField<ValueType>;
 
-        // Face storage
+        // Face storage: internalVector holds only internal faces
         NeoN::Field<ValueType> domainField(
-            mesh.exec(), mesh.nFaces(), mesh.boundaryMesh().offset()
+            mesh.exec(), mesh.nInternalFaces(), mesh.boundaryMesh().offset()
         );
         NeoN::fill(domainField.internalVector(), value);
         NeoN::fill(domainField.boundaryData().refValue(), value);

--- a/test/finiteVolume/cellCentred/boundary/surface/surfSymmetry.cpp
+++ b/test/finiteVolume/cellCentred/boundary/surface/surfSymmetry.cpp
@@ -36,17 +36,9 @@ TEST_CASE("symmetry_surface")
                 copyToHosts(field.boundaryData().refValue(), field.boundaryData().value());
 
             for (auto& v : refValuesH.view(boundary->range()))
-            {
-                const auto i = static_cast<NeoN::localIdx>(&boundaryValueV - refValuesH.data());
-                const auto ownerV = faceCellsH.view()[i];
-                REQUIRE(boundaryValueV == Catch::Approx(internalH.view()[ownerV]));
-            }
+                REQUIRE(v == Catch::Approx(0.0));
             for (auto& v : valuesH.view(boundary->range()))
-            {
-                const auto i = static_cast<NeoN::localIdx>(&boundaryValueV - valuesH.data());
-                const auto ownerV = faceCellsH.view()[i];
-                REQUIRE(boundaryValueV == Catch::Approx(internalH.view()[ownerV]));
-            }
+                REQUIRE(v == Catch::Approx(0.0));
         }
 
         // === vector field =====================================================

--- a/test/finiteVolume/cellCentred/boundary/surface/surfSymmetry.cpp
+++ b/test/finiteVolume/cellCentred/boundary/surface/surfSymmetry.cpp
@@ -16,12 +16,13 @@ TEST_CASE("symmetry_surface")
         auto mesh = NeoN::createSingleCellMesh(exec);
 
         // === scalar field =====================================================
+        // Surface symmetry for scalars zeros the flux at the symmetry plane
         {
-            auto field =
-                NeoN::Field<NeoN::scalar>(exec, mesh.nCells(), mesh.boundaryMesh().offset());
-            NeoN::fill(field.internalVector(), 5.0);
-            NeoN::fill(field.boundaryData().refValue(), -1.0);
-            NeoN::fill(field.boundaryData().value(), -1.0);
+            auto field = NeoN::Field<NeoN::scalar>(
+                exec, mesh.nInternalFaces(), mesh.boundaryMesh().offset()
+            );
+            NeoN::fill(field.boundaryData().refValue(), 5.0);
+            NeoN::fill(field.boundaryData().value(), 5.0);
 
             NeoN::Dictionary dict;
             auto boundary =
@@ -31,21 +32,16 @@ TEST_CASE("symmetry_surface")
 
             boundary->correctBoundaryCondition(field);
 
-            auto [refValuesH, valuesH, faceCellsH, internalH] = copyToHosts(
-                field.boundaryData().refValue(),
-                field.boundaryData().value(),
-                mesh.boundaryMesh().faceCells(),
-                field.internalVector()
-            );
+            auto [refValuesH, valuesH] =
+                copyToHosts(field.boundaryData().refValue(), field.boundaryData().value());
 
-            for (auto& boundaryValueV : refValuesH.view(boundary->range()))
+            for (auto& v : refValuesH.view(boundary->range()))
             {
                 const auto i = static_cast<NeoN::localIdx>(&boundaryValueV - refValuesH.data());
                 const auto ownerV = faceCellsH.view()[i];
                 REQUIRE(boundaryValueV == Catch::Approx(internalH.view()[ownerV]));
             }
-
-            for (auto& boundaryValueV : valuesH.view(boundary->range()))
+            for (auto& v : valuesH.view(boundary->range()))
             {
                 const auto i = static_cast<NeoN::localIdx>(&boundaryValueV - valuesH.data());
                 const auto ownerV = faceCellsH.view()[i];
@@ -54,11 +50,13 @@ TEST_CASE("symmetry_surface")
         }
 
         // === vector field =====================================================
+        // Surface symmetry for Vec3 zeros the normal component of the existing boundary value
         {
-            auto field = NeoN::Field<NeoN::Vec3>(exec, mesh.nCells(), mesh.boundaryMesh().offset());
-            NeoN::fill(field.internalVector(), NeoN::Vec3(1.0, 2.0, 3.0));
+            const NeoN::Vec3 inputVal(1.0, 2.0, 3.0);
+            auto field =
+                NeoN::Field<NeoN::Vec3>(exec, mesh.nInternalFaces(), mesh.boundaryMesh().offset());
             NeoN::fill(field.boundaryData().refValue(), NeoN::Vec3(-1.0, -1.0, -1.0));
-            NeoN::fill(field.boundaryData().value(), NeoN::Vec3(-1.0, -1.0, -1.0));
+            NeoN::fill(field.boundaryData().value(), inputVal);
 
             NeoN::Dictionary dict;
             auto boundary =
@@ -68,38 +66,28 @@ TEST_CASE("symmetry_surface")
 
             boundary->correctBoundaryCondition(field);
 
-            auto [refValuesH, valuesH, faceCellsH, internalH, nHatH] = copyToHosts(
+            auto [refValuesH, valuesH, nHatH] = copyToHosts(
                 field.boundaryData().refValue(),
                 field.boundaryData().value(),
-                mesh.boundaryMesh().faceCells(),
-                field.internalVector(),
                 mesh.boundaryMesh().nf()
             );
 
-            for (auto& boundaryValueV : refValuesH.view(boundary->range()))
+            for (auto& boundaryValueV : valuesH.view(boundary->range()))
             {
-                const auto i = static_cast<NeoN::localIdx>(&boundaryValueV - refValuesH.data());
-                const auto ownerV = faceCellsH.view()[i];
+                const auto i = static_cast<NeoN::localIdx>(&boundaryValueV - valuesH.data());
                 const auto nV = nHatH.view()[i];
-                const auto intV = internalH.view()[ownerV];
-                // const auto vn = vInt & n;
-                const auto vExpected = intV - nV * (intV & nV); // half-symmetry
-
+                const auto vExpected = inputVal - nV * (inputVal & nV);
                 for (auto d = 0u; d < 3; ++d)
                 {
                     REQUIRE(boundaryValueV[d] == Catch::Approx(vExpected[d]));
                 }
             }
 
-            for (auto& boundaryValueV : valuesH.view(boundary->range()))
+            for (auto& boundaryValueV : refValuesH.view(boundary->range()))
             {
-                const auto i = static_cast<NeoN::localIdx>(&boundaryValueV - valuesH.data());
-                const auto ownerV = faceCellsH.view()[i];
+                const auto i = static_cast<NeoN::localIdx>(&boundaryValueV - refValuesH.data());
                 const auto nV = nHatH.view()[i];
-                const auto intV = internalH.view()[ownerV];
-                // const auto vn = vInt & n;
-                const auto vExpected = intV - nV * (intV & nV);
-
+                const auto vExpected = inputVal - nV * (inputVal & nV);
                 for (auto d = 0u; d < 3; ++d)
                 {
                     REQUIRE(boundaryValueV[d] == Catch::Approx(vExpected[d]));

--- a/test/finiteVolume/cellCentred/faceNormalGradient/CMakeLists.txt
+++ b/test/finiteVolume/cellCentred/faceNormalGradient/CMakeLists.txt
@@ -3,3 +3,5 @@
 # SPDX-License-Identifier: Unlicense
 
 neon_unit_test(uncorrected)
+neon_unit_test(corrected)
+neon_unit_test(limitedCorrected)

--- a/test/finiteVolume/cellCentred/faceNormalGradient/corrected.cpp
+++ b/test/finiteVolume/cellCentred/faceNormalGradient/corrected.cpp
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
+                            // a custom main
+#include "catch2_common.hpp"
+
+#include "NeoN/NeoN.hpp"
+
+namespace fvcc = NeoN::finiteVolume::cellCentred;
+
+namespace NeoN
+{
+
+template<typename T>
+using I = std::initializer_list<T>;
+
+TEMPLATE_TEST_CASE("corrected", "[template]", NeoN::scalar)
+{
+    auto [execName, exec] = GENERATE(allAvailableExecutor());
+
+    const NeoN::localIdx nCells = 10;
+    // 1D uniform mesh is orthogonal, so corrVec = 0 everywhere
+    // Corrected result should be identical to uncorrected on this mesh
+    auto mesh = create1DUniformMesh(exec, nCells);
+    auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<TestType>>(mesh);
+
+    fvcc::SurfaceField<TestType> phif(exec, "phif", mesh, surfaceBCs);
+    fill(phif.internalVector(), zero<TestType>());
+
+    auto volumeBCs = fvcc::createCalculatedBCs<fvcc::VolumeBoundary<TestType>>(mesh);
+    fvcc::VolumeField<TestType> phi(exec, "phi", mesh, volumeBCs);
+    NeoN::parallelFor(
+        phi.internalVector(),
+        NEON_LAMBDA(const NeoN::localIdx i) { return scalar(i + 1) * one<TestType>(); }
+    );
+    phi.boundaryData().value() =
+        NeoN::Vector<TestType>(exec, {0.5 * one<TestType>(), 10.5 * one<TestType>()});
+
+    SECTION("Construct from TokenList" + execName)
+    {
+        NeoN::Input input = NeoN::TokenList({std::string("corrected")});
+        fvcc::FaceNormalGradient<TestType> corrected(exec, mesh, input);
+    }
+
+    SECTION("Construct from Dictionary" + execName)
+    {
+        NeoN::Input input = NeoN::Dictionary({{"faceNormalGradient", std::string("corrected")}});
+        fvcc::FaceNormalGradient<TestType> corrected(exec, mesh, input);
+    }
+
+    SECTION("faceNormalGrad equals uncorrected on orthogonal mesh" + execName)
+    {
+        // On orthogonal meshes corrVec = 0, so corrected == uncorrected
+        NeoN::Input input = NeoN::TokenList({std::string("corrected")});
+        fvcc::FaceNormalGradient<TestType> corrected(exec, mesh, input);
+        corrected.faceNormalGrad(phi, phif);
+
+        // internal faces
+        auto phifHost = phif.internalVector().copyToHost();
+        auto sPhif = phifHost.view();
+        for (NeoN::localIdx i = 0; i < nCells - 1; i++)
+        {
+            REQUIRE(
+                NeoN::mag(sPhif[i] - 10.0 * one<TestType>()) == Catch::Approx(0.0).margin(1e-8)
+            );
+        }
+        // boundary faces are now in boundaryData().value()
+        auto phifBHost = phif.boundaryData().value().copyToHost();
+        auto sPhifB = phifBHost.view();
+        // left boundary (bfi=0): gradient is -10.0
+        REQUIRE(NeoN::mag(sPhifB[0] + 10.0 * one<TestType>()) == Catch::Approx(0.0).margin(1e-8));
+        // right boundary (bfi=1): gradient is 10.0
+        REQUIRE(NeoN::mag(sPhifB[1] - 10.0 * one<TestType>()) == Catch::Approx(0.0).margin(1e-8));
+    }
+}
+}

--- a/test/finiteVolume/cellCentred/faceNormalGradient/limitedCorrected.cpp
+++ b/test/finiteVolume/cellCentred/faceNormalGradient/limitedCorrected.cpp
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
+                            // a custom main
+#include "catch2_common.hpp"
+
+#include "NeoN/NeoN.hpp"
+
+namespace fvcc = NeoN::finiteVolume::cellCentred;
+
+namespace NeoN
+{
+
+template<typename T>
+using I = std::initializer_list<T>;
+
+TEMPLATE_TEST_CASE("limitedCorrected", "[template]", NeoN::scalar)
+{
+    auto [execName, exec] = GENERATE(allAvailableExecutor());
+
+    const NeoN::localIdx nCells = 10;
+    // 1D uniform mesh is orthogonal, so corrVec = 0 everywhere
+    // LimitedCorrected result should be identical to uncorrected on this mesh
+    auto mesh = create1DUniformMesh(exec, nCells);
+    auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<TestType>>(mesh);
+
+    fvcc::SurfaceField<TestType> phif(exec, "phif", mesh, surfaceBCs);
+    fill(phif.internalVector(), zero<TestType>());
+
+    auto volumeBCs = fvcc::createCalculatedBCs<fvcc::VolumeBoundary<TestType>>(mesh);
+    fvcc::VolumeField<TestType> phi(exec, "phi", mesh, volumeBCs);
+    NeoN::parallelFor(
+        phi.internalVector(),
+        NEON_LAMBDA(const NeoN::localIdx i) { return scalar(i + 1) * one<TestType>(); }
+    );
+    phi.boundaryData().value() =
+        NeoN::Vector<TestType>(exec, {0.5 * one<TestType>(), 10.5 * one<TestType>()});
+
+    SECTION("Construct from TokenList with coefficient" + execName)
+    {
+        NeoN::Input input = NeoN::TokenList({std::string("limitedCorrected"), NeoN::scalar(0.333)});
+        fvcc::FaceNormalGradient<TestType> lc(exec, mesh, input);
+    }
+
+    SECTION("Construct from Dictionary with limitCoeff" + execName)
+    {
+        NeoN::Input input = NeoN::Dictionary(
+            {{"faceNormalGradient", std::string("limitedCorrected")},
+             {"limitCoeff", NeoN::scalar(0.333)}}
+        );
+        fvcc::FaceNormalGradient<TestType> lc(exec, mesh, input);
+    }
+
+    SECTION("faceNormalGrad equals uncorrected on orthogonal mesh" + execName)
+    {
+        // On orthogonal meshes corrVec = 0, so limitedCorrected == uncorrected
+        NeoN::Input input = NeoN::TokenList({std::string("limitedCorrected"), NeoN::scalar(0.333)});
+        fvcc::FaceNormalGradient<TestType> lc(exec, mesh, input);
+        lc.faceNormalGrad(phi, phif);
+
+        // internal faces
+        auto phifHost = phif.internalVector().copyToHost();
+        auto sPhif = phifHost.view();
+        for (NeoN::localIdx i = 0; i < nCells - 1; i++)
+        {
+            REQUIRE(
+                NeoN::mag(sPhif[i] - 10.0 * one<TestType>()) == Catch::Approx(0.0).margin(1e-8)
+            );
+        }
+        // boundary faces are now in boundaryData().value()
+        auto phifBHost = phif.boundaryData().value().copyToHost();
+        auto sPhifB = phifBHost.view();
+        // left boundary (bfi=0): gradient is -10.0
+        REQUIRE(NeoN::mag(sPhifB[0] + 10.0 * one<TestType>()) == Catch::Approx(0.0).margin(1e-8));
+        // right boundary (bfi=1): gradient is 10.0
+        REQUIRE(NeoN::mag(sPhifB[1] - 10.0 * one<TestType>()) == Catch::Approx(0.0).margin(1e-8));
+    }
+
+    SECTION("faceNormalGrad with full correction (limitCoeff=1) on orthogonal mesh" + execName)
+    {
+        // limitCoeff=1 behaves as full corrected — still equals uncorrected on orthogonal mesh
+        NeoN::Input input = NeoN::TokenList({std::string("limitedCorrected"), NeoN::scalar(1.0)});
+        fvcc::FaceNormalGradient<TestType> lc(exec, mesh, input);
+        lc.faceNormalGrad(phi, phif);
+
+        auto phifHost = phif.internalVector().copyToHost();
+        auto sPhif = phifHost.view();
+        for (NeoN::localIdx i = 0; i < nCells - 1; i++)
+        {
+            REQUIRE(
+                NeoN::mag(sPhif[i] - 10.0 * one<TestType>()) == Catch::Approx(0.0).margin(1e-8)
+            );
+        }
+    }
+}
+}

--- a/test/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
+++ b/test/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
@@ -48,6 +48,7 @@ TEMPLATE_TEST_CASE("uncorrected", "[template]", NeoN::scalar, NeoN::Vec3)
         fvcc::FaceNormalGradient<TestType> uncorrected(exec, mesh, input);
         uncorrected.faceNormalGrad(phi, phif);
 
+        // internal faces
         auto phifHost = phif.internalVector().copyToHost();
         auto sPhif = phifHost.view();
         for (NeoN::localIdx i = 0; i < nCells - 1; i++)
@@ -57,14 +58,13 @@ TEMPLATE_TEST_CASE("uncorrected", "[template]", NeoN::scalar, NeoN::Vec3)
                 NeoN::mag(sPhif[i] - 10.0 * one<TestType>()) == Catch::Approx(0.0).margin(1e-8)
             );
         }
-        // left boundary is  -10.0
-        REQUIRE(
-            NeoN::mag(sPhif[nCells - 1] + 10.0 * one<TestType>()) == Catch::Approx(0.0).margin(1e-8)
-        );
-        // right boundary is 10.0
-        REQUIRE(
-            NeoN::mag(sPhif[nCells] - 10.0 * one<TestType>()) == Catch::Approx(0.0).margin(1e-8)
-        );
+        // boundary faces are now in boundaryData().value()
+        auto phifBHost = phif.boundaryData().value().copyToHost();
+        auto sPhifB = phifBHost.view();
+        // left boundary (bfi=0): gradient is -10.0
+        REQUIRE(NeoN::mag(sPhifB[0] + 10.0 * one<TestType>()) == Catch::Approx(0.0).margin(1e-8));
+        // right boundary (bfi=1): gradient is 10.0
+        REQUIRE(NeoN::mag(sPhifB[1] - 10.0 * one<TestType>()) == Catch::Approx(0.0).margin(1e-8));
     }
 }
 }

--- a/test/finiteVolume/cellCentred/fields/surfaceField.cpp
+++ b/test/finiteVolume/cellCentred/fields/surfaceField.cpp
@@ -29,29 +29,24 @@ TEST_CASE("surfaceVector")
         }
 
         fvcc::SurfaceField<NeoN::scalar> sf(exec, "sf", mesh, bcs);
-        // the internal field is 4 because the mesh has 4 boundaryFaces
-        NeoN::fill(sf.internalVector(), 1.0);
+        // single-cell mesh has 0 internal faces and 4 boundary faces
+        REQUIRE(sf.internalVector().size() == 0);
+        REQUIRE(sf.boundaryData().value().size() == 4);
 
+        // Fill boundary values with 1.0 before correctBoundaryConditions
+        NeoN::fill(sf.boundaryData().value(), 1.0);
         {
-            auto internalValues = sf.internalVector().copyToHost();
-            for (NeoN::localIdx i = 0; i < internalValues.size(); ++i)
+            auto bValues = sf.boundaryData().value().copyToHost();
+            for (NeoN::localIdx i = 0; i < bValues.size(); ++i)
             {
-                REQUIRE(internalValues.view()[i] == 1.0);
+                REQUIRE(bValues.view()[i] == 1.0);
             }
         }
 
         sf.correctBoundaryConditions();
         REQUIRE(sf.exec() == exec);
-        REQUIRE(sf.internalVector().size() == 4);
 
-        // the correctBoundaryConditions also sets the internalfield to 2.0
-        // for surfaceVectors
-        auto internalValues = sf.internalVector().copyToHost();
-        for (NeoN::localIdx i = 0; i < internalValues.size(); ++i)
-        {
-            REQUIRE(internalValues.view()[i] == 2.0);
-        }
-
+        // correctBoundaryConditions sets boundary data to fixedValue (2.0)
         auto values = sf.boundaryData().value().copyToHost();
         for (NeoN::localIdx i = 0; i < values.size(); ++i)
         {

--- a/test/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/test/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -47,15 +47,16 @@ TEMPLATE_TEST_CASE("linear", "", NeoN::scalar, NeoN::Vec3)
 
     auto outHost = out.internalVector().copyToHost();
     auto nInternal = mesh.nInternalFaces();
-    auto nBoundary = mesh.nBoundaryFaces();
     for (NeoN::localIdx i = 0; i < nInternal; i++)
     {
         REQUIRE(outHost.view()[i] == one<TestType>());
     }
 
-    for (NeoN::localIdx i = nInternal; i < nInternal + nBoundary; i++)
+    // boundary face values are now in boundaryData().value()
+    auto outBHost = out.boundaryData().value().copyToHost();
+    for (NeoN::localIdx i = 0; i < mesh.nBoundaryFaces(); i++)
     {
-        REQUIRE(outHost.view()[i] == one<TestType>());
+        REQUIRE(outBHost.view()[i] == one<TestType>());
     }
 }
 }

--- a/test/finiteVolume/cellCentred/interpolation/upwind.cpp
+++ b/test/finiteVolume/cellCentred/interpolation/upwind.cpp
@@ -47,15 +47,16 @@ TEMPLATE_TEST_CASE("upwind", "", NeoN::scalar, NeoN::Vec3)
 
     auto outHost = out.internalVector().copyToHost();
     auto nInternal = mesh.nInternalFaces();
-    auto nBoundary = mesh.nBoundaryFaces();
     for (NeoN::localIdx i = 0; i < nInternal; i++)
     {
         REQUIRE(outHost.view()[i] == one<TestType>());
     }
 
-    for (NeoN::localIdx i = nInternal; i < nInternal + nBoundary; i++)
+    // boundary face values are now in boundaryData().value()
+    auto outBHost = out.boundaryData().value().copyToHost();
+    for (NeoN::localIdx i = 0; i < mesh.nBoundaryFaces(); i++)
     {
-        REQUIRE(outHost.view()[i] == one<TestType>());
+        REQUIRE(outBHost.view()[i] == one<TestType>());
     }
 }
 

--- a/test/finiteVolume/cellCentred/operator/gaussGreenDiv.cpp
+++ b/test/finiteVolume/cellCentred/operator/gaussGreenDiv.cpp
@@ -27,12 +27,11 @@ TEMPLATE_TEST_CASE("DivOperator", "[template]", NeoN::scalar, NeoN::Vec3)
     // TODO this should be handled outside of the unit test
     fvcc::SurfaceField<scalar> faceFlux(exec, "sf", mesh, surfaceBCs);
     fill(faceFlux.internalVector(), 1.0);
-    auto boundFaceFlux = faceFlux.internalVector().view();
-    // face on the left side has different orientation
+    fill(faceFlux.boundaryData().value(), 1.0);
+    // left boundary face (patch 0) has opposite orientation to the flow
+    auto bFaceFlux = faceFlux.boundaryData().value().view();
     parallelFor(
-        exec,
-        {mesh.nCells() - 1, mesh.nCells()},
-        NEON_LAMBDA(const localIdx i) { boundFaceFlux[i] = -1.0; }
+        exec, {0, 1}, NEON_LAMBDA(const localIdx i) { bFaceFlux[i] = -1.0; }
     );
 
     auto volumeBCs = fvcc::createCalculatedBCs<fvcc::VolumeBoundary<TestType>>(mesh);
@@ -101,6 +100,7 @@ TEST_CASE("DivOperator implicit boundary contributions are accumulated")
 
     fvcc::SurfaceField<NeoN::scalar> faceFlux(exec, "sf", mesh, surfaceBCs);
     fill(faceFlux.internalVector(), 1.0);
+    fill(faceFlux.boundaryData().value(), 1.0);
 
     Input input = TokenList({std::string("Gauss"), std::string("linear")});
 

--- a/test/finiteVolume/cellCentred/operator/laplacianOperator.cpp
+++ b/test/finiteVolume/cellCentred/operator/laplacianOperator.cpp
@@ -29,6 +29,7 @@ TEMPLATE_TEST_CASE("laplacianOperator fixedValue", "[template]", scalar, Vec3)
     auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<scalar>>(mesh);
     fvcc::SurfaceField<scalar> gamma(exec, "gamma", mesh, surfaceBCs);
     fill(gamma.internalVector(), 2.0);
+    fill(gamma.boundaryData().value(), 2.0);
 
     auto [boundaryType, firstValue, lastValue] = GENERATE(
         std::tuple<std::string, scalar, scalar> {"fixedValue", 0.5, 10.5},
@@ -146,6 +147,7 @@ TEMPLATE_TEST_CASE("laplacianOperator boundary contributions are accumulated", "
     auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<scalar>>(mesh);
     fvcc::SurfaceField<scalar> gamma(exec, "gamma", mesh, surfaceBCs);
     fill(gamma.internalVector(), 1.0);
+    fill(gamma.boundaryData().value(), 1.0);
 
     std::vector<fvcc::VolumeBoundary<TestType>> bcs;
     bcs.push_back(fvcc::VolumeBoundary<TestType>(

--- a/test/timeIntegration/ddtFluxCorr.cpp
+++ b/test/timeIntegration/ddtFluxCorr.cpp
@@ -114,8 +114,8 @@ TEST_CASE("timeIntegration: ddtPhiCorr on single-cell mesh", "[timeIntegration][
             auto fluxCorr = fvcc::ddtFluxCorr(u, flux, dt, scheme);
             auto corrBH = fluxCorr.boundaryData().value().copyToHost();
 
-            for (auto i = 0; i < mesh.nFaces(); ++i)
-                REQUIRE(corrH.view()[i] == Catch::Approx(0.0).margin(1e-12));
+            for (NeoN::localIdx i = 0; i < nBndFaces; ++i)
+                REQUIRE(corrBH.view()[i] == Catch::Approx(0.0).margin(1e-12));
         }
 
         // ─────────────────────────────────────────────
@@ -129,11 +129,11 @@ TEST_CASE("timeIntegration: ddtPhiCorr on single-cell mesh", "[timeIntegration][
             auto fluxCorr = fvcc::ddtFluxCorr(u, flux, dt, scheme);
             auto corrBH = fluxCorr.boundaryData().value().copyToHost();
 
-            for (auto i = 0; i < mesh.nFaces(); ++i) {
+            for (NeoN::localIdx i = 0; i < nBndFaces; ++i)
                 REQUIRE(
-                    corrH.view()[i] == Catch::Approx(expected[static_cast<size_t>(i)]).margin(1e-12)
+                    corrBH.view()[i]
+                    == Catch::Approx(expected[static_cast<size_t>(i)]).margin(1e-12)
                 );
-	    }
         }
     }
 }

--- a/test/timeIntegration/ddtFluxCorr.cpp
+++ b/test/timeIntegration/ddtFluxCorr.cpp
@@ -47,8 +47,8 @@ TEST_CASE("timeIntegration: ddtPhiCorr on single-cell mesh", "[timeIntegration][
         );
         auto uf0 = interp.interpolate(u0);
 
-        auto [uf0H, sfH] = copyToHosts(uf0.internalVector(), mesh.boundaryMesh().sf());
-        auto [uf0V, sfV] = views(uf0H, sfH);
+        auto [uf0BH, sfH] = copyToHosts(uf0.boundaryData().value(), mesh.boundaryMesh().sf());
+        auto [uf0BV, sfV] = views(uf0BH, sfH);
 
         // --- 4) Surface scalar field phi (with oldTime support)
         auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<Scalar>>(mesh);
@@ -73,16 +73,19 @@ TEST_CASE("timeIntegration: ddtPhiCorr on single-cell mesh", "[timeIntegration][
         const Scalar dt = 0.2;
         const Scalar invDt = 1.0 / dt;
 
-        // Helper: expected values (host-side)
+        // For single-cell mesh all faces are boundary faces; the test uses nBoundaryFaces
+        const auto nBndFaces = mesh.nBoundaryFaces();
+
+        // Helper: expected values for boundary faces (host-side)
         auto expectedFrom = [&](const SurfScalar& flux0Field)
         {
-            std::vector<Scalar> e(static_cast<size_t>(mesh.nFaces()), 0.0);
-            auto flux0FieldH = flux0Field.internalVector().copyToHost();
+            std::vector<Scalar> e(static_cast<size_t>(nBndFaces), 0.0);
+            auto flux0FieldH = flux0Field.boundaryData().value().copyToHost();
             auto flux0FieldV = flux0FieldH.view();
 
-            for (auto i = 0; i < mesh.nFaces(); ++i)
+            for (NeoN::localIdx i = 0; i < nBndFaces; ++i)
             {
-                const Scalar d = (sfV[i] & uf0V[i]);
+                const Scalar d = (sfV[i] & uf0BV[i]);
                 const auto tfluxCorr = (flux0FieldV[i] - d);
                 const auto ratio = NeoN::mag(tfluxCorr) / (NeoN::mag(flux0FieldV[i]) + 1.0e-30);
                 const auto coeff = 1.0 - Kokkos::min(ratio, Scalar(1));
@@ -96,19 +99,20 @@ TEST_CASE("timeIntegration: ddtPhiCorr on single-cell mesh", "[timeIntegration][
         // Case A: flux0 = sf·uf0  ⇒ correction ≈ 0
         // ─────────────────────────────────────────────
         {
-            auto [flux0V2, sfV2, uf0V2] =
-                views(flux0.internalVector(), mesh.boundaryMesh().sf(), uf0.internalVector());
+            auto [flux0BV2, sfV2, uf0BV2] = views(
+                flux0.boundaryData().value(), mesh.boundaryMesh().sf(), uf0.boundaryData().value()
+            );
 
             NeoN::parallelFor(
                 exec,
-                {size_t(0), mesh.nFaces()},
-                NEON_LAMBDA(const NeoN::localIdx i) { flux0V2[i] = (sfV2[i] & uf0V2[i]); }
+                {size_t(0), static_cast<size_t>(nBndFaces)},
+                NEON_LAMBDA(const NeoN::localIdx i) { flux0BV2[i] = (sfV2[i] & uf0BV2[i]); }
             );
 
-            flux.internalVector() = flux0.internalVector();
+            flux.boundaryData().value() = flux0.boundaryData().value();
 
             auto fluxCorr = fvcc::ddtFluxCorr(u, flux, dt, scheme);
-            auto corrH = fluxCorr.internalVector().copyToHost();
+            auto corrBH = fluxCorr.boundaryData().value().copyToHost();
 
             for (auto i = 0; i < mesh.nFaces(); ++i)
                 REQUIRE(corrH.view()[i] == Catch::Approx(0.0).margin(1e-12));
@@ -118,17 +122,18 @@ TEST_CASE("timeIntegration: ddtPhiCorr on single-cell mesh", "[timeIntegration][
         // Case B: flux0 = 0  ⇒ correction = -(sf·uf0)/dt
         // ─────────────────────────────────────────────
         {
-            flux0.internalVector() = Scalar {0.0};
-            flux.internalVector() = Scalar {0.0};
+            fill(flux0.boundaryData().value(), Scalar {0.0});
+            fill(flux.boundaryData().value(), Scalar {0.0});
 
             auto expected = expectedFrom(flux0);
             auto fluxCorr = fvcc::ddtFluxCorr(u, flux, dt, scheme);
-            auto corrH = fluxCorr.internalVector().copyToHost();
+            auto corrBH = fluxCorr.boundaryData().value().copyToHost();
 
-            for (auto i = 0; i < mesh.nFaces(); ++i)
+            for (auto i = 0; i < mesh.nFaces(); ++i) {
                 REQUIRE(
                     corrH.view()[i] == Catch::Approx(expected[static_cast<size_t>(i)]).margin(1e-12)
                 );
+	    }
         }
     }
 }


### PR DESCRIPTION
Implement non-orthogonality correction for surface normal gradients:

- Rename updateNonOrthDeltaCoeffs(Vec3) to updateNonOrthCorrectionVec3s in GeometrySchemeFactory and BasicGeometryScheme to match its actual purpose, and implement the correction vector computation: corrVec[f] = n̂ - delta * nonOrthDeltaCoeff

- Add corrected scheme: snGrad = nonOrthDeltaCoeff*(phi_N - phi_O)
  + corrVec · (w*grad(phi)_O + (1-w)*grad(phi)_N)

- Add limitedCorrected scheme: same as corrected but with a limiter that bounds the correction relative to the orthogonal part. Accepts limitCoeff from TokenList or Dictionary (default 0.333).

- Both schemes use a fused single kernel per face group and reuse GaussGreenGrad for cell-centred gradient computation.

- Add unit tests on a 1D uniform mesh (orthogonal, corrVec=0) verifying that corrected and limitedCorrected reduce to uncorrected.

