### PR TITLE
Add function to remove boundary contributions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ _build
 __pycache__
 _skbuild
 uv.lock
+*.back

--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,5 @@ __pycache__
 _skbuild
 uv.lock
 *.bck
+*log
+*.claude

--- a/.gitignore
+++ b/.gitignore
@@ -86,4 +86,4 @@ _build
 __pycache__
 _skbuild
 uv.lock
-*.back
+*.bck

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,7 +279,7 @@ endif()
 
 if(fmt_ADDED)
   install(
-    TARGETS fmt-header-only
+    TARGETS fmt fmt-header-only
     EXPORT NeoNTargets
     INCLUDES
     DESTINATION include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,9 @@ if(spdlog_ADDED)
     EXPORT SpdlogTargets
     INCLUDES
     DESTINATION include)
+  if(fmt_ADDED)
+    install(TARGETS fmt-header-only EXPORT SpdlogTargets)
+  endif()
   install(
     EXPORT SpdlogTargets
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/spdlog
@@ -278,11 +281,8 @@ if(spdlog_ADDED)
 endif()
 
 if(fmt_ADDED)
-  install(
-    TARGETS fmt fmt-header-only
-    EXPORT NeoNTargets
-    INCLUDES
-    DESTINATION include)
+  install(TARGETS fmt-header-only EXPORT NeoNTargets)
+  install(DIRECTORY "${fmt_SOURCE_DIR}/include/" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 endif()
 
 # install internal sundials version if(sundials_POPULATED) install( TARGETS cvode nvec arkode

--- a/_typos.toml
+++ b/_typos.toml
@@ -9,3 +9,4 @@ extend-exclude = ["third_party/*", "doc/Doxyfile.in"]
 nd = "nd"
 ilda = "ilda"
 tilda = "tilda"
+bck = "bck"

--- a/cmake/CxxThirdParty.cmake
+++ b/cmake/CxxThirdParty.cmake
@@ -78,7 +78,7 @@ cpmaddpackage(
   YES)
 
 if(${NeoN_WITH_SPDLOG})
-  set(SPDLOG_OPTIONS "SPDLOG_FMT_EXTERNAL ON")
+  set(SPDLOG_OPTIONS "SPDLOG_FMT_EXTERNAL_HO ON")
   cpmaddpackage(
     NAME
     spdlog

--- a/include/NeoN/linearAlgebra/linearSystem.hpp
+++ b/include/NeoN/linearAlgebra/linearSystem.hpp
@@ -231,5 +231,36 @@ LinearSystem<ValueType, MatrixType> createEmptyLinearSystem(const UnstructuredMe
     return {createSparsityPatternFaceToMatrixAddress<NeoN::localIdx>(mesh)};
 }
 
+/** @brief for testing purposes this function reverses boundary contributions previously added to
+ * the matrix diagonal and the RHS */
+template<typename ValueType>
+inline la::LinearSystem<ValueType>
+removeBoundaryContributions(const la::LinearSystem<ValueType>& lsIn)
+{
+    auto ls = la::LinearSystem<ValueType>(lsIn);
+    const auto matIt = ls.faceToMatrixAddress();
+    auto lsView = ls.view();
+    auto& matrix = lsView.matrix;
+    auto& rhs = lsView.rhs;
+    auto& bMatrix = lsView.boundaryMatrix;
+    auto& bRhs = lsView.boundaryRhs;
+    auto& mtx = ls.matrix();
+    const auto [diagOffs, rowOffs] = views(matIt->diagOffset(), mtx.rowOffs());
+
+    parallelFor(
+        ls.exec(),
+        {0, bMatrix.values.size()},
+        NEON_LAMBDA(const localIdx facei) {
+            const auto celli = bMatrix.sparsity.rowOffs[facei]; // cell index stored in rowOffs
+            Kokkos::atomic_add(
+                &matrix.values[rowOffs[celli] + diagOffs[celli]], bMatrix.values[facei]
+            );
+            Kokkos::atomic_add(&rhs[celli], bRhs[facei]);
+        },
+        "removeBoundaryContributions"
+    );
+
+    return ls;
+}
 
 } // namespace NeoN::la

--- a/include/NeoN/linearAlgebra/linearSystem.hpp
+++ b/include/NeoN/linearAlgebra/linearSystem.hpp
@@ -231,8 +231,7 @@ LinearSystem<ValueType, MatrixType> createEmptyLinearSystem(const UnstructuredMe
     return {createSparsityPatternFaceToMatrixAddress<NeoN::localIdx>(mesh)};
 }
 
-/** @brief for testing purposes this function reverses boundary contributions previously added to
- * the matrix diagonal and the RHS */
+/** @brief for testing purposes, this function reverses boundary contributions previously applied to the matrix diagonal and RHS for some operators (e.g., div). **/
 template<typename ValueType>
 inline la::LinearSystem<ValueType>
 removeBoundaryContributions(const la::LinearSystem<ValueType>& lsIn)

--- a/include/NeoN/linearAlgebra/matrix.hpp
+++ b/include/NeoN/linearAlgebra/matrix.hpp
@@ -244,6 +244,11 @@ using CSRMatrix = Matrix<ValueType, la::SparsityPattern<IndexType>>;
 template<typename ValueType, typename IndexType>
 [[nodiscard]] Vector<ValueType> upper(const CSRMatrix<ValueType, IndexType>&);
 
+/** @brief extract the lower triangular of the matrix
+ * @note this function is meant for testing purposes, it will recompute lower offsets
+ */
+template<typename ValueType, typename IndexType>
+[[nodiscard]] Vector<ValueType> lower(const CSRMatrix<ValueType, IndexType>&);
 
 /** @brief computes the inverted diagonal of a matrix and scales it by a, ie. a*D^-1
  * @note this function is a specialized function for CSR<Vec3> matrices assuming all diagonal
@@ -303,6 +308,5 @@ void scaledInvDiagNegLUx(
     Vector<scalar>& rAU,
     Vector<Vec3>& out
 );
-
 
 } // namespace NeoN

--- a/include/NeoN/linearAlgebra/matrix.hpp
+++ b/include/NeoN/linearAlgebra/matrix.hpp
@@ -244,12 +244,6 @@ using CSRMatrix = Matrix<ValueType, la::SparsityPattern<IndexType>>;
 template<typename ValueType, typename IndexType>
 [[nodiscard]] Vector<ValueType> upper(const CSRMatrix<ValueType, IndexType>&);
 
-/** @brief extract the lower triangular of the matrix
- * @note this function is meant for testing purposes, it will recompute lower offsets
- */
-template<typename ValueType, typename IndexType>
-[[nodiscard]] Vector<ValueType> lower(const CSRMatrix<ValueType, IndexType>&);
-
 /** @brief computes the inverted diagonal of a matrix and scales it by a, ie. a*D^-1
  * @note this function is a specialized function for CSR<Vec3> matrices assuming all diagonal
  * entries are identical

--- a/include/NeoN/mesh/unstructured/unstructuredMesh.hpp
+++ b/include/NeoN/mesh/unstructured/unstructuredMesh.hpp
@@ -332,7 +332,7 @@ UnstructuredMesh createSingleCellMesh(const Executor exec);
  * A 1D mesh in 3D space in which each cell has a left and a right boundary face.
  * The 1D mesh is aligned with the x coordinate of Cartesian coordinate system.
  */
-UnstructuredMesh create1DUniformMesh(const Executor exec, const localIdx nCells, scalar Lx = 1.0);
+UnstructuredMesh create1DUniformMesh(const Executor exec, const localIdx nCells, scalar lx = 1.0);
 
 /** @brief A factory function for a 2D uniform mesh (OpenFOAM-style hex slab)
  *
@@ -341,7 +341,7 @@ UnstructuredMesh create1DUniformMesh(const Executor exec, const localIdx nCells,
  * Four boundary patches: left (x=0), right (x=Lx), bottom (y=0), top (y=Ly)
  */
 UnstructuredMesh create2DUniformMesh(
-    const Executor exec, localIdx nx, localIdx ny, scalar Lx = 1.0, scalar Ly = 1.0
+    const Executor exec, localIdx nx, localIdx ny, scalar lx = 1.0, scalar ly = 1.0
 );
 
 /** @brief A factory function for a uniform 3D hex mesh
@@ -355,9 +355,9 @@ UnstructuredMesh create3DUniformMesh(
     localIdx nx,
     localIdx ny,
     localIdx nz,
-    scalar Lx = 1.0,
-    scalar Ly = 1.0,
-    scalar Lz = 1.0
+    scalar lx = 1.0,
+    scalar ly = 1.0,
+    scalar lz = 1.0
 );
 
 } // namespace NeoN

--- a/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
@@ -250,13 +250,13 @@ void computeDivImp(
             auto valueMat = flux * operatorScalingOwn * valFrac2 * one<ValueType>();
 
             Kokkos::atomic_add(&values[rowOwnStart + diagOffs[own]], valueMat);
-            bValues[bcfacei] = valueMat;
+            bValues[bcfacei] -= valueMat;
 
             auto valueRhs = (flux * operatorScalingOwn * (valFrac1 * refValue[bcfacei]))
                           + valFrac2 * refGradient[bcfacei] * (1 / deltaCoeffs[bcfacei]);
 
             Kokkos::atomic_sub(&rhs[own], valueRhs);
-            bRhs[bcfacei] = valueRhs;
+            bRhs[bcfacei] += valueRhs;
         },
         "computeInterfaceGaussGreenDivCoefficients"
     );

--- a/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
@@ -163,13 +163,13 @@ void computeLaplacianImpl(
             ValueType valueMat = flux * operatorScalingOwn * valueFraction[bcfacei]
                                * deltaCoeffs[facei] * one<ValueType>();
             Kokkos::atomic_sub(&values[rowOwnStart + diagOffs[own]], valueMat);
-            bValues[bcfacei] = valueMat;
+            bValues[bcfacei] += valueMat;
 
             ValueType valueRhs = flux * operatorScalingOwn
                                * (valueFraction[bcfacei] * deltaCoeffs[facei] * refValue[bcfacei]
                                   + (1.0 - valueFraction[bcfacei]) * refGradient[bcfacei]);
             Kokkos::atomic_sub(&rhs[own], valueRhs);
-            bRhs[bcfacei] = valueRhs;
+            bRhs[bcfacei] += valueRhs;
         },
         "computeInterfaceLaplacianCoefficients"
     );

--- a/src/linearAlgebra/matrix.cpp
+++ b/src/linearAlgebra/matrix.cpp
@@ -104,6 +104,7 @@ Vector<ValueType> upper(const CSRMatrix<ValueType, IndexType>& mtx)
     return upper;
 }
 
+
 void negLUx(
     const CSRMatrix<Vec3, localIdx>& mtx,
     const Vector<Vec3>& a,

--- a/src/mesh/unstructured/uniformMeshDataGenerator.cpp
+++ b/src/mesh/unstructured/uniformMeshDataGenerator.cpp
@@ -156,20 +156,20 @@ BoundaryMesh generateBoundaryData(
     {
         auto sz = static_cast<size_t>(bndId);
         auto fi = static_cast<size_t>(faceId);
-        auto ci_size_t = static_cast<size_t>(ci);
-        auto ci_label = static_cast<label>(ci);
+        auto ciSizeT = static_cast<size_t>(ci);
+        auto ciLabel = static_cast<label>(ci);
         scalar magA = mag(area);
         Vec3 normal = area * (1.0 / magA);
-        Vec3 delta = faceCentre - centres[ci_size_t];
+        Vec3 delta = faceCentre - centres[ciSizeT];
 
         faces.areas[fi] = area;
         faces.centres[fi] = faceCentre;
         faces.magnitudes[fi] = magA;
-        faces.owner[fi] = ci_label;
+        faces.owner[fi] = ciLabel;
 
-        bndFaceCells[sz] = ci_label;
+        bndFaceCells[sz] = ciLabel;
         bndCf[sz] = faceCentre;
-        bndCn[sz] = centres[ci_size_t];
+        bndCn[sz] = centres[ciSizeT];
         bndSf[sz] = area;
         bndMagSf[sz] = magA;
         bndNf[sz] = normal;

--- a/src/mesh/unstructured/unstructuredMesh.cpp
+++ b/src/mesh/unstructured/unstructuredMesh.cpp
@@ -162,27 +162,27 @@ UnstructuredMesh createSingleCellMesh(const Executor exec)
     );
 }
 
-UnstructuredMesh create1DUniformMesh(const Executor exec, const localIdx nCells, scalar Lx)
+UnstructuredMesh create1DUniformMesh(const Executor exec, const localIdx nCells, scalar lx)
 {
-    return create3DUniformMesh(exec, nCells, 1, 1, Lx, 1.0, 1.0);
+    return create3DUniformMesh(exec, nCells, 1, 1, lx, 1.0, 1.0);
 }
 
 UnstructuredMesh
-create2DUniformMesh(const Executor exec, localIdx nx, localIdx ny, scalar Lx, scalar Ly)
+create2DUniformMesh(const Executor exec, localIdx nx, localIdx ny, scalar lx, scalar ly)
 {
-    return create3DUniformMesh(exec, nx, ny, 1, Lx, Ly, 1.0);
+    return create3DUniformMesh(exec, nx, ny, 1, lx, ly, 1.0);
 }
 
 UnstructuredMesh create3DUniformMesh(
-    const Executor exec, localIdx nx, localIdx ny, localIdx nz, scalar Lx, scalar Ly, scalar Lz
+    const Executor exec, localIdx nx, localIdx ny, localIdx nz, scalar lx, scalar ly, scalar lz
 )
 {
     // Validate input parameters
     NF_ASSERT(nx > 0 && ny > 0 && nz > 0, "Number of cells in each direction must be positive");
-    NF_ASSERT(Lx > 0 && Ly > 0 && Lz > 0, "Domain lengths must be positive");
+    NF_ASSERT(lx > 0 && ly > 0 && lz > 0, "Domain lengths must be positive");
 
     // Hold the mesh parameters
-    detail::MeshParams p {nx, ny, nz, Lx, Ly, Lz};
+    detail::MeshParams p {nx, ny, nz, lx, ly, lz};
 
     const auto points = detail::generatePoints(p);
     const auto [cellVolumes, cellCentres] = detail::generateCellData(p);

--- a/test/finiteVolume/cellCentred/operator/gaussGreenDiv.cpp
+++ b/test/finiteVolume/cellCentred/operator/gaussGreenDiv.cpp
@@ -69,4 +69,106 @@ TEMPLATE_TEST_CASE("DivOperator", "[template]", NeoN::scalar, NeoN::Vec3)
     }
 }
 
+TEST_CASE("DivOperator implicit boundary contributions are accumulated")
+{
+    auto [execName, exec] = GENERATE(allAvailableExecutor());
+
+    const localIdx nCells = 10;
+    auto mesh = create1DUniformMesh(exec, nCells);
+    auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<NeoN::scalar>>(mesh);
+
+    fvcc::SurfaceField<NeoN::scalar> faceFlux(exec, "sf", mesh, surfaceBCs);
+    fill(faceFlux.internalVector(), 1.0);
+
+    Input input = TokenList({std::string("Gauss"), std::string("linear")});
+
+    SECTION("bRhs accumulates for fixedValue BC on " + execName)
+    {
+        std::vector<fvcc::VolumeBoundary<NeoN::scalar>> bcs;
+        bcs.push_back(fvcc::VolumeBoundary<NeoN::scalar>(
+            mesh,
+            Dictionary({{"type", std::string("fixedValue")}, {"fixedValue", NeoN::scalar(1.0)}}),
+            0
+        ));
+        bcs.push_back(fvcc::VolumeBoundary<NeoN::scalar>(
+            mesh,
+            Dictionary({{"type", std::string("fixedValue")}, {"fixedValue", NeoN::scalar(2.0)}}),
+            1
+        ));
+        auto phi = fvcc::VolumeField<NeoN::scalar>(exec, "phi", mesh, bcs);
+        fill(phi.internalVector(), NeoN::scalar(1.0));
+        phi.correctBoundaryConditions();
+
+        auto ls = NeoN::la::createEmptyLinearSystem<NeoN::scalar>(mesh);
+        dsl::SpatialOperator divOp = dsl::imp::div(faceFlux, phi);
+        divOp.read(input);
+
+        divOp.implicitOperation(ls);
+        auto bRhsFirst = ls.boundaryRhs().copyToHost();
+
+        // second call without reset: bRhs must accumulate, not overwrite
+        divOp.implicitOperation(ls);
+        auto bRhsSecond = ls.boundaryRhs().copyToHost();
+
+        auto bRhsFirstV = bRhsFirst.view();
+        auto bRhsSecondV = bRhsSecond.view();
+        for (localIdx i = 0; i < bRhsFirstV.size(); i++)
+        {
+            REQUIRE(NeoN::mag(bRhsFirstV[i]) > 0);
+            REQUIRE(bRhsSecondV[i] == Catch::Approx(2.0 * bRhsFirstV[i]).margin(1e-8));
+        }
+    }
+
+    SECTION("bValues has correct sign and accumulates for fixedGradient BC on " + execName)
+    {
+        std::vector<fvcc::VolumeBoundary<NeoN::scalar>> bcs;
+        bcs.push_back(fvcc::VolumeBoundary<NeoN::scalar>(
+            mesh,
+            Dictionary(
+                {{"type", std::string("fixedGradient")}, {"fixedGradient", NeoN::scalar(1.0)}}
+            ),
+            0
+        ));
+        bcs.push_back(fvcc::VolumeBoundary<NeoN::scalar>(
+            mesh,
+            Dictionary(
+                {{"type", std::string("fixedGradient")}, {"fixedGradient", NeoN::scalar(1.0)}}
+            ),
+            1
+        ));
+        auto phi = fvcc::VolumeField<NeoN::scalar>(exec, "phi", mesh, bcs);
+        fill(phi.internalVector(), NeoN::scalar(1.0));
+        phi.correctBoundaryConditions();
+
+        auto ls = NeoN::la::createEmptyLinearSystem<NeoN::scalar>(mesh);
+        dsl::SpatialOperator divOp = dsl::imp::div(faceFlux, phi);
+        divOp.read(input);
+
+        divOp.implicitOperation(ls);
+        auto bValuesFirst = ls.boundaryMatrix().values().copyToHost();
+        auto bRhsFirst = ls.boundaryRhs().copyToHost();
+
+        // second call without reset: contributions must accumulate, not overwrite
+        divOp.implicitOperation(ls);
+        auto bValuesSecond = ls.boundaryMatrix().values().copyToHost();
+        auto bRhsSecond = ls.boundaryRhs().copyToHost();
+
+        auto bValuesFirstV = bValuesFirst.view();
+        auto bValuesSecondV = bValuesSecond.view();
+        auto bRhsFirstV = bRhsFirst.view();
+        auto bRhsSecondV = bRhsSecond.view();
+        for (localIdx i = 0; i < bValuesFirstV.size(); i++)
+        {
+            // bValues stores the inverse of the diagonal contribution (bValues -= valueMat)
+            // so bValues must be negative when the diagonal contribution is positive
+            REQUIRE(bValuesFirstV[i] < 0);
+            REQUIRE(bValuesSecondV[i] == Catch::Approx(2.0 * bValuesFirstV[i]).margin(1e-8));
+        }
+        for (localIdx i = 0; i < bRhsFirstV.size(); i++)
+        {
+            REQUIRE(bRhsSecondV[i] == Catch::Approx(2.0 * bRhsFirstV[i]).margin(1e-8));
+        }
+    }
 }
+
+} // namespace NeoN

--- a/test/finiteVolume/cellCentred/operator/laplacianOperator.cpp
+++ b/test/finiteVolume/cellCentred/operator/laplacianOperator.cpp
@@ -136,4 +136,98 @@ TEMPLATE_TEST_CASE("laplacianOperator fixedValue", "[template]", scalar, Vec3)
     }
 }
 
+TEMPLATE_TEST_CASE("laplacianOperator boundary contributions are accumulated", "[template]", scalar)
+{
+    auto [execName, exec] = GENERATE(allAvailableExecutor());
+
+    const NeoN::localIdx nCells = 10;
+    auto mesh = create1DUniformMesh(exec, nCells);
+
+    auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<scalar>>(mesh);
+    fvcc::SurfaceField<scalar> gamma(exec, "gamma", mesh, surfaceBCs);
+    fill(gamma.internalVector(), 1.0);
+
+    std::vector<fvcc::VolumeBoundary<TestType>> bcs;
+    bcs.push_back(fvcc::VolumeBoundary<TestType>(
+        mesh,
+        Dictionary({{"type", std::string("fixedValue")}, {"fixedValue", 0.5 * one<TestType>()}}),
+        0
+    ));
+    bcs.push_back(fvcc::VolumeBoundary<TestType>(
+        mesh,
+        Dictionary({{"type", std::string("fixedValue")}, {"fixedValue", 10.5 * one<TestType>()}}),
+        1
+    ));
+
+    auto phi = fvcc::VolumeField<TestType>(exec, "phi", mesh, bcs);
+    parallelFor(
+        phi.internalVector(),
+        NEON_LAMBDA(const localIdx i) { return scalar(i + 1) * one<TestType>(); }
+    );
+    phi.correctBoundaryConditions();
+
+    Input input =
+        TokenList({std::string("Gauss"), std::string("linear"), std::string("uncorrected")});
+
+    if constexpr (std::is_same_v<TestType, scalar>)
+    {
+        SECTION("bValues and bRhs accumulate on repeated calls on " + execName)
+        {
+            auto ls = la::createEmptyLinearSystem<TestType>(mesh);
+            dsl::SpatialOperator lapOp = dsl::imp::laplacian(gamma, phi);
+            lapOp.read(input);
+
+            lapOp.implicitOperation(ls);
+            auto bValuesFirst = ls.boundaryMatrix().values().copyToHost();
+            auto bRhsFirst = ls.boundaryRhs().copyToHost();
+
+            // second call without reset: bValues and bRhs must accumulate, not overwrite
+            lapOp.implicitOperation(ls);
+            auto bValuesSecond = ls.boundaryMatrix().values().copyToHost();
+            auto bRhsSecond = ls.boundaryRhs().copyToHost();
+
+            auto bValuesFirstV = bValuesFirst.view();
+            auto bValuesSecondV = bValuesSecond.view();
+            auto bRhsFirstV = bRhsFirst.view();
+            auto bRhsSecondV = bRhsSecond.view();
+
+            for (localIdx i = 0; i < bValuesFirstV.size(); i++)
+            {
+                // fixedValue BC: boundary contribution to diagonal is positive (atomic_sub
+                // counterpart stored in bValues with matching sign)
+                REQUIRE(bValuesFirstV[i] > 0);
+                REQUIRE(bValuesSecondV[i] == Catch::Approx(2.0 * bValuesFirstV[i]).margin(1e-8));
+            }
+            for (localIdx i = 0; i < bRhsFirstV.size(); i++)
+            {
+                REQUIRE(bRhsFirstV[i] > 0);
+                REQUIRE(bRhsSecondV[i] == Catch::Approx(2.0 * bRhsFirstV[i]).margin(1e-8));
+            }
+        }
+
+        SECTION("removeBoundaryContributions restores interior-only diagonal on " + execName)
+        {
+            auto ls = la::createEmptyLinearSystem<TestType>(mesh);
+            dsl::SpatialOperator lapOp = dsl::imp::laplacian(gamma, phi);
+            lapOp.read(input);
+            lapOp.implicitOperation(ls);
+
+            auto lsNoBnd = la::removeBoundaryContributions(ls);
+            auto diagHost = lsNoBnd.matrix().diag().copyToHost();
+            auto diagV = diagHost.view();
+
+            // interior cells have 2 interior face neighbors; boundary cells have 1.
+            // after removing boundary contributions, each cell's diagonal reflects only
+            // interior face connections — boundary cells should have exactly half the
+            // magnitude of interior cells on a uniform 1D mesh.
+            for (localIdx i = 1; i < nCells - 1; i++)
+            {
+                REQUIRE(diagV[i] == Catch::Approx(diagV[1]).margin(1e-8));
+            }
+            REQUIRE(diagV[0] == Catch::Approx(0.5 * diagV[1]).margin(1e-8));
+            REQUIRE(diagV[nCells - 1] == Catch::Approx(0.5 * diagV[1]).margin(1e-8));
+        }
+    }
+}
+
 } // namespace NeoN

--- a/test/mesh/unstructured/unstructuredMesh.cpp
+++ b/test/mesh/unstructured/unstructuredMesh.cpp
@@ -161,9 +161,9 @@ TEST_CASE("Unstructured Mesh")
     {
         NeoN::localIdx nx = 3;
         NeoN::localIdx ny = 2;
-        NeoN::scalar Lx = 3.0;
-        NeoN::scalar Ly = 2.0;
-        auto mesh = NeoN::create2DUniformMesh(exec, nx, ny, Lx, Ly);
+        NeoN::scalar lx = 3.0;
+        NeoN::scalar ly = 2.0;
+        auto mesh = NeoN::create2DUniformMesh(exec, nx, ny, lx, ly);
 
         // 3x2 mesh: 6 hex cells, (3-1)*2 + 3*(2-1) = 4+3 = 7 internal faces
         // boundary: left(2) + right(2) + bottom(3) + top(3) = 10
@@ -272,10 +272,10 @@ TEST_CASE("Unstructured Mesh")
         NeoN::localIdx nx = 3;
         NeoN::localIdx ny = 2;
         NeoN::localIdx nz = 2;
-        NeoN::scalar Lx = 3.0;
-        NeoN::scalar Ly = 2.0;
-        NeoN::scalar Lz = 2.0;
-        auto mesh = NeoN::create3DUniformMesh(exec, nx, ny, nz, Lx, Ly, Lz);
+        NeoN::scalar lx = 3.0;
+        NeoN::scalar ly = 2.0;
+        NeoN::scalar lz = 2.0;
+        auto mesh = NeoN::create3DUniformMesh(exec, nx, ny, nz, lx, ly, lz);
 
         // 3x2x2: 12 cells
         // internal: x:(3-1)*2*2=8, y:3*(2-1)*2=6, z:3*2*(2-1)=6 → 20


### PR DESCRIPTION
This PR adds a function to remove boundary contributions from the matrix diagonal. The reasoning is that other CFD frameworks might or might not add boundary contributions to the diagonal matrix. Currently, NeoN directly adds the boundary contributions to the diagonal matrix and stores them in the boundMatrix. To simplify testing a function is added to remove these contributions.

**Additionally**:
-  This PR fixes the inconsistent handling of the boundary RHS vector where the values are overwritten instead of added by the operator.
- Not installing all required fmt targets
- add .bck and .claude to gitignore. This also prevents reuse from complaining