### PR TITLE
add custom matcher

### DIFF
--- a/.github/workflows/build_on_ubuntu.yaml
+++ b/.github/workflows/build_on_ubuntu.yaml
@@ -67,7 +67,7 @@ jobs:
           sudo apt update
           sudo apt install \
             ninja-build \
-            clang-18 \
+            clang-19 \
             gcc-10 \
             libomp-16-dev \
             build-essential \
@@ -76,8 +76,8 @@ jobs:
           sudo apt remove clang-14
           sudo rm /usr/bin/clang
           sudo rm /usr/bin/clang++
-          sudo ln -s /usr/bin/clang-18 /usr/bin/clang
-          sudo ln -s /usr/bin/clang++-18 /usr/bin/clang++
+          sudo ln -s /usr/bin/clang-19 /usr/bin/clang
+          sudo ln -s /usr/bin/clang++-19 /usr/bin/clang++
 
       - name: Get versions
         run: |
@@ -106,7 +106,7 @@ jobs:
             -DNeoN_DEVEL_TOOLS=OFF \
             -DNeoN_WITH_GINKGO=OFF \
             -DCMAKE_CXX_COMPILER=${{matrix.compiler.CXX}} \
-            -DNeoN_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF 
+            -DNeoN_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF
           cmake --build --preset ${{matrix.preset}}
 
       - name: Execute unit tests NeoN

--- a/.github/workflows/build_on_ubuntu.yaml
+++ b/.github/workflows/build_on_ubuntu.yaml
@@ -67,7 +67,7 @@ jobs:
           sudo apt update
           sudo apt install \
             ninja-build \
-            clang-16 \
+            clang-18 \
             gcc-10 \
             libomp-16-dev \
             build-essential \
@@ -76,8 +76,8 @@ jobs:
           sudo apt remove clang-14
           sudo rm /usr/bin/clang
           sudo rm /usr/bin/clang++
-          sudo ln -s /usr/bin/clang-16 /usr/bin/clang
-          sudo ln -s /usr/bin/clang++-16 /usr/bin/clang++
+          sudo ln -s /usr/bin/clang-18 /usr/bin/clang
+          sudo ln -s /usr/bin/clang++-18 /usr/bin/clang++
 
       - name: Get versions
         run: |
@@ -99,18 +99,15 @@ jobs:
           uv venv
           uv sync --no-install-project --all-extras -v
           source .venv/bin/activate
-          CMAKE_FLAGS_ARR=(
-            -DNeoN_BUILD_TESTS=ON
-            -DNeoN_BUILD_PYTHON_BINDINGS=ON
-            -DNeoN_DEVEL_TOOLS=OFF
-            -DNeoN_WITH_GINKGO=OFF
-            -DNeoN_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF
-          )
 
-          CC=${{matrix.compiler.CC}}
-          CXX=${{matrix.compiler.CXX}}
-          cmake --preset ${{matrix.preset}} "${CMAKE_FLAGS_ARR[@]}"
-          cmake --build  --preset ${{matrix.preset}}
+          cmake --preset ${{matrix.preset}} \
+            -DNeoN_BUILD_TESTS=ON \
+            -DNeoN_BUILD_PYTHON_BINDINGS=ON \
+            -DNeoN_DEVEL_TOOLS=OFF \
+            -DNeoN_WITH_GINKGO=OFF \
+            -DCMAKE_CXX_COMPILER=${{matrix.compiler.CXX}} \
+            -DNeoN_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF 
+          cmake --build --preset ${{matrix.preset}}
 
       - name: Execute unit tests NeoN
         run: |

--- a/.github/workflows/static_checks.yaml
+++ b/.github/workflows/static_checks.yaml
@@ -47,12 +47,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Add clang repo
-      run: |
-        sudo add-apt-repository 'deb http://apt.llvm.org/noble/ llvm-toolchain-noble-18 main'
-        wget https://apt.llvm.org/llvm-snapshot.gpg.key
-        sudo apt-key add llvm-snapshot.gpg.key
-
     - uses: actions/setup-python@v3
       with:
         python-version: "3.12"
@@ -63,8 +57,8 @@ jobs:
         sudo apt install \
            ninja-build \
            iwyu \
-           clang-18 \
-           libomp-18-dev \
+           clang-19 \
+           libomp-19-dev \
            libopenmpi-dev \
            openmpi-bin
 
@@ -77,13 +71,11 @@ jobs:
 
     - name: Create Compilation Database
       run: |
-        CC=clang \
-        CXX=clang++ \
         cmake --preset develop \
           -DNeoN_DEVEL_TOOLS=OFF \
           -DNeoN_WITH_GINKGO=OFF \
           -DNeoN_WITH_SUNDIALS=OFF \
-          -DCMAKE_CXX_COMPILER=clang++-18 \
+          -DCMAKE_CXX_COMPILER=clang++-19 \
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
           -DNeoN_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF \
           -DNeoN_ENABLE_IWYU=ON \
@@ -114,8 +106,8 @@ jobs:
       run: |
         sudo apt update
         sudo apt install \
-           clang-tidy-18 \
-           libomp-18-dev \
+           clang-tidy-19 \
+           libomp-19-dev \
            libopenmpi-dev \
            openmpi-bin
 
@@ -135,7 +127,7 @@ jobs:
           | sed 's/^"\(.*\)"$/\1/' \
           | grep -F -f pattern - > files
         # run clang-tidy on all specified files
-        clang-tidy-18 --fix --extra-arg=-w -p build/develop $(cat files)
+        clang-tidy-19 --fix --extra-arg=-w -p build/develop $(cat files)
     - name: Check for fixes
       id: tidy-fixes
       run: |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 NeoN has the following requirements
 
 *  _cmake > 3.22_
-*  _gcc >= 10_ or  _clang >= 16_
+*  _gcc >= 13_ or  _clang >= 19_
 *  _Kokkos 5.0.2_
 
 For GPU support

--- a/include/NeoN/core/database/fieldDatabase.hpp
+++ b/include/NeoN/core/database/fieldDatabase.hpp
@@ -48,9 +48,9 @@ public:
     {
         if (!db_.has_value())
         {
-            throw std::runtime_error(
+            throw std::runtime_error {
                 "Database not set: make sure the field is registered in the database"
-            );
+            };
         }
         return *db_.value();
     }

--- a/include/NeoN/dsl/expression.hpp
+++ b/include/NeoN/dsl/expression.hpp
@@ -220,7 +220,7 @@ public:
     {
         if (!hasOperatorOfType<OperatorType, Type>(name))
         {
-            throw std::runtime_error("No operator with given name and type found");
+            throw std::runtime_error {"No operator with given name and type found"};
         }
         auto opType = Type;
         auto matchNameAndType = [name, opType](const auto& op)
@@ -237,7 +237,7 @@ public:
                 temporalOperators_.begin(), temporalOperators_.end(), matchNameAndType
             );
         }
-        throw std::runtime_error("Unknown operator type");
+        throw std::runtime_error {"Unknown operator type"};
         // should never be reached, shut up compiler warning
         return spatialOperators_[0];
     }
@@ -248,7 +248,7 @@ public:
     {
         if (!hasOperator<Type>(name))
         {
-            throw std::runtime_error("No operator with given name and type found");
+            throw std::runtime_error {"No operator with given name and type found"};
         }
         auto opType = Type;
         auto matchNameAndType = [name, opType](const auto& op)

--- a/src/linearAlgebra/ginkgo.cpp
+++ b/src/linearAlgebra/ginkgo.cpp
@@ -141,11 +141,11 @@ std::shared_ptr<gko::Executor> NeoN::la::ginkgo::getGkoExecutor(NeoN::Executor e
                     Kokkos::device_id(), gko::ReferenceExecutor::create()
                 );
 #endif
-                throw std::runtime_error("No valid GPU executor mapping available");
+                throw std::runtime_error {"No valid GPU executor mapping available"};
             }
             else
             {
-                throw std::runtime_error("Unsupported executor type");
+                throw std::runtime_error {"Unsupported executor type"};
             }
             return gko::ReferenceExecutor::create();
         },

--- a/src/linearAlgebra/matrix.cpp
+++ b/src/linearAlgebra/matrix.cpp
@@ -14,6 +14,7 @@ template<typename ValueType, typename IndexType>
 Vector<ValueType> Matrix<ValueType, IndexType>::diag() const
 {
     auto diag = Vector<ValueType>(values_.exec(), nRows());
+    fill(diag, zero<ValueType>());
     auto [diagV, rowOffsV, colIdxV, matrixV] =
         views(diag, sparsityPattern_->rowOffs(), sparsityPattern_->colIdxs(), values_);
 

--- a/test/catch2/catch2_common.hpp
+++ b/test/catch2/catch2_common.hpp
@@ -14,6 +14,10 @@
 #include "executorGenerator.hpp"
 
 
+/** @brief a shortcut for  std::initializer_list */
+template<typename T>
+using I = std::initializer_list<T>;
+
 /**
  * @brief Conditionally enters a Catch2 SECTION if the given condition is true.
  * @param COND The boolean condition to evaluate.
@@ -76,7 +80,7 @@ struct EqualsRangeMatcher : Catch::Matchers::MatcherGenericBase
      * @param range The device field to compare against.
      * @param pred  The predicate used for element-wise comparison.
      */
-    EqualsRangeMatcher(const Range range, Predicate pred) : range {range.copyToHost()}, pred(pred)
+    EqualsRangeMatcher(const Range range, Predicate pred) : range {range.copyToHost()}, pred_(pred)
     {}
 
     /** @brief Performs the element-wise comparison against @p other.
@@ -85,11 +89,11 @@ struct EqualsRangeMatcher : Catch::Matchers::MatcherGenericBase
      * @return @c true if all elements compare equal under the stored predicate.
      */
     template<typename ValueType>
-    bool match(const std::vector<ValueType> other) const
+    bool match(const ValueType other) const
     {
         using std::begin;
         using std::end;
-        return std::equal(begin(range.view()), end(range.view()), begin(other), end(other), pred);
+        return std::equal(begin(range.view()), end(range.view()), begin(other), end(other), pred_);
     }
 
     /** @brief Returns a human-readable description of the matcher for Catch2 failure
@@ -98,8 +102,8 @@ struct EqualsRangeMatcher : Catch::Matchers::MatcherGenericBase
 
 private:
 
-    const Range range;    ///< Host copy of the device field.
-    const Predicate pred; ///< Predicate used for element-wise comparison.
+    const Range range;     ///< Host copy of the device field.
+    const Predicate pred_; ///< Predicate used for element-wise comparison.
 };
 
 /**

--- a/test/catch2/catch2_common.hpp
+++ b/test/catch2/catch2_common.hpp
@@ -2,10 +2,125 @@
 //
 // SPDX-License-Identifier: MIT
 
+#pragma once
+
 #include <catch2/catch_session.hpp>
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/generators/catch_generators_all.hpp>
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
+#include <catch2/generators/catch_generators_all.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
 
 #include "executorGenerator.hpp"
+
+
+/**
+ * @brief Conditionally enters a Catch2 SECTION if the given condition is true.
+ * @param COND The boolean condition to evaluate.
+ * @param ... The section name and optional description forwarded to SECTION.
+ */
+#define SECTION_IF(COND, ...)                                                                      \
+    if (COND) SECTION(__VA_ARGS__)
+
+/**
+ *  @brief Predicate for approximate floating-point comparison within a given margin.
+ *
+ * Used with @ref EqualsRangeMatcher and @ref IsEqualTo to compare scalar values
+ * using Catch2's Approx mechanism, allowing for a configurable absolute tolerance.
+ */
+struct ApproxScalar
+{
+    NeoN::scalar margin; ///< Absolute tolerance margin for the comparison.
+
+    /**
+     * @brief Returns true if @p rhs and @p lhs are equal within the stored margin.
+     * @param rhs Left-hand value passed to Catch::Approx.
+     * @param lhs Right-hand value to compare against.
+     */
+    bool operator()(double rhs, double lhs) const
+    {
+        return Catch::Approx(rhs).margin(margin) == lhs;
+    }
+};
+
+/** @brief Predicate for exact equality comparison using the built-in == operator.
+ *
+ * Used with @ref EqualsRangeMatcher and @ref IsEqualTo to compare integer or
+ * other exactly-comparable types (e.g. NeoN::Vec3, NeoN::label).
+ */
+struct EqualInt
+{
+    /**
+     * @brief Returns true if @p rhs and @p lhs are equal within the stored margin.
+     * @param rhs Left-hand value passed to Catch::Approx.
+     * @param lhs Right-hand value to compare against.
+     */
+    bool operator()(auto rhs, auto lhs) const { return rhs == lhs; }
+};
+
+
+/**
+ * @brief Catch2 matcher that compares a NeoN device field against an expected std::vector.
+ *
+ * Copies the field to host on construction, then element-wise compares it against
+ * the expected vector using the supplied predicate.
+ *
+ * @tparam Range     A NeoN field type that exposes @c copyToHost() and @c view().
+ * @tparam Predicate A binary callable returning @c bool, e.g. @ref ApproxScalar or @ref EqualInt.
+ */
+template<typename Range, typename Predicate>
+struct EqualsRangeMatcher : Catch::Matchers::MatcherGenericBase
+{
+    /**
+     * @brief Constructs the matcher, copying @p range to host memory.
+     * @param range The device field to compare against.
+     * @param pred  The predicate used for element-wise comparison.
+     */
+    EqualsRangeMatcher(const Range range, Predicate pred) : range {range.copyToHost()}, pred(pred)
+    {}
+
+    /** @brief Performs the element-wise comparison against @p other.
+     * @tparam ValueType Element type of the expected vector.
+     * @param other The expected values as a @c std::vector.
+     * @return @c true if all elements compare equal under the stored predicate.
+     */
+    template<typename ValueType>
+    bool match(const std::vector<ValueType> other) const
+    {
+        using std::begin;
+        using std::end;
+        return std::equal(begin(range.view()), end(range.view()), begin(other), end(other), pred);
+    }
+
+    /** @brief Returns a human-readable description of the matcher for Catch2 failure
+     * messages. */
+    std::string describe() const override { return "!= " + Catch::rangeToString(range.view()); }
+
+private:
+
+    const Range range;    ///< Host copy of the device field.
+    const Predicate pred; ///< Predicate used for element-wise comparison.
+};
+
+/**
+ * @brief Factory function that creates an @ref EqualsRangeMatcher for a NeoN field.
+ *
+ * Typical usage:
+ * @code
+ * REQUIRE_THAT(expected_vec, IsEqualTo(mesh.faceOwner(), EqualInt()));
+ * REQUIRE_THAT(expected_vec, IsEqualTo(field, ApproxScalar(1e-15)));
+ * @endcode
+ *
+ * @tparam Range     A NeoN field type that exposes @c copyToHost() and @c view().
+ * @tparam Predicate A binary callable returning @c bool (default: @ref ApproxScalar).
+ * @param range The device field to compare against.
+ * @param pred  The predicate used for element-wise comparison (default:
+ * ApproxScalar(1e-32)).
+ * @return An @ref EqualsRangeMatcher configured with the given field and predicate.
+ */
+template<typename Range, typename Predicate = ApproxScalar>
+auto IsEqualTo(const Range& range, Predicate pred = ApproxScalar(1e-32))
+    -> EqualsRangeMatcher<Range, Predicate>
+{
+    return EqualsRangeMatcher<Range, Predicate> {range, pred};
+}

--- a/test/dsl/coeff.cpp
+++ b/test/dsl/coeff.cpp
@@ -54,7 +54,7 @@ TEST_CASE("Coeff")
         {
             Coeff c = fieldB; // is a view with uniform value 1.0
             NeoN::parallelFor(
-                fieldA, NEON_LAMBDA(const auto i) { return c[i] + 2.0; }
+                fieldA, NEON_LAMBDA(const size_t i) { return c[i] + 2.0; }
             );
             auto resAexp = std::vector<NeoN::scalar> {3.0, 3.0, 3.0};
             REQUIRE_THAT(resAexp, IsEqualTo(fieldA));
@@ -64,7 +64,7 @@ TEST_CASE("Coeff")
         {
             Coeff c = Coeff(2.0);
             NeoN::parallelFor(
-                fieldA, NEON_LAMBDA(const auto i) { return c[i] + 2.0; }
+                fieldA, NEON_LAMBDA(const size_t i) { return c[i] + 2.0; }
             );
             auto resAexp = std::vector<NeoN::scalar> {4.0, 4.0, 4.0};
             REQUIRE_THAT(resAexp, IsEqualTo(fieldA));
@@ -74,7 +74,7 @@ TEST_CASE("Coeff")
         {
             Coeff c {-5.0, fieldB};
             NeoN::parallelFor(
-                fieldA, NEON_LAMBDA(const auto i) { return c[i] + 2.0; }
+                fieldA, NEON_LAMBDA(const size_t i) { return c[i] + 2.0; }
             );
             auto resAexp = std::vector<NeoN::scalar> {-3.0, -3.0, -3.0};
             REQUIRE_THAT(resAexp, IsEqualTo(fieldA));

--- a/test/dsl/coeff.cpp
+++ b/test/dsl/coeff.cpp
@@ -54,7 +54,7 @@ TEST_CASE("Coeff")
         {
             Coeff c = fieldB; // is a view with uniform value 1.0
             NeoN::parallelFor(
-                fieldA, NEON_LAMBDA(const size_t i) { return c[i] + 2.0; }
+                fieldA, NEON_LAMBDA(const NeoN::localIdx i) { return c[i] + 2.0; }
             );
             auto resAexp = std::vector<NeoN::scalar> {3.0, 3.0, 3.0};
             REQUIRE_THAT(resAexp, IsEqualTo(fieldA));
@@ -64,7 +64,7 @@ TEST_CASE("Coeff")
         {
             Coeff c = Coeff(2.0);
             NeoN::parallelFor(
-                fieldA, NEON_LAMBDA(const size_t i) { return c[i] + 2.0; }
+                fieldA, NEON_LAMBDA(const NeoN::localIdx i) { return c[i] + 2.0; }
             );
             auto resAexp = std::vector<NeoN::scalar> {4.0, 4.0, 4.0};
             REQUIRE_THAT(resAexp, IsEqualTo(fieldA));
@@ -74,7 +74,7 @@ TEST_CASE("Coeff")
         {
             Coeff c {-5.0, fieldB};
             NeoN::parallelFor(
-                fieldA, NEON_LAMBDA(const size_t i) { return c[i] + 2.0; }
+                fieldA, NEON_LAMBDA(const NeoN::localIdx i) { return c[i] + 2.0; }
             );
             auto resAexp = std::vector<NeoN::scalar> {-3.0, -3.0, -3.0};
             REQUIRE_THAT(resAexp, IsEqualTo(fieldA));

--- a/test/dsl/coeff.cpp
+++ b/test/dsl/coeff.cpp
@@ -29,24 +29,18 @@ TEST_CASE("Coeff")
 
         Coeff d {3.0, fA};
         dsl::detail::toVector(d, res);
-        auto hostResD = res.copyToHost();
-        REQUIRE(hostResD.data()[0] == 6.0);
-        REQUIRE(hostResD.data()[1] == 6.0);
-        REQUIRE(hostResD.data()[2] == 6.0);
+        auto resDexp = std::vector<NeoN::scalar> {6.0, 6.0, 6.0};
+        REQUIRE_THAT(resDexp, IsEqualTo(res));
 
         Coeff e = d * b;
         dsl::detail::toVector(e, res);
-        auto hostResE = res.copyToHost();
-        REQUIRE(hostResE.data()[0] == 12.0);
-        REQUIRE(hostResE.data()[1] == 12.0);
-        REQUIRE(hostResE.data()[2] == 12.0);
+        auto resEexp = std::vector<NeoN::scalar> {12.0, 12.0, 12.0};
+        REQUIRE_THAT(resEexp, IsEqualTo(res));
 
         Coeff f = b * d;
         dsl::detail::toVector(f, res);
-        auto hostResF = res.copyToHost();
-        REQUIRE(hostResF.data()[0] == 12.0);
-        REQUIRE(hostResF.data()[1] == 12.0);
-        REQUIRE(hostResF.data()[2] == 12.0);
+        auto resFexp = std::vector<NeoN::scalar> {12.0, 12.0, 12.0};
+        REQUIRE_THAT(resFexp, IsEqualTo(res));
     }
 
     SECTION("evaluation in parallelFor" + execName)
@@ -58,47 +52,32 @@ TEST_CASE("Coeff")
 
         SECTION("view")
         {
-            Coeff coeff = fieldB; // is a view with uniform value 1.0
-            {
-                NeoN::parallelFor(
-                    fieldA, NEON_LAMBDA(const NeoN::localIdx i) { return coeff[i] + 2.0; }
-                );
-            };
-            auto hostVectorA = fieldA.copyToHost();
-            REQUIRE(coeff.hasView() == true);
-            REQUIRE(hostVectorA.view()[0] == 3.0);
-            REQUIRE(hostVectorA.view()[1] == 3.0);
-            REQUIRE(hostVectorA.view()[2] == 3.0);
+            Coeff c = fieldB; // is a view with uniform value 1.0
+            NeoN::parallelFor(
+                fieldA, NEON_LAMBDA(const auto i) { return c[i] + 2.0; }
+            );
+            auto resAexp = std::vector<NeoN::scalar> {3.0, 3.0, 3.0};
+            REQUIRE_THAT(resAexp, IsEqualTo(fieldA));
         }
 
         SECTION("scalar")
         {
-            Coeff coeff = Coeff(2.0);
-            {
-                NeoN::parallelFor(
-                    fieldA, NEON_LAMBDA(const NeoN::localIdx i) { return coeff[i] + 2.0; }
-                );
-            };
-            auto hostVectorA = fieldA.copyToHost();
-            REQUIRE(coeff.hasView() == false);
-            REQUIRE(hostVectorA.view()[0] == 4.0);
-            REQUIRE(hostVectorA.view()[1] == 4.0);
-            REQUIRE(hostVectorA.view()[2] == 4.0);
+            Coeff c = Coeff(2.0);
+            NeoN::parallelFor(
+                fieldA, NEON_LAMBDA(const auto i) { return c[i] + 2.0; }
+            );
+            auto resAexp = std::vector<NeoN::scalar> {4.0, 4.0, 4.0};
+            REQUIRE_THAT(resAexp, IsEqualTo(fieldA));
         }
 
         SECTION("view and scalar")
         {
-            Coeff coeff {-5.0, fieldB};
-            {
-                NeoN::parallelFor(
-                    fieldA, NEON_LAMBDA(const NeoN::localIdx i) { return coeff[i] + 2.0; }
-                );
-            };
-            auto hostVectorA = fieldA.copyToHost();
-            REQUIRE(coeff.hasView() == true);
-            REQUIRE(hostVectorA.view()[0] == -3.0);
-            REQUIRE(hostVectorA.view()[1] == -3.0);
-            REQUIRE(hostVectorA.view()[2] == -3.0);
+            Coeff c {-5.0, fieldB};
+            NeoN::parallelFor(
+                fieldA, NEON_LAMBDA(const auto i) { return c[i] + 2.0; }
+            );
+            auto resAexp = std::vector<NeoN::scalar> {-3.0, -3.0, -3.0};
+            REQUIRE_THAT(resAexp, IsEqualTo(fieldA));
         }
     }
 }

--- a/test/finiteVolume/cellCentred/fields/volumeField.cpp
+++ b/test/finiteVolume/cellCentred/fields/volumeField.cpp
@@ -8,9 +8,6 @@
 
 #include "NeoN/NeoN.hpp"
 
-template<typename T>
-using I = std::initializer_list<T>;
-
 TEST_CASE("volumeVector")
 {
     namespace fvcc = NeoN::finiteVolume::cellCentred;

--- a/test/linearAlgebra/faceToMatrixAddress.cpp
+++ b/test/linearAlgebra/faceToMatrixAddress.cpp
@@ -35,19 +35,8 @@ TEST_CASE("FaceToMatrixAddress")
 
     SECTION("has correct diagOffs" + execName)
     {
-        auto diagOffs = mi->diagOffset().copyToHost();
-        auto diagOffsS = diagOffs.view();
-
-        REQUIRE(diagOffsS[0] == 0);
-        REQUIRE(diagOffsS[1] == 1);
-        REQUIRE(diagOffsS[2] == 1);
-        REQUIRE(diagOffsS[3] == 1);
-        REQUIRE(diagOffsS[4] == 1);
-        REQUIRE(diagOffsS[5] == 1);
-        REQUIRE(diagOffsS[6] == 1);
-        REQUIRE(diagOffsS[7] == 1);
-        REQUIRE(diagOffsS[8] == 1);
-        REQUIRE(diagOffsS[9] == 1);
+        auto exp = std::vector<NeoN::localIdx> {0, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+        REQUIRE_THAT(exp, IsEqualTo(mi->diagOffset(), EqualInt()));
     }
 }
 

--- a/test/linearAlgebra/matrix.cpp
+++ b/test/linearAlgebra/matrix.cpp
@@ -79,12 +79,7 @@ TEMPLATE_TEST_CASE("Matrix", "[template]", NeoN::scalar)
                 checkSparseView[3] = csrView.entry(2, 1);
             }
         );
-
-        auto checkHost = checkSparse.copyToHost();
-        REQUIRE(checkHost.view()[0] == 1.0);
-        REQUIRE(checkHost.view()[1] == 5.0);
-        REQUIRE(checkHost.view()[2] == 6.0);
-        REQUIRE(checkHost.view()[3] == 8.0);
+        REQUIRE_THAT(I({1.0, 5.0, 6.0, 8.0}), IsEqualTo(checkSparse));
 
         // Dense
         NeoN::Vector<NeoN::scalar> checkDense(exec, 9);
@@ -106,45 +101,24 @@ TEMPLATE_TEST_CASE("Matrix", "[template]", NeoN::scalar)
             }
         );
 
-        checkHost = checkDense.copyToHost();
-        REQUIRE(checkHost.view()[0] == 1.0);
-        REQUIRE(checkHost.view()[1] == 2.0);
-        REQUIRE(checkHost.view()[2] == 3.0);
-        REQUIRE(checkHost.view()[3] == 4.0);
-        REQUIRE(checkHost.view()[4] == 5.0);
-        REQUIRE(checkHost.view()[5] == 6.0);
-        REQUIRE(checkHost.view()[6] == 7.0);
-        REQUIRE(checkHost.view()[7] == 8.0);
-        REQUIRE(checkHost.view()[8] == 9.0);
+        auto expDense = std::vector<NeoN::scalar> {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0};
+        REQUIRE_THAT(expDense, IsEqualTo(checkDense));
     }
 
     SECTION("Can extract diagonal " + execName)
     {
-        auto diag = sparseMatrix.diag();
-        auto diagH = diag.copyToHost();
-
-        REQUIRE(diagH.view()[0] == 1.0);
-        REQUIRE(diagH.view()[1] == 5.0);
+        REQUIRE_THAT(I({1.0, 5.0, 0.0}), IsEqualTo(sparseMatrix.diag()));
     }
 
     SECTION("Can extract diagonal " + execName)
     {
-        auto diag = denseMatrix.diag();
-        auto diagH = diag.copyToHost();
-
-        REQUIRE(diagH.view()[0] == 1.0);
-        REQUIRE(diagH.view()[1] == 5.0);
-        REQUIRE(diagH.view()[2] == 9.0);
+        REQUIRE_THAT(I({1.0, 5.0, 9.0}), IsEqualTo(denseMatrix.diag()));
     }
 
     SECTION("Can extract upper " + execName)
     {
         auto upper = NeoN::la::upper(denseMatrix);
-        auto upperH = upper.copyToHost();
-
-        REQUIRE(upperH.view()[0] == 2.0);
-        REQUIRE(upperH.view()[1] == 3.0);
-        REQUIRE(upperH.view()[2] == 6.0);
+        REQUIRE_THAT(I({2.0, 3.0, 6.0}), IsEqualTo(upper));
     }
 
     // SECTION("Can computed scaledInverseDiagonal " + execName)
@@ -184,13 +158,7 @@ TEMPLATE_TEST_CASE("Matrix", "[template]", NeoN::scalar)
                 csrView.entry(2, 1) = -8.0;
             }
         );
-
-        auto hostMatrix = sparseMatrix.copyToHost();
-        auto checkHost = hostMatrix.values().view();
-        REQUIRE(checkHost[0] == -1.0);
-        REQUIRE(checkHost[1] == -5.0);
-        REQUIRE(checkHost[2] == -6.0);
-        REQUIRE(checkHost[3] == -8.0);
+        REQUIRE_THAT(I({-1.0, -5.0, -6.0, -8.0}), IsEqualTo(sparseMatrix.values()));
 
         // Dense
         auto denseView = denseMatrix.view();
@@ -209,18 +177,10 @@ TEMPLATE_TEST_CASE("Matrix", "[template]", NeoN::scalar)
                 denseView.entry(2, 2) = -9.0;
             }
         );
-
-        hostMatrix = denseMatrix.copyToHost();
-        checkHost = hostMatrix.values().view();
-        REQUIRE(checkHost[0] == -1.0);
-        REQUIRE(checkHost[1] == -2.0);
-        REQUIRE(checkHost[2] == -3.0);
-        REQUIRE(checkHost[3] == -4.0);
-        REQUIRE(checkHost[4] == -5.0);
-        REQUIRE(checkHost[5] == -6.0);
-        REQUIRE(checkHost[6] == -7.0);
-        REQUIRE(checkHost[7] == -8.0);
-        REQUIRE(checkHost[8] == -9.0);
+        REQUIRE_THAT(
+            I({-1.0, -2.0, -3.0, -4.0, -5.0, -6.0, -7.0, -8.0, -9.0}),
+            IsEqualTo(denseMatrix.values())
+        );
     }
 
     SECTION("Read directValue on " + execName)
@@ -229,51 +189,15 @@ TEMPLATE_TEST_CASE("Matrix", "[template]", NeoN::scalar)
         NeoN::Vector<NeoN::scalar> checkSparse(exec, 4);
         auto checkSparseView = checkSparse.view();
         auto csrView = sparseMatrixConst.view();
-        parallelFor(
-            exec,
-            {0, 1},
-            NEON_LAMBDA(const NeoN::localIdx) {
-                checkSparseView[0] = csrView.entry(0);
-                checkSparseView[1] = csrView.entry(1);
-                checkSparseView[2] = csrView.entry(2);
-                checkSparseView[3] = csrView.entry(3);
-            }
-        );
-        auto checkHost = checkSparse.copyToHost();
-        REQUIRE(checkHost.view()[0] == 1.0);
-        REQUIRE(checkHost.view()[1] == 5.0);
-        REQUIRE(checkHost.view()[2] == 6.0);
-        REQUIRE(checkHost.view()[3] == 8.0);
+        checkSparse.apply(NEON_LAMBDA(const NeoN::localIdx i) { return csrView.entry(i); });
+        REQUIRE_THAT(I({1.0, 5.0, 6.0, 8.0}), IsEqualTo(checkSparse));
 
         // Dense
         NeoN::Vector<NeoN::scalar> checkDense(exec, 9);
         auto checkDenseView = checkDense.view();
         auto denseView = denseMatrixConst.view();
-        parallelFor(
-            exec,
-            {0, 1},
-            NEON_LAMBDA(const NeoN::localIdx) {
-                checkDenseView[0] = denseView.entry(0);
-                checkDenseView[1] = denseView.entry(1);
-                checkDenseView[2] = denseView.entry(2);
-                checkDenseView[3] = denseView.entry(3);
-                checkDenseView[4] = denseView.entry(4);
-                checkDenseView[5] = denseView.entry(5);
-                checkDenseView[6] = denseView.entry(6);
-                checkDenseView[7] = denseView.entry(7);
-                checkDenseView[8] = denseView.entry(8);
-            }
-        );
-        checkHost = checkDense.copyToHost();
-        REQUIRE(checkHost.view()[0] == 1.0);
-        REQUIRE(checkHost.view()[1] == 2.0);
-        REQUIRE(checkHost.view()[2] == 3.0);
-        REQUIRE(checkHost.view()[3] == 4.0);
-        REQUIRE(checkHost.view()[4] == 5.0);
-        REQUIRE(checkHost.view()[5] == 6.0);
-        REQUIRE(checkHost.view()[6] == 7.0);
-        REQUIRE(checkHost.view()[7] == 8.0);
-        REQUIRE(checkHost.view()[8] == 9.0);
+        checkDense.apply(NEON_LAMBDA(const NeoN::localIdx i) { return denseView.entry(i); });
+        REQUIRE_THAT(I({1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0}), IsEqualTo(checkDense));
     }
 
     SECTION("Update existing directValue on " + execName)
@@ -290,14 +214,7 @@ TEMPLATE_TEST_CASE("Matrix", "[template]", NeoN::scalar)
                 csrView.entry(3) = -8.0;
             }
         );
-
-
-        auto hostMatrix = sparseMatrix.copyToHost();
-        auto checkHost = hostMatrix.values().view();
-        REQUIRE(checkHost[0] == -1.0);
-        REQUIRE(checkHost[1] == -5.0);
-        REQUIRE(checkHost[2] == -6.0);
-        REQUIRE(checkHost[3] == -8.0);
+        REQUIRE_THAT(I({-1.0, -5.0, -6.0, -8.0}), IsEqualTo(sparseMatrix.values()));
 
         // Dense
         auto denseView = denseMatrix.view();
@@ -316,18 +233,10 @@ TEMPLATE_TEST_CASE("Matrix", "[template]", NeoN::scalar)
                 denseView.entry(8) = -9.0;
             }
         );
-
-        hostMatrix = denseMatrix.copyToHost();
-        checkHost = hostMatrix.values().view();
-        REQUIRE(checkHost[0] == -1.0);
-        REQUIRE(checkHost[1] == -2.0);
-        REQUIRE(checkHost[2] == -3.0);
-        REQUIRE(checkHost[3] == -4.0);
-        REQUIRE(checkHost[4] == -5.0);
-        REQUIRE(checkHost[5] == -6.0);
-        REQUIRE(checkHost[6] == -7.0);
-        REQUIRE(checkHost[7] == -8.0);
-        REQUIRE(checkHost[8] == -9.0);
+        REQUIRE_THAT(
+            I({-1.0, -2.0, -3.0, -4.0, -5.0, -6.0, -7.0, -8.0, -9.0}),
+            IsEqualTo(denseMatrix.values())
+        );
     }
 
     SECTION("View " + execName)
@@ -360,9 +269,10 @@ TEMPLATE_TEST_CASE("Matrix", "[template]", NeoN::Vec3)
     auto [execName, exec] = GENERATE(allAvailableExecutor());
 
     // sparse matrix
-    NeoN::Vector<TestType> valuesSparse(
-        exec, {{1.0, 1.0, 1.0}, {5.0, 5.0, 5.0}, {6.0, 6.0, 6.0}, {8.0, 8.0, 8.0}}
-    );
+    std::vector<NeoN::Vec3> valuesSparseV {
+        {1.0, 1.0, 1.0}, {5.0, 5.0, 5.0}, {6.0, 6.0, 6.0}, {8.0, 8.0, 8.0}
+    };
+    NeoN::Vector<TestType> valuesSparse(exec, valuesSparseV);
     NeoN::Vector<NeoN::localIdx> colIdxSparse(exec, {0, 1, 2, 1});
     NeoN::Vector<NeoN::localIdx> rowOffsSparse(exec, {0, 1, 3, 4});
 

--- a/test/linearAlgebra/matrix.cpp
+++ b/test/linearAlgebra/matrix.cpp
@@ -187,14 +187,12 @@ TEMPLATE_TEST_CASE("Matrix", "[template]", NeoN::scalar)
     {
         // Sparse
         NeoN::Vector<NeoN::scalar> checkSparse(exec, 4);
-        auto checkSparseView = checkSparse.view();
         auto csrView = sparseMatrixConst.view();
         checkSparse.apply(NEON_LAMBDA(const NeoN::localIdx i) { return csrView.entry(i); });
         REQUIRE_THAT(I({1.0, 5.0, 6.0, 8.0}), IsEqualTo(checkSparse));
 
         // Dense
         NeoN::Vector<NeoN::scalar> checkDense(exec, 9);
-        auto checkDenseView = checkDense.view();
         auto denseView = denseMatrixConst.view();
         checkDense.apply(NEON_LAMBDA(const NeoN::localIdx i) { return denseView.entry(i); });
         REQUIRE_THAT(I({1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0}), IsEqualTo(checkDense));

--- a/test/linearAlgebra/sparsityPattern.cpp
+++ b/test/linearAlgebra/sparsityPattern.cpp
@@ -18,85 +18,30 @@ TEST_CASE("SparsityPattern")
 {
     auto [execName, exec] = GENERATE(allAvailableExecutor());
 
-    auto nCells = 10;
-    auto nFaces = 9;
+    auto nCells = 4;
 
     auto mesh = create1DUniformMesh(exec, nCells);
     auto mi = NeoN::la::createSparsityPatternFaceToMatrixAddress<NeoN::localIdx>(mesh);
     auto sp = mi->sparsityPattern();
 
-    SECTION("Can produce rowOffs " + execName)
+    // clang-format off
+    // Mesh:
+    // Cell Ids [ 0, 1, 2, 3]
+    //
+    // Matrix:
+    // Row/ColIdx 0   1   2  3
+    //   0        x   x
+    //   1        x   x   x
+    //   2            x   x  x
+    //   3                x  x
+    // clang-format on
+    SECTION("Can produce internal rowOffs and colIdx " + execName)
     {
-        auto rowPtr = sp->rowOffs().copyToHost();
-        auto rowPtrH = rowPtr.view();
+        auto rowPtrExp = std::vector<localIdx> {0, 2, 5, 8, 10};
+        auto colIdxExp = std::vector<localIdx> {0, 1, 0, 1, 2, 1, 2, 3, 2, 3};
 
-        REQUIRE(rowPtrH[0] == 0);
-        REQUIRE(rowPtrH[1] == 2);
-        REQUIRE(rowPtrH[2] == 5);
-        REQUIRE(rowPtrH[3] == 8);
-        REQUIRE(rowPtrH[4] == 11);
-        REQUIRE(rowPtrH[5] == 14);
-        REQUIRE(rowPtrH[6] == 17);
-        REQUIRE(rowPtrH[7] == 20);
-        REQUIRE(rowPtrH[8] == 23);
-        REQUIRE(rowPtrH[9] == 26);
-        REQUIRE(rowPtrH[10] == 28);
-    }
-
-    SECTION("Can produce column indices " + execName)
-    {
-        auto colIdx = sp->colIdxs();
-        auto colIdxH = colIdx.copyToHost();
-        auto colIdxHS = colIdxH.view();
-
-        REQUIRE(colIdx.size() == nCells + 2 * nFaces);
-        REQUIRE(colIdxHS[0] == 0);
-        REQUIRE(colIdxHS[1] == 1);
-
-        REQUIRE(colIdxHS[2] == 0);
-        REQUIRE(colIdxHS[3] == 1);
-        REQUIRE(colIdxHS[4] == 2);
-
-        REQUIRE(colIdxHS[5] == 1);
-        REQUIRE(colIdxHS[6] == 2);
-        REQUIRE(colIdxHS[7] == 3);
-
-        REQUIRE(colIdxHS[8] == 2);
-        REQUIRE(colIdxHS[9] == 3);
-        REQUIRE(colIdxHS[10] == 4);
-    }
-
-    SECTION("Can generate views " + execName)
-    {
-        auto spH = sp->copyToHost();
-        auto [colIdxs, rowOffs] = spH.view();
-
-        REQUIRE(colIdxs[0] == 0);
-        REQUIRE(colIdxs[1] == 1);
-
-        REQUIRE(colIdxs[2] == 0);
-        REQUIRE(colIdxs[3] == 1);
-        REQUIRE(colIdxs[4] == 2);
-
-        REQUIRE(colIdxs[5] == 1);
-        REQUIRE(colIdxs[6] == 2);
-        REQUIRE(colIdxs[7] == 3);
-
-        REQUIRE(colIdxs[8] == 2);
-        REQUIRE(colIdxs[9] == 3);
-        REQUIRE(colIdxs[10] == 4);
-
-        REQUIRE(rowOffs[0] == 0);
-        REQUIRE(rowOffs[1] == 2);
-        REQUIRE(rowOffs[2] == 5);
-        REQUIRE(rowOffs[3] == 8);
-        REQUIRE(rowOffs[4] == 11);
-        REQUIRE(rowOffs[5] == 14);
-        REQUIRE(rowOffs[6] == 17);
-        REQUIRE(rowOffs[7] == 20);
-        REQUIRE(rowOffs[8] == 23);
-        REQUIRE(rowOffs[9] == 26);
-        REQUIRE(rowOffs[10] == 28);
+        REQUIRE_THAT(rowPtrExp, IsEqualTo(sp->rowOffs(), EqualInt()));
+        REQUIRE_THAT(colIdxExp, IsEqualTo(sp->colIdxs(), EqualInt()));
     }
 }
 

--- a/test/linearAlgebra/utilities.cpp
+++ b/test/linearAlgebra/utilities.cpp
@@ -64,157 +64,67 @@ TEST_CASE("Utilities")
     SECTION("Can unpackhRowOffs " + execName)
     {
         auto res = NeoN::la::unpackRowOffs(rowOffs);
-        auto resHost = res.copyToHost();
-
-        REQUIRE(resHost.view()[0] == 0);
-        REQUIRE(resHost.view()[1] == 3);
-        REQUIRE(resHost.view()[2] == 6);
-        REQUIRE(resHost.view()[3] == 9);
-        REQUIRE(resHost.view()[4] == 12);
-        REQUIRE(resHost.view()[5] == 15);
+        auto rowOffsExp = std::vector<localIdx> {0, 3, 6, 9, 12, 15, 18, 21, 24, 27};
+        REQUIRE_THAT(rowOffsExp, IsEqualTo(res, EqualInt()));
     }
 
     SECTION("Can unpackRowOffs2 " + execName)
     {
         auto res = NeoN::la::unpackRowOffs(rowOffsS);
-        auto resHost = res.copyToHost();
-
-        REQUIRE(resHost.view()[0] == 0);
-        REQUIRE(resHost.view()[1] == 2);
-        REQUIRE(resHost.view()[2] == 4);
-        REQUIRE(resHost.view()[3] == 6);
-        REQUIRE(resHost.view()[4] == 9);
-        REQUIRE(resHost.view()[5] == 12);
-        REQUIRE(resHost.view()[6] == 15);
-        REQUIRE(resHost.view()[7] == 17);
-        REQUIRE(resHost.view()[8] == 19);
-        REQUIRE(resHost.view()[9] == 21);
+        auto exp = std::vector<localIdx> {0, 2, 4, 6, 9, 12, 15, 17, 19, 21};
+        REQUIRE_THAT(exp, IsEqualTo(res, EqualInt()));
     }
-
 
     SECTION("Can unpack mtxValues " + execName)
     {
         auto newRowOffs = NeoN::la::unpackRowOffs(rowOffs);
         auto res = NeoN::la::unpackMtxValues(mtxValues, rowOffs, newRowOffs);
-        auto resHost = res.copyToHost();
-
-        REQUIRE(resHost.view()[0] == 1.0);
-        REQUIRE(resHost.view()[1] == 2.0);
-        REQUIRE(resHost.view()[2] == 3.0);
-
-        REQUIRE(resHost.view()[3] == 1.0);
-        REQUIRE(resHost.view()[4] == 2.0);
-        REQUIRE(resHost.view()[5] == 3.0);
-
-        REQUIRE(resHost.view()[6] == 1.0);
-        REQUIRE(resHost.view()[7] == 2.0);
-        REQUIRE(resHost.view()[8] == 3.0);
-
-        REQUIRE(resHost.view()[9] == 4.0);
-        REQUIRE(resHost.view()[10] == 5.0);
-        REQUIRE(resHost.view()[11] == 6.0);
+        auto exp = std::vector<scalar> {1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0,
+                                        4.0, 5.0, 6.0, 4.0, 5.0, 6.0, 4.0, 5.0, 6.0,
+                                        7.0, 8.0, 9.0, 7.0, 8.0, 9.0, 7.0, 8.0, 9.0};
+        REQUIRE_THAT(exp, IsEqualTo(res));
     }
 
-    SECTION("Can unpackColIdx " + execName)
+    SECTION("Can unpackColIdx sparse " + execName)
     {
         auto newRowOffs = NeoN::la::unpackRowOffs(rowOffsS);
         auto res = NeoN::la::unpackColIdx(colIdxS, newRowOffs, rowOffsS);
-        auto resHost = res.copyToHost();
 
         REQUIRE(res.size() == 3 * colIdxS.size());
 
-        // row 1
-        REQUIRE(resHost.view()[0] == 0);
-        REQUIRE(resHost.view()[1] == 3);
-
-        // row 2
-        REQUIRE(resHost.view()[2] == 1);
-        REQUIRE(resHost.view()[3] == 4);
-
-        // row 3
-        REQUIRE(resHost.view()[4] == 2);
-        REQUIRE(resHost.view()[5] == 5);
-
-        // row 4
-        REQUIRE(resHost.view()[6] == 0);
-        REQUIRE(resHost.view()[7] == 3);
-        REQUIRE(resHost.view()[8] == 6);
-
-        // row 5
-        REQUIRE(resHost.view()[9] == 1);
-        REQUIRE(resHost.view()[10] == 4);
-        REQUIRE(resHost.view()[11] == 7);
-
-        // row 6
-        REQUIRE(resHost.view()[12] == 2);
-        REQUIRE(resHost.view()[13] == 5);
-        REQUIRE(resHost.view()[14] == 8);
-
-        // row 7
-        REQUIRE(resHost.view()[15] == 3);
-        REQUIRE(resHost.view()[16] == 6);
-
-        // row 8
-        REQUIRE(resHost.view()[17] == 4);
-        REQUIRE(resHost.view()[18] == 7);
-
-        // row 9
-        REQUIRE(resHost.view()[19] == 5);
-        REQUIRE(resHost.view()[20] == 8);
+        auto colIdxExp = std::vector<localIdx> {
+            0, 3,    // row 1
+            1, 4,    // row 2
+            2, 5,    // row 3
+            0, 3, 6, // row 4
+            1, 4, 7, // row 5
+            2, 5, 8, // row 6
+            3, 6,    // row 7
+            4, 7,    // row 8
+            5, 8     // row 9
+        };
+        REQUIRE_THAT(colIdxExp, IsEqualTo(res, EqualInt()));
     }
 
-    SECTION("Can unpackColIdx " + execName)
+    SECTION("Can unpackColIdx dense " + execName)
     {
         auto newRowOffs = NeoN::la::unpackRowOffs(rowOffs);
         auto res = NeoN::la::unpackColIdx(colIdx, newRowOffs, rowOffs);
-        auto resHost = res.copyToHost();
 
-        REQUIRE(res.size() == 3 * colIdx.size()); // 0
+        REQUIRE(res.size() == 3 * colIdx.size());
 
-        // row 1
-        REQUIRE(resHost.view()[0] == 0); // 0
-        REQUIRE(resHost.view()[1] == 3); // 1
-        REQUIRE(resHost.view()[2] == 6); // 2
-
-        // row 2
-        REQUIRE(resHost.view()[3] == 1);
-        REQUIRE(resHost.view()[4] == 4);
-        REQUIRE(resHost.view()[5] == 7);
-
-        // row 3
-        REQUIRE(resHost.view()[6] == 2);
-        REQUIRE(resHost.view()[7] == 5);
-        REQUIRE(resHost.view()[8] == 8);
-
-        // row 4
-        REQUIRE(resHost.view()[9] == 0);
-        REQUIRE(resHost.view()[10] == 3);
-        REQUIRE(resHost.view()[11] == 6);
-
-        // row 5
-        REQUIRE(resHost.view()[12] == 1);
-        REQUIRE(resHost.view()[13] == 4);
-        REQUIRE(resHost.view()[14] == 7);
-
-        // row 6
-        REQUIRE(resHost.view()[15] == 2);
-        REQUIRE(resHost.view()[16] == 5);
-        REQUIRE(resHost.view()[17] == 8);
-
-        // row 7
-        REQUIRE(resHost.view()[18] == 0);
-        REQUIRE(resHost.view()[19] == 3);
-        REQUIRE(resHost.view()[20] == 6);
-
-        // row 8
-        REQUIRE(resHost.view()[21] == 1);
-        REQUIRE(resHost.view()[22] == 4);
-        REQUIRE(resHost.view()[23] == 7);
-
-        // row 9
-        REQUIRE(resHost.view()[24] == 2);
-        REQUIRE(resHost.view()[25] == 5);
-        REQUIRE(resHost.view()[26] == 8);
+        auto colIdxExp = std::vector<localIdx> {
+            0, 3, 6, // row 1
+            1, 4, 7, // row 2
+            2, 5, 8, // row 3
+            0, 3, 6, // row 4
+            1, 4, 7, // row 5
+            2, 5, 8, // row 6
+            0, 3, 6, // row 7
+            1, 4, 7, // row 8
+            2, 5, 8  // row 9
+        };
+        REQUIRE_THAT(colIdxExp, IsEqualTo(res, EqualInt()));
     }
 
     // Residual of scalar matrix
@@ -232,10 +142,7 @@ TEST_CASE("Utilities")
 
         NeoN::la::computeResidual(csrMatrix, rhs, x, res);
 
-        auto resHost = res.copyToHost();
-
-        REQUIRE(resHost.view()[0] == 4.0);
-        REQUIRE(resHost.view()[1] == 13.0);
-        REQUIRE(resHost.view()[2] == 22.0);
+        auto residualExp = std::vector<scalar> {4.0, 13.0, 22.0};
+        REQUIRE_THAT(residualExp, IsEqualTo(res, ApproxScalar(1e-15)));
     }
 }

--- a/test/mesh/unstructured/unstructuredMesh.cpp
+++ b/test/mesh/unstructured/unstructuredMesh.cpp
@@ -38,44 +38,35 @@ TEST_CASE("Unstructured Mesh")
         // Verify mesh points
         // bc  [   internal  ]  bc
         // 0.0 [ 0.25 | 0.50 ] 1.0
-        auto hostPoints = mesh.points().copyToHost();
-        REQUIRE(hostPoints.view()[0][0] == 0.25);
-        REQUIRE(hostPoints.view()[1][0] == 0.5);
-        REQUIRE(hostPoints.view()[3][0] == 0.0);
-        REQUIRE(hostPoints.view()[nCells][0] == 1.0);
+        auto pointsExp = std::vector<NeoN::Vec3> {
+            {0.25, 0.0, 0.0}, {0.5, 0.0, 0.0}, {0.75, 0.0, 0.0}, {0.0, 0.0, 0.0}, {1.0, 0.0, 0.0}
+        };
+        REQUIRE_THAT(pointsExp, IsEqualTo(mesh.points(), EqualInt()));
 
         // Verify cell centers
-        auto hostCellCentres = mesh.cellCentres().copyToHost();
-        REQUIRE(hostCellCentres.view()[0][0] == 0.125);
-        REQUIRE(hostCellCentres.view()[1][0] == 0.375);
-        REQUIRE(hostCellCentres.view()[2][0] == 0.625);
-        REQUIRE(hostCellCentres.view()[3][0] == 0.875);
+        auto cellCentresExp = std::vector<NeoN::Vec3> {
+            {0.125, 0.0, 0.0}, {0.375, 0.0, 0.0}, {0.625, 0.0, 0.0}, {0.875, 0.0, 0.0}
+        };
+        REQUIRE_THAT(cellCentresExp, IsEqualTo(mesh.cellCentres(), EqualInt()));
 
         // Verify face owners
         // |_3 0 |_0 1 |_1 2 |_2 3 |_4
-        auto hostFaceOwner = mesh.faceOwner().copyToHost();
-        REQUIRE(hostFaceOwner.view()[0] == 0);
-        REQUIRE(hostFaceOwner.view()[1] == 1);
-        REQUIRE(hostFaceOwner.view()[2] == 2);
-        REQUIRE(hostFaceOwner.view()[3] == 0);
-        REQUIRE(hostFaceOwner.view()[4] == 3);
+        auto faceOwnerExp = std::vector<NeoN::label> {0, 1, 2, 0, 3};
+        REQUIRE_THAT(faceOwnerExp, IsEqualTo(mesh.faceOwner(), EqualInt()));
 
         // Verify face neighbors
         // |_3 0 |_0 1 |_1 2 |_2 3 |_4
-        auto hostFaceNeighbour = mesh.faceNeighbour().copyToHost();
-        REQUIRE(hostFaceNeighbour.view()[0] == 1);
-        REQUIRE(hostFaceNeighbour.view()[1] == 2);
-        REQUIRE(hostFaceNeighbour.view()[2] == 3);
+        auto faceNeighbourExp = std::vector<NeoN::label> {1, 2, 3};
+        REQUIRE_THAT(faceNeighbourExp, IsEqualTo(mesh.faceNeighbour(), EqualInt()));
 
         // Verify boundary mesh
-        auto hostBoundaryFaceCells = mesh.boundaryMesh().faceCells().copyToHost();
-        auto hostBoundaryCn = mesh.boundaryMesh().cn().copyToHost();
-        auto hostBoundaryDelta = mesh.boundaryMesh().delta().copyToHost();
-        REQUIRE(hostBoundaryFaceCells.view()[0] == 0);
-        REQUIRE(hostBoundaryFaceCells.view()[1] == 3);
-        REQUIRE(hostBoundaryCn.view()[0][0] == 0.125);
-        REQUIRE(hostBoundaryCn.view()[1][0] == 0.875);
-        REQUIRE(hostBoundaryDelta.view()[0][0] == -0.125);
-        REQUIRE(hostBoundaryDelta.view()[1][0] == 0.125);
+        auto faceCellsExp = std::vector<NeoN::localIdx> {0, 3};
+        REQUIRE_THAT(faceCellsExp, IsEqualTo(mesh.boundaryMesh().faceCells(), EqualInt()));
+
+        auto cnExp = std::vector<NeoN::Vec3> {{0.125, 0.0, 0.0}, {0.875, 0.0, 0.0}};
+        REQUIRE_THAT(cnExp, IsEqualTo(mesh.boundaryMesh().cn(), EqualInt()));
+
+        auto deltaExp = std::vector<NeoN::Vec3> {{-0.125, 0.0, 0.0}, {0.125, 0.0, 0.0}};
+        REQUIRE_THAT(deltaExp, IsEqualTo(mesh.boundaryMesh().delta(), EqualInt()));
     }
 }


### PR DESCRIPTION
This PR updates unit tests:
- adding a conditional `SECTION_IF` 
- a custom matcher function to simplify testing
- some fixes for the CI/CD pipelines

The purpose of `SECTION_IF` is to conditionally test when expected results might differ for example, for MPI based tests, eg.:

```
SECTION_IF(mpi.rank() == 0, "Has correct rank") {
   < anything useful for rank 0 here>
}
```
The custom matcher allows to compare vector data to std::vector and takes care of copying the data to host first.
```
auto res = NeoN::la::unpackRowOffs(rowOffs);
auto rowOffsExp = std::vector<localIdx> {0, 3, 6, 9, 12, 15, 18, 21, 24, 27};
REQUIRE_THAT(rowOffsExp, IsEqualTo(res, EqualInt()));
```

Additional fixes:
- The github clang pipeline used gcc.
