### PR TITLE
Mesh refactoring in preparation of distributed mesh

### DIFF
--- a/include/NeoN/mesh/unstructured/boundaryMesh.hpp
+++ b/include/NeoN/mesh/unstructured/boundaryMesh.hpp
@@ -21,6 +21,9 @@ namespace NeoN
  * as face cells, face centers, face normals, face areas normals, magnitudes of
  * face areas normals, delta vectors, weights, delta coefficients, and offsets.
  *
+ * Boundary faces are organised such that regular boundaries are stored first, followed
+ * by the processor boundaries.
+ *
  * The class also provides getter methods to access the individual fields and
  * their components.
  *
@@ -29,6 +32,8 @@ namespace NeoN
 class BoundaryMesh
 {
 public:
+
+    void validate() const;
 
     /**
      * @brief Constructor for the BoundaryMesh class.
@@ -44,7 +49,9 @@ public:
      * @param weights A field of weights used in cell to face interpolation.
      * @param deltaCoeffs A field of the inverse of distances between boundary faces and their
      * neighboring cell centers
-     * @param offset The offset of the faces of each boundary
+     * @param offset The offsets of the boundary faces, i.e. offset[i], offset[i+1] define beginning
+     * and end of a patch.
+     * @param neighbourRank corresponding mpiRank ouf neighbour
      */
     BoundaryMesh(
         const Executor& exec,
@@ -57,7 +64,9 @@ public:
         vectorVector delta,
         scalarVector weights,
         scalarVector deltaCoeffs,
-        std::vector<localIdx> offset
+        std::vector<localIdx> offset,
+        localIdx procBoundaryPatches,
+        std::vector<localIdx> neighbourRank
     );
 
 
@@ -199,6 +208,13 @@ public:
     View<const scalar> deltaCoeffs(const localIdx i) const;
 
     /**
+     * @brief Given a patchId the corresponding neighbour Rank gets returned
+     *
+     * -1 for patches without a distributed neighbour
+     */
+    localIdx neighbourRank(const localIdx i) const;
+
+    /**
      * @brief Get the offset of the boundary faces.
      *
      * @return A constant reference to the offset of the boundary faces.
@@ -206,6 +222,35 @@ public:
     // TODO consistent use of Vector on CPU
     const std::vector<localIdx>& offset() const;
 
+    /**@brief number of proc boundary patches */
+    localIdx nProcBoundaryPatches() const;
+
+    /**
+     * @brief Get the offset of the boundary faces.
+     *
+     * @return A constant reference to the offset of the boundary faces.
+     */
+    const std::vector<localIdx>& neighbourRank() const;
+
+    /**
+     * @brief Get the number of the boundaries.
+     */
+    localIdx nBoundaries() const { return offset_.size() - 1; }
+
+    /**
+     * @brief Get the number of the boundary faces.
+     */
+    localIdx nBoundaryFaces() const { return faceOwners_.size() - nProcBoundaryFaces(); }
+
+    /**
+     * @brief Get the number of the processor boundary faces.
+     */
+    localIdx nProcBoundaryFaces() const;
+
+    /**
+     * @brief Return whether this local mesh is a part of a global distributed mesh
+     */
+    bool isDistributed() const { return nProcBoundaryFaces() > 0; }
 
 private:
 
@@ -275,6 +320,18 @@ private:
      */
     // TODO consistent use of Vector on CPU
     std::vector<localIdx> offset_;
+
+    /**
+     * @brief number of processor patches
+     *
+     * Vector of cell to face distances.
+     */
+    localIdx procBoundaryPatches_;
+
+    /**
+     * @brief The mpi rank of the corresponding neighbour patch
+     */
+    std::vector<localIdx> neighbourRank_;
 };
 
 } // namespace NeoN

--- a/include/NeoN/mesh/unstructured/unstructuredMesh.hpp
+++ b/include/NeoN/mesh/unstructured/unstructuredMesh.hpp
@@ -43,11 +43,6 @@ public:
      * @param faceAreas The field of face areas.
      * @param faceOwners The list of labels of face owner cells.
      * @param faceNeighbors The list of labels of face neighbor cells.
-     * @param nCells The number of cells in the mesh.
-     * @param nInternalFaces The number of internal faces in the mesh.
-     * @param nBoundaryFaces The number of boundary faces in the mesh.
-     * @param nBoundaries The number of boundaries in the mesh.
-     * @param nFaces The number of faces in the mesh.
      * @param boundaryMesh The boundary mesh.
      */
     UnstructuredMesh(
@@ -60,11 +55,6 @@ public:
         scalarVector faceAreas,
         labelVector faceOwners,
         labelVector faceNeighbors,
-        localIdx nCells,
-        localIdx nInternalFaces,
-        localIdx nBoundaryFaces,
-        localIdx nBoundaries,
-        localIdx nFaces,
         BoundaryMesh boundaryMesh
     );
 
@@ -80,11 +70,6 @@ public:
      * @param faceAreas The field of face areas.
      * @param faceOwners The list of labels of face owner cells.
      * @param faceNeighbors The list of labels of face neighbor cells.
-     * @param nCells The number of cells in the mesh.
-     * @param nInternalFaces The number of internal faces in the mesh.
-     * @param nBoundaryFaces The number of boundary faces in the mesh.
-     * @param nBoundaries The number of boundaries in the mesh.
-     * @param nFaces The number of faces in the mesh.
      * @param boundaryMesh The boundary mesh.
      */
     UnstructuredMesh(
@@ -96,11 +81,6 @@ public:
         scalarVector faceAreas,
         labelVector faceOwners,
         labelVector faceNeighbors,
-        localIdx nCells,
-        localIdx nInternalFaces,
-        localIdx nBoundaryFaces,
-        localIdx nBoundaries,
-        localIdx nFaces,
         BoundaryMesh boundaryMesh
     );
 
@@ -189,19 +169,28 @@ public:
      */
     localIdx nBoundaryFaces() const;
 
+    localIdx nProcBoundaryFaces() const;
+
     /**
-     * @brief Get the number of boundaries in the mesh.
+     * @brief Get the total number of faces including boundary and processor faces in the mesh.
+     *
+     * @return The  total number of faces in the mesh.
+     */
+    localIdx nTotalFaces() const;
+
+    /**
+     * @brief Get the number of boundaries patches in the mesh.
      *
      * @return The number of boundaries in the mesh.
      */
     localIdx nBoundaries() const;
 
     /**
-     * @brief Get the number of faces in the mesh.
+     * @brief the offset local cellIds for the global mesh.
      *
-     * @return The number of faces in the mesh.
+     * @return the global offset
      */
-    localIdx nFaces() const;
+    localIdx globalOffset() const;
 
     /**
      * @brief Get the boundary mesh.
@@ -209,6 +198,8 @@ public:
      * @return The boundary mesh.
      */
     const BoundaryMesh& boundaryMesh() const;
+
+    BoundaryMesh& boundaryMesh();
 
     /**
      * @brief Get the stencil data base.
@@ -287,27 +278,15 @@ private:
     localIdx nInternalFaces_;
 
     /**
-     * @brief Number of boundary faces in the mesh.
-     */
-    localIdx nBoundaryFaces_;
-
-    /**
-     * @brief Number of boundaries in the mesh.
-     */
-    localIdx nBoundaries_;
-
-    /**
-     * @brief Number of faces in the mesh.
-     */
-    localIdx nFaces_;
-
-    /**
      * @brief Boundary mesh.
      *
      * The boundary mesh is a collection of boundary patches
      * that are used to define boundary conditions in the mesh.
      */
     BoundaryMesh boundaryMesh_;
+
+    //
+    localIdx globalOffset_;
 
     /**
      * @brief Stencil data base.

--- a/src/bindings/boundaryMesh.cpp
+++ b/src/bindings/boundaryMesh.cpp
@@ -40,6 +40,8 @@ void registerBoundaryMesh(nb::module_& m)
                 NeoN::vectorVector,
                 NeoN::scalarVector,
                 NeoN::scalarVector,
+                std::vector<NeoN::localIdx>,
+                NeoN::localIdx,
                 std::vector<NeoN::localIdx>>(),
             "exec"_a,
             "face_owners"_a,
@@ -52,6 +54,8 @@ void registerBoundaryMesh(nb::module_& m)
             "weights"_a,
             "delta_coeffs"_a,
             "offset"_a,
+            "procBoundaryPatches"_a,
+            "neighbourRank"_a,
             "Create a BoundaryMesh with all geometric data"
         )
 
@@ -129,11 +133,10 @@ void registerBoundaryMesh(nb::module_& m)
         )
         .def(
             "offset",
-            &NeoN::BoundaryMesh::offset,
+            nb::overload_cast<>(&NeoN::BoundaryMesh::offset, nb::const_),
             nb::rv_policy::reference_internal,
             "Get the offset vector for accessing boundary-specific data"
         )
-
         .def(
             "__repr__",
             [](const NeoN::BoundaryMesh& bm)

--- a/src/bindings/unstructuredMesh.cpp
+++ b/src/bindings/unstructuredMesh.cpp
@@ -39,11 +39,6 @@ void registerUnstructuredMesh(nb::module_& m)
                 NeoN::scalarVector,
                 NeoN::labelVector,
                 NeoN::labelVector,
-                NeoN::localIdx,
-                NeoN::localIdx,
-                NeoN::localIdx,
-                NeoN::localIdx,
-                NeoN::localIdx,
                 NeoN::BoundaryMesh>(),
             "points"_a,
             "cell_volumes"_a,
@@ -53,11 +48,6 @@ void registerUnstructuredMesh(nb::module_& m)
             "face_areas"_a,
             "face_owners"_a,
             "face_neighbors"_a,
-            "n_cells"_a,
-            "n_internal_faces"_a,
-            "n_boundary_faces"_a,
-            "n_boundaries"_a,
-            "n_faces"_a,
             "boundary_mesh"_a,
             "Create an UnstructuredMesh with all data"
         )
@@ -124,19 +114,18 @@ void registerUnstructuredMesh(nb::module_& m)
             "Get the number of boundary faces"
         )
         .def(
+            "n_total_faces",
+            &NeoN::UnstructuredMesh::nTotalFaces,
+            "Get the total number of faces (internal + boundary + processor faces)"
+        )
+        .def(
             "n_boundaries",
             &NeoN::UnstructuredMesh::nBoundaries,
             "Get the number of boundary patches"
         )
         .def(
-            "n_faces",
-            &NeoN::UnstructuredMesh::nFaces,
-            "Get the total number of faces (internal + boundary)"
-        )
-
-        .def(
             "boundary_mesh",
-            &NeoN::UnstructuredMesh::boundaryMesh,
+            nb::overload_cast<>(&NeoN::UnstructuredMesh::boundaryMesh, nb::const_),
             nb::rv_policy::reference_internal,
             "Get the boundary mesh"
         )
@@ -152,7 +141,7 @@ void registerUnstructuredMesh(nb::module_& m)
             [](const NeoN::UnstructuredMesh& mesh)
             {
                 return "<UnstructuredMesh: " + std::to_string(mesh.nCells()) + " cells, "
-                     + std::to_string(mesh.nFaces()) + " faces, "
+                     + std::to_string(mesh.nBoundaryFaces()) + " boundary faces, "
                      + std::to_string(mesh.nBoundaries()) + " boundaries>";
             }
         )
@@ -161,7 +150,8 @@ void registerUnstructuredMesh(nb::module_& m)
             [](const NeoN::UnstructuredMesh& mesh)
             {
                 return "UnstructuredMesh(cells=" + std::to_string(mesh.nCells())
-                     + ", faces=" + std::to_string(mesh.nFaces())
+                     + ", internal faces=" + std::to_string(mesh.nInternalFaces())
+                     + ", boundary faces=" + std::to_string(mesh.nBoundaryFaces())
                      + ", boundaries=" + std::to_string(mesh.nBoundaries()) + ")";
             }
         );

--- a/src/mesh/unstructured/boundaryMesh.cpp
+++ b/src/mesh/unstructured/boundaryMesh.cpp
@@ -4,8 +4,11 @@
 
 #include "NeoN/mesh/unstructured/boundaryMesh.hpp"
 
+
 namespace NeoN
 {
+
+void BoundaryMesh::validate() const {}
 
 BoundaryMesh::BoundaryMesh(
     const Executor& exec,
@@ -18,12 +21,15 @@ BoundaryMesh::BoundaryMesh(
     vectorVector delta,
     scalarVector weights,
     scalarVector deltaCoeffs,
-    std::vector<localIdx> offset
+    std::vector<localIdx> offset,
+    localIdx procBoundaryPatches,
+    std::vector<localIdx> neighbourRank
 )
     : exec_(exec), faceOwners_(faceOwners), faceCenters_(faceCenters),
       ownerCellCenters_(ownerCellCenters), faceNormals_(faceNormals), faceAreas_(faceAreas),
       faceUnitNormals_(faceUnitNormals), delta_(delta), weights_(weights),
-      deltaCoeffs_(deltaCoeffs), offset_(offset) {};
+      deltaCoeffs_(deltaCoeffs), offset_(offset), procBoundaryPatches_(procBoundaryPatches),
+      neighbourRank_(neighbourRank) {};
 
 // Accessor methods
 const labelVector& BoundaryMesh::faceOwners() const { return faceOwners_; }
@@ -95,9 +101,24 @@ View<const scalar> BoundaryMesh::weights(const localIdx i) const
 
 const scalarVector& BoundaryMesh::deltaCoeffs() const { return deltaCoeffs_; }
 
+localIdx BoundaryMesh::neighbourRank(const localIdx i) const { return neighbourRank_[i]; }
+
+const std::vector<localIdx>& BoundaryMesh::neighbourRank() const { return neighbourRank_; }
+
 View<const scalar> BoundaryMesh::deltaCoeffs(const localIdx i) const
 {
     return extractSubView(deltaCoeffs_, offset_, i);
+}
+
+localIdx BoundaryMesh::nProcBoundaryPatches() const { return procBoundaryPatches_; }
+
+localIdx BoundaryMesh::nProcBoundaryFaces() const
+{
+    if (nProcBoundaryPatches() == 0)
+    {
+        return 0;
+    }
+    return offset_[offset_.size() - 1] - offset_[offset_.size() - nProcBoundaryPatches() - 1];
 }
 
 const std::vector<localIdx>& BoundaryMesh::offset() const { return offset_; }

--- a/src/mesh/unstructured/uniformMeshDataGenerator.cpp
+++ b/src/mesh/unstructured/uniformMeshDataGenerator.cpp
@@ -296,7 +296,9 @@ BoundaryMesh generateBoundaryData(
         {exec, bndDelta},
         {exec, bndWeights},
         {exec, bndDeltaCoeffs},
-        offset
+        offset,
+        0,
+        {}
     );
 
     return boundaryMesh;

--- a/src/mesh/unstructured/unstructuredMesh.cpp
+++ b/src/mesh/unstructured/unstructuredMesh.cpp
@@ -10,6 +10,29 @@
 
 namespace NeoN
 {
+
+localIdx computeGlobalOffset(const BoundaryMesh& boundaryMesh, localIdx localNCells)
+{
+    // NOTE not yet implemented, will be added via separate PR
+    // if (!boundaryMesh.isDistributed())
+    // {
+    //     return 0;
+    // }
+    // mpi::Environment mpiEnviron;
+    // const auto nRanks = mpiEnviron.sizeRank();
+    // const auto myRank = mpiEnviron.rank();
+    // auto allNCells = std::vector<int>(nRanks);
+    // MPI_Allgather(&localNCells, 1, MPI_INT, allNCells.data(), 1, MPI_INT, mpiEnviron.comm());
+    // std::vector<localIdx> globalOffset(nRanks + 1, 0);
+    // for (int i = 0; i < nRanks; i++)
+    // {
+    //     globalOffset[i + 1] = globalOffset[i] + allNCells[i];
+    // }
+    // return globalOffset[myRank];
+    return 0;
+}
+
+
 UnstructuredMesh::UnstructuredMesh(
     Executor exec,
     vectorVector points,
@@ -20,18 +43,13 @@ UnstructuredMesh::UnstructuredMesh(
     scalarVector faceAreas,
     labelVector faceOwners,
     labelVector faceNeighbors,
-    localIdx nCells,
-    localIdx nInternalFaces,
-    localIdx nBoundaryFaces,
-    localIdx nBoundaries,
-    localIdx nFaces,
     BoundaryMesh boundaryMesh
 )
     : exec_(exec), points_(points), cellVolumes_(cellVolumes), cellCenters_(cellCenters),
       faceNormals_(faceNormals), faceCenters_(faceCenters), faceAreas_(faceAreas),
-      faceOwners_(faceOwners), faceNeighbors_(faceNeighbors), nCells_(nCells),
-      nInternalFaces_(nInternalFaces), nBoundaryFaces_(nBoundaryFaces), nBoundaries_(nBoundaries),
-      nFaces_(nFaces), boundaryMesh_(boundaryMesh), stencilDataBase_()
+      faceOwners_(faceOwners), faceNeighbors_(faceNeighbors), nCells_(cellVolumes.size()),
+      nInternalFaces_(faceNeighbors.size()), boundaryMesh_(boundaryMesh),
+      globalOffset_(computeGlobalOffset(boundaryMesh, cellVolumes.size())), stencilDataBase_()
 {}
 
 UnstructuredMesh::UnstructuredMesh(
@@ -43,11 +61,6 @@ UnstructuredMesh::UnstructuredMesh(
     scalarVector faceAreas,
     labelVector faceOwners,
     labelVector faceNeighbors,
-    localIdx nCells,
-    localIdx nInternalFaces,
-    localIdx nBoundaryFaces,
-    localIdx nBoundaries,
-    localIdx nFaces,
     BoundaryMesh boundaryMesh
 )
     : UnstructuredMesh(
@@ -60,11 +73,6 @@ UnstructuredMesh::UnstructuredMesh(
         faceAreas,
         faceOwners,
         faceNeighbors,
-        nCells,
-        nInternalFaces,
-        nBoundaryFaces,
-        nBoundaries,
-        nFaces,
         boundaryMesh
     )
 {}
@@ -106,13 +114,22 @@ localIdx UnstructuredMesh::nCells() const { return nCells_; }
 
 localIdx UnstructuredMesh::nInternalFaces() const { return nInternalFaces_; }
 
-localIdx UnstructuredMesh::nBoundaryFaces() const { return nBoundaryFaces_; }
+localIdx UnstructuredMesh::nBoundaryFaces() const { return boundaryMesh_.nBoundaryFaces(); }
 
-localIdx UnstructuredMesh::nBoundaries() const { return nBoundaries_; }
+localIdx UnstructuredMesh::nProcBoundaryFaces() const { return boundaryMesh_.nProcBoundaryFaces(); }
 
-localIdx UnstructuredMesh::nFaces() const { return nFaces_; }
+localIdx UnstructuredMesh::nBoundaries() const { return boundaryMesh_.nBoundaries(); }
+
+localIdx UnstructuredMesh::nTotalFaces() const
+{
+    return nInternalFaces() + nBoundaryFaces() + nProcBoundaryFaces();
+}
+
+localIdx UnstructuredMesh::globalOffset() const { return globalOffset_; }
 
 const BoundaryMesh& UnstructuredMesh::boundaryMesh() const { return boundaryMesh_; }
+
+BoundaryMesh& UnstructuredMesh::boundaryMesh() { return boundaryMesh_; }
 
 Dictionary& UnstructuredMesh::stencilDB() const { return stencilDataBase_; }
 
@@ -142,7 +159,9 @@ UnstructuredMesh createSingleCellMesh(const Executor exec)
         {exec, {{-0.5, 0.0, 0.0}, {0.0, 0.5, 0.0}, {0.5, 0.0, 0.0}, {0.0, -0.5, 0.0}}}, // delta
         {exec, {1, 1, 1, 1}},                                                           // weights
         {exec, {2.0, 2.0, 2.0, 2.0}}, // deltaCoeffs --> mag(1 / delta)
-        {0, 1, 2, 3, 4}               // offset
+        {0, 1, 2, 3, 4},              // offset
+        0,                            // number of proc boundary patches
+        {}                            // neighbourRank
     );
     return UnstructuredMesh(
         {exec, {{0, 0, 0}, {0, 1, 0}, {1, 1, 0}, {1, 0, 0}}}, // points,
@@ -152,12 +171,7 @@ UnstructuredMesh createSingleCellMesh(const Executor exec)
         faceCentersVec3s,
         faceAreas,
         {exec, {0, 0, 0, 0}}, // faceOwners
-        {exec, {}},           // faceNeighbors,
-        1,                    // nCells
-        0,                    // nInternalFaces,
-        4,                    // nBoundaryFaces,
-        4,                    // nBoundaries,
-        4,                    // nFaces,
+        {exec, {}},           // faceNeighbors
         boundaryMesh
     );
 }
@@ -258,11 +272,6 @@ UnstructuredMesh create3DUniformMesh(
         {exec, std::move(faces.magnitudes)},
         {exec, std::move(faces.owner)},
         labelVector(exec, std::move(faces.neighbour)),
-        nCells,
-        nInternalFaces,
-        nBoundaryFaces,
-        static_cast<localIdx>(offset.size() - 1), // nBoundaries
-        nFaces,
         std::move(boundaryMesh)
     );
 
@@ -270,4 +279,6 @@ UnstructuredMesh create3DUniformMesh(
 
     return mesh;
 }
+
+
 } // namespace NeoN

--- a/test/bindings/test_dsl.py
+++ b/test/bindings/test_dsl.py
@@ -10,7 +10,7 @@ from neon import exp, imp
 def test_dsl_scalar_operators(executor):
     # Setup
     name, exec = executor
-    mesh = neon.create_1d_uniform_mesh(exec, 10)
+    mesh = neon.create_1d_uniform_mesh(exec, 10, 1.0)
     phi = neon.ScalarVolumeField(exec, "phi", mesh)
 
     # 1. Test Temporal Operator Construction
@@ -83,7 +83,7 @@ def test_dsl_scalar_operators(executor):
 def test_dsl_vector_operators(executor):
     # Setup
     name, exec = executor
-    mesh = neon.create_1d_uniform_mesh(exec, 10)
+    mesh = neon.create_1d_uniform_mesh(exec, 10, 1.0)
     phi = neon.VectorVolumeField(exec, "phi", mesh)
     coeff = neon.ScalarVolumeField(exec, "coeff", mesh)
 

--- a/test/bindings/test_mesh.py
+++ b/test/bindings/test_mesh.py
@@ -27,14 +27,13 @@ def test_single_cell_mesh(executor):
 def test_1d_uniform_mesh(executor):
     name, exec = executor
     n_cells = 10
-    mesh = neon.create_1d_uniform_mesh(exec, n_cells)
+    mesh = neon.create_1d_uniform_mesh(exec, n_cells, 1.0)
 
     assert mesh.n_cells() == n_cells
     assert mesh.n_internal_faces() == n_cells - 1
-    assert mesh.n_faces() > 0
+    assert mesh.n_total_faces() > 0
     assert mesh.cell_volumes.size() == n_cells
     assert mesh.cell_centers.size() == n_cells
-    assert mesh.face_owners.size() == mesh.n_faces()
     assert mesh.face_neighbors.size() == mesh.n_internal_faces()
 
 
@@ -45,16 +44,12 @@ def test_mesh_geometry(executor):
     assert mesh.points.size() > 0
     assert mesh.cell_volumes.size() == mesh.n_cells()
     assert mesh.cell_centers.size() == mesh.n_cells()
-    assert mesh.face_centers.size() == mesh.n_faces()
-    assert mesh.face_normals.size() == mesh.n_faces()
-    assert mesh.face_areas.size() == mesh.n_faces()
 
 
 def test_mesh_topology(executor):
     name, exec = executor
-    mesh = neon.create_1d_uniform_mesh(exec, 5)
+    mesh = neon.create_1d_uniform_mesh(exec, 5, 1.0)
 
-    assert mesh.face_owners.size() == mesh.n_faces()
     assert mesh.face_neighbors.size() == mesh.n_internal_faces()
     assert mesh.boundary_mesh().face_owners().size() > 0
 

--- a/test/dsl/common.hpp
+++ b/test/dsl/common.hpp
@@ -5,6 +5,9 @@
 #define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
                             // a custom main
 #include "catch2_common.hpp"
+#include <catch2/catch_approx.hpp>
+
+#include <random>
 
 #include "NeoN/NeoN.hpp"
 
@@ -112,7 +115,7 @@ struct CreateSurfaceVector
 
         // Face storage
         NeoN::Field<ValueType> domainField(
-            mesh.exec(), mesh.nFaces(), mesh.boundaryMesh().offset()
+            mesh.exec(), mesh.nTotalFaces(), mesh.boundaryMesh().offset()
         );
         NeoN::fill(domainField.internalVector(), value);
         NeoN::fill(domainField.boundaryData().refValue(), value);
@@ -281,4 +284,29 @@ ValueType getRhs(const la::LinearSystem<ValueType, la::CSRMatrix<ValueType, loca
 {
     auto hostLs = ls.copyToHost();
     return hostLs.rhs().view()[0];
+}
+
+
+template<typename VectorValueType>
+void randomizeVector(NeoN::Vector<VectorValueType>& a)
+{
+    // std::random_device rd;  // Will be used to obtain a seed for the random number engine
+    // std::mt19937 gen(rd()); // Standard mersenne_twister_engine seeded with rd()
+    // std::uniform_real_distribution<> dis(1.0, 2.0);
+
+    auto b = a.copyToHost();
+    auto bV = b.view();
+
+    for (int i = 0; i < b.size(); i++)
+    {
+        bV[i] = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
+    }
+    auto c = b.copyToExecutor(a.exec());
+    a = c;
+}
+
+template<typename VectorValueType>
+void randomizeVector(fvcc::VolumeField<VectorValueType>& a)
+{
+    randomizeVector(a.internalVector());
 }

--- a/test/mesh/unstructured/unstructuredMesh.cpp
+++ b/test/mesh/unstructured/unstructuredMesh.cpp
@@ -40,7 +40,7 @@ TEST_CASE("Unstructured Mesh")
         REQUIRE(mesh.nInternalFaces() == 3);
         REQUIRE(mesh.nBoundaryFaces() == 2);
         REQUIRE(mesh.nBoundaries() == 2);
-        REQUIRE(mesh.nFaces() == 5);
+        REQUIRE(mesh.nTotalFaces() == 5);
 
         // Verify mesh points
         // bc  [   internal  ]  bc
@@ -97,7 +97,7 @@ TEST_CASE("Unstructured Mesh")
         REQUIRE(mesh.nInternalFaces() == 4);
         REQUIRE(mesh.nBoundaryFaces() == 8);
         REQUIRE(mesh.nBoundaries() == 4);
-        REQUIRE(mesh.nFaces() == 12);
+        REQUIRE(mesh.nTotalFaces() == 12);
 
         // Verify point count: two z-planes
         auto hostPoints = mesh.points().copyToHost();
@@ -171,7 +171,7 @@ TEST_CASE("Unstructured Mesh")
         REQUIRE(mesh.nInternalFaces() == 7);
         REQUIRE(mesh.nBoundaryFaces() == 10);
         REQUIRE(mesh.nBoundaries() == 4);
-        REQUIRE(mesh.nFaces() == 17);
+        REQUIRE(mesh.nTotalFaces() == 17);
 
         // Cell volume = (3/3) * (2/2) * 1.0 = 1.0
         auto cellVolumesExp = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
@@ -236,7 +236,7 @@ TEST_CASE("Unstructured Mesh")
         REQUIRE(mesh.nInternalFaces() == 12);
         REQUIRE(mesh.nBoundaryFaces() == 24);
         REQUIRE(mesh.nBoundaries() == 6);
-        REQUIRE(mesh.nFaces() == 36);
+        REQUIRE(mesh.nTotalFaces() == 36);
 
         auto hostPoints = mesh.points().copyToHost();
         REQUIRE(hostPoints.size() == 27);
@@ -284,7 +284,7 @@ TEST_CASE("Unstructured Mesh")
         REQUIRE(mesh.nInternalFaces() == 20);
         REQUIRE(mesh.nBoundaryFaces() == 32);
         REQUIRE(mesh.nBoundaries() == 6);
-        REQUIRE(mesh.nFaces() == 52);
+        REQUIRE(mesh.nTotalFaces() == 52);
 
         // Cell volume = (3/3) * (2/2) * (2/2) = 1.0
         auto cellVolumesExp =

--- a/test/timeIntegration/ddtFluxCorr.cpp
+++ b/test/timeIntegration/ddtFluxCorr.cpp
@@ -76,11 +76,11 @@ TEST_CASE("timeIntegration: ddtPhiCorr on single-cell mesh", "[timeIntegration][
         // Helper: expected values (host-side)
         auto expectedFrom = [&](const SurfScalar& flux0Field)
         {
-            std::vector<Scalar> e(static_cast<size_t>(mesh.nFaces()), 0.0);
+            std::vector<Scalar> e(static_cast<size_t>(mesh.nTotalFaces()), 0.0);
             auto flux0FieldH = flux0Field.internalVector().copyToHost();
             auto flux0FieldV = flux0FieldH.view();
 
-            for (auto i = 0; i < mesh.nFaces(); ++i)
+            for (auto i = 0; i < mesh.nTotalFaces(); ++i)
             {
                 const Scalar d = (sfV[i] & uf0V[i]);
                 const auto tfluxCorr = (flux0FieldV[i] - d);
@@ -102,7 +102,7 @@ TEST_CASE("timeIntegration: ddtPhiCorr on single-cell mesh", "[timeIntegration][
 
             NeoN::parallelFor(
                 exec,
-                {size_t(0), mesh.nFaces()},
+                {size_t(0), mesh.nTotalFaces()},
                 NEON_LAMBDA(const NeoN::localIdx i) { flux0V2[i] = (sfV2[i] & uf0V2[i]); }
             );
 
@@ -111,8 +111,10 @@ TEST_CASE("timeIntegration: ddtPhiCorr on single-cell mesh", "[timeIntegration][
             auto fluxCorr = fvcc::ddtFluxCorr(u, flux, dt, scheme);
             auto corrH = fluxCorr.internalVector().copyToHost();
 
-            for (auto i = 0; i < mesh.nFaces(); ++i)
+            for (auto i = 0; i < mesh.nTotalFaces(); ++i)
+            {
                 REQUIRE(corrH.view()[i] == Catch::Approx(0.0).margin(1e-12));
+            }
         }
 
         // ─────────────────────────────────────────────
@@ -126,10 +128,12 @@ TEST_CASE("timeIntegration: ddtPhiCorr on single-cell mesh", "[timeIntegration][
             auto fluxCorr = fvcc::ddtFluxCorr(u, flux, dt, scheme);
             auto corrH = fluxCorr.internalVector().copyToHost();
 
-            for (auto i = 0; i < mesh.nFaces(); ++i)
+            for (auto i = 0; i < mesh.nTotalFaces(); ++i)
+            {
                 REQUIRE(
                     corrH.view()[i] == Catch::Approx(expected[static_cast<size_t>(i)]).margin(1e-12)
                 );
+            }
         }
     }
 }


### PR DESCRIPTION
# Motivation
This PR takes mesh-related changes out of https://github.com/exasim-project/NeoN/pull/414 and prepares the unstructured mesh data structure for distributed cases.

Relevant changes:
- derive the number of faces/cells/ etc from the input rather than taking it as an argument. 

Corresponding PR on NeoFOAM https://github.com/exasim-project/NeoFOAM/pull/291