### PR TITLE
add processor boundary conditions for volume and surface fields

### DIFF
--- a/include/NeoN/finiteVolume/cellCentred/boundary/surface/processor.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/surface/processor.hpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <Kokkos_Core.hpp>
+
+#include "NeoN/core/primitives/vec3.hpp"
+#include "NeoN/finiteVolume/cellCentred/boundary/surfaceBoundaryFactory.hpp"
+#include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
+
+namespace NeoN::finiteVolume::cellCentred::surfaceBoundary
+{
+
+namespace detail
+{
+template<typename ValueType>
+void setProcBoundaryValue(
+    Field<ValueType>& domainVector,
+    const UnstructuredMesh& mesh,
+    std::pair<localIdx, localIdx> range
+);
+
+extern template void setProcBoundaryValue<
+    scalar>(Field<scalar>&, const UnstructuredMesh&, std::pair<localIdx, localIdx>);
+extern template void
+setProcBoundaryValue<Vec3>(Field<Vec3>&, const UnstructuredMesh&, std::pair<localIdx, localIdx>);
+}
+
+template<typename ValueType>
+class Processor : public SurfaceBoundaryFactory<ValueType>::template Register<Processor<ValueType>>
+{
+    using Base = SurfaceBoundaryFactory<ValueType>::template Register<Processor<ValueType>>;
+
+public:
+
+    Processor(const UnstructuredMesh& mesh, const Dictionary& dict, localIdx patchID)
+        : Base(mesh, dict, patchID), mesh_(mesh)
+    {}
+
+    virtual void correctBoundaryCondition([[maybe_unused]] Field<ValueType>& domainVector) final
+    {
+        detail::setProcBoundaryValue(domainVector, mesh_, this->range());
+    }
+
+
+    static std::string name() { return "processor"; }
+
+    static std::string doc()
+    {
+        return "Set processor boundary values from the corresponding processor-neighbour data.";
+    }
+
+    static std::string schema() { return "none"; }
+
+    virtual std::unique_ptr<SurfaceBoundaryFactory<ValueType>> clone() const override
+    {
+        return std::make_unique<Processor>(*this);
+    }
+
+private:
+
+    const UnstructuredMesh& mesh_;
+};
+
+}

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/calculated.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/calculated.hpp
@@ -31,6 +31,8 @@ public:
 
     static std::string name() { return "calculated"; }
 
+    std::string getName() const override { return name(); }
+
     static std::string doc() { return "TBD"; }
 
     static std::string schema() { return "none"; }

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/empty.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/empty.hpp
@@ -29,6 +29,8 @@ public:
 
     static std::string name() { return "empty"; }
 
+    std::string getName() const override { return name(); }
+
     static std::string doc() { return "Do nothing on the boundary."; }
 
     static std::string schema() { return "none"; }

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/extrapolated.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/extrapolated.hpp
@@ -77,6 +77,8 @@ public:
 
     static std::string name() { return "extrapolated"; }
 
+    std::string getName() const override { return name(); }
+
     static std::string doc() { return "TBD"; }
 
     static std::string schema() { return "none"; }

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedGradient.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedGradient.hpp
@@ -39,7 +39,6 @@ void setGradientValue(
         mesh.boundaryMesh().deltaCoeffs()
     );
 
-
     NeoN::parallelFor(
         domainVector.exec(),
         range,
@@ -78,6 +77,8 @@ public:
     }
 
     static std::string name() { return "fixedGradient"; }
+
+    std::string getName() const override { return name(); }
 
     static std::string doc() { return "Set a fixed gradient on the boundary."; }
 

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedValue.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedValue.hpp
@@ -67,6 +67,8 @@ public:
 
     static std::string name() { return "fixedValue"; }
 
+    std::string getName() const override { return name(); }
+
     static std::string doc() { return "Set a fixed value on the boundary"; }
 
     static std::string schema() { return "none"; }

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/processor.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/processor.hpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <Kokkos_Core.hpp>
+
+#include "NeoN/core/primitives/vec3.hpp"
+#include "NeoN/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp"
+#include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
+
+namespace NeoN::finiteVolume::cellCentred::volumeBoundary
+{
+
+namespace detail
+{
+template<typename ValueType>
+void setProcBoundaryValue(
+    Field<ValueType>& domainVector,
+    const UnstructuredMesh& mesh,
+    std::pair<localIdx, localIdx> range
+);
+
+extern template void setProcBoundaryValue<
+    scalar>(Field<scalar>&, const UnstructuredMesh&, std::pair<localIdx, localIdx>);
+extern template void
+setProcBoundaryValue<Vec3>(Field<Vec3>&, const UnstructuredMesh&, std::pair<localIdx, localIdx>);
+}
+
+template<typename ValueType>
+class Processor : public VolumeBoundaryFactory<ValueType>::template Register<Processor<ValueType>>
+{
+    using Base = VolumeBoundaryFactory<ValueType>::template Register<Processor<ValueType>>;
+
+public:
+
+    using ProcessorType = Processor<ValueType>;
+
+    Processor(const UnstructuredMesh& mesh, const Dictionary& dict, localIdx patchID)
+        : Base(mesh, dict, patchID, {.assignable = true, .fixesValue = false}), mesh_(mesh)
+    {}
+
+    virtual void correctBoundaryCondition([[maybe_unused]] Field<ValueType>& domainVector) final
+    {
+        detail::setProcBoundaryValue(domainVector, mesh_, this->range());
+    }
+
+    static std::string name() { return "processor"; }
+
+    static std::string doc()
+    {
+        return "Set processor boundary values from the corresponding processor-neighbour data.";
+    }
+
+    static std::string schema() { return "none"; }
+
+    virtual std::unique_ptr<VolumeBoundaryFactory<ValueType>> clone() const final
+    {
+        return std::make_unique<Processor>(*this);
+    }
+
+    std::string getName() const override { return name(); }
+
+
+private:
+
+    const UnstructuredMesh& mesh_;
+};
+}

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/symmetry.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/symmetry.hpp
@@ -126,6 +126,8 @@ public:
 
     static std::string name() { return "symmetry"; }
 
+    std::string getName() const override { return name(); }
+
     static std::string doc()
     {
         return "Symmetry plane (scalar: zero-gradient; vector: tangential projection).";

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp
@@ -25,7 +25,9 @@ class BoundaryContext;
 struct BoundaryAttributes
 {
     bool assignable; ///< whether values can be assigned to the boundary patch
-    bool fixesValue;
+    bool fixesValue; ///< whether the bc enforces a fixed field value (Dirichlet), not a
+                     ///< gradient/Neumann condition NOTE this is somewhat redundant to
+                     ///< valueFraction of boundaryData
 };
 
 template<typename ValueType>
@@ -57,6 +59,8 @@ public:
     }
 
     virtual std::unique_ptr<VolumeBoundaryFactory> clone() const = 0;
+
+    virtual std::string getName() const = 0;
 
     BoundaryAttributes attributes() const { return attributes_; }
 
@@ -107,6 +111,8 @@ public:
     {
         return boundaryCorrectionStrategy_->attributes();
     }
+
+    const std::string name() const { return boundaryCorrectionStrategy_->getName(); }
 
 private:
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,6 +52,8 @@ target_sources(
           "finiteVolume/cellCentred/stencil/cellToFaceStencil.cpp"
           "finiteVolume/cellCentred/boundary/boundary.cpp"
           "finiteVolume/cellCentred/boundary/boundaryContext.cpp"
+          "finiteVolume/cellCentred/boundary/surface/processor.cpp"
+          "finiteVolume/cellCentred/boundary/volume/processor.cpp"
           "finiteVolume/cellCentred/operators/ddtOperator.cpp"
           "finiteVolume/cellCentred/fields/volumeField.cpp"
           "finiteVolume/cellCentred/operators/gaussGreenGrad.cpp"

--- a/src/finiteVolume/cellCentred/boundary/surface/processor.cpp
+++ b/src/finiteVolume/cellCentred/boundary/surface/processor.cpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#include "NeoN/core/parallelAlgorithms.hpp"
+#include "NeoN/core/primitives/scalar.hpp"
+#include "NeoN/core/primitives/vec3.hpp"
+#include "NeoN/finiteVolume/cellCentred/boundary/surface/processor.hpp"
+
+namespace NeoN::finiteVolume::cellCentred::surfaceBoundary::detail
+{
+
+template<typename ValueType>
+void setProcBoundaryValue(
+    Field<ValueType>& domainVector,
+    const UnstructuredMesh& mesh,
+    std::pair<localIdx, localIdx> range
+)
+{
+    const auto iVector = domainVector.internalVector().view();
+
+    auto [refGradient, value, valueFraction, refValue, faceCells] = views(
+        domainVector.boundaryData().refGrad(),
+        domainVector.boundaryData().value(),
+        domainVector.boundaryData().valueFraction(),
+        domainVector.boundaryData().refValue(),
+        mesh.boundaryMesh().faceOwners()
+    );
+
+    NeoN::parallelFor(
+        domainVector.exec(),
+        range,
+        NEON_LAMBDA(const localIdx i) {
+            refGradient[i] = zero<ValueType>();
+            value[i] = iVector[faceCells[i]];
+            valueFraction[i] = 0.0;
+            refValue[i] = zero<ValueType>();
+        },
+        "setProcBoundaryValue"
+    );
+}
+
+template void setProcBoundaryValue<
+    scalar>(Field<scalar>&, const UnstructuredMesh&, std::pair<localIdx, localIdx>);
+template void
+setProcBoundaryValue<Vec3>(Field<Vec3>&, const UnstructuredMesh&, std::pair<localIdx, localIdx>);
+
+} // namespace NeoN::finiteVolume::cellCentred::surfaceBoundary::detail

--- a/src/finiteVolume/cellCentred/boundary/volume/processor.cpp
+++ b/src/finiteVolume/cellCentred/boundary/volume/processor.cpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#include "NeoN/core/parallelAlgorithms.hpp"
+#include "NeoN/core/primitives/scalar.hpp"
+#include "NeoN/core/primitives/vec3.hpp"
+#include "NeoN/finiteVolume/cellCentred/boundary/volume/processor.hpp"
+
+namespace NeoN::finiteVolume::cellCentred::volumeBoundary::detail
+{
+
+template<typename ValueType>
+void setProcBoundaryValue(
+    Field<ValueType>& domainVector,
+    const UnstructuredMesh& mesh,
+    std::pair<localIdx, localIdx> range
+)
+{
+    const auto iVector = domainVector.internalVector().view();
+
+    auto [refGradient, value, valueFraction, refValue, faceCells] = views(
+        domainVector.boundaryData().refGrad(),
+        domainVector.boundaryData().value(),
+        domainVector.boundaryData().valueFraction(),
+        domainVector.boundaryData().refValue(),
+        mesh.boundaryMesh().faceOwners()
+    );
+
+    NeoN::parallelFor(
+        domainVector.exec(),
+        range,
+        NEON_LAMBDA(const localIdx i) {
+            refGradient[i] = zero<ValueType>();
+            value[i] = iVector[faceCells[i]];
+            valueFraction[i] = 0.0;
+            refValue[i] = zero<ValueType>();
+        },
+        "setProcBoundaryValue"
+    );
+}
+
+template void setProcBoundaryValue<
+    scalar>(Field<scalar>&, const UnstructuredMesh&, std::pair<localIdx, localIdx>);
+template void
+setProcBoundaryValue<Vec3>(Field<Vec3>&, const UnstructuredMesh&, std::pair<localIdx, localIdx>);
+
+} // namespace NeoN::finiteVolume::cellCentred::volumeBoundary::detail


### PR DESCRIPTION
Ports the VolumeProcessor and SurfaceProcessor boundary condition implementations from [stack/distributed](https://github.com/exasim-project/NeoN/pull/414), along with updates to the volume boundary factory registration and forward declarations in existing boundary headers.
