### PR TITLE
Redesign matcher for unit testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Correct the Ginkgo version to 2.0.0 (unreleased) [#493](https://github.com/exasim-project/NeoN/pull/493)
 - Add tensor and symmTensor primitives, Su type sourceTerm and passing of fields to BCs [#428](https://github.com/exasim-project/NeoN/pull/428)
 - Add uniform mesh generator [#475](https://github.com/exasim-project/NeoN/pull/475)
+- Bump Ginkgo to 2.0,0 (unreleased version) [#475](https://github.com/exasim-project/NeoN/pull/475)
 
 ### Misc
 - Bump Ginkgo to 1.11 and Kokkos 4.7.01 [#409](https://github.com/exasim-project/NeoN/pull/409)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 - Correct the Ginkgo version to 2.0.0 (unreleased) [#493](https://github.com/exasim-project/NeoN/pull/493)
 - Add tensor and symmTensor primitives, Su type sourceTerm and passing of fields to BCs [#428](https://github.com/exasim-project/NeoN/pull/428)
 - Add uniform mesh generator [#475](https://github.com/exasim-project/NeoN/pull/475)
-- Bump Ginkgo to 2.0,0 (unreleased version) [#475](https://github.com/exasim-project/NeoN/pull/475)
 
 ### Misc
 - Bump Ginkgo to 1.11 and Kokkos 4.7.01 [#409](https://github.com/exasim-project/NeoN/pull/409)

--- a/test/catch2/catch2_common.hpp
+++ b/test/catch2/catch2_common.hpp
@@ -29,7 +29,7 @@ using I = std::initializer_list<T>;
 /**
  *  @brief Predicate for approximate floating-point comparison within a given margin.
  *
- * Used with @ref EqualsRangeMatcher and @ref IsEqualTo to compare scalar values
+ * Used with @ref EqualsMatcher and @ref Equals to compare scalar values
  * using Catch2's Approx mechanism, allowing for a configurable absolute tolerance.
  */
 struct ApproxScalar
@@ -53,8 +53,8 @@ struct ApproxScalar
  * Performs component-wise floating-point comparison using Catch2's
  * @ref Catch::Approx with a configurable absolute tolerance.
  *
- * This predicate is intended for use with @ref EqualsRangeMatcher and
- * @ref IsEqualTo when comparing vector-valued fields (e.g. cell centres,
+ * This predicate is intended for use with @ref EqualsMatcher and
+ * @ref Equals when comparing vector-valued fields (e.g. cell centres,
  * face centres, geometric quantities).
  *
  * Each component of the vector is compared independently using the same
@@ -67,8 +67,8 @@ struct ApproxScalar
  *     {0.375, 0.5, 0.5}
  * };
  *
- * REQUIRE_THAT(expected,
- *              IsEqualTo(mesh.cellCentres(), ApproxVec3{1e-12}));
+ * REQUIRE_THAT(mesh.cellCentres(),
+ *              Equals(expected, ApproxVec3{1e-12}));
  * @endcode
  */
 struct ApproxVec3
@@ -98,7 +98,7 @@ struct ApproxVec3
 
 /** @brief Predicate for exact equality comparison using the built-in == operator.
  *
- * Used with @ref EqualsRangeMatcher and @ref IsEqualTo to compare integer or
+ * Used with @ref EqualsMatcher and @ref Equals to compare integer or
  * other exactly-comparable types (e.g. NeoN::Vec3, NeoN::label).
  */
 struct EqualInt
@@ -111,50 +111,6 @@ struct EqualInt
     bool operator()(auto rhs, auto lhs) const { return rhs == lhs; }
 };
 
-
-/**
- * @brief Catch2 matcher that compares a NeoN device field against an expected std::vector.
- *
- * Copies the field to host on construction, then element-wise compares it against
- * the expected vector using the supplied predicate.
- *
- * @tparam Range     A NeoN field type that exposes @c copyToHost() and @c view().
- * @tparam Predicate A binary callable returning @c bool, e.g. @ref ApproxScalar or @ref
- EqualInt.
- */
-template<typename Range, typename Predicate>
-struct EqualsRangeMatcher : Catch::Matchers::MatcherGenericBase
-{
-    /**
-     * @brief Constructs the matcher, copying @p range to host memory.
-     * @param range The device field to compare against.
-     * @param pred  The predicate used for element-wise comparison.
-     */
-    EqualsRangeMatcher(const Range range, Predicate pred) : range {range.copyToHost()}, pred_(pred)
-    {}
-
-    /** @brief Performs the element-wise comparison against @p other.
-     * @tparam ValueType Element type of the expected vector.
-     * @param other The expected values as a @c std::vector.
-     * @return @c true if all elements compare equal under the stored predicate.
-     */
-    template<typename ValueType>
-    bool match(const ValueType other) const
-    {
-        using std::begin;
-        using std::end;
-        return std::equal(begin(range.view()), end(range.view()), begin(other), end(other), pred_);
-    }
-
-    /** @brief Returns a human-readable description of the matcher for Catch2 failure
-     * messages. */
-    std::string describe() const override { return "!= " + Catch::rangeToString(range.view()); }
-
-private:
-
-    const Range range;     ///< Host copy of the device field.
-    const Predicate pred_; ///< Predicate used for element-wise comparison.
-};
 
 /**
  * @brief Catch2 matcher for element-wise comparison between an actual field and expected values.
@@ -238,28 +194,6 @@ private:
     Predicate pred_;    ///< Predicate used for element-wise comparison.
 };
 
-/**
- * @brief Factory function that creates an @ref EqualsRangeMatcher for a NeoN field.
- *
- * Typical usage:
- * @code
- * REQUIRE_THAT(expected_vec, IsEqualTo(mesh.faceOwner(), EqualInt()));
- * REQUIRE_THAT(expected_vec, IsEqualTo(field, ApproxScalar(1e-15)));
- * @endcode
- *
- * @tparam Range     A NeoN field type that exposes @c copyToHost() and @c view().
- * @tparam Predicate A binary callable returning @c bool (default: @ref ApproxScalar).
- * @param range The device field to compare against.
- * @param pred  The predicate used for element-wise comparison (default:
- * ApproxScalar(1e-32)).
- * @return An @ref EqualsRangeMatcher configured with the given field and predicate.
- */
-template<typename Range, typename Predicate = ApproxScalar>
-auto IsEqualTo(const Range& range, Predicate pred = ApproxScalar(1e-32))
-    -> EqualsRangeMatcher<Range, Predicate>
-{
-    return EqualsRangeMatcher<Range, Predicate> {range, pred};
-}
 
 /**
  * @brief Factory function to create an @ref EqualsMatcher for element-wise comparison.

--- a/test/catch2/catch2_common.hpp
+++ b/test/catch2/catch2_common.hpp
@@ -183,10 +183,7 @@ struct EqualsMatcher : Catch::Matchers::MatcherGenericBase
      *
      * @return Description of the expected values.
      */
-    std::string describe() const override
-    {
-        return "is equal to " + Catch::rangeToString(expected_);
-    }
+    std::string describe() const override { return "equals " + Catch::rangeToString(expected_); }
 
 private:
 
@@ -226,3 +223,18 @@ auto Equals(Expected expected, Predicate pred = Predicate {1e-32})
 {
     return EqualsMatcher<Expected, Predicate> {std::move(expected), pred};
 }
+
+namespace Catch
+{
+
+template<typename T>
+struct StringMaker<NeoN::Vector<T>>
+{
+    static std::string convert(const NeoN::Vector<T>& v)
+    {
+        auto host = v.copyToHost();
+        return rangeToString(host.view());
+    }
+};
+
+} // namespace Catch

--- a/test/catch2/catch2_common.hpp
+++ b/test/catch2/catch2_common.hpp
@@ -119,7 +119,8 @@ struct EqualInt
  * the expected vector using the supplied predicate.
  *
  * @tparam Range     A NeoN field type that exposes @c copyToHost() and @c view().
- * @tparam Predicate A binary callable returning @c bool, e.g. @ref ApproxScalar or @ref EqualInt.
+ * @tparam Predicate A binary callable returning @c bool, e.g. @ref ApproxScalar or @ref
+ EqualInt.
  */
 template<typename Range, typename Predicate>
 struct EqualsRangeMatcher : Catch::Matchers::MatcherGenericBase
@@ -156,6 +157,88 @@ private:
 };
 
 /**
+ * @brief Catch2 matcher for element-wise comparison between an actual field and expected values.
+ *
+ * This matcher compares a NeoN field (or any compatible range) against an
+ * expected container using a user-provided predicate. The comparison is
+ * performed element-wise via @c std::equal.
+ *
+ * If the @p actual argument represents a device-resident field, it is first
+ * copied to host memory via @c copyToHost() before comparison.
+ *
+ * Typical usage:
+ * @code
+ * std::vector<NeoN::Vec3> expected = { ... };
+ *
+ * REQUIRE_THAT(mesh.cellCentres(),
+ *              Equals(expected, ApproxVec3{1e-12}));
+ * @endcode
+ *
+ * @tparam Expected   Container type holding expected values (e.g. std::vector).
+ * @tparam Predicate  Binary callable returning @c bool for comparing two elements
+ *                    (e.g. @ref ApproxScalar, @ref ApproxVec3, @ref EqualInt).
+ */
+template<typename Expected, typename Predicate>
+struct EqualsMatcher : Catch::Matchers::MatcherGenericBase
+{
+    /**
+     * @brief Constructs the matcher with expected values and comparison predicate.
+     *
+     * @param expected Container holding the expected values.
+     * @param pred     Predicate used for element-wise comparison.
+     */
+    EqualsMatcher(Expected expected, Predicate pred) : expected_(std::move(expected)), pred_(pred)
+    {}
+
+    /**
+     * @brief Performs element-wise comparison against the @p actual argument.
+     *
+     * The @p actual object is assumed to be a NeoN field (or compatible type)
+     * exposing @c copyToHost() and @c view(). The data is copied to host memory
+     * and compared against @ref expected_ using @ref pred_.
+     *
+     * @tparam Actual Type of the actual object passed by Catch2.
+     * @param actual  The object under test (typically a NeoN field).
+     * @return @c true if all elements compare equal under the predicate,
+     *         @c false otherwise.
+     */
+    template<typename Actual>
+    bool match(const Actual& actual) const
+    {
+        using std::begin;
+        using std::end;
+
+        // Copy device field to host if needed
+        auto actualHost = actual.copyToHost();
+
+        return std::equal(
+            begin(actualHost.view()),
+            end(actualHost.view()),
+            begin(expected_),
+            end(expected_),
+            pred_
+        );
+    }
+
+    /**
+     * @brief Returns a human-readable description of the matcher.
+     *
+     * This string is used by Catch2 when reporting assertion failures.
+     *
+     * @return Description of the expected values.
+     */
+    std::string describe() const override
+    {
+        return "is equal to " + Catch::rangeToString(expected_);
+    }
+
+private:
+
+    Expected expected_; ///< Container holding expected values.
+    Predicate pred_;    ///< Predicate used for element-wise comparison.
+};
+
+/**
  * @brief Factory function that creates an @ref EqualsRangeMatcher for a NeoN field.
  *
  * Typical usage:
@@ -176,4 +259,36 @@ auto IsEqualTo(const Range& range, Predicate pred = ApproxScalar(1e-32))
     -> EqualsRangeMatcher<Range, Predicate>
 {
     return EqualsRangeMatcher<Range, Predicate> {range, pred};
+}
+
+/**
+ * @brief Factory function to create an @ref EqualsMatcher for element-wise comparison.
+ *
+ * This function constructs an @ref EqualsMatcher that compares an actual range
+ * (e.g. NeoN field or container) against an expected container using a
+ * user-defined predicate.
+ *
+ * It is intended for use with Catch2's @ref REQUIRE_THAT macro:
+ * @code
+ * REQUIRE_THAT(mesh.cellCentres(),
+ *              Equals(expectedCentres, ApproxVec3{1e-12}));
+ * @endcode
+ *
+ * If no predicate is provided, @ref ApproxScalar is used by default for
+ * floating-point comparisons with a small tolerance.
+ *
+ * @tparam Expected   Type of the expected container (e.g. std::vector<T>).
+ * @tparam Predicate  Binary predicate used for element-wise comparison.
+ *                    Defaults to @ref ApproxScalar.
+ *
+ * @param expected    Container holding the expected values.
+ * @param pred        Predicate used for comparison (default: ApproxScalar{1e-32}).
+ *
+ * @return An @ref EqualsMatcher configured with the provided expected values
+ *         and comparison predicate.
+ */
+template<typename Expected, typename Predicate = ApproxScalar>
+auto Equals(Expected expected, Predicate pred = Predicate {1e-32})
+{
+    return EqualsMatcher<Expected, Predicate> {std::move(expected), pred};
 }

--- a/test/catch2/catch2_common.hpp
+++ b/test/catch2/catch2_common.hpp
@@ -227,9 +227,38 @@ auto Equals(Expected expected, Predicate pred = Predicate {1e-32})
 namespace Catch
 {
 
+/**
+ * @brief Catch2 string conversion for NeoN::Vector.
+ *
+ * This specialization of @c Catch::StringMaker enables Catch2 to print
+ * @c NeoN::Vector objects in assertion messages. Without this, Catch2
+ * falls back to a placeholder ("{?}") because it does not know how to
+ * convert the type to a string.
+ *
+ * The vector is first copied from device to host memory (if applicable)
+ * using @c copyToHost(), and then converted to a string using
+ * @c Catch::rangeToString.
+ *
+ * This allows assertions such as:
+ * @code
+ * REQUIRE_THAT(checkSparse, Equals(I({1.0, 5.0, 7.0, 8.0})));
+ * @endcode
+ * to produce informative output like:
+ * @code
+ * { 1.0, 5.0, 6.999999, 8.0 } is equal to { 1.0, 5.0, 7.0, 8.0 }
+ * @endcode
+ *
+ * @tparam T Value type stored in the NeoN::Vector.
+ */
 template<typename T>
 struct StringMaker<NeoN::Vector<T>>
 {
+    /**
+     * @brief Converts a NeoN::Vector into a human-readable string.
+     *
+     * @param v The vector to convert (possibly device-resident).
+     * @return A string representation of the vector contents.
+     */
     static std::string convert(const NeoN::Vector<T>& v)
     {
         auto host = v.copyToHost();

--- a/test/dsl/coeff.cpp
+++ b/test/dsl/coeff.cpp
@@ -30,17 +30,16 @@ TEST_CASE("Coeff")
         Coeff d {3.0, fA};
         dsl::detail::toVector(d, res);
         auto resDexp = std::vector<NeoN::scalar> {6.0, 6.0, 6.0};
-        REQUIRE_THAT(resDexp, IsEqualTo(res));
+        REQUIRE_THAT(res, Equals(resDexp));
 
         Coeff e = d * b;
         dsl::detail::toVector(e, res);
         auto resEexp = std::vector<NeoN::scalar> {12.0, 12.0, 12.0};
-        REQUIRE_THAT(resEexp, IsEqualTo(res));
-
+        REQUIRE_THAT(res, Equals(resEexp));
         Coeff f = b * d;
         dsl::detail::toVector(f, res);
         auto resFexp = std::vector<NeoN::scalar> {12.0, 12.0, 12.0};
-        REQUIRE_THAT(resFexp, IsEqualTo(res));
+        REQUIRE_THAT(res, Equals(resFexp));
     }
 
     SECTION("evaluation in parallelFor" + execName)
@@ -57,7 +56,7 @@ TEST_CASE("Coeff")
                 fieldA, NEON_LAMBDA(const NeoN::localIdx i) { return c[i] + 2.0; }
             );
             auto resAexp = std::vector<NeoN::scalar> {3.0, 3.0, 3.0};
-            REQUIRE_THAT(resAexp, IsEqualTo(fieldA));
+            REQUIRE_THAT(fieldA, Equals(resAexp));
         }
 
         SECTION("scalar")
@@ -67,7 +66,7 @@ TEST_CASE("Coeff")
                 fieldA, NEON_LAMBDA(const NeoN::localIdx i) { return c[i] + 2.0; }
             );
             auto resAexp = std::vector<NeoN::scalar> {4.0, 4.0, 4.0};
-            REQUIRE_THAT(resAexp, IsEqualTo(fieldA));
+            REQUIRE_THAT(fieldA, Equals(resAexp));
         }
 
         SECTION("view and scalar")
@@ -77,7 +76,7 @@ TEST_CASE("Coeff")
                 fieldA, NEON_LAMBDA(const NeoN::localIdx i) { return c[i] + 2.0; }
             );
             auto resAexp = std::vector<NeoN::scalar> {-3.0, -3.0, -3.0};
-            REQUIRE_THAT(resAexp, IsEqualTo(fieldA));
+            REQUIRE_THAT(fieldA, Equals(resAexp));
         }
     }
 }

--- a/test/finiteVolume/cellCentred/operator/sourceTerm.cpp
+++ b/test/finiteVolume/cellCentred/operator/sourceTerm.cpp
@@ -88,7 +88,7 @@ TEMPLATE_TEST_CASE("SourceTerm Su constructor", "[template]", NeoN::scalar, NeoN
         sTerm.explicitOperation(source);
 
         auto exp = std::vector<TestType>(static_cast<size_t>(coeff.size()), 5 * one<TestType>());
-        REQUIRE_THAT(exp, IsEqualTo(source, EqualInt()));
+        REQUIRE_THAT(source, Equals(exp, EqualInt()));
     }
 }
 

--- a/test/linearAlgebra/faceToMatrixAddress.cpp
+++ b/test/linearAlgebra/faceToMatrixAddress.cpp
@@ -36,7 +36,7 @@ TEST_CASE("FaceToMatrixAddress")
     SECTION("has correct diagOffs" + execName)
     {
         auto exp = std::vector<NeoN::localIdx> {0, 1, 1, 1, 1, 1, 1, 1, 1, 1};
-        REQUIRE_THAT(exp, IsEqualTo(mi->diagOffset(), EqualInt()));
+        REQUIRE_THAT(mi->diagOffset(), Equals(exp, EqualInt()));
     }
 }
 

--- a/test/linearAlgebra/matrix.cpp
+++ b/test/linearAlgebra/matrix.cpp
@@ -79,7 +79,7 @@ TEMPLATE_TEST_CASE("Matrix", "[template]", NeoN::scalar)
                 checkSparseView[3] = csrView.entry(2, 1);
             }
         );
-        REQUIRE_THAT(I({1.0, 5.0, 6.0, 8.0}), IsEqualTo(checkSparse));
+        REQUIRE_THAT(checkSparse, Equals(I({1.0, 5.0, 6.0, 8.0})));
 
         // Dense
         NeoN::Vector<NeoN::scalar> checkDense(exec, 9);
@@ -101,24 +101,24 @@ TEMPLATE_TEST_CASE("Matrix", "[template]", NeoN::scalar)
             }
         );
 
-        auto expDense = std::vector<NeoN::scalar> {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0};
-        REQUIRE_THAT(expDense, IsEqualTo(checkDense));
+        auto denseExp = std::vector<NeoN::scalar> {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0};
+        REQUIRE_THAT(checkDense, Equals(denseExp));
     }
 
     SECTION("Can extract diagonal " + execName)
     {
-        REQUIRE_THAT(I({1.0, 5.0, 0.0}), IsEqualTo(sparseMatrix.diag()));
+        REQUIRE_THAT(sparseMatrix.diag(), Equals(I({1.0, 5.0, 0.0})));
     }
 
     SECTION("Can extract diagonal " + execName)
     {
-        REQUIRE_THAT(I({1.0, 5.0, 9.0}), IsEqualTo(denseMatrix.diag()));
+        REQUIRE_THAT(denseMatrix.diag(), Equals(I({1.0, 5.0, 9.0})));
     }
 
     SECTION("Can extract upper " + execName)
     {
         auto upper = NeoN::la::upper(denseMatrix);
-        REQUIRE_THAT(I({2.0, 3.0, 6.0}), IsEqualTo(upper));
+        REQUIRE_THAT(upper, Equals(I({2.0, 3.0, 6.0})));
     }
 
     // SECTION("Can computed scaledInverseDiagonal " + execName)
@@ -158,7 +158,7 @@ TEMPLATE_TEST_CASE("Matrix", "[template]", NeoN::scalar)
                 csrView.entry(2, 1) = -8.0;
             }
         );
-        REQUIRE_THAT(I({-1.0, -5.0, -6.0, -8.0}), IsEqualTo(sparseMatrix.values()));
+        REQUIRE_THAT(sparseMatrix.values(), Equals(I({-1.0, -5.0, -6.0, -8.0})));
 
         // Dense
         auto denseView = denseMatrix.view();
@@ -178,8 +178,7 @@ TEMPLATE_TEST_CASE("Matrix", "[template]", NeoN::scalar)
             }
         );
         REQUIRE_THAT(
-            I({-1.0, -2.0, -3.0, -4.0, -5.0, -6.0, -7.0, -8.0, -9.0}),
-            IsEqualTo(denseMatrix.values())
+            denseMatrix.values(), Equals(I({-1.0, -2.0, -3.0, -4.0, -5.0, -6.0, -7.0, -8.0, -9.0}))
         );
     }
 
@@ -189,13 +188,13 @@ TEMPLATE_TEST_CASE("Matrix", "[template]", NeoN::scalar)
         NeoN::Vector<NeoN::scalar> checkSparse(exec, 4);
         auto csrView = sparseMatrixConst.view();
         checkSparse.apply(NEON_LAMBDA(const NeoN::localIdx i) { return csrView.entry(i); });
-        REQUIRE_THAT(I({1.0, 5.0, 6.0, 8.0}), IsEqualTo(checkSparse));
+        REQUIRE_THAT(checkSparse, Equals(I({1.0, 5.0, 6.0, 8.0})));
 
         // Dense
         NeoN::Vector<NeoN::scalar> checkDense(exec, 9);
         auto denseView = denseMatrixConst.view();
         checkDense.apply(NEON_LAMBDA(const NeoN::localIdx i) { return denseView.entry(i); });
-        REQUIRE_THAT(I({1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0}), IsEqualTo(checkDense));
+        REQUIRE_THAT(checkDense, Equals(I({1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0})));
     }
 
     SECTION("Update existing directValue on " + execName)
@@ -212,7 +211,7 @@ TEMPLATE_TEST_CASE("Matrix", "[template]", NeoN::scalar)
                 csrView.entry(3) = -8.0;
             }
         );
-        REQUIRE_THAT(I({-1.0, -5.0, -6.0, -8.0}), IsEqualTo(sparseMatrix.values()));
+        REQUIRE_THAT(sparseMatrix.values(), Equals(I({-1.0, -5.0, -6.0, -8.0})));
 
         // Dense
         auto denseView = denseMatrix.view();
@@ -232,8 +231,7 @@ TEMPLATE_TEST_CASE("Matrix", "[template]", NeoN::scalar)
             }
         );
         REQUIRE_THAT(
-            I({-1.0, -2.0, -3.0, -4.0, -5.0, -6.0, -7.0, -8.0, -9.0}),
-            IsEqualTo(denseMatrix.values())
+            denseMatrix.values(), Equals(I({-1.0, -2.0, -3.0, -4.0, -5.0, -6.0, -7.0, -8.0, -9.0}))
         );
     }
 

--- a/test/linearAlgebra/sparsityPattern.cpp
+++ b/test/linearAlgebra/sparsityPattern.cpp
@@ -40,8 +40,8 @@ TEST_CASE("SparsityPattern")
         auto rowPtrExp = std::vector<localIdx> {0, 2, 5, 8, 10};
         auto colIdxExp = std::vector<localIdx> {0, 1, 0, 1, 2, 1, 2, 3, 2, 3};
 
-        REQUIRE_THAT(rowPtrExp, IsEqualTo(sp->rowOffs(), EqualInt()));
-        REQUIRE_THAT(colIdxExp, IsEqualTo(sp->colIdxs(), EqualInt()));
+        REQUIRE_THAT(sp->rowOffs(), Equals(rowPtrExp, EqualInt()));
+        REQUIRE_THAT(sp->colIdxs(), Equals(colIdxExp, EqualInt()));
     }
 }
 

--- a/test/linearAlgebra/utilities.cpp
+++ b/test/linearAlgebra/utilities.cpp
@@ -65,14 +65,14 @@ TEST_CASE("Utilities")
     {
         auto res = NeoN::la::unpackRowOffs(rowOffs);
         auto rowOffsExp = std::vector<localIdx> {0, 3, 6, 9, 12, 15, 18, 21, 24, 27};
-        REQUIRE_THAT(rowOffsExp, IsEqualTo(res, EqualInt()));
+        REQUIRE_THAT(res, Equals(rowOffsExp, EqualInt()));
     }
 
     SECTION("Can unpackRowOffs2 " + execName)
     {
         auto res = NeoN::la::unpackRowOffs(rowOffsS);
         auto exp = std::vector<localIdx> {0, 2, 4, 6, 9, 12, 15, 17, 19, 21};
-        REQUIRE_THAT(exp, IsEqualTo(res, EqualInt()));
+        REQUIRE_THAT(res, Equals(exp, EqualInt()));
     }
 
     SECTION("Can unpack mtxValues " + execName)
@@ -82,7 +82,7 @@ TEST_CASE("Utilities")
         auto exp = std::vector<scalar> {1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0,
                                         4.0, 5.0, 6.0, 4.0, 5.0, 6.0, 4.0, 5.0, 6.0,
                                         7.0, 8.0, 9.0, 7.0, 8.0, 9.0, 7.0, 8.0, 9.0};
-        REQUIRE_THAT(exp, IsEqualTo(res));
+        REQUIRE_THAT(res, Equals(exp));
     }
 
     SECTION("Can unpackColIdx sparse " + execName)
@@ -103,7 +103,7 @@ TEST_CASE("Utilities")
             4, 7,    // row 8
             5, 8     // row 9
         };
-        REQUIRE_THAT(colIdxExp, IsEqualTo(res, EqualInt()));
+        REQUIRE_THAT(res, Equals(colIdxExp, EqualInt()));
     }
 
     SECTION("Can unpackColIdx dense " + execName)
@@ -124,7 +124,7 @@ TEST_CASE("Utilities")
             1, 4, 7, // row 8
             2, 5, 8  // row 9
         };
-        REQUIRE_THAT(colIdxExp, IsEqualTo(res, EqualInt()));
+        REQUIRE_THAT(res, Equals(colIdxExp, EqualInt()));
     }
 
     // Residual of scalar matrix
@@ -143,6 +143,6 @@ TEST_CASE("Utilities")
         NeoN::la::computeResidual(csrMatrix, rhs, x, res);
 
         auto residualExp = std::vector<scalar> {4.0, 13.0, 22.0};
-        REQUIRE_THAT(residualExp, IsEqualTo(res, ApproxScalar(1e-15)));
+        REQUIRE_THAT(res, Equals(residualExp, ApproxScalar(1e-15)));
     }
 }

--- a/test/mesh/unstructured/unstructuredMesh.cpp
+++ b/test/mesh/unstructured/unstructuredMesh.cpp
@@ -175,7 +175,7 @@ TEST_CASE("Unstructured Mesh")
 
         // Cell volume = (3/3) * (2/2) * 1.0 = 1.0
         auto cellVolumesExp = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
-        // REQUIRE_THAT(cellVolumesExp, IsEqualTo(mesh.cellVolumes(), ApproxScalar(1e-12)));
+        REQUIRE_THAT(mesh.cellVolumes(), Equals(cellVolumesExp, ApproxScalar(1e-12)));
     }
 
     SECTION("2D mesh patch face centres lie on correct planes (3x2) " + execName)
@@ -215,7 +215,7 @@ TEST_CASE("Unstructured Mesh")
             {1.5, ymax, 0.5},
             {2.5, ymax, 0.5} // top
         };
-        // REQUIRE_THAT(cfExp, IsEqualTo(bm.cf(), ApproxVec3 {1e-12}));
+        REQUIRE_THAT(bm.cf(), Equals(cfExp, ApproxVec3 {1e-12}));
     }
 
     SECTION("Can create a uniform 3D mesh (2x2x2) " + execName)

--- a/test/mesh/unstructured/unstructuredMesh.cpp
+++ b/test/mesh/unstructured/unstructuredMesh.cpp
@@ -61,21 +61,20 @@ TEST_CASE("Unstructured Mesh")
 
         // Verify face neighbours (x-direction)
         auto faceNeighbourExp = std::vector<NeoN::label> {1, 2, 3};
-        // REQUIRE_THAT(faceNeighbourExp, IsEqualTo(mesh.faceNeighbour(), EqualInt()));
         REQUIRE_THAT(mesh.faceNeighbour(), Equals(faceNeighbourExp, EqualInt()));
 
         // Verify boundary mesh: first 2 boundary faces are xmin/xmax
         // Verify neighbouring cell for boundary faces
         auto faceCellsExp = std::vector<NeoN::localIdx> {0, 3};
-        // REQUIRE_THAT(faceCellsExp, IsEqualTo(mesh.boundaryMesh().faceCells(), EqualInt()));
+        REQUIRE_THAT(mesh.boundaryMesh().faceCells(), Equals(faceCellsExp, EqualInt()));
 
         // // Verify neighbor cell centres
         auto cnExp = std::vector<NeoN::Vec3> {{0.125, 0.5, 0.5}, {0.875, 0.5, 0.5}};
-        // REQUIRE_THAT(cnExp, IsEqualTo(mesh.boundaryMesh().cn(), ApproxVec3 {1e-12}));
+        REQUIRE_THAT(mesh.boundaryMesh().cn(), Equals(cnExp, ApproxVec3 {1e-12}));
 
         // // Verify delta vectors
         auto deltaExp = std::vector<NeoN::Vec3> {{-0.125, 0.0, 0.0}, {0.125, 0.0, 0.0}};
-        // REQUIRE_THAT(deltaExp, IsEqualTo(mesh.boundaryMesh().delta(), ApproxVec3 {1e-12}));
+        REQUIRE_THAT(mesh.boundaryMesh().delta(), Equals(deltaExp, ApproxVec3 {1e-12}));
 
         // Verify stencilDB has patchNames
         REQUIRE(mesh.stencilDB().contains(std::string("stencilPatchNames")));
@@ -106,13 +105,13 @@ TEST_CASE("Unstructured Mesh")
 
         // Verify cell volumes (each cell is 0.5 * 0.5 * 1.0 = 0.25)
         auto cellVolumesExp = {0.25, 0.25, 0.25, 0.25};
-        // REQUIRE_THAT(cellVolumesExp, IsEqualTo(mesh.cellVolumes(), ApproxScalar(1e-12)));
+        REQUIRE_THAT(mesh.cellVolumes(), Equals(cellVolumesExp, ApproxScalar(1e-12)));
 
         // Verify cell centres (z should be 0.5, halfway through the slab)
         auto cellCentresExp = std::vector<NeoN::Vec3> {
             {0.25, 0.25, 0.5}, {0.75, 0.25, 0.5}, {0.25, 0.75, 0.5}, {0.75, 0.75, 0.5}
         };
-        // REQUIRE_THAT(cellCentresExp, IsEqualTo(mesh.cellCentres(), ApproxVec3 {1e-12}));
+        REQUIRE_THAT(mesh.cellCentres(), Equals(cellCentresExp, ApproxVec3 {1e-12}));
 
         // Verify the number of neighbouring cells for boundary faces
         // 4 patches: left(2), right(2), bottom(2), top(2)
@@ -131,7 +130,7 @@ TEST_CASE("Unstructured Mesh")
             {0.0, 0.25, 0.0},
             {0.0, 0.25, 0.0}
         };
-        // REQUIRE_THAT(boundaryDeltaExp, IsEqualTo(bm.delta(), ApproxVec3 {1e-12}));
+        REQUIRE_THAT(bm.delta(), Equals(boundaryDeltaExp, ApproxVec3 {1e-12}));
     }
 
     SECTION("Uniform 2D mesh stores patch names in stencilDB " + execName)

--- a/test/mesh/unstructured/unstructuredMesh.cpp
+++ b/test/mesh/unstructured/unstructuredMesh.cpp
@@ -243,7 +243,7 @@ TEST_CASE("Unstructured Mesh")
 
         // Each cell is 0.5 * 0.5 * 0.5 = 0.125
         auto cellVolumesExp = {0.125, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125};
-        // REQUIRE_THAT(cellVolumesExp, IsEqualTo(mesh.cellVolumes(), ApproxScalar(1e-12)));
+        REQUIRE_THAT(mesh.cellVolumes(), Equals(cellVolumesExp, ApproxScalar(1e-12)));
 
         // Cell centres at 0.25 increments
         // cell(0,0,0) → (0.25, 0.25, 0.25)
@@ -258,7 +258,7 @@ TEST_CASE("Unstructured Mesh")
             {0.25, 0.75, 0.75},
             {0.75, 0.75, 0.75}
         };
-        // REQUIRE_THAT(cellCentresExp, IsEqualTo(mesh.cellCentres(), ApproxVec3 {1e-12}));
+        REQUIRE_THAT(mesh.cellCentres(), Equals(cellCentresExp, ApproxVec3 {1e-12}));
 
         // Boundary delta: left boundary first face should have negative x delta
         auto hostBndDelta = mesh.boundaryMesh().delta().copyToHost();
@@ -289,7 +289,7 @@ TEST_CASE("Unstructured Mesh")
         // Cell volume = (3/3) * (2/2) * (2/2) = 1.0
         auto cellVolumesExp =
             std::vector<NeoN::scalar> {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
-        REQUIRE_THAT(cellVolumesExp, IsEqualTo(mesh.cellVolumes(), ApproxScalar(1e-12)));
+        REQUIRE_THAT(mesh.cellVolumes(), Equals(cellVolumesExp, ApproxScalar(1e-12)));
     }
 
     SECTION("3D mesh patch face centres lie on correct planes (3x2x4) " + execName)

--- a/test/mesh/unstructured/unstructuredMesh.cpp
+++ b/test/mesh/unstructured/unstructuredMesh.cpp
@@ -53,28 +53,29 @@ TEST_CASE("Unstructured Mesh")
         auto cellCentresExp = std::vector<NeoN::Vec3> {
             {0.125, 0.5, 0.5}, {0.375, 0.5, 0.5}, {0.625, 0.5, 0.5}, {0.875, 0.5, 0.5}
         };
-        REQUIRE_THAT(cellCentresExp, IsEqualTo(mesh.cellCentres(), ApproxVec3 {1e-12}));
+        REQUIRE_THAT(mesh.cellCentres(), Equals(cellCentresExp, ApproxVec3 {1e-12}));
 
         // Verify face owners (x-direction)
         auto faceOwnerExp = std::vector<NeoN::label> {0, 1, 2, 0, 3};
-        REQUIRE_THAT(faceOwnerExp, IsEqualTo(mesh.faceOwner(), EqualInt()));
+        REQUIRE_THAT(mesh.faceOwner(), Equals(faceOwnerExp, EqualInt()));
 
         // Verify face neighbours (x-direction)
         auto faceNeighbourExp = std::vector<NeoN::label> {1, 2, 3};
-        REQUIRE_THAT(faceNeighbourExp, IsEqualTo(mesh.faceNeighbour(), EqualInt()));
+        // REQUIRE_THAT(faceNeighbourExp, IsEqualTo(mesh.faceNeighbour(), EqualInt()));
+        REQUIRE_THAT(mesh.faceNeighbour(), Equals(faceNeighbourExp, EqualInt()));
 
         // Verify boundary mesh: first 2 boundary faces are xmin/xmax
         // Verify neighbouring cell for boundary faces
         auto faceCellsExp = std::vector<NeoN::localIdx> {0, 3};
-        REQUIRE_THAT(faceCellsExp, IsEqualTo(mesh.boundaryMesh().faceCells(), EqualInt()));
+        // REQUIRE_THAT(faceCellsExp, IsEqualTo(mesh.boundaryMesh().faceCells(), EqualInt()));
 
         // // Verify neighbor cell centres
         auto cnExp = std::vector<NeoN::Vec3> {{0.125, 0.5, 0.5}, {0.875, 0.5, 0.5}};
-        REQUIRE_THAT(cnExp, IsEqualTo(mesh.boundaryMesh().cn(), ApproxVec3 {1e-12}));
+        // REQUIRE_THAT(cnExp, IsEqualTo(mesh.boundaryMesh().cn(), ApproxVec3 {1e-12}));
 
         // // Verify delta vectors
         auto deltaExp = std::vector<NeoN::Vec3> {{-0.125, 0.0, 0.0}, {0.125, 0.0, 0.0}};
-        REQUIRE_THAT(deltaExp, IsEqualTo(mesh.boundaryMesh().delta(), ApproxVec3 {1e-12}));
+        // REQUIRE_THAT(deltaExp, IsEqualTo(mesh.boundaryMesh().delta(), ApproxVec3 {1e-12}));
 
         // Verify stencilDB has patchNames
         REQUIRE(mesh.stencilDB().contains(std::string("stencilPatchNames")));
@@ -105,13 +106,13 @@ TEST_CASE("Unstructured Mesh")
 
         // Verify cell volumes (each cell is 0.5 * 0.5 * 1.0 = 0.25)
         auto cellVolumesExp = {0.25, 0.25, 0.25, 0.25};
-        REQUIRE_THAT(cellVolumesExp, IsEqualTo(mesh.cellVolumes(), ApproxScalar(1e-12)));
+        // REQUIRE_THAT(cellVolumesExp, IsEqualTo(mesh.cellVolumes(), ApproxScalar(1e-12)));
 
         // Verify cell centres (z should be 0.5, halfway through the slab)
         auto cellCentresExp = std::vector<NeoN::Vec3> {
             {0.25, 0.25, 0.5}, {0.75, 0.25, 0.5}, {0.25, 0.75, 0.5}, {0.75, 0.75, 0.5}
         };
-        REQUIRE_THAT(cellCentresExp, IsEqualTo(mesh.cellCentres(), ApproxVec3 {1e-12}));
+        // REQUIRE_THAT(cellCentresExp, IsEqualTo(mesh.cellCentres(), ApproxVec3 {1e-12}));
 
         // Verify the number of neighbouring cells for boundary faces
         // 4 patches: left(2), right(2), bottom(2), top(2)
@@ -130,7 +131,7 @@ TEST_CASE("Unstructured Mesh")
             {0.0, 0.25, 0.0},
             {0.0, 0.25, 0.0}
         };
-        REQUIRE_THAT(boundaryDeltaExp, IsEqualTo(bm.delta(), ApproxVec3 {1e-12}));
+        // REQUIRE_THAT(boundaryDeltaExp, IsEqualTo(bm.delta(), ApproxVec3 {1e-12}));
     }
 
     SECTION("Uniform 2D mesh stores patch names in stencilDB " + execName)
@@ -175,7 +176,7 @@ TEST_CASE("Unstructured Mesh")
 
         // Cell volume = (3/3) * (2/2) * 1.0 = 1.0
         auto cellVolumesExp = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
-        REQUIRE_THAT(cellVolumesExp, IsEqualTo(mesh.cellVolumes(), ApproxScalar(1e-12)));
+        // REQUIRE_THAT(cellVolumesExp, IsEqualTo(mesh.cellVolumes(), ApproxScalar(1e-12)));
     }
 
     SECTION("2D mesh patch face centres lie on correct planes (3x2) " + execName)
@@ -215,7 +216,7 @@ TEST_CASE("Unstructured Mesh")
             {1.5, ymax, 0.5},
             {2.5, ymax, 0.5} // top
         };
-        REQUIRE_THAT(cfExp, IsEqualTo(bm.cf(), ApproxVec3 {1e-12}));
+        // REQUIRE_THAT(cfExp, IsEqualTo(bm.cf(), ApproxVec3 {1e-12}));
     }
 
     SECTION("Can create a uniform 3D mesh (2x2x2) " + execName)
@@ -243,7 +244,7 @@ TEST_CASE("Unstructured Mesh")
 
         // Each cell is 0.5 * 0.5 * 0.5 = 0.125
         auto cellVolumesExp = {0.125, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125};
-        REQUIRE_THAT(cellVolumesExp, IsEqualTo(mesh.cellVolumes(), ApproxScalar(1e-12)));
+        // REQUIRE_THAT(cellVolumesExp, IsEqualTo(mesh.cellVolumes(), ApproxScalar(1e-12)));
 
         // Cell centres at 0.25 increments
         // cell(0,0,0) → (0.25, 0.25, 0.25)
@@ -258,7 +259,7 @@ TEST_CASE("Unstructured Mesh")
             {0.25, 0.75, 0.75},
             {0.75, 0.75, 0.75}
         };
-        REQUIRE_THAT(cellCentresExp, IsEqualTo(mesh.cellCentres(), ApproxVec3 {1e-12}));
+        // REQUIRE_THAT(cellCentresExp, IsEqualTo(mesh.cellCentres(), ApproxVec3 {1e-12}));
 
         // Boundary delta: left boundary first face should have negative x delta
         auto hostBndDelta = mesh.boundaryMesh().delta().copyToHost();


### PR DESCRIPTION
## What is it about?
- Redesign the custom matcher so that comparison in unit tests is expressed in a natural direction: 
_actual values should equal expected values._
- Define a new string maker to provide useful debugging info

## Why?
The current custom matcher leads to the expression of comparison in unit tests:
```
REQUIRE_THAT(expected, IsEqualTo(actual, pred));  // current
```
It is mentally inverted compared to how people usually think: actual should equal expected.

It is also not consistent with the usage of `REQUIRE(actual, expected)`.

## How to use the redesigned feature?
**Scalar field**
```
REQUIRE_THAT(mesh.volumes(), Equals(volumesExp, ApproxScalar{1e-12}));
```
**Vector field**
```
REQUIRE_THAT(mesh.cellCentres(), Equals(cellCentresExp, ApproxVec3{1e-12}));
```
**Integer/Exact**
```
REQUIRE_THAT(mesh.faceOwner(), Equals(faceOwnerExp, EqualInt{}));
```
## Outcome
- The comparison in unit tests is expressed in a more natural way.
- Improve readability of unit tests
- Provide useful debugging info when unit tests fail
An example of debugging info:
```
Unstructured Mesh
  Can create a 1D uniform meshGPUExecutor
-------------------------------------------------------------------------------
/storage/home/ctwang/Code/NeoN/test/mesh/unstructured/unstructuredMesh.cpp:26
...............................................................................

/storage/home/ctwang/Code/NeoN/test/mesh/unstructured/unstructuredMesh.cpp:56: FAILED:
  REQUIRE_THAT( mesh.cellCentres(), Equals(cellCentresExp, ApproxVec3 {1e-12}) )
with expansion:
  { (0.125 0.5 0.5), (0.375 0.5 0.5), (0.625 0.5 0.5), (0.875 0.5 0.5) } equals
  { (0.25 0.5 0.5), (0.375 0.5 0.5), (0.625 0.5 0.5), (0.875 0.5 0.5) }
```
