### PR TITLE
Add computeDivProcBoundImpl and computeLaplacianProcBoundImpl for pro…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Add experimental support for cell based assembly strategies [#471](https://github.com/exasim-project/NeoN/pull/471),[#517](https://github.com/exasim-project/NeoN/pull/517)
 - Add experimental support for COO and CSR Matrices [#486](https://github.com/exasim-project/NeoN/pull/486)
 - Add experimental umpire support [#455](https://github.com/exasim-project/NeoN/pull/455)
-- Add experimental MPI support [#519](https://github.com/exasim-project/NeoN/pull/519), [#520](https://github.com/exasim-project/NeoN/pull/520)
+- Add experimental MPI support [#519](https://github.com/exasim-project/NeoN/pull/519), [#520](https://github.com/exasim-project/NeoN/pull/520) [#512](https://github.com/exasim-project/NeoN/pull/512)
 - Add python bindings via nanobind [#382](https://github.com/exasim-project/NeoN/pull/382)
 - Correct the Ginkgo version to 2.0.0 (unreleased) [#493](https://github.com/exasim-project/NeoN/pull/493)
 - Add tensor and symmTensor primitives, Su type sourceTerm and passing of fields to BCs [#428](https://github.com/exasim-project/NeoN/pull/428)

--- a/cmake/Install.cmake
+++ b/cmake/Install.cmake
@@ -48,7 +48,7 @@ endif()
 
 if(fmt_ADDED)
   install(
-    TARGETS fmt-header-only
+    TARGETS fmt fmt-header-only
     EXPORT ${PROJECT_NAME}Targets
     INCLUDES
     DESTINATION include)

--- a/include/NeoN/distributed/partitioning.hpp
+++ b/include/NeoN/distributed/partitioning.hpp
@@ -63,6 +63,31 @@ oneDPartitionField(FieldType field, UnstructuredMesh& mesh, NeoN::mpi::Environme
     auto bcsPart = setProcessorBoundaryHelper(mesh, field.boundaryConditions(), mpiEnviron);
     FieldType ret(field.exec(), field.name + "Part", mesh, bcsPart);
     ret.internalVector() = internalVector;
+
+    const auto nProcBoundaryFaces = mesh.nProcBoundaryFaces();
+    if (nProcBoundaryFaces > 0)
+    {
+        const localIdx localSize =
+            static_cast<localIdx>(field.internalVector().size()) / mpiEnviron.sizeRank();
+        const localIdx firstIdx = mpiEnviron.rank() * mesh.nCells();
+        const auto nBoundaryFaces = mesh.nBoundaryFaces();
+        auto weightsH = mesh.boundaryMesh().weights().copyToHost();
+        auto globalInternalH = field.internalVector().copyToHost();
+        auto retBdH = ret.boundaryData().value().copyToHost();
+        const auto weightsHV = weightsH.view();
+        const auto globalInternalHV = globalInternalH.view();
+        auto retBdHV = retBdH.view();
+        for (localIdx procFacei = 0; procFacei < nProcBoundaryFaces; procFacei++)
+        {
+            const auto bcfacei = nBoundaryFaces + procFacei;
+            // weight > 0: owner side (right-facing) — neighbour is at firstIdx + localSize
+            // weight < 0: non-owner side (left-facing) — neighbour is at firstIdx - 1
+            const localIdx gIdx = weightsHV[bcfacei] > 0 ? firstIdx + localSize : firstIdx - 1;
+            retBdHV[bcfacei] = globalInternalHV[gIdx];
+        }
+        ret.boundaryData().value() = retBdH.copyToExecutor(field.exec());
+    }
+
     return ret;
 }
 

--- a/include/NeoN/fields/boundaryData.hpp
+++ b/include/NeoN/fields/boundaryData.hpp
@@ -102,11 +102,16 @@ public:
 
 
     /** @copydoc BoundaryData::value()*/
-    const Vector<ValueType>& value() const { return value_; }
+    const Vector<ValueType>& value() const
+    {
+        waitAll();
+        return value_;
+    }
 
     /**
      * @brief Get the view storing the computed values from the boundary
      * condition.
+     * @note calls waitAll to ensure all boundary data is updated.
      * @return The view storing the computed values.
      */
     Vector<ValueType>& value()

--- a/include/NeoN/fields/boundaryData.hpp
+++ b/include/NeoN/fields/boundaryData.hpp
@@ -41,6 +41,8 @@ class BoundaryData
 
 public:
 
+    using BoundaryDataType = ValueType;
+
     ~BoundaryData()
     {
         // commBuffers_ backs the memory of any in-flight MPI_Isend/MPI_Irecv calls.

--- a/include/NeoN/fields/boundaryData.hpp
+++ b/include/NeoN/fields/boundaryData.hpp
@@ -286,7 +286,7 @@ public:
         commBuffers_.push_back(std::move(buf));
     }
 
-    bool isComplete()
+    bool isComplete() const
     {
         if (requests_.empty() || !communicating_) return true;
         for (auto& req : requests_)
@@ -300,7 +300,7 @@ public:
 
 #endif
 
-    void waitAll()
+    void waitAll() const
     {
 #ifdef NF_WITH_MPI_SUPPORT
         if (requests_.empty() || !communicating_) return;
@@ -350,10 +350,10 @@ public:
 
 private:
 
-    Executor exec_;              ///< The executor on which the field is stored
-    Vector<ValueType> value_;    ///< The Vector storing the computed values from the
-                                 ///< boundary condition.
-    Vector<ValueType> refValue_; ///< The Vector storing the Dirichlet boundary values.
+    Executor exec_;                   ///< The executor on which the field is stored
+    mutable Vector<ValueType> value_; ///< The Vector storing the computed values from the
+                                      ///< boundary condition.
+    Vector<ValueType> refValue_;      ///< The Vector storing the Dirichlet boundary values.
     Vector<scalar>
         valueFraction_; ///< Fraction between Dirichlet (1.0) and Neuman (0.0) boundary value
     Vector<ValueType> refGrad_; ///< The Vector storing the Neumann boundary values.
@@ -371,9 +371,11 @@ private:
         localIdx rangeStart;
         localIdx patchSize;
     };
-    std::vector<MPI_Request> requests_;   ///< Pending MPI requests (send+recv pairs per patch).
-    std::vector<CommBuffer> commBuffers_; ///< Send/recv staging buffers for pending requests.
-    bool communicating_ = false;
+    mutable std::vector<MPI_Request>
+        requests_; ///< Pending MPI requests (send+recv pairs per patch).
+    mutable std::vector<CommBuffer>
+        commBuffers_; ///< Send/recv staging buffers for pending requests.
+    mutable bool communicating_ = false;
 #endif
 };
 

--- a/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/faceNormalGradient.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/faceNormalGradient.hpp
@@ -64,7 +64,7 @@ public:
     //   limitedCorrected → limiter[f] * corrVec[f] · interpGrad[f]
     // Default (uncorrected): fills internal vector with zeros.
     virtual void
-    implicitCorrection(const VolumeField<ValueType>& phi, SurfaceField<ValueType>& corrField) const
+    implicitCorrection(const VolumeField<ValueType>&, SurfaceField<ValueType>& corrField) const
     {
         NeoN::fill(corrField.internalVector(), zero<ValueType>());
     }

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp
@@ -14,7 +14,6 @@
 namespace NeoN::finiteVolume::cellCentred
 {
 
-
 /* @brief
  *
  */
@@ -68,7 +67,9 @@ private:
     SurfaceInterpolation<ValueType> surfaceInterpolation_;
 };
 
-// FIXME is this needed?
+// Required on MSVC: without extern template, each TU (DLL and EXE) gets its own
+// instantiation of table() static local, so the DLL's addSubType() inserts into
+// a different map than the one the test binary queries.
 extern template class GaussGreenDiv<scalar>;
 extern template class GaussGreenDiv<Vec3>;
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp
@@ -14,6 +14,7 @@
 namespace NeoN::finiteVolume::cellCentred
 {
 
+
 /* @brief
  *
  */
@@ -67,6 +68,7 @@ private:
     SurfaceInterpolation<ValueType> surfaceInterpolation_;
 };
 
+// FIXME is this needed?
 extern template class GaussGreenDiv<scalar>;
 extern template class GaussGreenDiv<Vec3>;
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp
@@ -15,14 +15,6 @@
 namespace NeoN::finiteVolume::cellCentred
 {
 
-template<typename ValueType>
-void computeLaplacianExp(
-    const FaceNormalGradient<ValueType>& faceNormalGradient,
-    const SurfaceField<scalar>& gamma,
-    const VolumeField<ValueType>& phi,
-    Vector<ValueType>& lapPhi,
-    const dsl::Coeff operatorScaling
-);
 
 template<typename ValueType>
 class GaussGreenLaplacian :
@@ -80,6 +72,7 @@ private:
     FaceNormalGradient<ValueType> faceNormalGradient_;
 };
 
+// FIXME is this needed
 extern template class GaussGreenLaplacian<scalar>;
 extern template class GaussGreenLaplacian<Vec3>;
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp
@@ -72,7 +72,9 @@ private:
     FaceNormalGradient<ValueType> faceNormalGradient_;
 };
 
-// FIXME is this needed
+// Required on MSVC: without extern template, each TU (DLL and EXE) gets its own
+// instantiation of table() static local, so the DLL's addSubType() inserts into
+// a different map than the one the test binary queries.
 extern template class GaussGreenLaplacian<scalar>;
 extern template class GaussGreenLaplacian<Vec3>;
 

--- a/include/NeoN/linearAlgebra/faceToMatrixAddress.hpp
+++ b/include/NeoN/linearAlgebra/faceToMatrixAddress.hpp
@@ -113,26 +113,13 @@ public:
     FaceToMatrixAddress(const FaceToMatrixAddress& mi);
 
 
-    [[nodiscard]] FaceToMatrixAddress copyToExecutor(Executor dstExec) const override
-    {
-        return {
-            ownerOffset_.copyToExecutor(dstExec),
-            neighbourOffset_.copyToExecutor(dstExec),
-            diagOffset_.copyToExecutor(dstExec)
-        };
-    }
-
+    FaceToMatrixAddress copyToExecutor(Executor dstExec) const;
 
     /**
      * @brief Get a view representation of the matrix's data.
      * @return FaceToMatrixView for easy access to matrix elements.
      */
-    [[nodiscard]] FaceToMatrixView view(View<const localIdx> rowOffsView) const
-    {
-        return FaceToMatrixView(
-            ownerOffset_.view(), neighbourOffset_.view(), diagOffset_.view(), rowOffsView
-        );
-    }
+    [[nodiscard]] FaceToMatrixView view(View<const localIdx> rowOffsView) const;
 
     /*@brief getter for ownerOffset */
     const Array<uint8_t>& ownerOffset() const;

--- a/include/NeoN/linearAlgebra/faceToMatrixAddress.hpp
+++ b/include/NeoN/linearAlgebra/faceToMatrixAddress.hpp
@@ -164,4 +164,9 @@ std::shared_ptr<const SparsityType> createBoundarySparsityPattern(
     const UnstructuredMesh& mesh, const FaceToMatrixAddress& faceToMatrixAddress
 );
 
+template<typename SparsityType>
+std::shared_ptr<const SparsityType> createOffDiagonalSparsityPattern(
+    const UnstructuredMesh& mesh, const FaceToMatrixAddress& faceToMatrixAddress
+);
+
 }

--- a/include/NeoN/linearAlgebra/linearSystem.hpp
+++ b/include/NeoN/linearAlgebra/linearSystem.hpp
@@ -89,9 +89,9 @@ public:
     LinearSystem(
         const SystemMatrixType& matrix,
         const Vector<ValueType>& rhs,
+        const BoundaryMatrixType& offDiagonalMatrix,
         const BoundaryMatrixType& boundaryMatrix,
         const Vector<ValueType>& boundaryRhs,
-        const BoundaryMatrixType& offDiagonalMatrix,
         std::shared_ptr<MeshIterationStrategy> strategy = std::make_shared<FaceBasedIterator>()
     )
         : matrix_(matrix), rhs_(rhs), boundaryMatrix_(boundaryMatrix),
@@ -102,17 +102,6 @@ public:
         validate();
     }
 
-    LinearSystem(
-        const SystemMatrixType& matrix,
-        const Vector<ValueType>& rhs,
-        const BoundaryMatrixType& boundaryMatrix,
-        const Vector<ValueType>& boundaryRhs,
-        std::shared_ptr<MeshIterationStrategy> strategy = std::make_shared<FaceBasedIterator>()
-    )
-        : LinearSystem(
-            matrix, rhs, boundaryMatrix, boundaryRhs, emptyMatrix(matrix.exec()), strategy
-        )
-    {}
 
     LinearSystem(const LinearSystem& ls)
         : matrix_(ls.matrix_), rhs_(ls.rhs_), boundaryMatrix_(ls.boundaryMatrix_),
@@ -150,9 +139,9 @@ public:
         return {
             matrix_.copyToExecutor(exec),
             rhs_.copyToExecutor(exec),
+            offDiagonalMatrix_.copyToExecutor(exec),
             boundaryMatrix_.copyToExecutor(exec),
-            boundaryRhs_.copyToExecutor(exec),
-            offDiagonalMatrix_.copyToExecutor(exec)
+            boundaryRhs_.copyToExecutor(exec)
         };
     }
 
@@ -206,15 +195,6 @@ public:
 
 private:
 
-    static BoundaryMatrixType emptyMatrix(const Executor& exec)
-    {
-        using IndexType = typename BoundaryMatrixType::MatrixSparsityType::SparsityIndexType;
-        auto sp = std::make_shared<const typename BoundaryMatrixType::MatrixSparsityType>(
-            Vector<IndexType>(exec, 0), Vector<IndexType>(exec, 0), Dimensions {0, 0}
-        );
-        return BoundaryMatrixType(Vector<ValueType>(exec, 0, zero<ValueType>()), sp);
-    }
-
     // internal values
     SystemMatrixType matrix_;
 
@@ -254,17 +234,18 @@ LinearSystem<ValueType, SystemMatrixType, BoundaryMatrixType> createEmptyLinearS
     const auto nCells = static_cast<localIdx>(mesh.nCells());
     const auto nProcFaces = static_cast<localIdx>(mesh.nProcBoundaryFaces());
     using IndexType = typename BoundaryMatrixType::MatrixSparsityType::SparsityIndexType;
-    auto offDiagSp = std::make_shared<const typename BoundaryMatrixType::MatrixSparsityType>(
-        Vector<IndexType>(exec, nProcFaces, 0),
-        Vector<IndexType>(exec, nProcFaces, 0),
-        Dimensions {nCells, nCells}
-    );
+
+    auto offDiagSp =
+        createOffDiagonalSparsityPattern<typename BoundaryMatrixType::MatrixSparsityType>(
+            mesh, *mi
+        );
+
     return {
         SystemMatrixType(Vector<ValueType>(sp->exec(), sp->nnz(), zero<ValueType>()), sp, mi),
         Vector<ValueType>(sp->exec(), sp->rows(), zero<ValueType>()),
+        BoundaryMatrixType(Vector<ValueType>(exec, nProcFaces, zero<ValueType>()), offDiagSp),
         BoundaryMatrixType(Vector<ValueType>(bSp->exec(), bSp->nnz(), zero<ValueType>()), bSp),
         Vector<ValueType>(bSp->exec(), bSp->nnz(), zero<ValueType>()),
-        BoundaryMatrixType(Vector<ValueType>(exec, nProcFaces, zero<ValueType>()), offDiagSp),
         strategy
     };
 }

--- a/include/NeoN/linearAlgebra/linearSystem.hpp
+++ b/include/NeoN/linearAlgebra/linearSystem.hpp
@@ -91,18 +91,33 @@ public:
         const Vector<ValueType>& rhs,
         const BoundaryMatrixType& boundaryMatrix,
         const Vector<ValueType>& boundaryRhs,
+        const BoundaryMatrixType& offDiagonalMatrix,
         std::shared_ptr<MeshIterationStrategy> strategy = std::make_shared<FaceBasedIterator>()
     )
-        : matrix_(matrix), rhs_(rhs), boundaryMatrix_(boundaryMatrix), boundaryRhs_(boundaryRhs),
+        : matrix_(matrix), rhs_(rhs), boundaryMatrix_(boundaryMatrix),
+          offDiagonalMatrix_(offDiagonalMatrix), boundaryRhs_(boundaryRhs),
           meshIteratorContext_(std::make_shared<MeshIteratorContext>())
     {
         meshIteratorContext_->setStrategy(strategy);
         validate();
     }
 
+    LinearSystem(
+        const SystemMatrixType& matrix,
+        const Vector<ValueType>& rhs,
+        const BoundaryMatrixType& boundaryMatrix,
+        const Vector<ValueType>& boundaryRhs,
+        std::shared_ptr<MeshIterationStrategy> strategy = std::make_shared<FaceBasedIterator>()
+    )
+        : LinearSystem(
+            matrix, rhs, boundaryMatrix, boundaryRhs, emptyMatrix(matrix.exec()), strategy
+        )
+    {}
+
     LinearSystem(const LinearSystem& ls)
         : matrix_(ls.matrix_), rhs_(ls.rhs_), boundaryMatrix_(ls.boundaryMatrix_),
-          boundaryRhs_(ls.boundaryRhs_), meshIteratorContext_(ls.meshIteratorContext_)
+          offDiagonalMatrix_(ls.offDiagonalMatrix_), boundaryRhs_(ls.boundaryRhs_),
+          meshIteratorContext_(ls.meshIteratorContext_)
     {
         validate();
     }
@@ -113,10 +128,9 @@ public:
 
     [[nodiscard]] const SystemMatrixType& matrix() const { return matrix_; }
 
-    // TODO use correct nonLocalMatrix
-    [[nodiscard]] BoundaryMatrixType& nonLocalMatrix() { return boundaryMatrix_; }
+    [[nodiscard]] BoundaryMatrixType& offDiagonalMatrix() { return offDiagonalMatrix_; }
 
-    [[nodiscard]] const BoundaryMatrixType& nonLocalMatrix() const { return boundaryMatrix_; }
+    [[nodiscard]] const BoundaryMatrixType& offDiagonalMatrix() const { return offDiagonalMatrix_; }
 
     [[nodiscard]] BoundaryMatrixType& boundaryMatrix() { return boundaryMatrix_; }
 
@@ -137,7 +151,8 @@ public:
             matrix_.copyToExecutor(exec),
             rhs_.copyToExecutor(exec),
             boundaryMatrix_.copyToExecutor(exec),
-            boundaryRhs_.copyToExecutor(exec)
+            boundaryRhs_.copyToExecutor(exec),
+            offDiagonalMatrix_.copyToExecutor(exec)
         };
     }
 
@@ -147,6 +162,7 @@ public:
         fill(rhs_, zero<ValueType>());
         fill(boundaryMatrix_.values(), zero<ValueType>());
         fill(boundaryRhs_, zero<ValueType>());
+        fill(offDiagonalMatrix_.values(), zero<ValueType>());
     }
 
     [[nodiscard]] LinearSystemView<
@@ -190,6 +206,15 @@ public:
 
 private:
 
+    static BoundaryMatrixType emptyMatrix(const Executor& exec)
+    {
+        using IndexType = typename BoundaryMatrixType::MatrixSparsityType::SparsityIndexType;
+        auto sp = std::make_shared<const typename BoundaryMatrixType::MatrixSparsityType>(
+            Vector<IndexType>(exec, 0), Vector<IndexType>(exec, 0), Dimensions {0, 0}
+        );
+        return BoundaryMatrixType(Vector<ValueType>(exec, 0, zero<ValueType>()), sp);
+    }
+
     // internal values
     SystemMatrixType matrix_;
 
@@ -197,6 +222,10 @@ private:
 
     // boundary values
     BoundaryMatrixType boundaryMatrix_;
+
+    // store values on boundaries that are non local
+    // eg on processor boundaries
+    BoundaryMatrixType offDiagonalMatrix_;
 
     Vector<ValueType> boundaryRhs_;
 
@@ -221,11 +250,21 @@ LinearSystem<ValueType, SystemMatrixType, BoundaryMatrixType> createEmptyLinearS
         );
     auto bSp =
         createBoundarySparsityPattern<typename BoundaryMatrixType::MatrixSparsityType>(mesh, *mi);
+    const auto exec = sp->exec();
+    const auto nCells = static_cast<localIdx>(mesh.nCells());
+    const auto nProcFaces = static_cast<localIdx>(mesh.nProcBoundaryFaces());
+    using IndexType = typename BoundaryMatrixType::MatrixSparsityType::SparsityIndexType;
+    auto offDiagSp = std::make_shared<const typename BoundaryMatrixType::MatrixSparsityType>(
+        Vector<IndexType>(exec, nProcFaces, 0),
+        Vector<IndexType>(exec, nProcFaces, 0),
+        Dimensions {nCells, nCells}
+    );
     return {
         SystemMatrixType(Vector<ValueType>(sp->exec(), sp->nnz(), zero<ValueType>()), sp, mi),
         Vector<ValueType>(sp->exec(), sp->rows(), zero<ValueType>()),
         BoundaryMatrixType(Vector<ValueType>(bSp->exec(), bSp->nnz(), zero<ValueType>()), bSp),
         Vector<ValueType>(bSp->exec(), bSp->nnz(), zero<ValueType>()),
+        BoundaryMatrixType(Vector<ValueType>(exec, nProcFaces, zero<ValueType>()), offDiagSp),
         strategy
     };
 }

--- a/include/NeoN/linearAlgebra/linearSystem.hpp
+++ b/include/NeoN/linearAlgebra/linearSystem.hpp
@@ -113,6 +113,11 @@ public:
 
     [[nodiscard]] const SystemMatrixType& matrix() const { return matrix_; }
 
+    // TODO use correct nonLocalMatrix
+    [[nodiscard]] BoundaryMatrixType& nonLocalMatrix() { return boundaryMatrix_; }
+
+    [[nodiscard]] const BoundaryMatrixType& nonLocalMatrix() const { return boundaryMatrix_; }
+
     [[nodiscard]] BoundaryMatrixType& boundaryMatrix() { return boundaryMatrix_; }
 
     [[nodiscard]] const BoundaryMatrixType& boundaryMatrix() const { return boundaryMatrix_; }

--- a/include/NeoN/linearAlgebra/matrix.hpp
+++ b/include/NeoN/linearAlgebra/matrix.hpp
@@ -157,9 +157,7 @@ public:
      */
     [[nodiscard]] localIdx nNonZeros() const { return sparsityPattern_->nnz(); }
 
-    void reset()
-    { /* TODO: implement */
-    }
+    void reset() { values_ = ValueType {}; }
 
 
     /**

--- a/include/NeoN/linearAlgebra/matrix.hpp
+++ b/include/NeoN/linearAlgebra/matrix.hpp
@@ -157,6 +157,11 @@ public:
      */
     [[nodiscard]] localIdx nNonZeros() const { return sparsityPattern_->nnz(); }
 
+    void reset()
+    { /* TODO: implement */
+    }
+
+
     /**
      * @brief Get a reference to values vector.
      * @return Vector containing the matrix values.

--- a/include/NeoN/mesh/unstructured/unstructuredMesh.hpp
+++ b/include/NeoN/mesh/unstructured/unstructuredMesh.hpp
@@ -169,8 +169,6 @@ public:
      */
     localIdx nBoundaryFaces() const;
 
-    localIdx nProcBoundaryFaces() const;
-
     /**
      * @brief Get the total number of faces including boundary and processor faces in the mesh.
      *
@@ -184,6 +182,13 @@ public:
      * @return The number of boundaries in the mesh.
      */
     localIdx nBoundaries() const;
+
+    /**
+     * @brief Get the number of processor-boundary faces (inter-rank faces).
+     *
+     * Returns 0 for single-process runs.
+     */
+    localIdx nProcBoundaryFaces() const;
 
     /**
      * @brief the offset local cellIds for the global mesh.

--- a/src/finiteVolume/cellCentred/boundary/surface/processor.cpp
+++ b/src/finiteVolume/cellCentred/boundary/surface/processor.cpp
@@ -18,13 +18,13 @@ void setProcBoundaryValue(
 )
 {
     const auto iVector = domainVector.internalVector().view();
+    const auto nInternalFaces = static_cast<localIdx>(mesh.nInternalFaces());
 
-    auto [refGradient, value, valueFraction, refValue, faceCells] = views(
+    auto [refGradient, value, valueFraction, refValue] = views(
         domainVector.boundaryData().refGrad(),
         domainVector.boundaryData().value(),
         domainVector.boundaryData().valueFraction(),
-        domainVector.boundaryData().refValue(),
-        mesh.boundaryMesh().faceOwners()
+        domainVector.boundaryData().refValue()
     );
 
     NeoN::parallelFor(
@@ -32,7 +32,7 @@ void setProcBoundaryValue(
         range,
         NEON_LAMBDA(const localIdx i) {
             refGradient[i] = zero<ValueType>();
-            value[i] = iVector[faceCells[i]];
+            value[i] = iVector[nInternalFaces + i];
             valueFraction[i] = 0.0;
             refValue[i] = zero<ValueType>();
         },

--- a/src/finiteVolume/cellCentred/boundary/surface/processor.cpp
+++ b/src/finiteVolume/cellCentred/boundary/surface/processor.cpp
@@ -13,18 +13,17 @@ namespace NeoN::finiteVolume::cellCentred::surfaceBoundary::detail
 template<typename ValueType>
 void setProcBoundaryValue(
     Field<ValueType>& domainVector,
-    const UnstructuredMesh& mesh,
+    [[maybe_unused]] const UnstructuredMesh& mesh,
     std::pair<localIdx, localIdx> range
 )
 {
-    const auto iVector = domainVector.internalVector().view();
-    const auto nInternalFaces = static_cast<localIdx>(mesh.nInternalFaces());
-
-    auto [refGradient, value, valueFraction, refValue] = views(
+    const auto internalVector = domainVector.internalVector().view();
+    auto [refGradient, valueFraction, value, refValue, faceCells] = views(
         domainVector.boundaryData().refGrad(),
-        domainVector.boundaryData().value(),
         domainVector.boundaryData().valueFraction(),
-        domainVector.boundaryData().refValue()
+        domainVector.boundaryData().value(),
+        domainVector.boundaryData().refValue(),
+        mesh.boundaryMesh().faceOwners()
     );
 
     NeoN::parallelFor(
@@ -32,8 +31,8 @@ void setProcBoundaryValue(
         range,
         NEON_LAMBDA(const localIdx i) {
             refGradient[i] = zero<ValueType>();
-            value[i] = iVector[nInternalFaces + i];
             valueFraction[i] = 0.0;
+            value[i] = internalVector[faceCells[i]];
             refValue[i] = zero<ValueType>();
         },
         "setProcBoundaryValue"

--- a/src/finiteVolume/cellCentred/faceNormalGradient/corrected.cpp
+++ b/src/finiteVolume/cellCentred/faceNormalGradient/corrected.cpp
@@ -78,6 +78,22 @@ void computeCorrectedFaceNormalGrad(
             },
             "computeCorrectedFaceNormalGradBoundary"
         );
+
+        auto nProcBoundaryFaces = mesh.nProcBoundaryFaces();
+        if (nProcBoundaryFaces > 0)
+        {
+            NeoN::parallelFor(
+                exec,
+                {0, nProcBoundaryFaces},
+                NEON_LAMBDA(const localIdx procFacei) {
+                    auto bcfacei = nBoundaryFaces + procFacei;
+                    auto own = boundaryFaceOwners[bcfacei];
+                    phifB[bcfacei] =
+                        nonOrthDeltaCoeffsB[bcfacei] * (phiBCValue[bcfacei] - phi[own]);
+                },
+                "computeCorrectedFaceNormalGradProcBoundary"
+            );
+        }
     }
     else
     {

--- a/src/finiteVolume/cellCentred/faceNormalGradient/limitedCorrected.cpp
+++ b/src/finiteVolume/cellCentred/faceNormalGradient/limitedCorrected.cpp
@@ -91,6 +91,22 @@ void computeLimitedCorrectedFaceNormalGrad(
             },
             "computeLimitedCorrectedFaceNormalGradBoundary"
         );
+
+        auto nProcBoundaryFaces = mesh.nProcBoundaryFaces();
+        if (nProcBoundaryFaces > 0)
+        {
+            NeoN::parallelFor(
+                exec,
+                {0, nProcBoundaryFaces},
+                NEON_LAMBDA(const localIdx procFacei) {
+                    auto bcfacei = nBoundaryFaces + procFacei;
+                    auto own = boundaryFaceOwners[bcfacei];
+                    phifB[bcfacei] =
+                        nonOrthDeltaCoeffsB[bcfacei] * (phiBCValue[bcfacei] - phi[own]);
+                },
+                "computeLimitedCorrectedFaceNormalGradProcBoundary"
+            );
+        }
     }
     else
     {

--- a/src/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
+++ b/src/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
@@ -52,6 +52,21 @@ void computeFaceNormalGrad(
         },
         "computeFaceNormalGradBoundary"
     );
+
+    auto nProcBoundaryFaces = mesh.nProcBoundaryFaces();
+    if (nProcBoundaryFaces > 0)
+    {
+        NeoN::parallelFor(
+            exec,
+            {0, nProcBoundaryFaces},
+            NEON_LAMBDA(const localIdx procFacei) {
+                auto bcfacei = nBoundaryFaces + procFacei;
+                auto own = boundaryFaceOwners[bcfacei];
+                phifB[bcfacei] = nonOrthDeltaCoeffsB[bcfacei] * (phiBCValue[bcfacei] - phi[own]);
+            },
+            "computeFaceNormalGradProcBoundary"
+        );
+    }
 }
 
 #define NF_DECLARE_COMPUTE_IMP_FNG(TYPENAME)                                                       \

--- a/src/finiteVolume/cellCentred/interpolation/linear.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/linear.cpp
@@ -50,6 +50,23 @@ void computeLinearInterpolation(
         NEON_LAMBDA(const localIdx bfi) { dstB[bfi] = weightB[bfi] * boundS[bfi]; },
         "computeLinearInterpolationBoundary"
     );
+
+    auto nProcBoundaryFaces = dst.mesh().nProcBoundaryFaces();
+    if (nProcBoundaryFaces > 0)
+    {
+        const auto bfOwners = dst.mesh().boundaryMesh().faceOwners().view();
+        NeoN::parallelFor(
+            exec,
+            {0, nProcBoundaryFaces},
+            NEON_LAMBDA(const localIdx procFacei) {
+                auto bcfacei = nBoundaryFaces + procFacei;
+                auto own = bfOwners[bcfacei];
+                dstB[bcfacei] =
+                    weightB[bcfacei] * srcS[own] + (1 - weightB[bcfacei]) * boundS[bcfacei];
+            },
+            "computeLinearInterpolationProcBoundary"
+        );
+    }
 }
 
 #define NF_DECLARE_COMPUTE_IMP_LIN_INT(TYPENAME)                                                   \

--- a/src/finiteVolume/cellCentred/interpolation/upwind.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/upwind.cpp
@@ -83,6 +83,21 @@ void computeUpwindInterpolationWeights(
         NEON_LAMBDA(const localIdx bfi) { weightB[bfi] = 1.0; },
         "computeUpwindWeightsBoundary"
     );
+
+    auto nProcBoundaryFaces = src.mesh().nProcBoundaryFaces();
+    if (nProcBoundaryFaces > 0)
+    {
+        const auto bFluxV = flux.boundaryData().value().view();
+        parallelFor(
+            exec,
+            {0, nProcBoundaryFaces},
+            NEON_LAMBDA(const localIdx procFacei) {
+                auto bcfacei = nBoundaryFaces + procFacei;
+                weightB[bcfacei] = bFluxV[bcfacei] >= 0 ? scalar(1) : scalar(0);
+            },
+            "computeUpwindWeightsProcBoundary"
+        );
+    }
 }
 
 #define NF_DECLARE_COMPUTE_IMP_UPW_INT(TYPENAME)                                                   \

--- a/src/finiteVolume/cellCentred/interpolation/upwind.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/upwind.cpp
@@ -54,6 +54,23 @@ void computeUpwindInterpolation(
         NEON_LAMBDA(const localIdx bfi) { dstB[bfi] = weightB[bfi] * boundS[bfi]; },
         "computeUpwindInterpolationBoundary"
     );
+
+    auto nProcBoundaryFaces = dst.mesh().nProcBoundaryFaces();
+    if (nProcBoundaryFaces > 0)
+    {
+        const auto bfOwners = dst.mesh().boundaryMesh().faceOwners().view();
+        const auto bFluxV = flux.boundaryData().value().view();
+        parallelFor(
+            exec,
+            {0, nProcBoundaryFaces},
+            NEON_LAMBDA(const localIdx procFacei) {
+                auto bcfacei = nBoundaryFaces + procFacei;
+                auto own = bfOwners[bcfacei];
+                dstB[bcfacei] = bFluxV[bcfacei] >= 0 ? srcS[own] : boundS[bcfacei];
+            },
+            "computeUpwindInterpolationProcBoundary"
+        );
+    }
 }
 
 

--- a/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
@@ -128,7 +128,92 @@ void computeDivExp(
 }
 
 template<typename ValueType>
-void computeDivBoundImp(
+void computeDivProcBoundImpl(
+    la::LinearSystem<ValueType>& ls,
+    const SurfaceField<scalar>& faceFlux,
+    const VolumeField<ValueType>& phi,
+    const SurfaceField<scalar>& weights,
+    const dsl::Coeff operatorScaling
+)
+{
+    const auto exec = phi.exec();
+    const auto& mesh = phi.mesh();
+
+    auto faceFluxV = faceFlux.internalVector().view();
+
+    const auto [surfFaceCells, isOwner] =
+        views(mesh.boundaryMesh().faceOwners(), mesh.boundaryMesh().weights());
+
+    const auto [bweights] = views(weights.internalVector());
+
+    auto bValues = ls.nonLocalMatrix().values().view();
+    auto values = ls.matrix().values().view();
+    const auto ma = ls.faceToMatrixAddress()->view(ls.matrix().sparsity()->rowOffs().view());
+
+    const auto nInternalFaces = mesh.nInternalFaces();
+    const auto nBoundaryFaces = mesh.nBoundaryFaces();
+    auto totalFaces = faceFluxV.size();
+    parallelFor(
+        exec,
+        {nInternalFaces + nBoundaryFaces, totalFaces},
+        NEON_LAMBDA(const localIdx facei) {
+            auto bcfacei = facei - (nInternalFaces);
+            // TODO this is weird needing two indices
+            auto bcfaceii = facei - (nInternalFaces + nBoundaryFaces);
+            auto cell = surfFaceCells[bcfacei];
+            auto c = operatorScaling[cell];
+
+            // Conservative upwind divergence for processor boundary faces.
+            // S_f points from owner to neighbour by construction; F = faceFlux is signed.
+            //
+            // From the global computeDivImp for face f (own→nei, weight w = 0 or 1 for upwind):
+            //   A[own,own] -= w*F*c         (diagonal of owner)
+            //   A[own,nei] -= (1-w)*F*c     (off-diagonal: owner row, nei column)
+            //   A[nei,own] += w*F*c         (off-diagonal: nei row, own column)
+            //   A[nei,nei] += (1-w)*F*c     (diagonal of neighbour)
+            //
+            // Each rank uses the raw upwind weight: w_raw = (F >= 0) ? 1 : 0.
+            // The owner's diagonal coefficient is w_raw; the non-owner's is (1 - w_raw).
+            auto isOwnerFace = isOwner[bcfacei] > 0.0;
+            auto sign = isOwnerFace ? scalar(-1) : scalar(1);
+            auto w_raw = bweights[facei]; // use global face index, not boundary-local bcfacei
+            // Diagonal weight: owner uses w_raw, non-owner uses (1-w_raw)
+            auto w_diag = isOwnerFace ? w_raw : (scalar(1) - w_raw);
+            auto F = faceFluxV[facei];
+            auto value = sign * w_diag * F * c * one<ValueType>();
+
+            Kokkos::atomic_sub(&values[ma.diagIdx(cell)], value);
+            // bValues[bcfaceii] += value ; // this will be
+
+            // Off-diagonal (ghost coupling).
+            //
+            // Div is asymmetric: in the global computeDivImp the two off-diagonals
+            // around face (own, nei) are
+            //     M[own, nei] = +F * (1 - w) * c       (upper)
+            //     M[nei, own] = -F *  w      * c       (lower)
+            // i.e. they have opposite signs.
+            //
+            // On the owner-side rank we are storing M[local=own, ghost=nei]:
+            //   sign = -1, w_diag = w_raw, so we want valueOff = +F*(1-w_raw)*c
+            // On the non-owner-side rank we are storing M[local=nei, ghost=own]:
+            //   sign = +1, w_diag = (1 - w_raw), so we want valueOff = -F*w_raw*c
+            //                                              = -F*(1 - w_diag)*c
+            //
+            // Both cases are captured by negating `sign` in front of the magnitude:
+            //   owner:     -(-1) * (1 - w_raw)        = +(1 - w)
+            //   non-owner: -(+1) * (1 - (1-w_raw))    = -w
+            // This mirrors the diag formula `value = sign * w_diag * F * c`, which
+            // already encodes the asymmetric +diag[own]/-diag[nei] split correctly.
+            auto valueOff = -sign * (scalar(1) - w_diag) * F * c * one<ValueType>();
+            bValues[bcfaceii] += valueOff;
+        },
+        "computeProcInterfaceGaussGreenDivCoefficients"
+    );
+}
+
+
+template<typename ValueType>
+void computeDivBoundImpl(
     la::LinearSystem<ValueType>& ls,
     const SurfaceField<scalar>& faceFlux,
     const VolumeField<ValueType>& phi,
@@ -368,6 +453,7 @@ void GaussGreenDiv<ValueType>::div(
 ) const
 {
     const auto weights = surfaceInterpolation_.weight(faceFlux, phi);
+    computeDivProcBoundImpl(ls, faceFlux, phi, weights, operatorScaling);
     if (auto* cellIter = dynamic_cast<la::CellBasedIterator*>(ls.getMeshIterator()->get().get()))
     {
         if (!cellIter->getCellBasedData())
@@ -382,7 +468,7 @@ void GaussGreenDiv<ValueType>::div(
     {
         computeDivIntImp(ls, faceFlux, phi, weights, operatorScaling);
     }
-    computeDivBoundImp(ls, faceFlux, phi, weights, operatorScaling);
+    computeDivBoundImpl(ls, faceFlux, phi, weights, operatorScaling);
 }
 
 template class GaussGreenDiv<scalar>;

--- a/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
@@ -133,79 +133,51 @@ void computeDivProcBoundImpl(
     const SurfaceField<scalar>& faceFlux,
     const VolumeField<ValueType>& phi,
     const SurfaceField<scalar>& weights,
-    const dsl::Coeff operatorScaling
+    const dsl::Coeff coeff
 )
 {
     const auto exec = phi.exec();
     const auto& mesh = phi.mesh();
 
-    auto faceFluxV = faceFlux.internalVector().view();
+    const auto nBoundaryFaces = mesh.nBoundaryFaces();
+    const auto nProcBoundaryFaces = mesh.nProcBoundaryFaces();
+    if (nProcBoundaryFaces == 0) return;
 
     const auto [surfFaceCells, isOwner] =
         views(mesh.boundaryMesh().faceOwners(), mesh.boundaryMesh().weights());
 
-    const auto [bweights] = views(weights.internalVector());
+    const auto bFluxV = faceFlux.boundaryData().value().view();
+    const auto bWeightsV = weights.boundaryData().value().view();
+    auto bValues = ls.offDiagonalMatrix().values().view();
 
-    auto bValues = ls.nonLocalMatrix().values().view();
     auto values = ls.matrix().values().view();
     const auto ma = ls.faceToMatrixAddress()->view(ls.matrix().sparsity()->rowOffs().view());
 
-    const auto nInternalFaces = mesh.nInternalFaces();
-    const auto nBoundaryFaces = mesh.nBoundaryFaces();
-    auto totalFaces = faceFluxV.size();
     parallelFor(
         exec,
-        {nInternalFaces + nBoundaryFaces, totalFaces},
-        NEON_LAMBDA(const localIdx facei) {
-            auto bcfacei = facei - (nInternalFaces);
-            // TODO this is weird needing two indices
-            auto bcfaceii = facei - (nInternalFaces + nBoundaryFaces);
+        {0, nProcBoundaryFaces},
+        NEON_LAMBDA(const localIdx procFacei) {
+            auto bcfacei = nBoundaryFaces + procFacei;
             auto cell = surfFaceCells[bcfacei];
-            auto c = operatorScaling[cell];
 
-            // Conservative upwind divergence for processor boundary faces.
+            auto ownCoeff = coeff[cell];
+
             // S_f points from owner to neighbour by construction; F = faceFlux is signed.
             //
             // From the global computeDivImp for face f (own→nei, weight w = 0 or 1 for upwind):
             //   A[own,own] -= w*F*c         (diagonal of owner)
-            //   A[own,nei] -= (1-w)*F*c     (off-diagonal: owner row, nei column)
-            //   A[nei,own] += w*F*c         (off-diagonal: nei row, own column)
             //   A[nei,nei] += (1-w)*F*c     (diagonal of neighbour)
             //
-            // Each rank uses the raw upwind weight: w_raw = (F >= 0) ? 1 : 0.
-            // The owner's diagonal coefficient is w_raw; the non-owner's is (1 - w_raw).
             auto isOwnerFace = isOwner[bcfacei] > 0.0;
             auto sign = isOwnerFace ? scalar(-1) : scalar(1);
-            auto w_raw = bweights[facei]; // use global face index, not boundary-local bcfacei
-            // Diagonal weight: owner uses w_raw, non-owner uses (1-w_raw)
-            auto w_diag = isOwnerFace ? w_raw : (scalar(1) - w_raw);
-            auto F = faceFluxV[facei];
-            auto value = sign * w_diag * F * c * one<ValueType>();
 
-            Kokkos::atomic_sub(&values[ma.diagIdx(cell)], value);
-            // bValues[bcfaceii] += value ; // this will be
+            auto weight = isOwnerFace ? bWeightsV[bcfacei] : (scalar(1) - bWeightsV[bcfacei]);
+            auto fluxContrib = sign * weight * bFluxV[bcfacei] * ownCoeff * one<ValueType>();
 
-            // Off-diagonal (ghost coupling).
-            //
-            // Div is asymmetric: in the global computeDivImp the two off-diagonals
-            // around face (own, nei) are
-            //     M[own, nei] = +F * (1 - w) * c       (upper)
-            //     M[nei, own] = -F *  w      * c       (lower)
-            // i.e. they have opposite signs.
-            //
-            // On the owner-side rank we are storing M[local=own, ghost=nei]:
-            //   sign = -1, w_diag = w_raw, so we want valueOff = +F*(1-w_raw)*c
-            // On the non-owner-side rank we are storing M[local=nei, ghost=own]:
-            //   sign = +1, w_diag = (1 - w_raw), so we want valueOff = -F*w_raw*c
-            //                                              = -F*(1 - w_diag)*c
-            //
-            // Both cases are captured by negating `sign` in front of the magnitude:
-            //   owner:     -(-1) * (1 - w_raw)        = +(1 - w)
-            //   non-owner: -(+1) * (1 - (1-w_raw))    = -w
-            // This mirrors the diag formula `value = sign * w_diag * F * c`, which
-            // already encodes the asymmetric +diag[own]/-diag[nei] split correctly.
-            auto valueOff = -sign * (scalar(1) - w_diag) * F * c * one<ValueType>();
-            bValues[bcfaceii] += valueOff;
+            Kokkos::atomic_sub(&values[ma.diagIdx(cell)], fluxContrib);
+            auto valueOff =
+                -sign * (scalar(1) - weight) * bFluxV[bcfacei] * ownCoeff * one<ValueType>();
+            bValues[procFacei] += valueOff;
         },
         "computeProcInterfaceGaussGreenDivCoefficients"
     );
@@ -290,7 +262,7 @@ void computeDivIntImp(
     const dsl::Coeff coeff
 )
 {
-    const UnstructuredMesh& mesh = phi.mesh();
+    const auto& mesh = phi.mesh();
     const auto nInternalFaces = mesh.nInternalFaces();
     const auto exec = phi.exec();
 
@@ -452,8 +424,8 @@ void GaussGreenDiv<ValueType>::div(
     const dsl::Coeff operatorScaling
 ) const
 {
+    // TODO boundary weights should be separate so that we can start internal assembly
     const auto weights = surfaceInterpolation_.weight(faceFlux, phi);
-    computeDivProcBoundImpl(ls, faceFlux, phi, weights, operatorScaling);
     if (auto* cellIter = dynamic_cast<la::CellBasedIterator*>(ls.getMeshIterator()->get().get()))
     {
         if (!cellIter->getCellBasedData())
@@ -469,6 +441,7 @@ void GaussGreenDiv<ValueType>::div(
         computeDivIntImp(ls, faceFlux, phi, weights, operatorScaling);
     }
     computeDivBoundImpl(ls, faceFlux, phi, weights, operatorScaling);
+    computeDivProcBoundImpl(ls, faceFlux, phi, weights, operatorScaling);
 }
 
 template class GaussGreenDiv<scalar>;

--- a/src/finiteVolume/cellCentred/operators/gaussGreenGrad.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenGrad.cpp
@@ -75,6 +75,23 @@ void computeGrad(
         "computeGradBoundary"
     );
 
+    auto nProcBoundaryFaces = mesh.nProcBoundaryFaces();
+    if (nProcBoundaryFaces > 0)
+    {
+        const auto bSf = mesh.boundaryMesh().faceNormals().view();
+        parallelFor(
+            exec,
+            {0, nProcBoundaryFaces},
+            NEON_LAMBDA(const localIdx procFacei) {
+                auto bcfacei = nBoundaryFaces + procFacei;
+                auto own = boundaryFaceOwners[bcfacei];
+                Vec3 flux = bSf[bcfacei] * surfPhifB[bcfacei];
+                Kokkos::atomic_add(&surfGradPhi[own], flux);
+            },
+            "computeProcGradBoundary"
+        );
+    }
+
     parallelFor(
         exec,
         {0, mesh.nCells()},

--- a/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
@@ -58,13 +58,15 @@ void computeLaplacianExp(
         "computeLaplacianExplicitInternal"
     );
 
-    // Boundary faces: only the owner cell is on this rank.
+    // Physical (non-proc) boundary faces: only the owner cell is on this rank.
+    // For non-proc patches, OpenFOAM's full face index and NeoN's compressed
+    // index agree (empty patches like defaultFaces have size()==0 in fvPatch),
+    // so faceArea[i] = mesh.magFaceAreas()[i] is correct here.
     parallelFor(
         exec,
         {0, nBoundaryFaces},
         NEON_LAMBDA(const localIdx bfi) {
             auto own = boundaryFaceOwners[bfi];
-            // TODO Issue #515
             ValueType valueOwn = faceArea[nInternalFaces + bfi] * fnGradB[bfi];
             Kokkos::atomic_add(&result[own], valueOwn);
         },
@@ -78,6 +80,52 @@ void computeLaplacianExp(
         "computeLaplacianExplicitCells"
     );
 }
+
+template<typename ValueType>
+void computeLaplacianProcBoundImpl(
+    la::LinearSystem<ValueType>& ls,
+    const SurfaceField<scalar>& gamma,
+    const VolumeField<ValueType>& phi,
+    const dsl::Coeff operatorScaling,
+    const FaceNormalGradient<ValueType>& faceNormalGradient
+)
+{
+    const auto exec = phi.exec();
+    const auto& mesh = phi.mesh();
+
+    auto gammaV = gamma.internalVector().view();
+
+    const auto [deltaCoeffs, surfFaceCells] =
+        views(faceNormalGradient.deltaCoeffs().internalVector(), mesh.boundaryMesh().faceOwners());
+    const auto bcMagSf = mesh.boundaryMesh().faceAreas().view();
+
+    auto values = ls.matrix().values().view();
+    auto bValues = ls.nonLocalMatrix().values().view();
+
+    const auto nInternalFaces = mesh.nInternalFaces();
+    const auto nBoundaryFaces = mesh.nBoundaryFaces();
+    const auto ma = ls.faceToMatrixAddress()->view(ls.matrix().sparsity()->rowOffs().view());
+
+    auto totalFaces = gammaV.size();
+    parallelFor(
+        exec,
+        {nInternalFaces + nBoundaryFaces, totalFaces},
+        NEON_LAMBDA(const localIdx facei) {
+            auto bcfacei = facei - nInternalFaces;
+            auto bcfaceii = facei - (nInternalFaces + nBoundaryFaces);
+            auto cell = surfFaceCells[bcfacei];
+            auto c = operatorScaling[cell];
+
+            auto flux = gammaV[facei] * bcMagSf[bcfacei] * deltaCoeffs[facei];
+            auto value = flux * c * one<ValueType>();
+
+            Kokkos::atomic_sub(&values[ma.diagIdx(cell)], value);
+            bValues[bcfaceii] += value;
+        },
+        "computeInterfaceLaplacianCoefficients"
+    );
+}
+
 
 template<typename ValueType>
 void computeLaplacianBoundImpl(
@@ -124,23 +172,13 @@ void computeLaplacianBoundImpl(
             auto refValFrac = valueFraction[bfi];
             auto refGradFrac = 1.0 - refValFrac;
 
-            // TODO Issue #515
             auto flux = bGammaV[bfi] * magFaceArea[nInternalFaces + bfi];
             auto fluxContrib =
                 flux * ownRowCoeff * refValFrac * bDeltaCoeffs[bfi] * one<ValueType>();
 
-            // since upper triangular value is "outside" of system matrix
-            // it is stored separately in bMatrix
             bValues[bfi] += fluxContrib;
-            // diagonal contribution
             Kokkos::atomic_sub(&values[ma.diagIdx(ownRow)], fluxContrib);
 
-            // Explicit RHS contribution from the mixed BC:
-            //   φ_f = valFrac1 * refValue               (Dirichlet part)
-            //       + valFrac2 * (φ_C + refGradient/δ)  (Neumann part)
-            // The implicit valFrac2 * φ_C term is handled via fluxContrib above.
-            // bweights converts the Dirichlet face value to a cell-to-face flux contribution;
-            // the Neumann gradient correction (refGradient/δ) enters directly as a known increment.
             auto valueRhs =
                 flux * ownRowCoeff
                 * (refValFrac * bDeltaCoeffs[bfi] * refValue[bfi] + refGradFrac * refGradient[bfi]);
@@ -344,6 +382,7 @@ void GaussGreenLaplacian<ValueType>::laplacian(
     const dsl::Coeff coeff
 )
 {
+    computeLaplacianProcBoundImpl(ls, gamma, phi, coeff, faceNormalGradient_);
     if (auto* cellIter = dynamic_cast<la::CellBasedIterator*>(ls.getMeshIterator()->get().get()))
     {
         if (!cellIter->getCellBasedData())
@@ -360,7 +399,8 @@ void GaussGreenLaplacian<ValueType>::laplacian(
     }
     computeLaplacianBoundImpl(ls, gamma, phi, coeff, faceNormalGradient_);
     computeLaplacianNonOrthCorrImpl(ls, gamma, phi, coeff, faceNormalGradient_);
-};
+}
+
 
 template class GaussGreenLaplacian<scalar>;
 template class GaussGreenLaplacian<Vec3>;

--- a/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
@@ -67,6 +67,7 @@ void computeLaplacianExp(
         {0, nBoundaryFaces},
         NEON_LAMBDA(const localIdx bfi) {
             auto own = boundaryFaceOwners[bfi];
+            // TODO Issue #515 faceArea should not contain boundary data
             ValueType valueOwn = faceArea[nInternalFaces + bfi] * fnGradB[bfi];
             Kokkos::atomic_add(&result[own], valueOwn);
         },
@@ -86,41 +87,41 @@ void computeLaplacianProcBoundImpl(
     la::LinearSystem<ValueType>& ls,
     const SurfaceField<scalar>& gamma,
     const VolumeField<ValueType>& phi,
-    const dsl::Coeff operatorScaling,
+    const dsl::Coeff coeff,
     const FaceNormalGradient<ValueType>& faceNormalGradient
 )
 {
     const auto exec = phi.exec();
     const auto& mesh = phi.mesh();
 
-    auto gammaV = gamma.internalVector().view();
-
-    const auto [deltaCoeffs, surfFaceCells] =
-        views(faceNormalGradient.deltaCoeffs().internalVector(), mesh.boundaryMesh().faceOwners());
-    const auto bcMagSf = mesh.boundaryMesh().faceAreas().view();
-
-    auto values = ls.matrix().values().view();
-    auto bValues = ls.nonLocalMatrix().values().view();
-
-    const auto nInternalFaces = mesh.nInternalFaces();
     const auto nBoundaryFaces = mesh.nBoundaryFaces();
+    const auto nProcBoundaryFaces = mesh.nProcBoundaryFaces();
+    if (nProcBoundaryFaces == 0) return;
     const auto ma = ls.faceToMatrixAddress()->view(ls.matrix().sparsity()->rowOffs().view());
 
-    auto totalFaces = gammaV.size();
+    const auto [bGammaV, bDeltaCoeffs, surfFaceCells] = views(
+        gamma.boundaryData().value(),
+        faceNormalGradient.deltaCoeffs().boundaryData().value(),
+        mesh.boundaryMesh().faceOwners()
+    );
+    const auto bcMagSf = mesh.boundaryMesh().faceAreas().view();
+    auto bValues = ls.offDiagonalMatrix().values().view();
+
+    auto values = ls.matrix().values().view();
+
     parallelFor(
         exec,
-        {nInternalFaces + nBoundaryFaces, totalFaces},
-        NEON_LAMBDA(const localIdx facei) {
-            auto bcfacei = facei - nInternalFaces;
-            auto bcfaceii = facei - (nInternalFaces + nBoundaryFaces);
+        {0, nProcBoundaryFaces},
+        NEON_LAMBDA(const localIdx procFacei) {
+            auto bcfacei = nBoundaryFaces + procFacei;
             auto cell = surfFaceCells[bcfacei];
-            auto c = operatorScaling[cell];
+            auto ownCoeff = coeff[cell];
 
-            auto flux = gammaV[facei] * bcMagSf[bcfacei] * deltaCoeffs[facei];
-            auto value = flux * c * one<ValueType>();
+            auto flux = bGammaV[bcfacei] * bcMagSf[bcfacei] * bDeltaCoeffs[bcfacei];
+            auto value = flux * ownCoeff * one<ValueType>();
 
             Kokkos::atomic_sub(&values[ma.diagIdx(cell)], value);
-            bValues[bcfaceii] += value;
+            bValues[procFacei] += value;
         },
         "computeInterfaceLaplacianCoefficients"
     );
@@ -171,7 +172,7 @@ void computeLaplacianBoundImpl(
 
             auto refValFrac = valueFraction[bfi];
             auto refGradFrac = 1.0 - refValFrac;
-
+            // TODO Issue #515 magFaceArea should not contain boundary data
             auto flux = bGammaV[bfi] * magFaceArea[nInternalFaces + bfi];
             auto fluxContrib =
                 flux * ownRowCoeff * refValFrac * bDeltaCoeffs[bfi] * one<ValueType>();
@@ -382,7 +383,6 @@ void GaussGreenLaplacian<ValueType>::laplacian(
     const dsl::Coeff coeff
 )
 {
-    computeLaplacianProcBoundImpl(ls, gamma, phi, coeff, faceNormalGradient_);
     if (auto* cellIter = dynamic_cast<la::CellBasedIterator*>(ls.getMeshIterator()->get().get()))
     {
         if (!cellIter->getCellBasedData())
@@ -399,6 +399,7 @@ void GaussGreenLaplacian<ValueType>::laplacian(
     }
     computeLaplacianBoundImpl(ls, gamma, phi, coeff, faceNormalGradient_);
     computeLaplacianNonOrthCorrImpl(ls, gamma, phi, coeff, faceNormalGradient_);
+    computeLaplacianProcBoundImpl(ls, gamma, phi, coeff, faceNormalGradient_);
 }
 
 

--- a/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
@@ -99,12 +99,13 @@ void computeLaplacianProcBoundImpl(
     if (nProcBoundaryFaces == 0) return;
     const auto ma = ls.faceToMatrixAddress()->view(ls.matrix().sparsity()->rowOffs().view());
 
-    const auto [bGammaV, bDeltaCoeffs, surfFaceCells] = views(
+    const auto [bGammaV, bDeltaCoeffs, boundaryFaceOwner] = views(
         gamma.boundaryData().value(),
         faceNormalGradient.deltaCoeffs().boundaryData().value(),
         mesh.boundaryMesh().faceOwners()
     );
     const auto bcMagSf = mesh.boundaryMesh().faceAreas().view();
+
     auto bValues = ls.offDiagonalMatrix().values().view();
 
     auto values = ls.matrix().values().view();
@@ -114,7 +115,7 @@ void computeLaplacianProcBoundImpl(
         {0, nProcBoundaryFaces},
         NEON_LAMBDA(const localIdx procFacei) {
             auto bcfacei = nBoundaryFaces + procFacei;
-            auto cell = surfFaceCells[bcfacei];
+            auto cell = boundaryFaceOwner[bcfacei];
             auto ownCoeff = coeff[cell];
 
             auto flux = bGammaV[bcfacei] * bcMagSf[bcfacei] * bDeltaCoeffs[bcfacei];

--- a/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
@@ -5,9 +5,104 @@
 #include "NeoN/core/containerFreeFunctions.hpp"
 #include "NeoN/core/parallelAlgorithms.hpp"
 #include "NeoN/finiteVolume/cellCentred/stencil/basicGeometryScheme.hpp"
+#ifdef NF_WITH_MPI_SUPPORT
+#include "NeoN/core/mpi/environment.hpp"
+#include "NeoN/core/mpi/operators.hpp"
+#endif
 
 namespace NeoN::finiteVolume::cellCentred
 {
+
+#ifdef NF_WITH_MPI_SUPPORT
+namespace
+{
+
+/** @brief Returns the [start, end) face-index ranges of all processor boundary patches in
+ *  the order they appear in the boundary mesh offset array. */
+std::vector<std::pair<localIdx, localIdx>> collectProcPatchRanges(const UnstructuredMesh& mesh)
+{
+    const auto& bMesh = mesh.boundaryMesh();
+    const auto& off = bMesh.offset();
+    const auto nBounds = bMesh.nBoundaries();
+    const auto nProcPatches = bMesh.nProcBoundaryPatches();
+
+    std::vector<std::pair<localIdx, localIdx>> ranges;
+    ranges.reserve(static_cast<std::size_t>(nProcPatches));
+    for (localIdx i = nBounds - nProcPatches; i < nBounds; ++i)
+        ranges.push_back({off[static_cast<std::size_t>(i)], off[static_cast<std::size_t>(i + 1)]});
+    return ranges;
+}
+
+/** @brief Computes the face-normal projection of the owner-cell-to-face distance for each
+ *  processor boundary face, exchanges these distances with the neighbouring ranks via
+ *  non-blocking MPI, and returns the received neighbour distances as a device Vector of
+ *  size nProcBoundaryFaces. */
+Vector<scalar> exchangeProcOwnerDistance(const Executor& exec, const UnstructuredMesh& mesh)
+{
+    const auto& bMesh = mesh.boundaryMesh();
+    const auto nBoundaryFaces = mesh.nBoundaryFaces();
+    const auto nProcFaces = mesh.nProcBoundaryFaces();
+
+    auto bFaceCentersH = bMesh.faceCenters().copyToHost();
+    auto bFaceNormalsH = bMesh.faceNormals().copyToHost();
+    auto bFaceAreasH = bMesh.faceAreas().copyToHost();
+    auto bFaceOwnersH = bMesh.faceOwners().copyToHost();
+    auto cellCentersH = mesh.cellCenters().copyToHost();
+
+    const auto bFaceCenters = bFaceCentersH.view();
+    const auto bFaceNormals = bFaceNormalsH.view();
+    const auto bFaceAreas = bFaceAreasH.view();
+    const auto bFaceOwners = bFaceOwnersH.view();
+    const auto cellCenters = cellCentersH.view();
+
+    std::vector<scalar> dOwn(static_cast<std::size_t>(nProcFaces));
+    std::vector<scalar> dNei(static_cast<std::size_t>(nProcFaces), scalar(0));
+    for (localIdx i = 0; i < nProcFaces; ++i)
+    {
+        const localIdx bfi = nBoundaryFaces + i;
+        const Vec3 n = (1.0 / bFaceAreas[bfi]) * bFaceNormals[bfi];
+        dOwn[static_cast<std::size_t>(i)] =
+            std::abs(n & (bFaceCenters[bfi] - cellCenters[bFaceOwners[bfi]]));
+    }
+
+    const auto ranges = collectProcPatchRanges(mesh);
+    std::vector<MPI_Request> requests(2 * ranges.size(), MPI_REQUEST_NULL);
+    mpi::Environment mpiEnv;
+    for (std::size_t p = 0; p < ranges.size(); ++p)
+    {
+        const auto [rangeStart, rangeEnd] = ranges[p];
+        const localIdx patchOff = rangeStart - nBoundaryFaces;
+        const auto neighborRank = static_cast<mpi_label_t>(bMesh.neighbourRankForRange(ranges[p]));
+        const auto byteCount = static_cast<mpi_label_t>((rangeEnd - rangeStart) * sizeof(scalar));
+        mpi::isend<char>(
+            reinterpret_cast<const char*>(dOwn.data() + patchOff),
+            byteCount,
+            neighborRank,
+            0,
+            mpiEnv.comm(),
+            &requests[2 * p]
+        );
+        mpi::irecv<char>(
+            reinterpret_cast<char*>(dNei.data() + patchOff),
+            byteCount,
+            neighborRank,
+            0,
+            mpiEnv.comm(),
+            &requests[2 * p + 1]
+        );
+    }
+    if (!requests.empty())
+        MPI_Waitall(static_cast<int>(requests.size()), requests.data(), MPI_STATUSES_IGNORE);
+
+    Vector<scalar> result(SerialExecutor {}, nProcFaces, scalar(0));
+    auto resultView = result.view();
+    for (localIdx i = 0; i < nProcFaces; ++i)
+        resultView[i] = dNei[static_cast<std::size_t>(i)];
+    return result.copyToExecutor(exec);
+}
+
+} // anonymous namespace
+#endif
 
 BasicGeometryScheme::BasicGeometryScheme(const UnstructuredMesh& mesh)
     : GeometrySchemeFactory(mesh), mesh_(mesh)
@@ -136,6 +231,32 @@ void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
         },
         "basicGeometricScheme::updateNonOrthDeltaCoeffsBoundary"
     );
+
+#ifdef NF_WITH_MPI_SUPPORT
+    const auto nBoundaryFaces = mesh_.nBoundaryFaces();
+    const auto nProcBoundaryFaces = mesh_.nProcBoundaryFaces();
+    if (nProcBoundaryFaces > 0)
+    {
+        const auto bFaceCenters = mesh_.boundaryMesh().faceCenters().view();
+        const auto bFaceNormals = mesh_.boundaryMesh().faceNormals().view();
+        const auto bFaceAreas = mesh_.boundaryMesh().faceAreas().view();
+        const auto dNei = exchangeProcOwnerDistance(exec, mesh_);
+        const auto dNeiView = dNei.view();
+        parallelFor(
+            exec,
+            {0, nProcBoundaryFaces},
+            NEON_LAMBDA(const localIdx procFacei) {
+                const localIdx bfi = nBoundaryFaces + procFacei;
+                const Vec3 n = (1.0 / bFaceAreas[bfi]) * bFaceNormals[bfi];
+                const Vec3 co = cellCenters[surfFaceCells[bfi]];
+                const scalar dOwn = std::abs(n & (bFaceCenters[bfi] - co));
+                nonOrthDeltaCoeffB[bfi] =
+                    1.0 / std::max(dOwn + dNeiView[procFacei], scalar(ROOTVSMALL));
+            },
+            "basicGeometricScheme::updateNonOrthDeltaCoeffsProcBoundary"
+        );
+    }
+#endif
 }
 
 

--- a/src/finiteVolume/cellCentred/stencil/cellToFaceStencil.cpp
+++ b/src/finiteVolume/cellCentred/stencil/cellToFaceStencil.cpp
@@ -14,8 +14,6 @@ SegmentedVector<localIdx, localIdx> CellToFaceStencil::computeInternalStencil() 
 {
     const auto exec = mesh_.exec();
     const auto nCells = mesh_.nCells();
-    const auto [faceOwners, faceNeighbors] = views(mesh_.faceOwners(), mesh_.faceNeighbors());
-
     const auto nInternalFaces = mesh_.nInternalFaces();
 
     const SerialExecutor serialExec;

--- a/src/linearAlgebra/faceToMatrixAddress.cpp
+++ b/src/linearAlgebra/faceToMatrixAddress.cpp
@@ -104,34 +104,38 @@ void setBoundarySparsityPatternImpl(
     );
 }
 
+
 template<typename IndexType>
-void setProcBoundarySparsityPattern(
+void setOffDiagonalSparsityPatternImpl(
     const UnstructuredMesh& mesh,
-    const Array<uint8_t>&,
+    const Array<uint8_t>& diagOffs,
     Vector<IndexType>& rowIdx,
     Vector<IndexType>& colIdx
 )
 {
     const auto exec = mesh.exec();
+    const auto nBoundaryFaces = static_cast<localIdx>(mesh.nBoundaryFaces());
+    const auto nProcFaces = static_cast<std::size_t>(mesh.nProcBoundaryFaces());
+    const auto diagOffsV = diagOffs.view();
     const auto faceCellsV = mesh.boundaryMesh().faceOwners().view();
-    const auto nBoundaryFaces = mesh.nBoundaryFaces();
-    const auto nProcBoundaryFaces = mesh.nProcBoundaryFaces();
+    NF_ASSERT(nProcFaces == rowIdx.size(), "Inconsistent size");
+    NF_ASSERT(nProcFaces == colIdx.size(), "Inconsistent size");
+
     auto rowIdxV = rowIdx.view();
-
-    NF_ASSERT(nBoundaryFaces + nProcBoundaryFaces == faceCellsV.size(), "Inconsistent size");
-    NF_ASSERT(nProcBoundaryFaces == rowIdx.size(), "Inconsistent size");
-    NF_ASSERT(nProcBoundaryFaces == colIdx.size(), "Inconsistent size");
-
+    auto colIdxV = colIdx.view();
+    auto globalOffset = mesh.globalOffset();
     parallelFor(
         exec,
-        {0, nProcBoundaryFaces},
-        KOKKOS_LAMBDA(const localIdx bfacei) {
-            // TODO compute colIdx
-            rowIdxV[bfacei] = faceCellsV[bfacei + nBoundaryFaces];
+        {0, nProcFaces},
+        KOKKOS_LAMBDA(const localIdx pfacei) {
+            localIdx celli = faceCellsV[nBoundaryFaces + pfacei];
+            colIdxV[pfacei] = celli + diagOffsV[celli];
+            rowIdxV[pfacei] = celli + globalOffset;
         },
-        "setSparsityPatternFaceToMatrixAddress::setProcBoundarySparsity"
+        "setOffDiagonalSparsityPatternImpl"
     );
 }
+
 
 template<typename IndexType>
 void setSparsityPatternFaceToMatrixAddressSerial(
@@ -245,6 +249,37 @@ void setSparsityPatternFaceToMatrixAddressSerial(
     rowOffs = rowOffsH.copyToExecutor(exec);
 }
 
+template<typename IndexType>
+void setProcBoundarySparsityPattern(
+    const UnstructuredMesh& mesh,
+    const Array<uint8_t>&,
+    Vector<IndexType>& rowIdx,
+    Vector<IndexType>& colIdx
+)
+{
+    const auto exec = mesh.exec();
+    const auto faceCellsV = mesh.boundaryMesh().faceOwners().view();
+    const auto nBoundaryFaces = mesh.nBoundaryFaces();
+    const auto nProcBoundaryFaces = mesh.nProcBoundaryFaces();
+    auto rowIdxV = rowIdx.view();
+    auto globalOffset = mesh.globalOffset();
+
+    NF_ASSERT(nBoundaryFaces + nProcBoundaryFaces == faceCellsV.size(), "Inconsistent size");
+    NF_ASSERT(nProcBoundaryFaces == rowIdx.size(), "Inconsistent size");
+    NF_ASSERT(nProcBoundaryFaces == colIdx.size(), "Inconsistent size");
+
+    parallelFor(
+        exec,
+        {0, nProcBoundaryFaces},
+        KOKKOS_LAMBDA(const localIdx bfacei) {
+            // TODO compute colIdx
+            rowIdxV[bfacei] = faceCellsV[bfacei + nBoundaryFaces] + globalOffset;
+        },
+        "setSparsityPatternFaceToMatrixAddress::setProcBoundarySparsity"
+    );
+}
+
+
 template<typename SparsityType>
 std::pair<std::shared_ptr<const SparsityType>, std::shared_ptr<const FaceToMatrixAddress>>
 createSparsityPatternFaceToMatrixAddress(const UnstructuredMesh& mesh)
@@ -325,6 +360,7 @@ createBoundarySparsityPattern<CooSparsityPattern<localIdx>>(
     );
 }
 
+
 template<>
 std::shared_ptr<const CsrSparsityPattern<localIdx>>
 createBoundarySparsityPattern<CsrSparsityPattern<localIdx>>(
@@ -339,6 +375,39 @@ createBoundarySparsityPattern<CsrSparsityPattern<localIdx>>(
     auto rowPtrs = rowsToRowOffs(rowIdx);
     return std::make_shared<const CsrSparsityPattern<localIdx>>(
         std::move(colIdx), std::move(rowPtrs), Dimensions {mesh.nCells(), nBoundaryFaces}
+    );
+}
+
+template<>
+std::shared_ptr<const CooSparsityPattern<localIdx>>
+createOffDiagonalSparsityPattern<CooSparsityPattern<localIdx>>(
+    const UnstructuredMesh& mesh, const FaceToMatrixAddress& faceToMatrixAddress
+)
+{
+    const auto exec = mesh.exec();
+    const auto nProcFaces = static_cast<localIdx>(mesh.nProcBoundaryFaces());
+    Vector<localIdx> rowIdx(exec, nProcFaces, 0);
+    Vector<localIdx> colIdx(exec, nProcFaces, 0);
+    setOffDiagonalSparsityPatternImpl(mesh, faceToMatrixAddress.diagOffset(), rowIdx, colIdx);
+    return std::make_shared<const CooSparsityPattern<localIdx>>(
+        std::move(colIdx), std::move(rowIdx), Dimensions {mesh.nCells(), nProcFaces}
+    );
+}
+
+template<>
+std::shared_ptr<const CsrSparsityPattern<localIdx>>
+createOffDiagonalSparsityPattern<CsrSparsityPattern<localIdx>>(
+    const UnstructuredMesh& mesh, const FaceToMatrixAddress& faceToMatrixAddress
+)
+{
+    const auto exec = mesh.exec();
+    const auto nProcFaces = static_cast<localIdx>(mesh.nProcBoundaryFaces());
+    Vector<localIdx> rowIdx(exec, nProcFaces, 0);
+    Vector<localIdx> colIdx(exec, nProcFaces, 0);
+    setOffDiagonalSparsityPatternImpl(mesh, faceToMatrixAddress.diagOffset(), rowIdx, colIdx);
+    auto rowPtrs = rowsToRowOffs(rowIdx);
+    return std::make_shared<const CsrSparsityPattern<localIdx>>(
+        std::move(colIdx), std::move(rowPtrs), Dimensions {mesh.nCells(), nProcFaces}
     );
 }
 

--- a/src/linearAlgebra/faceToMatrixAddress.cpp
+++ b/src/linearAlgebra/faceToMatrixAddress.cpp
@@ -9,6 +9,10 @@
 #include "NeoN/linearAlgebra/csrSparsityPattern.hpp"
 #include "NeoN/linearAlgebra/faceToMatrixAddress.hpp"
 
+#ifdef NF_WITH_MPI_SUPPORT
+#include "NeoN/distributed/communicationPattern.hpp"
+#endif
+
 namespace NeoN::la
 {
 
@@ -108,7 +112,7 @@ void setBoundarySparsityPatternImpl(
 template<typename IndexType>
 void setOffDiagonalSparsityPatternImpl(
     const UnstructuredMesh& mesh,
-    const Array<uint8_t>& diagOffs,
+    const std::vector<int>& recvIdx,
     Vector<IndexType>& rowIdx,
     Vector<IndexType>& colIdx
 )
@@ -116,10 +120,14 @@ void setOffDiagonalSparsityPatternImpl(
     const auto exec = mesh.exec();
     const auto nBoundaryFaces = static_cast<localIdx>(mesh.nBoundaryFaces());
     const auto nProcFaces = static_cast<std::size_t>(mesh.nProcBoundaryFaces());
-    const auto diagOffsV = diagOffs.view();
     const auto faceCellsV = mesh.boundaryMesh().faceOwners().view();
     NF_ASSERT(nProcFaces == rowIdx.size(), "Inconsistent size");
     NF_ASSERT(nProcFaces == colIdx.size(), "Inconsistent size");
+    NF_ASSERT(nProcFaces == recvIdx.size(), "Inconsistent size");
+
+    std::vector<IndexType> recvIdxTyped(recvIdx.begin(), recvIdx.end());
+    Vector<IndexType> recvIdxDevice(exec, std::move(recvIdxTyped));
+    const auto recvIdxV = recvIdxDevice.view();
 
     auto rowIdxV = rowIdx.view();
     auto colIdxV = colIdx.view();
@@ -129,8 +137,8 @@ void setOffDiagonalSparsityPatternImpl(
         {0, nProcFaces},
         KOKKOS_LAMBDA(const localIdx pfacei) {
             localIdx celli = faceCellsV[nBoundaryFaces + pfacei];
-            colIdxV[pfacei] = celli + diagOffsV[celli];
             rowIdxV[pfacei] = celli + globalOffset;
+            colIdxV[pfacei] = recvIdxV[pfacei];
         },
         "setOffDiagonalSparsityPatternImpl"
     );
@@ -262,6 +270,7 @@ void setProcBoundarySparsityPattern(
     const auto nBoundaryFaces = mesh.nBoundaryFaces();
     const auto nProcBoundaryFaces = mesh.nProcBoundaryFaces();
     auto rowIdxV = rowIdx.view();
+    auto colIdxV = colIdx.view();
     auto globalOffset = mesh.globalOffset();
 
     NF_ASSERT(nBoundaryFaces + nProcBoundaryFaces == faceCellsV.size(), "Inconsistent size");
@@ -274,6 +283,7 @@ void setProcBoundarySparsityPattern(
         KOKKOS_LAMBDA(const localIdx bfacei) {
             // TODO compute colIdx
             rowIdxV[bfacei] = faceCellsV[bfacei + nBoundaryFaces] + globalOffset;
+            colIdxV[bfacei] = faceCellsV[bfacei + nBoundaryFaces] + globalOffset;
         },
         "setSparsityPatternFaceToMatrixAddress::setProcBoundarySparsity"
     );
@@ -381,14 +391,20 @@ createBoundarySparsityPattern<CsrSparsityPattern<localIdx>>(
 template<>
 std::shared_ptr<const CooSparsityPattern<localIdx>>
 createOffDiagonalSparsityPattern<CooSparsityPattern<localIdx>>(
-    const UnstructuredMesh& mesh, const FaceToMatrixAddress& faceToMatrixAddress
+    const UnstructuredMesh& mesh, const FaceToMatrixAddress& /* faceToMatrixAddress */
 )
 {
     const auto exec = mesh.exec();
     const auto nProcFaces = static_cast<localIdx>(mesh.nProcBoundaryFaces());
     Vector<localIdx> rowIdx(exec, nProcFaces, 0);
     Vector<localIdx> colIdx(exec, nProcFaces, 0);
-    setOffDiagonalSparsityPatternImpl(mesh, faceToMatrixAddress.diagOffset(), rowIdx, colIdx);
+
+#ifdef NF_WITH_MPI_SUPPORT
+    auto recvIdx = NeoN::computeCommunicationPattern(mesh).recvIdx;
+#else
+    std::vector<int> recvIdx;
+#endif
+    setOffDiagonalSparsityPatternImpl(mesh, recvIdx, rowIdx, colIdx);
     return std::make_shared<const CooSparsityPattern<localIdx>>(
         std::move(colIdx), std::move(rowIdx), Dimensions {mesh.nCells(), nProcFaces}
     );
@@ -397,14 +413,20 @@ createOffDiagonalSparsityPattern<CooSparsityPattern<localIdx>>(
 template<>
 std::shared_ptr<const CsrSparsityPattern<localIdx>>
 createOffDiagonalSparsityPattern<CsrSparsityPattern<localIdx>>(
-    const UnstructuredMesh& mesh, const FaceToMatrixAddress& faceToMatrixAddress
+    const UnstructuredMesh& mesh, const FaceToMatrixAddress& /* faceToMatrixAddress */
 )
 {
     const auto exec = mesh.exec();
     const auto nProcFaces = static_cast<localIdx>(mesh.nProcBoundaryFaces());
     Vector<localIdx> rowIdx(exec, nProcFaces, 0);
     Vector<localIdx> colIdx(exec, nProcFaces, 0);
-    setOffDiagonalSparsityPatternImpl(mesh, faceToMatrixAddress.diagOffset(), rowIdx, colIdx);
+
+#ifdef NF_WITH_MPI_SUPPORT
+    auto recvIdx = NeoN::computeCommunicationPattern(mesh).recvIdx;
+#else
+    std::vector<int> recvIdx;
+#endif
+    setOffDiagonalSparsityPatternImpl(mesh, recvIdx, rowIdx, colIdx);
     auto rowPtrs = rowsToRowOffs(rowIdx);
     return std::make_shared<const CsrSparsityPattern<localIdx>>(
         std::move(colIdx), std::move(rowPtrs), Dimensions {mesh.nCells(), nProcFaces}

--- a/src/linearAlgebra/faceToMatrixAddress.cpp
+++ b/src/linearAlgebra/faceToMatrixAddress.cpp
@@ -12,6 +12,52 @@
 namespace NeoN::la
 {
 
+// ---------------------------------------------------------------------------
+// FaceToMatrixAddress
+// ---------------------------------------------------------------------------
+
+void FaceToMatrixAddress::validate() const
+{
+    NF_ASSERT(ownerOffset_.exec() == neighbourOffset_.exec(), "Executors are not the same");
+    NF_ASSERT(ownerOffset_.exec() == diagOffset_.exec(), "Executors are not the same");
+    NF_ASSERT(
+        ownerOffset_.size() == neighbourOffset_.size(),
+        "ownerOffset and neighbourOffset must have the same size"
+    );
+}
+
+FaceToMatrixAddress::FaceToMatrixAddress(
+    Array<uint8_t> ownerOffset, Array<uint8_t> neighbourOffset, Array<uint8_t> diagOffset
+)
+    : ownerOffset_(std::move(ownerOffset)), neighbourOffset_(std::move(neighbourOffset)),
+      diagOffset_(std::move(diagOffset))
+{
+    validate();
+}
+
+FaceToMatrixAddress::FaceToMatrixAddress(const FaceToMatrixAddress& mi)
+    : ownerOffset_(mi.ownerOffset_), neighbourOffset_(mi.neighbourOffset_),
+      diagOffset_(mi.diagOffset_)
+{
+    validate();
+}
+
+FaceToMatrixAddress FaceToMatrixAddress::copyToExecutor(Executor dstExec) const
+{
+    return {
+        ownerOffset_.copyToExecutor(dstExec),
+        neighbourOffset_.copyToExecutor(dstExec),
+        diagOffset_.copyToExecutor(dstExec)
+    };
+}
+
+FaceToMatrixView FaceToMatrixAddress::view(View<const localIdx> rowOffsView) const
+{
+    return FaceToMatrixView(
+        ownerOffset_.view(), neighbourOffset_.view(), diagOffset_.view(), rowOffsView
+    );
+}
+
 const NeoN::Array<uint8_t>& FaceToMatrixAddress::ownerOffset() const { return ownerOffset_; }
 
 const NeoN::Array<uint8_t>& FaceToMatrixAddress::neighbourOffset() const
@@ -27,60 +73,65 @@ NeoN::Array<uint8_t>& FaceToMatrixAddress::neighbourOffset() { return neighbourO
 
 NeoN::Array<uint8_t>& FaceToMatrixAddress::diagOffset() { return diagOffset_; }
 
-void FaceToMatrixAddress::validate() const
-{
-    NF_ASSERT(ownerOffset_.exec() == neighbourOffset_.exec(), "Executors are not the same");
-    NF_ASSERT(ownerOffset_.exec() == diagOffset_.exec(), "Executors are not the same");
-    NF_ASSERT(
-        ownerOffset_.size() == neighbourOffset_.size(),
-        "ownerOffset and neighbourOffset must have the same size"
-    );
-}
-
-FaceToMatrixAddress::FaceToMatrixAddress(
-    Array<uint8_t> ownerOffset, Array<uint8_t> neighbourOffset, Array<uint8_t> diagOffset
-)
-    : ownerOffset_(ownerOffset), neighbourOffset_(neighbourOffset), diagOffset_(diagOffset)
-{
-    validate();
-}
-
-FaceToMatrixAddress::FaceToMatrixAddress(const FaceToMatrixAddress& mi)
-    : ownerOffset_(mi.ownerOffset_), neighbourOffset_(mi.neighbourOffset_),
-      diagOffset_(mi.diagOffset_)
-{
-    validate();
-}
-
 // ---------------------------------------------------------------------------
-// Internal helpers for building the sparsity data from a mesh
+// Internal helpers
 // ---------------------------------------------------------------------------
 
-/** @brief */
 template<typename IndexType>
 void setBoundarySparsityPatternImpl(
     const UnstructuredMesh& mesh,
     const Array<uint8_t>& diagOffs,
     Vector<IndexType>& rowIdx,
-    Vector<IndexType>& bColIdx
+    Vector<IndexType>& colIdx
 )
 {
     const auto exec = mesh.exec();
     const auto nBoundaryFaces = static_cast<std::size_t>(mesh.nBoundaryFaces());
     const auto diagOffsV = diagOffs.view();
     const auto faceCellsV = mesh.boundaryMesh().faceOwners().view();
+    const auto nBoundaryFaces = mesh.nBoundaryFaces();
+    NF_ASSERT(nBoundaryFaces == rowIdx.size(), "Inconsistent size");
+    NF_ASSERT(nBoundaryFaces == colIdx.size(), "Inconsistent size");
+
     auto rowIdxV = rowIdx.view();
-    auto bColIdxV = bColIdx.view();
+    auto colIdxV = colIdx.view();
     parallelFor(
         exec,
         {0, nBoundaryFaces},
         KOKKOS_LAMBDA(const localIdx bfacei) {
             localIdx celli = faceCellsV[bfacei];
-            bColIdxV[bfacei] = celli + diagOffsV[celli]; // TODO the meaning of bColIdxV  is
-                                                         // currently unused and undefined
+            colIdxV[bfacei] = celli + diagOffsV[celli];
             rowIdxV[bfacei] = celli;
         },
         "setSparsityPatternFaceToMatrixAddress::setBoundarySparsity"
+    );
+}
+
+template<typename IndexType>
+void setProcBoundarySparsityPattern(
+    const UnstructuredMesh& mesh,
+    const Array<uint8_t>& diagOffs,
+    Vector<IndexType>& rowIdx,
+    Vector<IndexType>& colIdx
+)
+{
+    const auto exec = mesh.exec();
+    const auto faceCellsV = mesh.boundaryMesh().faceOwners().view();
+    const auto nBoundaryFaces = mesh.nBoundaryFaces();
+    const auto nProcBoundaryFaces = mesh.nProcBoundaryFaces();
+    auto rowIdxV = rowIdx.view();
+
+    NF_ASSERT(nBoundaryFaces + nProcBoundaryFaces == faceCellsV.size(), "Inconsistent size");
+    NF_ASSERT(nProcBoundaryFaces == rowIdx.size(), "Inconsistent size");
+    NF_ASSERT(nProcBoundaryFaces == colIdx.size(), "Inconsistent size");
+
+    parallelFor(
+        exec,
+        {0, nProcBoundaryFaces},
+        KOKKOS_LAMBDA(const localIdx bfacei) {
+            rowIdxV[bfacei] = faceCellsV[bfacei + nBoundaryFaces];
+        },
+        "setSparsityPatternFaceToMatrixAddress::setProcBoundarySparsity"
     );
 }
 
@@ -94,12 +145,10 @@ void setSparsityPatternFaceToMatrixAddressSerial(
     Vector<IndexType>& colIdx
 )
 {
-    // TODO: currently the whole algorithm is performed in serial on the host
-    // move it to executor
     const auto nInternalFaces = mesh.nInternalFaces();
     auto nCells = mesh.nCells();
 
-    // start with one to include the diagonal
+    // Start with one to include the diagonal
     auto nFacesPerCellH = Vector<localIdx>(SerialExecutor {}, nCells, 1);
     auto [neiOffsetH, ownOffsetH, diagOffsetH, faceOwnH, faceNeiH] =
         copyToHosts(neiOffs, ownOffs, diagOffs, mesh.faceOwners(), mesh.faceNeighbors());
@@ -107,48 +156,36 @@ void setSparsityPatternFaceToMatrixAddressSerial(
     auto [nFacesPerCellHV, neiOffsetHV, ownOffsetHV, diagOffsetHV, faceOwnHV, faceNeiHV] =
         views(nFacesPerCellH, neiOffsetH, ownOffsetH, diagOffsetH, faceOwnH, faceNeiH);
 
-    // accumulate number non-zeros per row
-    // only the internalfaces define the sparsity pattern
-    // get the number of faces per cell to allocate the correct size
+    // Accumulate number of non-zeros per row
     parallelFor(
         SerialExecutor {},
         {0, nInternalFaces},
         KOKKOS_LAMBDA(const localIdx facei) {
-            // hit on performance on serial
             auto own = faceOwnHV[facei];
             auto nei = faceNeiHV[facei];
-
             Kokkos::atomic_inc(&nFacesPerCellHV[own]);
             Kokkos::atomic_inc(&nFacesPerCellHV[nei]);
         },
         "setSparsityPatternFaceToMatrixAddress::accumulateNonZeros"
     );
 
-    // get number of total non-zeros
     auto rowOffsH = rowOffs.copyToHost();
     auto rowOffsHV = rowOffsH.view();
     segmentsFromIntervals(nFacesPerCellH, rowOffsH);
     auto colIdxH = colIdx.copyToHost();
     auto colIdxHV = colIdxH.view();
-    fill(nFacesPerCellH, 0); // reset nFacesPerCell
+    fill(nFacesPerCellH, 0); // Reset nFacesPerCell
 
-    // compute the lower triangular part of the matrix
+    // Compute lower triangular part
     parallelFor(
         SerialExecutor {},
         {0, nInternalFaces},
         KOKKOS_LAMBDA(const localIdx facei) {
             auto nei = faceNeiHV[facei];
             auto own = faceOwnHV[facei];
-
-            // TODO this is probably inherently serial
-            // return the oldValues
-            // hit on performance on serial
             auto segIdxNei = Kokkos::atomic_fetch_add(&nFacesPerCellHV[nei], 1);
             neiOffsetHV[facei] = static_cast<uint8_t>(segIdxNei);
-
             auto startSegNei = rowOffsHV[nei];
-            // neighbour --> current cell
-            // colIdx for row[neighbour] stores owner as a column entry
             Kokkos::atomic_store(&colIdxHV[startSegNei + segIdxNei], own);
         },
         "setSparsityPatternFaceToMatrixAddress::computeLowerTriangular"
@@ -158,36 +195,29 @@ void setSparsityPatternFaceToMatrixAddressSerial(
         nFacesPerCellH,
         KOKKOS_LAMBDA(const localIdx celli) {
             auto nFaces = nFacesPerCellHV[celli];
-            // store number of lower entries as diagonal offset
             diagOffsetHV[celli] = static_cast<uint8_t>(nFaces);
             colIdxHV[rowOffsHV[celli] + nFaces] = celli;
             return nFaces + 1;
         }
     );
 
-    // compute the upper triangular part of the matrix
+    // Compute upper triangular part
     parallelFor(
         SerialExecutor {},
         {0, nInternalFaces},
         KOKKOS_LAMBDA(const localIdx facei) {
             auto nei = faceNeiHV[facei];
             auto own = faceOwnHV[facei];
-
-            // return the oldValues
-            // hit on performance on serial
             auto segIdxOwn =
                 static_cast<uint8_t>(Kokkos::atomic_fetch_add(&nFacesPerCellHV[own], 1));
             ownOffsetHV[facei] = segIdxOwn;
-
             auto startSegOwn = rowOffsHV[own];
-            // owner --> current cell
-            // colIdx --> needs to be store the neighbour
             Kokkos::atomic_store(&colIdxHV[startSegOwn + segIdxOwn], nei);
         },
         "setSparsityPatternFaceToMatrixAddress::computeUpperTriangular"
     );
 
-    // NOTE copy back to device
+    // Copy results back to device
     const auto exec = mesh.exec();
     ownOffs = ownOffsetH.copyToExecutor(exec);
     neiOffs = neiOffsetH.copyToExecutor(exec);
@@ -258,17 +288,21 @@ createSparsityPatternFaceToMatrixAddress<CooSparsityPattern<localIdx>>(const Uns
     return {sp, ftma};
 }
 
+// ---------------------------------------------------------------------------
+// createBoundarySparsityPattern specializations
+// ---------------------------------------------------------------------------
+
 template<>
 std::shared_ptr<const CooSparsityPattern<localIdx>>
 createBoundarySparsityPattern<CooSparsityPattern<localIdx>>(
-    const UnstructuredMesh& mesh, const FaceToMatrixAddress& faceToMatrixAddress
+    const UnstructuredMesh& mesh, const FaceToMatrixAddress& ftma
 )
 {
     const auto exec = mesh.exec();
     const auto nBoundaryFaces = static_cast<localIdx>(mesh.nBoundaryFaces());
     Vector<localIdx> rowIdx(exec, nBoundaryFaces, 0);
     Vector<localIdx> colIdx(exec, nBoundaryFaces, 0);
-    setBoundarySparsityPatternImpl(mesh, faceToMatrixAddress.diagOffset(), rowIdx, colIdx);
+    setBoundarySparsityPatternImpl(mesh, ftma.diagOffset(), rowIdx, colIdx);
     return std::make_shared<const CooSparsityPattern<localIdx>>(
         std::move(colIdx), std::move(rowIdx), Dimensions {mesh.nCells(), mesh.nCells()}
     );
@@ -277,14 +311,14 @@ createBoundarySparsityPattern<CooSparsityPattern<localIdx>>(
 template<>
 std::shared_ptr<const CsrSparsityPattern<localIdx>>
 createBoundarySparsityPattern<CsrSparsityPattern<localIdx>>(
-    const UnstructuredMesh& mesh, const FaceToMatrixAddress& faceToMatrixAddress
+    const UnstructuredMesh& mesh, const FaceToMatrixAddress& ftma
 )
 {
     const auto exec = mesh.exec();
     const auto nBoundaryFaces = static_cast<localIdx>(mesh.nBoundaryFaces());
     Vector<localIdx> rowIdx(exec, nBoundaryFaces, 0);
     Vector<localIdx> colIdx(exec, nBoundaryFaces, 0);
-    setBoundarySparsityPatternImpl(mesh, faceToMatrixAddress.diagOffset(), rowIdx, colIdx);
+    setBoundarySparsityPatternImpl(mesh, ftma.diagOffset(), rowIdx, colIdx);
     auto rowPtrs = rowsToRowOffs(rowIdx);
     return std::make_shared<const CsrSparsityPattern<localIdx>>(
         std::move(colIdx), std::move(rowPtrs), Dimensions {mesh.nCells(), nBoundaryFaces}
@@ -297,4 +331,4 @@ template std::pair<
     std::shared_ptr<const FaceToMatrixAddress>>
 createSparsityPatternFaceToMatrixAddress<CsrSparsityPattern<localIdx>>(const UnstructuredMesh&);
 
-}
+} // namespace NeoN::la

--- a/src/linearAlgebra/faceToMatrixAddress.cpp
+++ b/src/linearAlgebra/faceToMatrixAddress.cpp
@@ -12,10 +12,6 @@
 namespace NeoN::la
 {
 
-// ---------------------------------------------------------------------------
-// FaceToMatrixAddress
-// ---------------------------------------------------------------------------
-
 void FaceToMatrixAddress::validate() const
 {
     NF_ASSERT(ownerOffset_.exec() == neighbourOffset_.exec(), "Executors are not the same");
@@ -74,9 +70,10 @@ NeoN::Array<uint8_t>& FaceToMatrixAddress::neighbourOffset() { return neighbourO
 NeoN::Array<uint8_t>& FaceToMatrixAddress::diagOffset() { return diagOffset_; }
 
 // ---------------------------------------------------------------------------
-// Internal helpers
+// Internal helpers for building the sparsity data from a mesh
 // ---------------------------------------------------------------------------
 
+/** @brief */
 template<typename IndexType>
 void setBoundarySparsityPatternImpl(
     const UnstructuredMesh& mesh,
@@ -89,7 +86,6 @@ void setBoundarySparsityPatternImpl(
     const auto nBoundaryFaces = static_cast<std::size_t>(mesh.nBoundaryFaces());
     const auto diagOffsV = diagOffs.view();
     const auto faceCellsV = mesh.boundaryMesh().faceOwners().view();
-    const auto nBoundaryFaces = mesh.nBoundaryFaces();
     NF_ASSERT(nBoundaryFaces == rowIdx.size(), "Inconsistent size");
     NF_ASSERT(nBoundaryFaces == colIdx.size(), "Inconsistent size");
 
@@ -100,7 +96,8 @@ void setBoundarySparsityPatternImpl(
         {0, nBoundaryFaces},
         KOKKOS_LAMBDA(const localIdx bfacei) {
             localIdx celli = faceCellsV[bfacei];
-            colIdxV[bfacei] = celli + diagOffsV[celli];
+            colIdxV[bfacei] = celli + diagOffsV[celli]; // TODO the meaning of colIdxV  is
+                                                        // currently unused and undefined
             rowIdxV[bfacei] = celli;
         },
         "setSparsityPatternFaceToMatrixAddress::setBoundarySparsity"
@@ -110,7 +107,7 @@ void setBoundarySparsityPatternImpl(
 template<typename IndexType>
 void setProcBoundarySparsityPattern(
     const UnstructuredMesh& mesh,
-    const Array<uint8_t>& diagOffs,
+    const Array<uint8_t>&,
     Vector<IndexType>& rowIdx,
     Vector<IndexType>& colIdx
 )
@@ -129,6 +126,7 @@ void setProcBoundarySparsityPattern(
         exec,
         {0, nProcBoundaryFaces},
         KOKKOS_LAMBDA(const localIdx bfacei) {
+            // TODO compute colIdx
             rowIdxV[bfacei] = faceCellsV[bfacei + nBoundaryFaces];
         },
         "setSparsityPatternFaceToMatrixAddress::setProcBoundarySparsity"
@@ -145,10 +143,12 @@ void setSparsityPatternFaceToMatrixAddressSerial(
     Vector<IndexType>& colIdx
 )
 {
+    // TODO: currently the whole algorithm is performed in serial on the host
+    // move it to executor
     const auto nInternalFaces = mesh.nInternalFaces();
     auto nCells = mesh.nCells();
 
-    // Start with one to include the diagonal
+    // start with one to include the diagonal
     auto nFacesPerCellH = Vector<localIdx>(SerialExecutor {}, nCells, 1);
     auto [neiOffsetH, ownOffsetH, diagOffsetH, faceOwnH, faceNeiH] =
         copyToHosts(neiOffs, ownOffs, diagOffs, mesh.faceOwners(), mesh.faceNeighbors());
@@ -156,36 +156,48 @@ void setSparsityPatternFaceToMatrixAddressSerial(
     auto [nFacesPerCellHV, neiOffsetHV, ownOffsetHV, diagOffsetHV, faceOwnHV, faceNeiHV] =
         views(nFacesPerCellH, neiOffsetH, ownOffsetH, diagOffsetH, faceOwnH, faceNeiH);
 
-    // Accumulate number of non-zeros per row
+    // accumulate number non-zeros per row
+    // only the internalfaces define the sparsity pattern
+    // get the number of faces per cell to allocate the correct size
     parallelFor(
         SerialExecutor {},
         {0, nInternalFaces},
         KOKKOS_LAMBDA(const localIdx facei) {
+            // hit on performance on serial
             auto own = faceOwnHV[facei];
             auto nei = faceNeiHV[facei];
+
             Kokkos::atomic_inc(&nFacesPerCellHV[own]);
             Kokkos::atomic_inc(&nFacesPerCellHV[nei]);
         },
         "setSparsityPatternFaceToMatrixAddress::accumulateNonZeros"
     );
 
+    // get number of total non-zeros
     auto rowOffsH = rowOffs.copyToHost();
     auto rowOffsHV = rowOffsH.view();
     segmentsFromIntervals(nFacesPerCellH, rowOffsH);
     auto colIdxH = colIdx.copyToHost();
     auto colIdxHV = colIdxH.view();
-    fill(nFacesPerCellH, 0); // Reset nFacesPerCell
+    fill(nFacesPerCellH, 0); // reset nFacesPerCell
 
-    // Compute lower triangular part
+    // compute the lower triangular part of the matrix
     parallelFor(
         SerialExecutor {},
         {0, nInternalFaces},
         KOKKOS_LAMBDA(const localIdx facei) {
             auto nei = faceNeiHV[facei];
             auto own = faceOwnHV[facei];
+
+            // TODO this is probably inherently serial
+            // return the oldValues
+            // hit on performance on serial
             auto segIdxNei = Kokkos::atomic_fetch_add(&nFacesPerCellHV[nei], 1);
             neiOffsetHV[facei] = static_cast<uint8_t>(segIdxNei);
+
             auto startSegNei = rowOffsHV[nei];
+            // neighbour --> current cell
+            // colIdx for row[neighbour] stores owner as a column entry
             Kokkos::atomic_store(&colIdxHV[startSegNei + segIdxNei], own);
         },
         "setSparsityPatternFaceToMatrixAddress::computeLowerTriangular"
@@ -195,29 +207,36 @@ void setSparsityPatternFaceToMatrixAddressSerial(
         nFacesPerCellH,
         KOKKOS_LAMBDA(const localIdx celli) {
             auto nFaces = nFacesPerCellHV[celli];
+            // store number of lower entries as diagonal offset
             diagOffsetHV[celli] = static_cast<uint8_t>(nFaces);
             colIdxHV[rowOffsHV[celli] + nFaces] = celli;
             return nFaces + 1;
         }
     );
 
-    // Compute upper triangular part
+    // compute the upper triangular part of the matrix
     parallelFor(
         SerialExecutor {},
         {0, nInternalFaces},
         KOKKOS_LAMBDA(const localIdx facei) {
             auto nei = faceNeiHV[facei];
             auto own = faceOwnHV[facei];
+
+            // return the oldValues
+            // hit on performance on serial
             auto segIdxOwn =
                 static_cast<uint8_t>(Kokkos::atomic_fetch_add(&nFacesPerCellHV[own], 1));
             ownOffsetHV[facei] = segIdxOwn;
+
             auto startSegOwn = rowOffsHV[own];
+            // owner --> current cell
+            // colIdx --> needs to be store the neighbour
             Kokkos::atomic_store(&colIdxHV[startSegOwn + segIdxOwn], nei);
         },
         "setSparsityPatternFaceToMatrixAddress::computeUpperTriangular"
     );
 
-    // Copy results back to device
+    // NOTE copy back to device
     const auto exec = mesh.exec();
     ownOffs = ownOffsetH.copyToExecutor(exec);
     neiOffs = neiOffsetH.copyToExecutor(exec);
@@ -244,8 +263,9 @@ createSparsityPatternFaceToMatrixAddress(const UnstructuredMesh& mesh)
     auto sp = std::make_shared<const SparsityType>(
         std::move(colIdx), std::move(rowOffs), Dimensions {nCells, nCells}
     );
-    auto ftma = std::make_shared<const FaceToMatrixAddress>(ownOffs, neiOffs, diagOffs);
-    return {sp, ftma};
+    auto faceToMatrixAddress =
+        std::make_shared<const FaceToMatrixAddress>(ownOffs, neiOffs, diagOffs);
+    return {sp, faceToMatrixAddress};
 }
 
 // COO specialization: internal algorithm produces CSR-style rowOffs, so we must expand
@@ -284,25 +304,22 @@ createSparsityPatternFaceToMatrixAddress<CooSparsityPattern<localIdx>>(const Uns
     auto sp = std::make_shared<const CooSparsityPattern<localIdx>>(
         std::move(colIdx), std::move(cooRowIdx), Dimensions {nCells, nCells}
     );
-    auto ftma = std::make_shared<const FaceToMatrixAddress>(ownOffs, neiOffs, diagOffs);
-    return {sp, ftma};
+    auto faceToMatrixAddress =
+        std::make_shared<const FaceToMatrixAddress>(ownOffs, neiOffs, diagOffs);
+    return {sp, faceToMatrixAddress};
 }
-
-// ---------------------------------------------------------------------------
-// createBoundarySparsityPattern specializations
-// ---------------------------------------------------------------------------
 
 template<>
 std::shared_ptr<const CooSparsityPattern<localIdx>>
 createBoundarySparsityPattern<CooSparsityPattern<localIdx>>(
-    const UnstructuredMesh& mesh, const FaceToMatrixAddress& ftma
+    const UnstructuredMesh& mesh, const FaceToMatrixAddress& faceToMatrixAddress
 )
 {
     const auto exec = mesh.exec();
     const auto nBoundaryFaces = static_cast<localIdx>(mesh.nBoundaryFaces());
     Vector<localIdx> rowIdx(exec, nBoundaryFaces, 0);
     Vector<localIdx> colIdx(exec, nBoundaryFaces, 0);
-    setBoundarySparsityPatternImpl(mesh, ftma.diagOffset(), rowIdx, colIdx);
+    setBoundarySparsityPatternImpl(mesh, faceToMatrixAddress.diagOffset(), rowIdx, colIdx);
     return std::make_shared<const CooSparsityPattern<localIdx>>(
         std::move(colIdx), std::move(rowIdx), Dimensions {mesh.nCells(), mesh.nCells()}
     );
@@ -311,14 +328,14 @@ createBoundarySparsityPattern<CooSparsityPattern<localIdx>>(
 template<>
 std::shared_ptr<const CsrSparsityPattern<localIdx>>
 createBoundarySparsityPattern<CsrSparsityPattern<localIdx>>(
-    const UnstructuredMesh& mesh, const FaceToMatrixAddress& ftma
+    const UnstructuredMesh& mesh, const FaceToMatrixAddress& faceToMatrixAddress
 )
 {
     const auto exec = mesh.exec();
     const auto nBoundaryFaces = static_cast<localIdx>(mesh.nBoundaryFaces());
     Vector<localIdx> rowIdx(exec, nBoundaryFaces, 0);
     Vector<localIdx> colIdx(exec, nBoundaryFaces, 0);
-    setBoundarySparsityPatternImpl(mesh, ftma.diagOffset(), rowIdx, colIdx);
+    setBoundarySparsityPatternImpl(mesh, faceToMatrixAddress.diagOffset(), rowIdx, colIdx);
     auto rowPtrs = rowsToRowOffs(rowIdx);
     return std::make_shared<const CsrSparsityPattern<localIdx>>(
         std::move(colIdx), std::move(rowPtrs), Dimensions {mesh.nCells(), nBoundaryFaces}
@@ -331,4 +348,4 @@ template std::pair<
     std::shared_ptr<const FaceToMatrixAddress>>
 createSparsityPatternFaceToMatrixAddress<CsrSparsityPattern<localIdx>>(const UnstructuredMesh&);
 
-} // namespace NeoN::la
+}

--- a/src/linearAlgebra/ginkgo.cpp
+++ b/src/linearAlgebra/ginkgo.cpp
@@ -276,7 +276,7 @@ createGkoMtxImpl(std::shared_ptr<const gko::Executor> exec, const CSRMatrix<Vec3
 
 template<typename IndexType>
 std::shared_ptr<const gko::LinOp>
-createGkoMtxImpl(std::shared_ptr<const gko::Executor> exec, const COOMatrix<Vec3, IndexType>& mtx)
+createGkoMtxImpl(std::shared_ptr<const gko::Executor>, const COOMatrix<Vec3, IndexType>&)
 {
     NF_THROW("createGkoMtxImpl: COOMatrix<Vec3> is not supported");
 }

--- a/src/mesh/unstructured/unstructuredMesh.cpp
+++ b/src/mesh/unstructured/unstructuredMesh.cpp
@@ -261,9 +261,6 @@ UnstructuredMesh create3DUniformMesh(
         exec, dim, p, cellCenters, nInternalFaces, nBoundaryFaces, offset, faces
     );
 
-    // Note: With the localIdx type (int32_t), the limit is 2 x 10^9 cells
-    const localIdx nCells = nx * ny * nz;
-
     UnstructuredMesh mesh(
         vectorVector(exec, std::move(points)),
         scalarVector(exec, std::move(cellVolumes)),

--- a/test/distributed/CMakeLists.txt
+++ b/test/distributed/CMakeLists.txt
@@ -4,4 +4,5 @@
 
 if(NeoN_WITH_MPI)
   neon_unit_test(partitioning MPI_SIZE 3)
+  neon_unit_test(operator MPI_SIZE 3)
 endif()

--- a/test/distributed/operator.cpp
+++ b/test/distributed/operator.cpp
@@ -75,7 +75,6 @@ TEST_CASE("Distributed Operator")
     auto meshPart = create1DUniformMeshPart(exec, meshGlobal.nCells() / mpiEnviron.sizeRank());
 
     auto uPart = detail::oneDPartitionField(U, meshPart, mpiEnviron);
-    auto pPart = detail::oneDPartitionField(p, meshPart, mpiEnviron);
     auto phiPart = detail::oneDPartitionField(phi, meshPart, mpiEnviron);
     auto gammaPart = detail::oneDPartitionField(gamma, meshPart, mpiEnviron);
 

--- a/test/distributed/operator.cpp
+++ b/test/distributed/operator.cpp
@@ -128,6 +128,7 @@ TEST_CASE("Distributed Operator")
             std::shared_ptr<const NeoN::la::CooSparsityPattern<localIdx>> cooSparsity =
                 lsDst.offDiagonalMatrix().sparsity();
             REQUIRE_THAT(cooSparsity->rowIdxs(), Equals(I {3}, EqualInt()));
+            REQUIRE_THAT(cooSparsity->colIdxs(), Equals(I {4}, EqualInt()));
         }
         SECTION_IF(
             mpiEnviron.rank() == 1, "Rank 1 offDiagonalMatrix matches global off(4,3) and off(7,8)"
@@ -140,6 +141,7 @@ TEST_CASE("Distributed Operator")
             std::shared_ptr<const NeoN::la::CooSparsityPattern<localIdx>> cooSparsity =
                 lsDst.offDiagonalMatrix().sparsity();
             REQUIRE_THAT(cooSparsity->rowIdxs(), Equals(I {4, 7}, EqualInt()));
+            REQUIRE_THAT(cooSparsity->colIdxs(), Equals(I {3, 8}, EqualInt()));
         }
         SECTION_IF(mpiEnviron.rank() == 2, "Rank 2 offDiagonalMatrix matches global off(8,7)")
         {
@@ -149,6 +151,7 @@ TEST_CASE("Distributed Operator")
             std::shared_ptr<const NeoN::la::CooSparsityPattern<localIdx>> cooSparsity =
                 lsDst.offDiagonalMatrix().sparsity();
             REQUIRE_THAT(cooSparsity->rowIdxs(), Equals(I {8}, EqualInt()));
+            REQUIRE_THAT(cooSparsity->colIdxs(), Equals(I {7}, EqualInt()));
         }
     }
 

--- a/test/distributed/operator.cpp
+++ b/test/distributed/operator.cpp
@@ -12,7 +12,7 @@ using Catch::randomizeVector;
 namespace NeoN
 {
 
-auto generateInput = [](std::string scheme, std::string post)
+auto GENERATE_INPUT = [](std::string scheme, std::string post)
 {
     auto constructDiv = [](auto post) { return "div(phi" + post + ",U" + post + ")"; };
     auto constructGamma = [](auto post) { return "laplacian(gamma" + post + ",U" + post + ")"; };
@@ -38,15 +38,15 @@ TEST_CASE("Distributed Operator")
 
     auto [execName, exec] = GENERATE(allAvailableExecutor());
 
-    auto input = generateInput("upwind", "");
-    auto inputPart = generateInput("upwind", "Part");
+    auto input = GENERATE_INPUT("upwind", "");
+    auto inputPart = GENERATE_INPUT("upwind", "Part");
 
     auto nCells = 12;
     auto meshGlobal = create1DUniformMesh(exec, nCells);
     auto mesh = create1DUniformMesh(exec, nCells);
 
     auto volBCs = fvcc::createCalculatedBCs<fvcc::VolumeBoundary<scalar>>(mesh);
-    auto U = finiteVolume::cellCentred::VolumeField<scalar>(
+    auto u = finiteVolume::cellCentred::VolumeField<scalar>(
         exec, "U", mesh, Vector<scalar>(exec, nCells, 2.0 * one<scalar>()), volBCs
     );
     auto p = finiteVolume::cellCentred::VolumeField<scalar>(
@@ -54,7 +54,7 @@ TEST_CASE("Distributed Operator")
     );
 
     srand(42);
-    randomizeVector(U);
+    randomizeVector(u);
     randomizeVector(p);
 
     auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<scalar>>(mesh);
@@ -67,14 +67,14 @@ TEST_CASE("Distributed Operator")
     fill(gamma.internalVector(), 2.0);
 
     // assembly on global mesh
-    auto expr = dsl::imp::div(phi, U) - dsl::imp::laplacian(gamma, U);
+    auto expr = dsl::imp::div(phi, u) - dsl::imp::laplacian(gamma, u);
     expr.read(input);
     auto ls = expr.assemble(mesh, 1.0, 1.0);
 
     NeoN::mpi::Environment mpiEnviron;
     auto meshPart = create1DUniformMeshPart(exec, meshGlobal.nCells() / mpiEnviron.sizeRank());
 
-    auto uPart = detail::oneDPartitionField(U, meshPart, mpiEnviron);
+    auto uPart = detail::oneDPartitionField(u, meshPart, mpiEnviron);
     auto phiPart = detail::oneDPartitionField(phi, meshPart, mpiEnviron);
     auto gammaPart = detail::oneDPartitionField(gamma, meshPart, mpiEnviron);
 

--- a/test/distributed/operator.cpp
+++ b/test/distributed/operator.cpp
@@ -125,6 +125,9 @@ TEST_CASE("Distributed Operator")
             REQUIRE_THAT(
                 lsDst.offDiagonalMatrix().values(), Equals(take(ls.matrix().values(), {10, 11}))
             );
+            std::shared_ptr<const NeoN::la::CooSparsityPattern<localIdx>> cooSparsity =
+                lsDst.offDiagonalMatrix().sparsity();
+            REQUIRE_THAT(cooSparsity->rowIdxs(), Equals(I {3}, EqualInt()));
         }
         SECTION_IF(
             mpiEnviron.rank() == 1, "Rank 1 offDiagonalMatrix matches global off(4,3) and off(7,8)"
@@ -134,12 +137,18 @@ TEST_CASE("Distributed Operator")
             auto globalView = globalHost.view();
             std::vector<scalar> expected = {globalView[11], globalView[22]};
             REQUIRE_THAT(lsDst.offDiagonalMatrix().values(), Equals(expected));
+            std::shared_ptr<const NeoN::la::CooSparsityPattern<localIdx>> cooSparsity =
+                lsDst.offDiagonalMatrix().sparsity();
+            REQUIRE_THAT(cooSparsity->rowIdxs(), Equals(I {4, 7}, EqualInt()));
         }
         SECTION_IF(mpiEnviron.rank() == 2, "Rank 2 offDiagonalMatrix matches global off(8,7)")
         {
             REQUIRE_THAT(
                 lsDst.offDiagonalMatrix().values(), Equals(take(ls.matrix().values(), {23, 24}))
             );
+            std::shared_ptr<const NeoN::la::CooSparsityPattern<localIdx>> cooSparsity =
+                lsDst.offDiagonalMatrix().sparsity();
+            REQUIRE_THAT(cooSparsity->rowIdxs(), Equals(I {8}, EqualInt()));
         }
     }
 

--- a/test/distributed/operator.cpp
+++ b/test/distributed/operator.cpp
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#include "catch2_common.hpp"
+
+#include "../dsl/common.hpp"
+
+namespace dsl = NeoN::dsl;
+using Catch::randomizeVector;
+
+namespace NeoN
+{
+
+auto generateInput = [](std::string scheme, std::string post)
+{
+    auto constructDiv = [](auto post) { return "div(phi" + post + ",U" + post + ")"; };
+    auto constructGamma = [](auto post) { return "laplacian(gamma" + post + ",U" + post + ")"; };
+
+    return NeoN::Dictionary {
+        {
+            "laplacianSchemes",
+            NeoN::Dictionary {
+                {constructGamma(post),
+                 NeoN::TokenList(
+                     {std::string("Gauss"), std::string("linear"), std::string("uncorrected")}
+                 )}
+            },
+        },
+        {"divSchemes",
+         NeoN::Dictionary {{constructDiv(post), NeoN::TokenList({std::string("Gauss"), scheme})}}}
+    };
+};
+
+TEST_CASE("Distributed Operator")
+{
+    float epsilon = 1e-32;
+
+    auto [execName, exec] = GENERATE(allAvailableExecutor());
+
+    auto input = generateInput("upwind", "");
+    auto inputPart = generateInput("upwind", "Part");
+
+    auto nCells = 12;
+    auto meshGlobal = create1DUniformMesh(exec, nCells);
+    auto mesh = create1DUniformMesh(exec, nCells);
+
+    auto volBCs = fvcc::createCalculatedBCs<fvcc::VolumeBoundary<scalar>>(mesh);
+    auto U = finiteVolume::cellCentred::VolumeField<scalar>(
+        exec, "U", mesh, Vector<scalar>(exec, nCells, 2.0 * one<scalar>()), volBCs
+    );
+    auto p = finiteVolume::cellCentred::VolumeField<scalar>(
+        exec, "p", mesh, Vector<scalar>(exec, nCells, 2.0 * one<scalar>()), volBCs
+    );
+
+    srand(42);
+    randomizeVector(U);
+    randomizeVector(p);
+
+    auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<scalar>>(mesh);
+    auto phi = finiteVolume::cellCentred::SurfaceField<scalar>(exec, "phi", mesh, surfaceBCs);
+    auto gamma = finiteVolume::cellCentred::SurfaceField<scalar>(exec, "gamma", mesh, surfaceBCs);
+
+    fill(phi.internalVector(), 1.0);
+    srand(42);
+    randomizeVector(phi.internalVector());
+    fill(gamma.internalVector(), 2.0);
+
+    // assembly on global mesh
+    auto expr = dsl::imp::div(phi, U) - dsl::imp::laplacian(gamma, U);
+    expr.read(input);
+    auto ls = expr.assemble(mesh, 1.0, 1.0);
+
+    NeoN::mpi::Environment mpiEnviron;
+    auto meshPart = create1DUniformMeshPart(exec, meshGlobal.nCells() / mpiEnviron.sizeRank());
+
+    auto uPart = detail::oneDPartitionField(U, meshPart, mpiEnviron);
+    auto pPart = detail::oneDPartitionField(p, meshPart, mpiEnviron);
+    auto phiPart = detail::oneDPartitionField(phi, meshPart, mpiEnviron);
+    auto gammaPart = detail::oneDPartitionField(gamma, meshPart, mpiEnviron);
+
+    auto exprDist = dsl::imp::div(phiPart, uPart) - dsl::imp::laplacian(gammaPart, uPart);
+
+    exprDist.read(inputPart);
+
+    auto lsDst = exprDist.assemble(meshPart, 1.0, 1.0);
+
+    fill(ls.rhs(), 2.0);
+    fill(lsDst.rhs(), 2.0);
+
+    localIdx firstElement = 0;
+    localIdx lastElement = 0;
+    SECTION_IF(mpiEnviron.rank() == 0, "Correct mtx on rank 0")
+    {
+        lastElement = 10;
+        REQUIRE_THAT(
+            lsDst.matrix().values(), Equals(take(ls.matrix().values(), {firstElement, lastElement}))
+        );
+    }
+    SECTION_IF(mpiEnviron.rank() == 1, "Correct mtx on rank 1")
+    {
+        firstElement = 12;
+        lastElement = 22;
+        REQUIRE_THAT(
+            lsDst.matrix().values(), Equals(take(ls.matrix().values(), {firstElement, lastElement}))
+        );
+    }
+    SECTION_IF(mpiEnviron.rank() == 2, "Correct mtx on rank 2")
+    {
+        firstElement = 24;
+        lastElement = 34;
+        REQUIRE_THAT(
+            lsDst.matrix().values(), Equals(take(ls.matrix().values(), {firstElement, lastElement}))
+        );
+    }
+
+    // The global 12-cell 1D CSR matrix has 34 values (row 0: 2 entries, rows 1-10: 3 each,
+    // row 11: 2 entries). Proc-boundary off-diagonal entries sit at:
+    //   off(3,4)=global[10], off(4,3)=global[11], off(7,8)=global[22], off(8,7)=global[23].
+    // These are excluded from each rank's main matrix and stored in offDiagonalMatrix instead.
+    SECTION("Correct offDiagonalMatrix on partitioned mesh")
+    {
+        SECTION_IF(mpiEnviron.rank() == 0, "Rank 0 offDiagonalMatrix matches global off(3,4)")
+        {
+            REQUIRE_THAT(
+                lsDst.offDiagonalMatrix().values(), Equals(take(ls.matrix().values(), {10, 11}))
+            );
+        }
+        SECTION_IF(
+            mpiEnviron.rank() == 1, "Rank 1 offDiagonalMatrix matches global off(4,3) and off(7,8)"
+        )
+        {
+            auto globalHost = ls.matrix().values().copyToHost();
+            auto globalView = globalHost.view();
+            std::vector<scalar> expected = {globalView[11], globalView[22]};
+            REQUIRE_THAT(lsDst.offDiagonalMatrix().values(), Equals(expected));
+        }
+        SECTION_IF(mpiEnviron.rank() == 2, "Rank 2 offDiagonalMatrix matches global off(8,7)")
+        {
+            REQUIRE_THAT(
+                lsDst.offDiagonalMatrix().values(), Equals(take(ls.matrix().values(), {23, 24}))
+            );
+        }
+    }
+
+#if NF_WITH_GINKGO
+    Dictionary solverDict {
+        {{"solver", std::string {"Ginkgo"}},
+         {"type", "solver::Cg"},
+         {"criteria", Dictionary {{{"iteration", 3}, {"relative_residual_norm", 1e-7}}}}}
+    };
+
+    auto solver = NeoN::la::Solver(exec, solverDict);
+    auto x = Vector<scalar>(exec, 12);
+    fill(x, 0.0);
+
+    auto xPart = Vector<scalar>(exec, 4);
+    fill(xPart, 0.0);
+
+    auto solverStats = solver.solve(ls, x);
+    auto solverStatsDist = solver.solve(lsDst, xPart);
+
+    auto [numIterDist, initResNormDist, finalResNormDist, solveTimeDist] =
+        solverStatsDist.entries[0];
+    auto [numIter, initResNorm, finalResNorm, solveTime] = solverStats.entries[0];
+
+    // TODO: add solution and residual norm checks once MPI-distributed Ginkgo solve is supported.
+    // The local solver operates per-rank; a global distributed solve requires MPI communication
+    // during CG iterations which is not yet implemented.
+    REQUIRE(numIterDist != 0);
+#endif
+}
+
+}

--- a/test/linearAlgebra/cooSparsityPattern.cpp
+++ b/test/linearAlgebra/cooSparsityPattern.cpp
@@ -37,10 +37,10 @@ TEST_CASE("SparsityPattern")
     // clang-format on
     SECTION("Can produce internal rowOffs and colIdx " + execName)
     {
-        auto rowPtrExp = std::vector<localIdx> {0, 2, 5, 8, 10};
+        auto rowIdxExp = std::vector<localIdx> {0, 0, 1, 1, 1, 2, 2, 2, 3, 3};
         auto colIdxExp = std::vector<localIdx> {0, 1, 0, 1, 2, 1, 2, 3, 2, 3};
 
-        REQUIRE_THAT(sp->rowOffs(), Equals(rowPtrExp, EqualInt()));
+        REQUIRE_THAT(sp->rowIdxs(), Equals(rowIdxExp, EqualInt()));
         REQUIRE_THAT(sp->colIdxs(), Equals(colIdxExp, EqualInt()));
     }
 

--- a/test/linearAlgebra/cooSparsityPattern.cpp
+++ b/test/linearAlgebra/cooSparsityPattern.cpp
@@ -37,10 +37,10 @@ TEST_CASE("SparsityPattern")
     // clang-format on
     SECTION("Can produce internal rowOffs and colIdx " + execName)
     {
-        auto rowIdxExp = std::vector<localIdx> {0, 0, 1, 1, 1, 2, 2, 2, 3, 3};
+        auto rowPtrExp = std::vector<localIdx> {0, 2, 5, 8, 10};
         auto colIdxExp = std::vector<localIdx> {0, 1, 0, 1, 2, 1, 2, 3, 2, 3};
 
-        REQUIRE_THAT(sp->rowIdxs(), Equals(rowIdxExp, EqualInt()));
+        REQUIRE_THAT(sp->rowOffs(), Equals(rowPtrExp, EqualInt()));
         REQUIRE_THAT(sp->colIdxs(), Equals(colIdxExp, EqualInt()));
     }
 

--- a/test/linearAlgebra/faceToMatrixAddress.cpp
+++ b/test/linearAlgebra/faceToMatrixAddress.cpp
@@ -23,7 +23,7 @@ TEST_CASE("FaceToMatrixAddress")
 
     // TODO use 2D/3D versions of create1DUniform mesh
     auto mesh = create1DUniformMesh(exec, nCells);
-    auto [csrSp, mi] = NeoN::la::createSparsityPatternFaceToMatrixAddress<
+    auto [sp, mi] = NeoN::la::createSparsityPatternFaceToMatrixAddress<
         NeoN::la::CsrSparsityPattern<NeoN::localIdx>>(mesh);
 
     SECTION("Can construct sparsity pattern " + execName)

--- a/test/linearAlgebra/ginkgo.cpp
+++ b/test/linearAlgebra/ginkgo.cpp
@@ -142,7 +142,7 @@ TEST_CASE("MatrixAssembly - Ginkgo")
         Vector<scalar> bRhs(exec, {});
 
         auto linearSystem = LinearSystem<scalar, NeoN::la::CSRMatrix<scalar, NeoN::localIdx>>(
-            csrMatrix, rhs, bCooMatrix, bRhs
+            csrMatrix, rhs, bCooMatrix, bCooMatrix, bRhs
         );
 
         Vector<scalar> x(exec, {0.0, 0.0, 0.0});
@@ -192,7 +192,7 @@ TEST_CASE("MatrixAssembly - Ginkgo")
         Vector<Vec3> x(exec, {{0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}});
 
         auto linearSystem = LinearSystem<Vec3, NeoN::la::CSRMatrix<Vec3, NeoN::localIdx>>(
-            csrMatrix, rhs, bCooMatrix, bRhs
+            csrMatrix, rhs, bCooMatrix, bCooMatrix, bRhs
         );
 
         SECTION("Segregated" + execName)

--- a/test/linearAlgebra/linearSystem.cpp
+++ b/test/linearAlgebra/linearSystem.cpp
@@ -62,49 +62,17 @@ TEMPLATE_TEST_CASE("LinearSystem", "[template]", NeoN::scalar)
         REQUIRE(linearSystem.rhs().size() == nCells);
     }
 
-    SECTION("construct zero initialized from sparsity with CSR matrix " + execName)
-    {
-        auto nCells = 10;
-        auto nFaces = 9;
-        auto nnz = nCells + 2 * nFaces;
-        auto mesh = create1DUniformMesh(exec, nCells);
-
-        using CSRMatrix = NeoN::la::CSRMatrix<scalar, localIdx>;
-
-        auto linearSystem = NeoN::la::createEmptyLinearSystem<scalar, CSRMatrix, CSRMatrix>(mesh);
-
-        REQUIRE(linearSystem.matrix().values().size() == nnz);
-        REQUIRE(linearSystem.matrix().colIdxs().size() == nnz);
-        REQUIRE(linearSystem.matrix().rowOffs().size() == nCells + 1);
-        REQUIRE(linearSystem.matrix().nRows() == nCells);
-        REQUIRE(linearSystem.rhs().size() == nCells);
-    }
-
-    SECTION("construct zero initialized from sparsity with COO matrix " + execName)
-    {
-        auto nCells = 10;
-        auto nFaces = 9;
-        auto nnz = nCells + 2 * nFaces;
-        auto mesh = create1DUniformMesh(exec, nCells);
-
-        using COOMatrix = NeoN::la::COOMatrix<scalar, localIdx>;
-
-        auto linearSystem = NeoN::la::createEmptyLinearSystem<scalar, COOMatrix, COOMatrix>(mesh);
-
-        REQUIRE(linearSystem.matrix().values().size() == nnz);
-        REQUIRE(linearSystem.matrix().colIdxs().size() == nnz);
-        REQUIRE(linearSystem.matrix().nRows() == nCells);
-        REQUIRE(linearSystem.rhs().size() == nCells);
-    }
 
     SECTION("view read/write " + execName)
     {
         Vector<scalar> rhs(exec, {10.0, 20.0, 30.0});
         Vector<scalar> bRhs(exec, {0.0, 0.0, 0.0});
-        LinearSystem<scalar, CSRMatrix<scalar, localIdx>> ls(csrMatrix, rhs, bCooMatrix, bRhs);
+        LinearSystem<scalar, NeoN::la::CSRMatrix<scalar, NeoN::localIdx>> linearSystem(
+            csrMatrix, rhs, bCooMatrix, bRhs
+        );
 
-        auto lsView = ls.view();
-        auto hostLS = ls.copyToHost();
+        auto lsView = linearSystem.view();
+        auto hostLS = linearSystem.copyToHost();
         auto hostLSView = hostLS.view();
 
         // some simple sanity checks
@@ -143,7 +111,7 @@ TEMPLATE_TEST_CASE("LinearSystem", "[template]", NeoN::scalar)
         );
 
         // Check modification.
-        auto hostLS2 = ls.copyToHost();
+        auto hostLS2 = linearSystem.copyToHost();
         auto hostLS2View = hostLS2.view();
         for (NeoN::localIdx i = 0; i < hostLS2View.matrix.values.size(); ++i)
         {

--- a/test/linearAlgebra/linearSystem.cpp
+++ b/test/linearAlgebra/linearSystem.cpp
@@ -62,6 +62,40 @@ TEMPLATE_TEST_CASE("LinearSystem", "[template]", NeoN::scalar)
         REQUIRE(linearSystem.rhs().size() == nCells);
     }
 
+    SECTION("construct zero initialized from sparsity with CSR matrix " + execName)
+    {
+        auto nCells = 10;
+        auto nFaces = 9;
+        auto nnz = nCells + 2 * nFaces;
+        auto mesh = create1DUniformMesh(exec, nCells);
+
+        using CSRMatrix = NeoN::la::CSRMatrix<scalar, localIdx>;
+
+        auto linearSystem = NeoN::la::createEmptyLinearSystem<scalar, CSRMatrix, CSRMatrix>(mesh);
+
+        REQUIRE(linearSystem.matrix().values().size() == nnz);
+        REQUIRE(linearSystem.matrix().colIdxs().size() == nnz);
+        REQUIRE(linearSystem.matrix().rowOffs().size() == nCells + 1);
+        REQUIRE(linearSystem.matrix().nRows() == nCells);
+        REQUIRE(linearSystem.rhs().size() == nCells);
+    }
+
+    SECTION("construct zero initialized from sparsity with COO matrix " + execName)
+    {
+        auto nCells = 10;
+        auto nFaces = 9;
+        auto nnz = nCells + 2 * nFaces;
+        auto mesh = create1DUniformMesh(exec, nCells);
+
+        using COOMatrix = NeoN::la::COOMatrix<scalar, localIdx>;
+
+        auto linearSystem = NeoN::la::createEmptyLinearSystem<scalar, COOMatrix, COOMatrix>(mesh);
+
+        REQUIRE(linearSystem.matrix().values().size() == nnz);
+        REQUIRE(linearSystem.matrix().colIdxs().size() == nnz);
+        REQUIRE(linearSystem.matrix().nRows() == nCells);
+        REQUIRE(linearSystem.rhs().size() == nCells);
+    }
 
     SECTION("view read/write " + execName)
     {

--- a/test/linearAlgebra/linearSystem.cpp
+++ b/test/linearAlgebra/linearSystem.cpp
@@ -36,7 +36,7 @@ TEMPLATE_TEST_CASE("LinearSystem", "[template]", NeoN::scalar)
         Vector<scalar> rhs(exec, 3, 0.0);
         Vector<scalar> bRhs(exec, 3, 0.0);
         LinearSystem<scalar, NeoN::la::CSRMatrix<scalar, NeoN::localIdx>> linearSystem(
-            csrMatrix, rhs, bCooMatrix, bRhs
+            csrMatrix, rhs, bCooMatrix, bCooMatrix, bRhs
         );
 
         REQUIRE(linearSystem.matrix().values().size() == 9);
@@ -102,7 +102,7 @@ TEMPLATE_TEST_CASE("LinearSystem", "[template]", NeoN::scalar)
         Vector<scalar> rhs(exec, {10.0, 20.0, 30.0});
         Vector<scalar> bRhs(exec, {0.0, 0.0, 0.0});
         LinearSystem<scalar, NeoN::la::CSRMatrix<scalar, NeoN::localIdx>> linearSystem(
-            csrMatrix, rhs, bCooMatrix, bRhs
+            csrMatrix, rhs, bCooMatrix, bCooMatrix, bRhs
         );
 
         auto lsView = linearSystem.view();

--- a/test/linearAlgebra/utilities.cpp
+++ b/test/linearAlgebra/utilities.cpp
@@ -141,8 +141,9 @@ TEST_CASE("Utilities")
         Vector<localIdx> bColIdx(exec, {0, 1, 2});
         Vector<localIdx> bRowOffs(exec, {0, 1, 2});
         COOMatrix<scalar, localIdx> bCooMatrix(bValues, bColIdx, bRowOffs, {3, 1});
+        Vector<scalar> bRhs(exec, 3, 0.0);
         LinearSystem<scalar, CSRMatrix<scalar, localIdx>> linearSystem(
-            csrMatrix, rhs, bCooMatrix, rhs
+            csrMatrix, rhs, bCooMatrix, bRhs
         );
 
         NeoN::la::computeResidual(csrMatrix, rhs, x, res);

--- a/test/linearAlgebra/utilities.cpp
+++ b/test/linearAlgebra/utilities.cpp
@@ -143,7 +143,7 @@ TEST_CASE("Utilities")
         COOMatrix<scalar, localIdx> bCooMatrix(bValues, bColIdx, bRowOffs, {3, 1});
         Vector<scalar> bRhs(exec, 3, 0.0);
         LinearSystem<scalar, CSRMatrix<scalar, localIdx>> linearSystem(
-            csrMatrix, rhs, bCooMatrix, bRhs
+            csrMatrix, rhs, bCooMatrix, bCooMatrix, bRhs
         );
 
         NeoN::la::computeResidual(csrMatrix, rhs, x, res);


### PR DESCRIPTION
Implements matrix-coefficient assembly at processor-boundary faces for both the Gauss-Green divergence and Laplacian operators and tests it against non distributed counterparts. This is also taken from https://github.com/exasim-project/NeoN/pull/414 and currently misses the distributed solver test.
