### PR TITLE
add take implementation

### DIFF
--- a/include/NeoN/core/vector/vector.hpp
+++ b/include/NeoN/core/vector/vector.hpp
@@ -220,6 +220,30 @@ public:
     [[nodiscard]] const ValueType* data() const { return data_; }
 
     /**
+     * @brief Direct access to the underlying field data
+     * @return Pointer to the first cell data in the field.
+     */
+    [[nodiscard]] ValueType* begin() { return data_; }
+
+    /**
+     * @brief Direct access to the underlying field data
+     * @return Pointer to the first cell data in the field.
+     */
+    [[nodiscard]] const ValueType* begin() const { return data_; }
+
+    /**
+     * @brief Direct access to the underlying field data
+     * @return Pointer to the first cell data in the field.
+     */
+    [[nodiscard]] ValueType* end() { return data_ + size(); }
+
+    /**
+     * @brief Direct access to the underlying field data
+     * @return Pointer to the first cell data in the field.
+     */
+    [[nodiscard]] const ValueType* end() const { return data_ + size(); }
+
+    /**
      * @brief Gets the executor associated with the field.
      * @return Reference to the executor.
      */

--- a/include/NeoN/core/vector/vectorFreeFunctions.hpp
+++ b/include/NeoN/core/vector/vectorFreeFunctions.hpp
@@ -63,10 +63,10 @@ template<unsigned int I>
 template<unsigned int I>
 void setComponent(const Vector<scalar>& in, Vector<Vec3>& out);
 
-/** @brief Given a Vector and an index range [first, last] a subvector is created
+/** @brief Given a Vector and an index range [first, first+length] a subvector is created
  * @returns The resulting subset vector
  */
 template<typename ValueType>
-Vector<ValueType> take(const Vector<ValueType>& in, localIdx first, localIdx last);
+Vector<ValueType> take(const Vector<ValueType>& in, localIdx first, localIdx length);
 
 } // namespace NeoN

--- a/include/NeoN/core/vector/vectorFreeFunctions.hpp
+++ b/include/NeoN/core/vector/vectorFreeFunctions.hpp
@@ -67,6 +67,6 @@ void setComponent(const Vector<scalar>& in, Vector<Vec3>& out);
  * @returns The resulting subset vector
  */
 template<typename ValueType>
-Vector<ValueType> take(const Vector<ValueType>& in, localIdx first, localIdx length);
+Vector<ValueType> take(const Vector<ValueType>& in, std::pair<localIdx, localIdx> range);
 
 } // namespace NeoN

--- a/include/NeoN/core/vector/vectorFreeFunctions.hpp
+++ b/include/NeoN/core/vector/vectorFreeFunctions.hpp
@@ -62,4 +62,11 @@ template<unsigned int I>
  */
 template<unsigned int I>
 void setComponent(const Vector<scalar>& in, Vector<Vec3>& out);
+
+/** @brief Given a Vector and an index range [first, last] a subvector is created
+ * @returns The resulting subset vector
+ */
+template<typename ValueType>
+Vector<ValueType> take(const Vector<ValueType>& in, localIdx first, localIdx last);
+
 } // namespace NeoN

--- a/src/core/vector/vectorFreeFunctions.cpp
+++ b/src/core/vector/vectorFreeFunctions.cpp
@@ -156,17 +156,20 @@ template void setComponent<1>(const Vector<scalar>&, Vector<Vec3>&);
 template void setComponent<2>(const Vector<scalar>&, Vector<Vec3>&);
 
 template<typename ValueType>
-Vector<ValueType> take(const Vector<ValueType>& in, localIdx first, localIdx last)
+Vector<ValueType> take(const Vector<ValueType>& in, localIdx first, localIdx length)
 {
-    NF_ASSERT(last >= first, "Invalid index range");
+    NF_ASSERT(length < 0, "Invalid length");
     const auto exec = in.exec();
 
-    auto out = Vector<ValueType>(exec, (last - first));
+    auto out = Vector<ValueType>(exec, (length));
     auto outV = out.view();
     const auto inV = in.view();
 
     NeoN::parallelFor(
-        exec, {first, last}, NEON_LAMBDA(const localIdx i) { outV[i - first] = inV[i]; }, "copyMap"
+        exec,
+        {first, first + length},
+        NEON_LAMBDA(const localIdx i) { outV[i - first] = inV[i]; },
+        "copyMap"
     );
 
     return out;

--- a/src/core/vector/vectorFreeFunctions.cpp
+++ b/src/core/vector/vectorFreeFunctions.cpp
@@ -156,30 +156,17 @@ template void setComponent<1>(const Vector<scalar>&, Vector<Vec3>&);
 template void setComponent<2>(const Vector<scalar>&, Vector<Vec3>&);
 
 template<typename ValueType>
-Vector<ValueType> take(const Vector<ValueType>& in, localIdx first, localIdx length)
+Vector<ValueType> take(const Vector<ValueType>& in, std::pair<localIdx, localIdx> range)
 {
-    NF_ASSERT(length < 0, "Invalid length");
-    const auto exec = in.exec();
-
-    auto out = Vector<ValueType>(exec, (length));
-    auto outV = out.view();
-    const auto inV = in.view();
-
-    NeoN::parallelFor(
-        exec,
-        {first, first + length},
-        NEON_LAMBDA(const localIdx i) { outV[i - first] = inV[i]; },
-        "copyMap"
-    );
-
-    return out;
+    auto rangeView = in.view(range);
+    return {in.exec(), rangeView.data(), rangeView.size()};
 }
 
 // operator instantiation
 #define NN_VECTOR_OPERATOR_INSTANTIATION(Type)                                                     \
     /* free function operator with additional requirements  */                                     \
     template void scalarMul<Type>(Vector<Type>&, const scalar);                                    \
-    template Vector<Type> take<Type>(const Vector<Type>&, localIdx, localIdx);                     \
+    template Vector<Type> take<Type>(const Vector<Type>&, std::pair<localIdx, localIdx>);          \
     template void add<Type>(Vector<Type>&, const std::type_identity_t<Type>&);                     \
     template void add<Type>(Vector<Type>&, const Vector<std::type_identity_t<Type>>&);             \
     template void sub<Type>(Vector<Type>&, const std::type_identity_t<Type>&);                     \
@@ -190,7 +177,7 @@ Vector<ValueType> take(const Vector<ValueType>& in, localIdx first, localIdx len
 #define NN_VECTOR_OPERATOR_INSTANTIATION_VEC3(Type)                                                \
     /* free function operator with additional requirements  */                                     \
     template void scalarMul<Type>(Vector<Type>&, const scalar);                                    \
-    template Vector<Type> take<Type>(const Vector<Type>&, localIdx, localIdx);                     \
+    template Vector<Type> take<Type>(const Vector<Type>&, std::pair<localIdx, localIdx>);          \
     template void add<Type>(Vector<Type>&, const std::type_identity_t<Type>&);                     \
     template void add<Type>(Vector<Type>&, const Vector<std::type_identity_t<Type>>&);             \
     template void sub<Type>(Vector<Type>&, const std::type_identity_t<Type>&);                     \

--- a/src/core/vector/vectorFreeFunctions.cpp
+++ b/src/core/vector/vectorFreeFunctions.cpp
@@ -155,11 +155,28 @@ template void setComponent<0>(const Vector<scalar>&, Vector<Vec3>&);
 template void setComponent<1>(const Vector<scalar>&, Vector<Vec3>&);
 template void setComponent<2>(const Vector<scalar>&, Vector<Vec3>&);
 
+template<typename ValueType>
+Vector<ValueType> take(const Vector<ValueType>& in, localIdx first, localIdx last)
+{
+    NF_ASSERT(last >= first, "Invalid index range");
+    const auto exec = in.exec();
+
+    auto out = Vector<ValueType>(exec, (last - first));
+    auto outV = out.view();
+    const auto inV = in.view();
+
+    NeoN::parallelFor(
+        exec, {first, last}, NEON_LAMBDA(const localIdx i) { outV[i - first] = inV[i]; }, "copyMap"
+    );
+
+    return out;
+}
 
 // operator instantiation
 #define NN_VECTOR_OPERATOR_INSTANTIATION(Type)                                                     \
     /* free function operator with additional requirements  */                                     \
     template void scalarMul<Type>(Vector<Type>&, const scalar);                                    \
+    template Vector<Type> take<Type>(const Vector<Type>&, localIdx, localIdx);                     \
     template void add<Type>(Vector<Type>&, const std::type_identity_t<Type>&);                     \
     template void add<Type>(Vector<Type>&, const Vector<std::type_identity_t<Type>>&);             \
     template void sub<Type>(Vector<Type>&, const std::type_identity_t<Type>&);                     \
@@ -170,6 +187,7 @@ template void setComponent<2>(const Vector<scalar>&, Vector<Vec3>&);
 #define NN_VECTOR_OPERATOR_INSTANTIATION_VEC3(Type)                                                \
     /* free function operator with additional requirements  */                                     \
     template void scalarMul<Type>(Vector<Type>&, const scalar);                                    \
+    template Vector<Type> take<Type>(const Vector<Type>&, localIdx, localIdx);                     \
     template void add<Type>(Vector<Type>&, const std::type_identity_t<Type>&);                     \
     template void add<Type>(Vector<Type>&, const Vector<std::type_identity_t<Type>>&);             \
     template void sub<Type>(Vector<Type>&, const std::type_identity_t<Type>&);                     \

--- a/test/catch2/catch2_common.hpp
+++ b/test/catch2/catch2_common.hpp
@@ -27,7 +27,7 @@ using I = std::initializer_list<T>;
     if (COND) SECTION(__VA_ARGS__)
 
 /**
- * @brief Predicate for approximate comparison of NeoN::Vec3 values andfloating-point comparison
+ * @brief Predicate for approximate comparison of NeoN::Vec3 values and floating-point comparison
  * within a given margin.
  *
  * Performs component-wise floating-point comparison using Catch2's
@@ -48,7 +48,7 @@ using I = std::initializer_list<T>;
  * };
  *
  * REQUIRE_THAT(mesh.cellCentres(),
- *              Equals(expected, ApproxVec3{1e-12}));
+ *              Equals(expected, Approx{1e-12}));
  * @endcode
  */
 struct Approx
@@ -156,6 +156,7 @@ struct EqualsMatcher : Catch::Matchers::MatcherGenericBase
 
         // Copy device field to host if needed
         auto actualHost = actual.copyToHost();
+        // FIXME test if expected has a copyToHost
 
         return std::equal(
             begin(actualHost.view()),

--- a/test/catch2/catch2_common.hpp
+++ b/test/catch2/catch2_common.hpp
@@ -18,6 +18,14 @@
 template<typename T>
 using I = std::initializer_list<T>;
 
+/** @brief Detects whether T has a copyToHost() member function. */
+template<typename T, typename = void>
+inline constexpr bool hasCopyToHost = false;
+
+template<typename T>
+inline constexpr bool
+    hasCopyToHost<T, std::void_t<decltype(std::declval<const T&>().copyToHost())>> = true;
+
 /**
  * @brief Conditionally enters a Catch2 SECTION if the given condition is true.
  * @param COND The boolean condition to evaluate.
@@ -156,7 +164,7 @@ struct EqualsMatcher : Catch::Matchers::MatcherGenericBase
 
         auto actualHost = actual.copyToHost();
 
-        if constexpr (requires { expected_.copyToHost(); })
+        if constexpr (hasCopyToHost<Expected>)
         {
             auto expectedHost = expected_.copyToHost();
             return std::equal(

--- a/test/catch2/catch2_common.hpp
+++ b/test/catch2/catch2_common.hpp
@@ -27,28 +27,8 @@ using I = std::initializer_list<T>;
     if (COND) SECTION(__VA_ARGS__)
 
 /**
- *  @brief Predicate for approximate floating-point comparison within a given margin.
- *
- * Used with @ref EqualsMatcher and @ref Equals to compare scalar values
- * using Catch2's Approx mechanism, allowing for a configurable absolute tolerance.
- */
-struct ApproxScalar
-{
-    NeoN::scalar margin; ///< Absolute tolerance margin for the comparison.
-
-    /**
-     * @brief Returns true if @p rhs and @p lhs are equal within the stored margin.
-     * @param rhs Left-hand value passed to Catch::Approx.
-     * @param lhs Right-hand value to compare against.
-     */
-    bool operator()(double rhs, double lhs) const
-    {
-        return Catch::Approx(rhs).margin(margin) == lhs;
-    }
-};
-
-/**
- * @brief Predicate for approximate comparison of NeoN::Vec3 values.
+ * @brief Predicate for approximate comparison of NeoN::Vec3 values andfloating-point comparison
+ * within a given margin.
  *
  * Performs component-wise floating-point comparison using Catch2's
  * @ref Catch::Approx with a configurable absolute tolerance.
@@ -71,7 +51,7 @@ struct ApproxScalar
  *              Equals(expected, ApproxVec3{1e-12}));
  * @endcode
  */
-struct ApproxVec3
+struct Approx
 {
     NeoN::scalar margin; ///< Absolute tolerance used for each component.
 
@@ -93,6 +73,16 @@ struct ApproxVec3
         return Catch::Approx(rhs[0]).margin(margin) == lhs[0]
             && Catch::Approx(rhs[1]).margin(margin) == lhs[1]
             && Catch::Approx(rhs[2]).margin(margin) == lhs[2];
+    }
+
+    /**
+     * @brief Returns true if @p rhs and @p lhs are equal within the stored margin.
+     * @param rhs Left-hand value passed to Catch::Approx.
+     * @param lhs Right-hand value to compare against.
+     */
+    bool operator()(double rhs, double lhs) const
+    {
+        return Catch::Approx(rhs).margin(margin) == lhs;
     }
 };
 
@@ -218,7 +208,7 @@ private:
  * @return An @ref EqualsMatcher configured with the provided expected values
  *         and comparison predicate.
  */
-template<typename Expected, typename Predicate = ApproxScalar>
+template<typename Expected, typename Predicate = Approx>
 auto Equals(Expected expected, Predicate pred = Predicate {1e-32})
 {
     return EqualsMatcher<Expected, Predicate> {std::move(expected), pred};
@@ -226,6 +216,21 @@ auto Equals(Expected expected, Predicate pred = Predicate {1e-32})
 
 namespace Catch
 {
+
+/**
+ * @brief Disable Catch2's built-in range StringMaker for NeoN::Vector.
+ *
+ * NeoN::Vector exposes @c begin()/@c end() and is therefore detected as a range
+ * by Catch2's @ref is_range trait. Without this specialization, both Catch2's
+ * generic range StringMaker and the NeoN-specific one below match, producing
+ * an "ambiguous partial specializations" error. Disabling the range trait lets
+ * the NeoN-specific specialization win unambiguously and ensures
+ * device-resident vectors are copied to host before stringification.
+ */
+template<typename T>
+struct is_range<NeoN::Vector<T>> : std::false_type
+{
+};
 
 /**
  * @brief Catch2 string conversion for NeoN::Vector.

--- a/test/catch2/catch2_common.hpp
+++ b/test/catch2/catch2_common.hpp
@@ -154,17 +154,29 @@ struct EqualsMatcher : Catch::Matchers::MatcherGenericBase
         using std::begin;
         using std::end;
 
-        // Copy device field to host if needed
         auto actualHost = actual.copyToHost();
-        // FIXME test if expected has a copyToHost
 
-        return std::equal(
-            begin(actualHost.view()),
-            end(actualHost.view()),
-            begin(expected_),
-            end(expected_),
-            pred_
-        );
+        if constexpr (requires { expected_.copyToHost(); })
+        {
+            auto expectedHost = expected_.copyToHost();
+            return std::equal(
+                begin(actualHost.view()),
+                end(actualHost.view()),
+                begin(expectedHost.view()),
+                end(expectedHost.view()),
+                pred_
+            );
+        }
+        else
+        {
+            return std::equal(
+                begin(actualHost.view()),
+                end(actualHost.view()),
+                begin(expected_),
+                end(expected_),
+                pred_
+            );
+        }
     }
 
     /**

--- a/test/core/vector/vector.cpp
+++ b/test/core/vector/vector.cpp
@@ -286,22 +286,15 @@ TEMPLATE_TEST_CASE("take", "[template]", NeoN::scalar, NeoN::Vec3)
 {
     auto [execName, exec] = GENERATE(allAvailableExecutor());
 
+
+    auto one = NeoN::one<TestType>();
     NeoN::Vector<TestType> a(
-        exec,
-        {1.0 * NeoN::one<TestType>(),
-         2.0 * NeoN::one<TestType>(),
-         3.0 * NeoN::one<TestType>(),
-         4.0 * NeoN::one<TestType>(),
-         5.0 * NeoN::one<TestType>(),
-         6.0 * NeoN::one<TestType>()}
+        exec, {1.0 * one, 2.0 * one, 3.0 * one, 4.0 * one, 5.0 * one, 6.0 * one}
     );
 
-    NeoN::Vector<TestType> aExp(
-        exec,
-        {2.0 * NeoN::one<TestType>(), 3.0 * NeoN::one<TestType>(), 4.0 * NeoN::one<TestType>()}
-    );
+    NeoN::Vector<TestType> aExp(exec, {2.0 * one, 3.0 * one, 4.0 * one});
 
-    auto takeRes = take(a, 1, 3);
+    auto takeRes = take(a, {1, 4});
 
     REQUIRE_THAT(takeRes, Equals(aExp, Approx {1e-12}));
 }

--- a/test/core/vector/vector.cpp
+++ b/test/core/vector/vector.cpp
@@ -301,7 +301,7 @@ TEMPLATE_TEST_CASE("take", "[template]", NeoN::scalar, NeoN::Vec3)
         {2.0 * NeoN::one<TestType>(), 3.0 * NeoN::one<TestType>(), 4.0 * NeoN::one<TestType>()}
     );
 
-    auto takeRes = take(a, 1, 4);
+    auto takeRes = take(a, 1, 3);
 
     REQUIRE_THAT(takeRes, Equals(aExp, Approx {1e-12}));
 }

--- a/test/core/vector/vector.cpp
+++ b/test/core/vector/vector.cpp
@@ -281,3 +281,27 @@ TEST_CASE("getViews")
         REQUIRE(value == 5.0);
     }
 }
+
+TEMPLATE_TEST_CASE("take", "[template]", NeoN::scalar, NeoN::Vec3)
+{
+    auto [execName, exec] = GENERATE(allAvailableExecutor());
+
+    NeoN::Vector<TestType> a(
+        exec,
+        {1.0 * NeoN::one<TestType>(),
+         2.0 * NeoN::one<TestType>(),
+         3.0 * NeoN::one<TestType>(),
+         4.0 * NeoN::one<TestType>(),
+         5.0 * NeoN::one<TestType>(),
+         6.0 * NeoN::one<TestType>()}
+    );
+
+    NeoN::Vector<TestType> aExp(
+        exec,
+        {2.0 * NeoN::one<TestType>(), 3.0 * NeoN::one<TestType>(), 4.0 * NeoN::one<TestType>()}
+    );
+
+    auto takeRes = take(a, 1, 4);
+
+    REQUIRE_THAT(takeRes, Equals(aExp, Approx {1e-12}));
+}

--- a/test/finiteVolume/cellCentred/boundary/surface/surfSymmetry.cpp
+++ b/test/finiteVolume/cellCentred/boundary/surface/surfSymmetry.cpp
@@ -7,8 +7,6 @@
 
 #include "NeoN/NeoN.hpp"
 
-using Catch::Approx;
-
 TEST_CASE("symmetry_surface")
 {
     auto [execName, exec] = GENERATE(allAvailableExecutor());
@@ -44,14 +42,14 @@ TEST_CASE("symmetry_surface")
             {
                 const auto i = static_cast<NeoN::localIdx>(&boundaryValueV - refValuesH.data());
                 const auto ownerV = faceCellsH.view()[i];
-                REQUIRE(boundaryValueV == Approx(internalH.view()[ownerV]));
+                REQUIRE(boundaryValueV == Catch::Approx(internalH.view()[ownerV]));
             }
 
             for (auto& boundaryValueV : valuesH.view(boundary->range()))
             {
                 const auto i = static_cast<NeoN::localIdx>(&boundaryValueV - valuesH.data());
                 const auto ownerV = faceCellsH.view()[i];
-                REQUIRE(boundaryValueV == Approx(internalH.view()[ownerV]));
+                REQUIRE(boundaryValueV == Catch::Approx(internalH.view()[ownerV]));
             }
         }
 
@@ -89,7 +87,7 @@ TEST_CASE("symmetry_surface")
 
                 for (auto d = 0u; d < 3; ++d)
                 {
-                    REQUIRE(boundaryValueV[d] == Approx(vExpected[d]));
+                    REQUIRE(boundaryValueV[d] == Catch::Approx(vExpected[d]));
                 }
             }
 
@@ -104,7 +102,7 @@ TEST_CASE("symmetry_surface")
 
                 for (auto d = 0u; d < 3; ++d)
                 {
-                    REQUIRE(boundaryValueV[d] == Approx(vExpected[d]));
+                    REQUIRE(boundaryValueV[d] == Catch::Approx(vExpected[d]));
                 }
             }
         }

--- a/test/finiteVolume/cellCentred/boundary/volume/volSymmetry.cpp
+++ b/test/finiteVolume/cellCentred/boundary/volume/volSymmetry.cpp
@@ -7,8 +7,6 @@
 
 #include "NeoN/NeoN.hpp"
 
-using Catch::Approx;
-
 TEST_CASE("symmetry_volume")
 {
     auto [execName, exec] = GENERATE(allAvailableExecutor());
@@ -47,18 +45,18 @@ TEST_CASE("symmetry_volume")
             {
                 const auto i = static_cast<NeoN::localIdx>(&boundaryValueV - refValuesH.data());
                 const auto ownerV = faceCellsH.view()[i];
-                REQUIRE(boundaryValueV == Approx(internalH.view()[ownerV]));
+                REQUIRE(boundaryValueV == Catch::Approx(internalH.view()[ownerV]));
             }
 
             for (auto& boundaryValueV : valuesH.view(boundary->range()))
             {
                 const auto i = static_cast<NeoN::localIdx>(&boundaryValueV - valuesH.data());
                 const auto ownerV = faceCellsH.view()[i];
-                REQUIRE(boundaryValueV == Approx(internalH.view()[ownerV]));
+                REQUIRE(boundaryValueV == Catch::Approx(internalH.view()[ownerV]));
             }
 
             for (auto& gradValueV : refGradH.view(boundary->range()))
-                REQUIRE(gradValueV == Approx(0.0));
+                REQUIRE(gradValueV == Catch::Approx(0.0));
         }
 
         // === vector field =====================================================
@@ -97,7 +95,7 @@ TEST_CASE("symmetry_volume")
 
                 for (auto d = 0u; d < 3; ++d)
                 {
-                    REQUIRE(boundaryValueV[d] == Approx(vExpected[d]));
+                    REQUIRE(boundaryValueV[d] == Catch::Approx(vExpected[d]));
                 }
             }
 
@@ -105,7 +103,7 @@ TEST_CASE("symmetry_volume")
             {
                 for (auto d = 0u; d < 3; ++d)
                 {
-                    REQUIRE(gradValueV[d] == Approx(0.0));
+                    REQUIRE(gradValueV[d] == Catch::Approx(0.0));
                 }
             }
         }

--- a/test/finiteVolume/cellCentred/operator/gaussGreenDiv.cpp
+++ b/test/finiteVolume/cellCentred/operator/gaussGreenDiv.cpp
@@ -86,7 +86,7 @@ TEMPLATE_TEST_CASE("DivOperator", "[template]", NeoN::scalar, NeoN::Vec3)
             computeResidual(ls.matrix(), ls.rhs(), phi.internalVector(), res);
 
             auto resExp = std::vector<NeoN::scalar>(res.size(), 0);
-            REQUIRE_THAT(res, Equals(resExp, ApproxScalar {1e-12}));
+            REQUIRE_THAT(res, Equals(resExp, Approx {1e-12}));
         }
     }
 }

--- a/test/linearAlgebra/utilities.cpp
+++ b/test/linearAlgebra/utilities.cpp
@@ -148,7 +148,7 @@ TEST_CASE("Utilities")
         NeoN::la::computeResidual(csrMatrix, rhs, x, res);
 
         auto residualExp = std::vector<scalar> {4.0, 13.0, 22.0};
-        REQUIRE_THAT(res, Equals(residualExp, ApproxScalar(1e-15)));
+        REQUIRE_THAT(res, Equals(residualExp, Approx(1e-15)));
     }
 
     SECTION("Can convert empty rowsToRowOffs  " + execName)

--- a/test/mesh/unstructured/unstructuredMesh.cpp
+++ b/test/mesh/unstructured/unstructuredMesh.cpp
@@ -53,7 +53,7 @@ TEST_CASE("Unstructured Mesh")
         auto cellCentresExp = std::vector<NeoN::Vec3> {
             {0.125, 0.5, 0.5}, {0.375, 0.5, 0.5}, {0.625, 0.5, 0.5}, {0.875, 0.5, 0.5}
         };
-        REQUIRE_THAT(mesh.cellCentres(), Equals(cellCentresExp, ApproxVec3 {1e-12}));
+        REQUIRE_THAT(mesh.cellCentres(), Equals(cellCentresExp, Approx {1e-12}));
 
         // Verify face owners (x-direction)
         auto faceOwnerExp = std::vector<NeoN::label> {0, 1, 2, 0, 3};
@@ -70,11 +70,11 @@ TEST_CASE("Unstructured Mesh")
 
         // // Verify neighbor cell centres
         auto cnExp = std::vector<NeoN::Vec3> {{0.125, 0.5, 0.5}, {0.875, 0.5, 0.5}};
-        REQUIRE_THAT(mesh.boundaryMesh().cn(), Equals(cnExp, ApproxVec3 {1e-12}));
+        REQUIRE_THAT(mesh.boundaryMesh().cn(), Equals(cnExp, Approx {1e-12}));
 
         // // Verify delta vectors
         auto deltaExp = std::vector<NeoN::Vec3> {{-0.125, 0.0, 0.0}, {0.125, 0.0, 0.0}};
-        REQUIRE_THAT(mesh.boundaryMesh().delta(), Equals(deltaExp, ApproxVec3 {1e-12}));
+        REQUIRE_THAT(mesh.boundaryMesh().delta(), Equals(deltaExp, Approx {1e-12}));
 
         // Verify stencilDB has patchNames
         REQUIRE(mesh.stencilDB().contains(std::string("stencilPatchNames")));
@@ -105,13 +105,13 @@ TEST_CASE("Unstructured Mesh")
 
         // Verify cell volumes (each cell is 0.5 * 0.5 * 1.0 = 0.25)
         auto cellVolumesExp = {0.25, 0.25, 0.25, 0.25};
-        REQUIRE_THAT(mesh.cellVolumes(), Equals(cellVolumesExp, ApproxScalar(1e-12)));
+        REQUIRE_THAT(mesh.cellVolumes(), Equals(cellVolumesExp, Approx(1e-12)));
 
         // Verify cell centres (z should be 0.5, halfway through the slab)
         auto cellCentresExp = std::vector<NeoN::Vec3> {
             {0.25, 0.25, 0.5}, {0.75, 0.25, 0.5}, {0.25, 0.75, 0.5}, {0.75, 0.75, 0.5}
         };
-        REQUIRE_THAT(mesh.cellCentres(), Equals(cellCentresExp, ApproxVec3 {1e-12}));
+        REQUIRE_THAT(mesh.cellCentres(), Equals(cellCentresExp, Approx {1e-12}));
 
         // Verify the number of neighbouring cells for boundary faces
         // 4 patches: left(2), right(2), bottom(2), top(2)
@@ -130,7 +130,7 @@ TEST_CASE("Unstructured Mesh")
             {0.0, 0.25, 0.0},
             {0.0, 0.25, 0.0}
         };
-        REQUIRE_THAT(bm.delta(), Equals(boundaryDeltaExp, ApproxVec3 {1e-12}));
+        REQUIRE_THAT(bm.delta(), Equals(boundaryDeltaExp, Approx {1e-12}));
     }
 
     SECTION("Uniform 2D mesh stores patch names in stencilDB " + execName)
@@ -175,7 +175,7 @@ TEST_CASE("Unstructured Mesh")
 
         // Cell volume = (3/3) * (2/2) * 1.0 = 1.0
         auto cellVolumesExp = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
-        REQUIRE_THAT(mesh.cellVolumes(), Equals(cellVolumesExp, ApproxScalar(1e-12)));
+        REQUIRE_THAT(mesh.cellVolumes(), Equals(cellVolumesExp, Approx(1e-12)));
     }
 
     SECTION("2D mesh patch face centres lie on correct planes (3x2) " + execName)
@@ -215,7 +215,7 @@ TEST_CASE("Unstructured Mesh")
             {1.5, ymax, 0.5},
             {2.5, ymax, 0.5} // top
         };
-        REQUIRE_THAT(bm.cf(), Equals(cfExp, ApproxVec3 {1e-12}));
+        REQUIRE_THAT(bm.cf(), Equals(cfExp, Approx {1e-12}));
     }
 
     SECTION("Can create a uniform 3D mesh (2x2x2) " + execName)
@@ -243,7 +243,7 @@ TEST_CASE("Unstructured Mesh")
 
         // Each cell is 0.5 * 0.5 * 0.5 = 0.125
         auto cellVolumesExp = {0.125, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125};
-        REQUIRE_THAT(mesh.cellVolumes(), Equals(cellVolumesExp, ApproxScalar(1e-12)));
+        REQUIRE_THAT(mesh.cellVolumes(), Equals(cellVolumesExp, Approx(1e-12)));
 
         // Cell centres at 0.25 increments
         // cell(0,0,0) → (0.25, 0.25, 0.25)
@@ -258,7 +258,7 @@ TEST_CASE("Unstructured Mesh")
             {0.25, 0.75, 0.75},
             {0.75, 0.75, 0.75}
         };
-        REQUIRE_THAT(mesh.cellCentres(), Equals(cellCentresExp, ApproxVec3 {1e-12}));
+        REQUIRE_THAT(mesh.cellCentres(), Equals(cellCentresExp, Approx {1e-12}));
 
         // Boundary delta: left boundary first face should have negative x delta
         auto hostBndDelta = mesh.boundaryMesh().delta().copyToHost();
@@ -289,7 +289,7 @@ TEST_CASE("Unstructured Mesh")
         // Cell volume = (3/3) * (2/2) * (2/2) = 1.0
         auto cellVolumesExp =
             std::vector<NeoN::scalar> {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
-        REQUIRE_THAT(mesh.cellVolumes(), Equals(cellVolumesExp, ApproxScalar(1e-12)));
+        REQUIRE_THAT(mesh.cellVolumes(), Equals(cellVolumesExp, Approx(1e-12)));
     }
 
     SECTION("3D mesh patch face centres lie on correct planes (3x2x4) " + execName)

--- a/test/timeIntegration/ddtFluxCorr.cpp
+++ b/test/timeIntegration/ddtFluxCorr.cpp
@@ -8,7 +8,6 @@
 #include "../dsl/common.hpp"
 #include "NeoN/NeoN.hpp"
 
-using Catch::Approx;
 namespace fvcc = NeoN::finiteVolume::cellCentred;
 
 using Scalar = NeoN::scalar;
@@ -112,7 +111,7 @@ TEST_CASE("timeIntegration: ddtPhiCorr on single-cell mesh", "[timeIntegration][
             auto corrH = fluxCorr.internalVector().copyToHost();
 
             for (auto i = 0; i < mesh.nFaces(); ++i)
-                REQUIRE(corrH.view()[i] == Approx(0.0).margin(1e-12));
+                REQUIRE(corrH.view()[i] == Catch::Approx(0.0).margin(1e-12));
         }
 
         // ─────────────────────────────────────────────
@@ -127,7 +126,9 @@ TEST_CASE("timeIntegration: ddtPhiCorr on single-cell mesh", "[timeIntegration][
             auto corrH = fluxCorr.internalVector().copyToHost();
 
             for (auto i = 0; i < mesh.nFaces(); ++i)
-                REQUIRE(corrH.view()[i] == Approx(expected[static_cast<size_t>(i)]).margin(1e-12));
+                REQUIRE(
+                    corrH.view()[i] == Catch::Approx(expected[static_cast<size_t>(i)]).margin(1e-12)
+                );
         }
     }
 }


### PR DESCRIPTION
# Motivation
taken from https://github.com/exasim-project/NeoN/pull/414 this PR adds a function named `take` that can extract a range of values from a vector. This is mostly used for testing in distributed settings. 

It also unifies the Approx struct to handle scalar and Vec3 and allows to  implement   `REQUIRE_THAT(takeRes, Equals(aExp, Approx {1e-12}));` where res and exp are both `NeoN::Vectors.`
