### PR TITLE
Add corrected and limited-corrected face-normal gradient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ uv.lock
 *.bck
 *log
 *.claude
+CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Version 0.3.0 (unreleased)
 ## Features
+- Add corrected and limited-corrected face-normal gradient schemes [#514](https://github.com/exasim-project/NeoN/pull/514)
 - Add experimental support for COO and CSR Matrices [#486](https://github.com/exasim-project/NeoN/pull/486)
 - Add experimental umpire support [#455](https://github.com/exasim-project/NeoN/pull/455)
 - Add python bindings via nanobind [#382](https://github.com/exasim-project/NeoN/pull/382)

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -13,7 +13,7 @@ SPDX-License-Identifier = "MIT"
 
 [[annotations]]
 path = [
-    "CMakePresets.json", ".clang-format", ".clang-tidy", ".pre-commit-config.yaml", "spack.yaml", "REUSE.toml", "scripts/san_ignores.txt", "CITATION.cff", "CLAUDE.md"
+    "CMakePresets.json", ".clang-format", ".clang-tidy", ".pre-commit-config.yaml", "spack.yaml", "REUSE.toml", "scripts/san_ignores.txt", "CITATION.cff",
 ]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2023 - 2024 NeoN authors"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -13,7 +13,7 @@ SPDX-License-Identifier = "MIT"
 
 [[annotations]]
 path = [
-    "CMakePresets.json", ".clang-format", ".clang-tidy", ".pre-commit-config.yaml", "spack.yaml", "REUSE.toml", "scripts/san_ignores.txt", "CITATION.cff"
+    "CMakePresets.json", ".clang-format", ".clang-tidy", ".pre-commit-config.yaml", "spack.yaml", "REUSE.toml", "scripts/san_ignores.txt", "CITATION.cff", "CLAUDE.md"
 ]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2023 - 2024 NeoN authors"

--- a/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/corrected.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/corrected.hpp
@@ -27,6 +27,13 @@ void computeCorrectedFaceNormalGrad(
 );
 
 template<typename ValueType>
+void computeCorrectionTerm(
+    const VolumeField<ValueType>& volField,
+    const std::shared_ptr<GeometryScheme> geometryScheme,
+    SurfaceField<ValueType>& corrField
+);
+
+template<typename ValueType>
 class Corrected :
     public FaceNormalGradientFactory<ValueType>::template Register<Corrected<ValueType>>
 {
@@ -59,6 +66,15 @@ public:
     virtual const SurfaceField<scalar>& deltaCoeffs() const override
     {
         return geometryScheme_->nonOrthDeltaCoeffs();
+    }
+
+    bool hasImplicitCorrection() const override { return true; }
+
+    virtual void implicitCorrection(
+        const VolumeField<ValueType>& phi, SurfaceField<ValueType>& corrField
+    ) const override
+    {
+        computeCorrectionTerm(phi, geometryScheme_, corrField);
     }
 
     std::unique_ptr<FaceNormalGradientFactory<ValueType>> clone() const override

--- a/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/corrected.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/corrected.hpp
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "NeoN/core/executor/executor.hpp"
+#include "NeoN/finiteVolume/cellCentred/faceNormalGradient/faceNormalGradient.hpp"
+#include "NeoN/finiteVolume/cellCentred/fields/volumeField.hpp"
+#include "NeoN/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp"
+#include "NeoN/finiteVolume/cellCentred/stencil/geometryScheme.hpp"
+#include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
+
+#include <Kokkos_Core.hpp>
+
+#include <functional>
+
+
+namespace NeoN::finiteVolume::cellCentred
+{
+
+template<typename ValueType>
+void computeCorrectedFaceNormalGrad(
+    const VolumeField<ValueType>& volField,
+    const std::shared_ptr<GeometryScheme> geometryScheme,
+    SurfaceField<ValueType>& surfaceField
+);
+
+template<typename ValueType>
+class Corrected :
+    public FaceNormalGradientFactory<ValueType>::template Register<Corrected<ValueType>>
+{
+    using Base = FaceNormalGradientFactory<ValueType>::template Register<Corrected<ValueType>>;
+
+public:
+
+    Corrected(const Executor& exec, const UnstructuredMesh& mesh, Input)
+        : Base(exec, mesh), geometryScheme_(GeometryScheme::readOrCreate(mesh)) {};
+
+    Corrected(const Executor& exec, const UnstructuredMesh& mesh)
+        : Base(exec, mesh), geometryScheme_(GeometryScheme::readOrCreate(mesh)) {};
+
+    static std::string name() { return "corrected"; }
+
+    static std::string doc()
+    {
+        return "Corrected face normal gradient with explicit non-orthogonality correction";
+    }
+
+    static std::string schema() { return "none"; }
+
+    virtual void faceNormalGrad(
+        const VolumeField<ValueType>& volField, SurfaceField<ValueType>& surfaceField
+    ) const override
+    {
+        computeCorrectedFaceNormalGrad(volField, geometryScheme_, surfaceField);
+    }
+
+    virtual const SurfaceField<scalar>& deltaCoeffs() const override
+    {
+        return geometryScheme_->nonOrthDeltaCoeffs();
+    }
+
+    std::unique_ptr<FaceNormalGradientFactory<ValueType>> clone() const override
+    {
+        return std::make_unique<Corrected>(*this);
+    }
+
+private:
+
+    const std::shared_ptr<GeometryScheme> geometryScheme_;
+};
+
+// instantiate the template class
+template class Corrected<scalar>;
+template class Corrected<Vec3>;
+
+} // namespace NeoN

--- a/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/faceNormalGradient.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/faceNormalGradient.hpp
@@ -8,6 +8,7 @@
 
 #include <Kokkos_Core.hpp>
 
+#include "NeoN/core/containerFreeFunctions.hpp"
 #include "NeoN/core/executor/executor.hpp"
 #include "NeoN/core/input.hpp"
 #include "NeoN/core/runtimeSelectionFactory.hpp"
@@ -54,6 +55,20 @@ public:
 
     virtual const SurfaceField<scalar>& deltaCoeffs() const = 0;
 
+    // Returns true when this scheme contributes a non-zero explicit correction
+    // term to the implicit Laplacian RHS (i.e. corrected and limitedCorrected).
+    virtual bool hasImplicitCorrection() const { return false; }
+
+    // Fills corrField.internalVector() with the per-face correction term:
+    //   corrected        → corrVec[f] · interpGrad[f]
+    //   limitedCorrected → limiter[f] * corrVec[f] · interpGrad[f]
+    // Default (uncorrected): fills internal vector with zeros.
+    virtual void
+    implicitCorrection(const VolumeField<ValueType>& phi, SurfaceField<ValueType>& corrField) const
+    {
+        NeoN::fill(corrField.internalVector(), zero<ValueType>());
+    }
+
     // Pure virtual function for cloning
     virtual std::unique_ptr<FaceNormalGradientFactory<ValueType>> clone() const = 0;
 
@@ -98,6 +113,13 @@ public:
 
     const SurfaceField<scalar>& deltaCoeffs() const { return faceNormalGradKernel_->deltaCoeffs(); }
 
+    bool hasImplicitCorrection() const { return faceNormalGradKernel_->hasImplicitCorrection(); }
+
+    void
+    implicitCorrection(const VolumeField<ValueType>& phi, SurfaceField<ValueType>& corrField) const
+    {
+        faceNormalGradKernel_->implicitCorrection(phi, corrField);
+    }
 
     SurfaceField<ValueType> faceNormalGrad(const VolumeField<ValueType>& volVector) const
     {

--- a/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/limitedCorrected.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/limitedCorrected.hpp
@@ -29,6 +29,14 @@ void computeLimitedCorrectedFaceNormalGrad(
 );
 
 template<typename ValueType>
+void computeLimitedCorrectionTerm(
+    const VolumeField<ValueType>& volField,
+    const std::shared_ptr<GeometryScheme> geometryScheme,
+    scalar limitCoeff,
+    SurfaceField<ValueType>& corrField
+);
+
+template<typename ValueType>
 class LimitedCorrected :
     public FaceNormalGradientFactory<ValueType>::template Register<LimitedCorrected<ValueType>>
 {
@@ -66,6 +74,15 @@ public:
     virtual const SurfaceField<scalar>& deltaCoeffs() const override
     {
         return geometryScheme_->nonOrthDeltaCoeffs();
+    }
+
+    bool hasImplicitCorrection() const override { return true; }
+
+    virtual void implicitCorrection(
+        const VolumeField<ValueType>& phi, SurfaceField<ValueType>& corrField
+    ) const override
+    {
+        computeLimitedCorrectionTerm(phi, geometryScheme_, limitCoeff_, corrField);
     }
 
     std::unique_ptr<FaceNormalGradientFactory<ValueType>> clone() const override

--- a/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/limitedCorrected.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/limitedCorrected.hpp
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "NeoN/core/executor/executor.hpp"
+#include "NeoN/core/input.hpp"
+#include "NeoN/finiteVolume/cellCentred/faceNormalGradient/faceNormalGradient.hpp"
+#include "NeoN/finiteVolume/cellCentred/fields/volumeField.hpp"
+#include "NeoN/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp"
+#include "NeoN/finiteVolume/cellCentred/stencil/geometryScheme.hpp"
+#include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
+
+#include <Kokkos_Core.hpp>
+
+#include <functional>
+
+
+namespace NeoN::finiteVolume::cellCentred
+{
+
+template<typename ValueType>
+void computeLimitedCorrectedFaceNormalGrad(
+    const VolumeField<ValueType>& volField,
+    const std::shared_ptr<GeometryScheme> geometryScheme,
+    scalar limitCoeff,
+    SurfaceField<ValueType>& surfaceField
+);
+
+template<typename ValueType>
+class LimitedCorrected :
+    public FaceNormalGradientFactory<ValueType>::template Register<LimitedCorrected<ValueType>>
+{
+    using Base =
+        FaceNormalGradientFactory<ValueType>::template Register<LimitedCorrected<ValueType>>;
+
+    static constexpr scalar defaultLimitCoeff = 0.333;
+
+public:
+
+    LimitedCorrected(const Executor& exec, const UnstructuredMesh& mesh, const Input& inputs)
+        : Base(exec, mesh), geometryScheme_(GeometryScheme::readOrCreate(mesh)),
+          limitCoeff_(readLimitCoeff(inputs)) {};
+
+    LimitedCorrected(const Executor& exec, const UnstructuredMesh& mesh)
+        : Base(exec, mesh), geometryScheme_(GeometryScheme::readOrCreate(mesh)),
+          limitCoeff_(defaultLimitCoeff) {};
+
+    static std::string name() { return "limitedCorrected"; }
+
+    static std::string doc()
+    {
+        return "Limited corrected face normal gradient with bounded non-orthogonality correction";
+    }
+
+    static std::string schema() { return "none"; }
+
+    virtual void faceNormalGrad(
+        const VolumeField<ValueType>& volField, SurfaceField<ValueType>& surfaceField
+    ) const override
+    {
+        computeLimitedCorrectedFaceNormalGrad(volField, geometryScheme_, limitCoeff_, surfaceField);
+    }
+
+    virtual const SurfaceField<scalar>& deltaCoeffs() const override
+    {
+        return geometryScheme_->nonOrthDeltaCoeffs();
+    }
+
+    std::unique_ptr<FaceNormalGradientFactory<ValueType>> clone() const override
+    {
+        return std::make_unique<LimitedCorrected>(*this);
+    }
+
+private:
+
+    static scalar readLimitCoeff(const Input& inputs)
+    {
+        if (std::holds_alternative<NeoN::Dictionary>(inputs))
+        {
+            const auto& dict = std::get<NeoN::Dictionary>(inputs);
+            if (dict.contains("limitCoeff"))
+            {
+                return dict.get<scalar>("limitCoeff");
+            }
+            return defaultLimitCoeff;
+        }
+        // TokenList: coefficient follows the scheme name (already consumed by factory)
+        auto& tl = std::get<NeoN::TokenList>(inputs);
+        return tl.next<scalar>();
+    }
+
+    const std::shared_ptr<GeometryScheme> geometryScheme_;
+    scalar limitCoeff_;
+};
+
+// instantiate the template class
+template class LimitedCorrected<scalar>;
+template class LimitedCorrected<Vec3>;
+
+} // namespace NeoN

--- a/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/limitedCorrected.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/faceNormalGradient/limitedCorrected.hpp
@@ -43,7 +43,7 @@ class LimitedCorrected :
     using Base =
         FaceNormalGradientFactory<ValueType>::template Register<LimitedCorrected<ValueType>>;
 
-    static constexpr scalar defaultLimitCoeff = 0.333;
+    static constexpr scalar DEFAULT_LIMIT_COEFF = 0.333;
 
 public:
 
@@ -53,7 +53,7 @@ public:
 
     LimitedCorrected(const Executor& exec, const UnstructuredMesh& mesh)
         : Base(exec, mesh), geometryScheme_(GeometryScheme::readOrCreate(mesh)),
-          limitCoeff_(defaultLimitCoeff) {};
+          limitCoeff_(DEFAULT_LIMIT_COEFF) {};
 
     static std::string name() { return "limitedCorrected"; }
 
@@ -101,7 +101,7 @@ private:
             {
                 return dict.get<scalar>("limitCoeff");
             }
-            return defaultLimitCoeff;
+            return DEFAULT_LIMIT_COEFF;
         }
         // TokenList: coefficient follows the scheme name (already consumed by factory)
         auto& tl = std::get<NeoN::TokenList>(inputs);

--- a/include/NeoN/finiteVolume/cellCentred/operators/ddtFluxCorr.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/ddtFluxCorr.hpp
@@ -45,45 +45,36 @@ inline void ddtFluxCorrBDF1Kernel(
     const auto nBoundaryFaces = mesh.nBoundaryFaces();
 
     // Internal faces
-    {
-        auto [outV, flux0V, uf0V, SfV] = views(
-            fluxCorr.internalVector(),
-            flux0.internalVector(),
-            uf0.internalVector(),
-            mesh.faceNormals()
-        );
-        parallelFor(
-            exec,
-            {size_t(0), static_cast<size_t>(nInternalFaces)},
-            NEON_LAMBDA(const localIdx i) {
-                const auto d = (SfV[i] & uf0V[i]);
-                const auto corr = flux0V[i] - d;
-                const scalar limiter = ddtFluxCorrLimiter(mag(flux0V[i]), mag(corr));
-                outV[i] = limiter * a1 * corr;
-            },
-            "ddtFluxCorr::BDF1::internal"
-        );
-    }
+    auto [outV, flux0V, uf0V, SfV] = views(
+        fluxCorr.internalVector(), flux0.internalVector(), uf0.internalVector(), mesh.faceNormals()
+    );
+    parallelFor(
+        exec,
+        {size_t(0), static_cast<size_t>(nInternalFaces)},
+        NEON_LAMBDA(const localIdx i) {
+            const auto d = (SfV[i] & uf0V[i]);
+            const auto corr = flux0V[i] - d;
+            const scalar limiter = ddtFluxCorrLimiter(mag(flux0V[i]), mag(corr));
+            outV[i] = limiter * a1 * corr;
+        },
+        "ddtFluxCorr::BDF1::internal"
+    );
 
     // Boundary faces
-    {
-        auto [outBV, flux0BV, uf0BV] = views(
-            fluxCorr.boundaryData().value(),
-            flux0.boundaryData().value(),
-            uf0.boundaryData().value()
-        );
-        parallelFor(
-            exec,
-            {size_t(0), static_cast<size_t>(nBoundaryFaces)},
-            NEON_LAMBDA(const localIdx bfi) {
-                const auto d = (SfV[nInternalFaces + bfi] & uf0BV[bfi]);
-                const auto corr = flux0BV[bfi] - d;
-                const scalar limiter = ddtFluxCorrLimiter(mag(flux0BV[bfi]), mag(corr));
-                outBV[bfi] = limiter * a1 * corr;
-            },
-            "ddtFluxCorr::BDF1::boundary"
-        );
-    }
+    auto [outBV, flux0BV, uf0BV] = views(
+        fluxCorr.boundaryData().value(), flux0.boundaryData().value(), uf0.boundaryData().value()
+    );
+    parallelFor(
+        exec,
+        {size_t(0), static_cast<size_t>(nBoundaryFaces)},
+        NEON_LAMBDA(const localIdx bfi) {
+            const auto d = (SfV[nInternalFaces + bfi] & uf0BV[bfi]);
+            const auto corr = flux0BV[bfi] - d;
+            const scalar limiter = ddtFluxCorrLimiter(mag(flux0BV[bfi]), mag(corr));
+            outBV[bfi] = limiter * a1 * corr;
+        },
+        "ddtFluxCorr::BDF1::boundary"
+    );
 }
 
 // ------------------------------------------------------------------

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp
@@ -42,6 +42,15 @@ void computeLaplacianBoundImpl(
 );
 
 template<typename ValueType>
+void computeLaplacianNonOrthCorrImpl(
+    la::LinearSystem<ValueType>& ls,
+    const SurfaceField<scalar>& gamma,
+    const VolumeField<ValueType>& phi,
+    const dsl::Coeff coeff,
+    const FaceNormalGradient<ValueType>& faceNormalGradient
+);
+
+template<typename ValueType>
 class GaussGreenLaplacian :
     public LaplacianOperatorFactory<ValueType>::template Register<GaussGreenLaplacian<ValueType>>
 {
@@ -64,18 +73,16 @@ public:
         VolumeField<ValueType>& lapPhi,
         const SurfaceField<scalar>& gamma,
         const VolumeField<ValueType>& phi,
-        const dsl::Coeff operatorScaling
+        const dsl::Coeff coeff
     ) override
     {
         computeLaplacianExp<ValueType>(
-            faceNormalGradient_, gamma, phi, lapPhi.internalVector(), operatorScaling
+            faceNormalGradient_, gamma, phi, lapPhi.internalVector(), coeff
         );
     };
 
     virtual VolumeField<ValueType> laplacian(
-        const SurfaceField<scalar>& gamma,
-        const VolumeField<ValueType>& phi,
-        const dsl::Coeff operatorScaling
+        const SurfaceField<scalar>& gamma, const VolumeField<ValueType>& phi, const dsl::Coeff coeff
     ) const override
     {
         std::string name = "laplacian(" + gamma.name + "," + phi.name + ")";
@@ -88,7 +95,7 @@ public:
         NeoN::fill(lapPhi.internalVector(), zero<ValueType>());
         NeoN::fill(lapPhi.boundaryData().value(), zero<ValueType>());
         computeLaplacianExp<ValueType>(
-            faceNormalGradient_, gamma, phi, lapPhi.internalVector(), operatorScaling
+            faceNormalGradient_, gamma, phi, lapPhi.internalVector(), coeff
         );
         return lapPhi;
     };
@@ -97,21 +104,22 @@ public:
         Vector<ValueType>& lapPhi,
         const SurfaceField<scalar>& gamma,
         const VolumeField<ValueType>& phi,
-        const dsl::Coeff operatorScaling
+        const dsl::Coeff coeff
     ) override
     {
-        computeLaplacianExp<ValueType>(faceNormalGradient_, gamma, phi, lapPhi, operatorScaling);
+        computeLaplacianExp<ValueType>(faceNormalGradient_, gamma, phi, lapPhi, coeff);
     };
 
     virtual void laplacian(
         la::LinearSystem<ValueType>& ls,
         const SurfaceField<scalar>& gamma,
         const VolumeField<ValueType>& phi,
-        const dsl::Coeff operatorScaling
+        const dsl::Coeff coeff
     ) override
     {
-        computeLaplacianIntImpl(ls, gamma, phi, operatorScaling, faceNormalGradient_);
-        computeLaplacianBoundImpl(ls, gamma, phi, operatorScaling, faceNormalGradient_);
+        computeLaplacianIntImpl(ls, gamma, phi, coeff, faceNormalGradient_);
+        computeLaplacianBoundImpl(ls, gamma, phi, coeff, faceNormalGradient_);
+        computeLaplacianNonOrthCorrImpl(ls, gamma, phi, coeff, faceNormalGradient_);
     };
 
     std::unique_ptr<LaplacianOperatorFactory<ValueType>> clone() const override

--- a/include/NeoN/finiteVolume/cellCentred/stencil/basicGeometryScheme.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/stencil/basicGeometryScheme.hpp
@@ -27,8 +27,9 @@ public:
     void updateNonOrthDeltaCoeffs(const Executor& exec, SurfaceField<scalar>& nonOrthDeltaCoeffs)
         override;
 
-    void
-    updateNonOrthDeltaCoeffs(const Executor& exec, SurfaceField<Vec3>& nonOrthDeltaCoeffs) override;
+    void updateNonOrthCorrectionVec3s(
+        const Executor& exec, SurfaceField<Vec3>& nonOrthCorrectionVec3s
+    ) override;
 
 
 private:

--- a/include/NeoN/finiteVolume/cellCentred/stencil/geometryScheme.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/stencil/geometryScheme.hpp
@@ -30,8 +30,9 @@ public:
     virtual void
     updateNonOrthDeltaCoeffs(const Executor& exec, SurfaceField<scalar>& nonOrthDeltaCoeffs) = 0;
 
-    virtual void
-    updateNonOrthDeltaCoeffs(const Executor& exec, SurfaceField<Vec3>& nonOrthDeltaCoeffs) = 0;
+    virtual void updateNonOrthCorrectionVec3s(
+        const Executor& exec, SurfaceField<Vec3>& nonOrthCorrectionVec3s
+    ) = 0;
 };
 
 /* @class GeometryScheme

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,6 +61,8 @@ target_sources(
           "finiteVolume/cellCentred/interpolation/linear.cpp"
           "finiteVolume/cellCentred/interpolation/upwind.cpp"
           "finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp"
+          "finiteVolume/cellCentred/faceNormalGradient/corrected.cpp"
+          "finiteVolume/cellCentred/faceNormalGradient/limitedCorrected.cpp"
           "finiteVolume/cellCentred/auxiliary/coNum.cpp"
           "timeIntegration/timeIntegration.cpp"
           "timeIntegration/rungeKutta.cpp")

--- a/src/finiteVolume/cellCentred/faceNormalGradient/corrected.cpp
+++ b/src/finiteVolume/cellCentred/faceNormalGradient/corrected.cpp
@@ -86,11 +86,64 @@ void computeCorrectedFaceNormalGrad(
     }
 }
 
+template<typename ValueType>
+void computeCorrectionTerm(
+    const VolumeField<ValueType>& volField,
+    const std::shared_ptr<GeometryScheme> geometryScheme,
+    SurfaceField<ValueType>& corrField
+)
+{
+    if constexpr (std::is_same_v<ValueType, scalar>)
+    {
+        const UnstructuredMesh& mesh = corrField.mesh();
+        const auto& exec = corrField.exec();
+
+        GaussGreenGrad gradScheme(exec, mesh);
+        VolumeField<Vec3> gradPhi = gradScheme.grad(volField);
+
+        const auto [owners, neighbors] = views(mesh.faceOwners(), mesh.faceNeighbors());
+
+        const auto [corrf, weights, corrVec] = views(
+            corrField.internalVector(),
+            geometryScheme->weights().internalVector(),
+            geometryScheme->nonOrthCorrectionVec3s().internalVector()
+        );
+
+        const auto gradPhiV = gradPhi.internalVector().view();
+        auto nInternalFaces = mesh.nInternalFaces();
+
+        NeoN::parallelFor(
+            exec,
+            {0, nInternalFaces},
+            NEON_LAMBDA(const localIdx facei) {
+                Vec3 interpGrad = weights[facei] * gradPhiV[owners[facei]]
+                                + (scalar(1) - weights[facei]) * gradPhiV[neighbors[facei]];
+                corrf[facei] = corrVec[facei] & interpGrad;
+            },
+            "computeCorrectionTermInternal"
+        );
+        // boundary correction is intentionally not written: the laplacian RHS update
+        // iterates only internal faces, so corrField.boundaryData() is never read.
+    }
+    else
+    {
+        NF_ERROR_EXIT("implicitCorrection for Vec3 fields is not implemented: "
+                      "requires tensor gradient support");
+    }
+}
+
 #define NF_DECLARE_COMPUTE_CORRECTED_FNG(TYPENAME)                                                 \
     template void computeCorrectedFaceNormalGrad<                                                  \
         TYPENAME>(const VolumeField<TYPENAME>&, const std::shared_ptr<GeometryScheme>, SurfaceField<TYPENAME>&)
 
 NF_DECLARE_COMPUTE_CORRECTED_FNG(scalar);
 NF_DECLARE_COMPUTE_CORRECTED_FNG(Vec3);
+
+#define NF_DECLARE_COMPUTE_CORRECTION_TERM(TYPENAME)                                               \
+    template void computeCorrectionTerm<                                                           \
+        TYPENAME>(const VolumeField<TYPENAME>&, const std::shared_ptr<GeometryScheme>, SurfaceField<TYPENAME>&)
+
+NF_DECLARE_COMPUTE_CORRECTION_TERM(scalar);
+NF_DECLARE_COMPUTE_CORRECTION_TERM(Vec3);
 
 } // namespace NeoN

--- a/src/finiteVolume/cellCentred/faceNormalGradient/corrected.cpp
+++ b/src/finiteVolume/cellCentred/faceNormalGradient/corrected.cpp
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#include <memory>
+#include <type_traits>
+
+#include "NeoN/core/error.hpp"
+#include "NeoN/finiteVolume/cellCentred/faceNormalGradient/corrected.hpp"
+
+namespace NeoN::finiteVolume::cellCentred
+{
+
+template<typename ValueType>
+void computeCorrectedFaceNormalGrad(
+    const VolumeField<ValueType>& volField,
+    const std::shared_ptr<GeometryScheme> geometryScheme,
+    SurfaceField<ValueType>& surfaceField
+)
+{
+    if constexpr (std::is_same_v<ValueType, scalar>)
+    {
+        const UnstructuredMesh& mesh = surfaceField.mesh();
+        const auto& exec = surfaceField.exec();
+
+        // Compute cell-centred gradient via Gauss-Green
+        GaussGreenGrad gradScheme(exec, mesh);
+        VolumeField<Vec3> gradPhi = gradScheme.grad(volField);
+
+        const auto [owners, neighbors, boundaryFaceOwners] =
+            views(mesh.faceOwners(), mesh.faceNeighbors(), mesh.boundaryMesh().faceOwners());
+
+        const auto
+            [phif,
+             phifB,
+             phi,
+             phiBCValue,
+             nonOrthDeltaCoeffs,
+             nonOrthDeltaCoeffsB,
+             weights,
+             corrVec] =
+                views(
+                    surfaceField.internalVector(),
+                    surfaceField.boundaryData().value(),
+                    volField.internalVector(),
+                    volField.boundaryData().value(),
+                    geometryScheme->nonOrthDeltaCoeffs().internalVector(),
+                    geometryScheme->nonOrthDeltaCoeffs().boundaryData().value(),
+                    geometryScheme->weights().internalVector(),
+                    geometryScheme->nonOrthCorrectionVec3s().internalVector()
+                );
+
+        const auto gradPhiV = gradPhi.internalVector().view();
+
+        auto nInternalFaces = mesh.nInternalFaces();
+        auto nBoundaryFaces = mesh.nBoundaryFaces();
+
+        NeoN::parallelFor(
+            exec,
+            {0, nInternalFaces},
+            NEON_LAMBDA(const localIdx facei) {
+                scalar ortho =
+                    nonOrthDeltaCoeffs[facei] * (phi[neighbors[facei]] - phi[owners[facei]]);
+                Vec3 interpGrad = weights[facei] * gradPhiV[owners[facei]]
+                                + (scalar(1) - weights[facei]) * gradPhiV[neighbors[facei]];
+                phif[facei] = ortho + (corrVec[facei] & interpGrad);
+            },
+            "computeCorrectedFaceNormalGradInternal"
+        );
+
+        // corrVec is zero at boundaries — boundary snGrad reduces to the uncorrected form.
+        NeoN::parallelFor(
+            exec,
+            {0, nBoundaryFaces},
+            NEON_LAMBDA(const localIdx bfi) {
+                auto own = boundaryFaceOwners[bfi];
+                phifB[bfi] = nonOrthDeltaCoeffsB[bfi] * (phiBCValue[bfi] - phi[own]);
+            },
+            "computeCorrectedFaceNormalGradBoundary"
+        );
+    }
+    else
+    {
+        NF_ERROR_EXIT("corrected snGrad for Vec3 fields is not implemented: "
+                      "requires tensor gradient support");
+    }
+}
+
+#define NF_DECLARE_COMPUTE_CORRECTED_FNG(TYPENAME)                                                 \
+    template void computeCorrectedFaceNormalGrad<                                                  \
+        TYPENAME>(const VolumeField<TYPENAME>&, const std::shared_ptr<GeometryScheme>, SurfaceField<TYPENAME>&)
+
+NF_DECLARE_COMPUTE_CORRECTED_FNG(scalar);
+NF_DECLARE_COMPUTE_CORRECTED_FNG(Vec3);
+
+} // namespace NeoN

--- a/src/finiteVolume/cellCentred/faceNormalGradient/limitedCorrected.cpp
+++ b/src/finiteVolume/cellCentred/faceNormalGradient/limitedCorrected.cpp
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#include <memory>
+#include <type_traits>
+
+#include "NeoN/core/error.hpp"
+#include "NeoN/finiteVolume/cellCentred/faceNormalGradient/limitedCorrected.hpp"
+
+namespace NeoN::finiteVolume::cellCentred
+{
+
+template<typename ValueType>
+void computeLimitedCorrectedFaceNormalGrad(
+    const VolumeField<ValueType>& volField,
+    const std::shared_ptr<GeometryScheme> geometryScheme,
+    scalar limitCoeff,
+    SurfaceField<ValueType>& surfaceField
+)
+{
+    if constexpr (std::is_same_v<ValueType, scalar>)
+    {
+        const UnstructuredMesh& mesh = surfaceField.mesh();
+        const auto& exec = surfaceField.exec();
+
+        // Compute cell-centred gradient via Gauss-Green
+        GaussGreenGrad gradScheme(exec, mesh);
+        VolumeField<Vec3> gradPhi = gradScheme.grad(volField);
+
+        const auto [owners, neighbors, boundaryFaceOwners] =
+            views(mesh.faceOwners(), mesh.faceNeighbors(), mesh.boundaryMesh().faceOwners());
+
+        const auto
+            [phif,
+             phifB,
+             phi,
+             phiBCValue,
+             nonOrthDeltaCoeffs,
+             nonOrthDeltaCoeffsB,
+             weights,
+             corrVec] =
+                views(
+                    surfaceField.internalVector(),
+                    surfaceField.boundaryData().value(),
+                    volField.internalVector(),
+                    volField.boundaryData().value(),
+                    geometryScheme->nonOrthDeltaCoeffs().internalVector(),
+                    geometryScheme->nonOrthDeltaCoeffs().boundaryData().value(),
+                    geometryScheme->weights().internalVector(),
+                    geometryScheme->nonOrthCorrectionVec3s().internalVector()
+                );
+
+        const auto gradPhiV = gradPhi.internalVector().view();
+
+        auto nInternalFaces = mesh.nInternalFaces();
+        auto nBoundaryFaces = mesh.nBoundaryFaces();
+        const scalar lc = limitCoeff;
+        const scalar oneMinusLc = scalar(1) - lc;
+
+        NeoN::parallelFor(
+            exec,
+            {0, nInternalFaces},
+            NEON_LAMBDA(const localIdx facei) {
+                scalar ortho =
+                    nonOrthDeltaCoeffs[facei] * (phi[neighbors[facei]] - phi[owners[facei]]);
+                Vec3 interpGrad = weights[facei] * gradPhiV[owners[facei]]
+                                + (scalar(1) - weights[facei]) * gradPhiV[neighbors[facei]];
+                scalar corr = corrVec[facei] & interpGrad;
+
+                // Limiter: bounds the correction relative to the orthogonal part
+                scalar absCorr = std::abs(corr);
+                scalar limiter =
+                    (absCorr > scalar(0)) ? std::min(
+                        lc * std::abs(ortho) / (oneMinusLc * absCorr + ROOTVSMALL), scalar(1)
+                    )
+                                          : scalar(1);
+
+                phif[facei] = ortho + limiter * corr;
+            },
+            "computeLimitedCorrectedFaceNormalGradInternal"
+        );
+
+        // corrVec is zero at boundaries — boundary snGrad reduces to the uncorrected form.
+        NeoN::parallelFor(
+            exec,
+            {0, nBoundaryFaces},
+            NEON_LAMBDA(const localIdx bfi) {
+                auto own = boundaryFaceOwners[bfi];
+                phifB[bfi] = nonOrthDeltaCoeffsB[bfi] * (phiBCValue[bfi] - phi[own]);
+            },
+            "computeLimitedCorrectedFaceNormalGradBoundary"
+        );
+    }
+    else
+    {
+        NF_ERROR_EXIT("limitedCorrected snGrad for Vec3 fields is not implemented: "
+                      "requires tensor gradient support");
+    }
+}
+
+#define NF_DECLARE_COMPUTE_LIMITED_CORRECTED_FNG(TYPENAME)                                         \
+    template void computeLimitedCorrectedFaceNormalGrad<                                           \
+        TYPENAME>(const VolumeField<TYPENAME>&, const std::shared_ptr<GeometryScheme>, scalar, SurfaceField<TYPENAME>&)
+
+NF_DECLARE_COMPUTE_LIMITED_CORRECTED_FNG(scalar);
+NF_DECLARE_COMPUTE_LIMITED_CORRECTED_FNG(Vec3);
+
+} // namespace NeoN

--- a/src/finiteVolume/cellCentred/faceNormalGradient/limitedCorrected.cpp
+++ b/src/finiteVolume/cellCentred/faceNormalGradient/limitedCorrected.cpp
@@ -106,4 +106,73 @@ void computeLimitedCorrectedFaceNormalGrad(
 NF_DECLARE_COMPUTE_LIMITED_CORRECTED_FNG(scalar);
 NF_DECLARE_COMPUTE_LIMITED_CORRECTED_FNG(Vec3);
 
+template<typename ValueType>
+void computeLimitedCorrectionTerm(
+    const VolumeField<ValueType>& volField,
+    const std::shared_ptr<GeometryScheme> geometryScheme,
+    scalar limitCoeff,
+    SurfaceField<ValueType>& corrField
+)
+{
+    if constexpr (std::is_same_v<ValueType, scalar>)
+    {
+        const UnstructuredMesh& mesh = corrField.mesh();
+        const auto& exec = corrField.exec();
+
+        GaussGreenGrad gradScheme(exec, mesh);
+        VolumeField<Vec3> gradPhi = gradScheme.grad(volField);
+
+        const auto [owners, neighbors] = views(mesh.faceOwners(), mesh.faceNeighbors());
+
+        const auto [corrf, phi, nonOrthDeltaCoeffs, weights, corrVec] = views(
+            corrField.internalVector(),
+            volField.internalVector(),
+            geometryScheme->nonOrthDeltaCoeffs().internalVector(),
+            geometryScheme->weights().internalVector(),
+            geometryScheme->nonOrthCorrectionVec3s().internalVector()
+        );
+
+        const auto gradPhiV = gradPhi.internalVector().view();
+        auto nInternalFaces = mesh.nInternalFaces();
+        const scalar lc = limitCoeff;
+        const scalar oneMinusLc = scalar(1) - lc;
+
+        NeoN::parallelFor(
+            exec,
+            {0, nInternalFaces},
+            NEON_LAMBDA(const localIdx facei) {
+                scalar ortho =
+                    nonOrthDeltaCoeffs[facei] * (phi[neighbors[facei]] - phi[owners[facei]]);
+                Vec3 interpGrad = weights[facei] * gradPhiV[owners[facei]]
+                                + (scalar(1) - weights[facei]) * gradPhiV[neighbors[facei]];
+                scalar corr = corrVec[facei] & interpGrad;
+
+                scalar absCorr = std::abs(corr);
+                scalar limiter =
+                    (absCorr > scalar(0)) ? std::min(
+                        lc * std::abs(ortho) / (oneMinusLc * absCorr + ROOTVSMALL), scalar(1)
+                    )
+                                          : scalar(1);
+
+                corrf[facei] = limiter * corr;
+            },
+            "computeLimitedCorrectionTermInternal"
+        );
+        // boundary correction is intentionally not written: the laplacian RHS update
+        // iterates only internal faces, so corrField.boundaryData() is never read.
+    }
+    else
+    {
+        NF_ERROR_EXIT("implicitCorrection for Vec3 fields is not implemented: "
+                      "requires tensor gradient support");
+    }
+}
+
+#define NF_DECLARE_COMPUTE_LIMITED_CORRECTION_TERM(TYPENAME)                                       \
+    template void computeLimitedCorrectionTerm<                                                    \
+        TYPENAME>(const VolumeField<TYPENAME>&, const std::shared_ptr<GeometryScheme>, scalar, SurfaceField<TYPENAME>&)
+
+NF_DECLARE_COMPUTE_LIMITED_CORRECTION_TERM(scalar);
+NF_DECLARE_COMPUTE_LIMITED_CORRECTION_TERM(Vec3);
+
 } // namespace NeoN

--- a/src/finiteVolume/cellCentred/operators/gaussGreenGrad.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenGrad.cpp
@@ -245,8 +245,8 @@ void computeGradTensor(
         mesh.cellVolumes(),
         mesh.boundaryMesh().faceOwners()
     );
-    const auto UfInt = uf.internalVector().view();
-    const auto UfBound = uf.boundaryData().value().view();
+    const auto ufInt = uf.internalVector().view();
+    const auto ufBound = uf.boundaryData().value().view();
 
     const localIdx nInt = mesh.nInternalFaces();
     const localIdx nBnd = mesh.nBoundaryFaces();
@@ -256,7 +256,7 @@ void computeGradTensor(
         {0, nInt},
         NEON_LAMBDA(const localIdx f) {
             const Vec3 sf = SfAll[f];
-            const Vec3 faceU = UfInt[f];
+            const Vec3 faceU = ufInt[f];
             const auto o = owner[f];
             const auto n = nei[f];
             // gradU(row,col) += Sf[col] * U[row]  (Gauss-Green)
@@ -280,7 +280,7 @@ void computeGradTensor(
             const auto o = bFaceCells[bi];
             // TODO Issue #515
             const Vec3 sf = SfAll[nInt + bi];
-            const Vec3 faceU = UfBound[bi];
+            const Vec3 faceU = ufBound[bi];
             for (size_t row = 0; row < 3; ++row)
             {
                 for (size_t col = 0; col < 3; ++col)

--- a/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
@@ -216,6 +216,35 @@ void computeLaplacianIntImpl(
         },
         "computeLocalLaplacianCoefficients"
     );
+
+    // Non-orthogonal correction (deferred correction) for corrected / limitedCorrected snGrad:
+    //   rhs[own] += corr[f] * γ_f * |S_f| * coeff[own]
+    //   rhs[nei] -= corr[f] * γ_f * |S_f| * coeff[nei]
+    // The correction is zero for uncorrected via the default implicitCorrection() implementation,
+    // so the if-guard skips unnecessary work and allocation.
+    if (faceNormalGradient.hasImplicitCorrection())
+    {
+        SurfaceField<ValueType> corrField(
+            exec, "snGradCorr", mesh, createCalculatedBCs<SurfaceBoundary<ValueType>>(mesh)
+        );
+        faceNormalGradient.implicitCorrection(phi, corrField);
+
+        const auto corrV = corrField.internalVector().view();
+        auto rhs = ls.rhs().view();
+
+        parallelFor(
+            exec,
+            {0, nInternalFaces},
+            NEON_LAMBDA(const localIdx facei) {
+                auto corrFlux = corrV[facei] * gammaV[facei] * magFaceArea[facei];
+                auto own = ownV[facei];
+                auto nei = neiV[facei];
+                Kokkos::atomic_add(&rhs[own], corrFlux * coeff[own]);
+                Kokkos::atomic_sub(&rhs[nei], corrFlux * coeff[nei]);
+            },
+            "computeLaplacianImplicitCorrection"
+        );
+    }
 }
 
 #define NN_DECLARE_COMPUTE_IMP_LAP(TYPENAME)                                                                                                                      \

--- a/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
@@ -165,6 +165,49 @@ void computeLaplacianBoundImpl(
 }
 
 template<typename ValueType>
+void computeLaplacianNonOrthCorrImpl(
+    la::LinearSystem<ValueType>& ls,
+    const SurfaceField<scalar>& gamma,
+    const VolumeField<ValueType>& phi,
+    const dsl::Coeff coeff,
+    const FaceNormalGradient<ValueType>& faceNormalGradient
+)
+{
+    if (!faceNormalGradient.hasImplicitCorrection()) return;
+
+    const UnstructuredMesh& mesh = phi.mesh();
+    const auto exec = phi.exec();
+    const auto nInternalFaces = mesh.nInternalFaces();
+
+    const auto [ownV, neiV] = views(mesh.faceOwners(), mesh.faceNeighbors());
+    const auto [gammaV, magFaceArea] = views(gamma.internalVector(), mesh.faceAreas());
+
+    SurfaceField<ValueType> corrField(
+        exec, "snGradCorr", mesh, createCalculatedBCs<SurfaceBoundary<ValueType>>(mesh)
+    );
+    faceNormalGradient.implicitCorrection(phi, corrField);
+
+    const auto corrV = corrField.internalVector().view();
+    auto rhs = ls.rhs().view();
+
+    // Non-orthogonal correction (deferred correction) for corrected / limitedCorrected snGrad:
+    //   rhs[own] += corr[f] * γ_f * |S_f| * coeff[own]
+    //   rhs[nei] -= corr[f] * γ_f * |S_f| * coeff[nei]
+    parallelFor(
+        exec,
+        {0, nInternalFaces},
+        NEON_LAMBDA(const localIdx facei) {
+            auto corrFlux = corrV[facei] * gammaV[facei] * magFaceArea[facei];
+            auto own = ownV[facei];
+            auto nei = neiV[facei];
+            Kokkos::atomic_add(&rhs[own], corrFlux * coeff[own]);
+            Kokkos::atomic_sub(&rhs[nei], corrFlux * coeff[nei]);
+        },
+        "computeLaplacianImplicitCorrection"
+    );
+}
+
+template<typename ValueType>
 void computeLaplacianIntImpl(
     la::LinearSystem<ValueType>& ls,
     const SurfaceField<scalar>& gamma,
@@ -216,41 +259,14 @@ void computeLaplacianIntImpl(
         },
         "computeLocalLaplacianCoefficients"
     );
-
-    // Non-orthogonal correction (deferred correction) for corrected / limitedCorrected snGrad:
-    //   rhs[own] += corr[f] * γ_f * |S_f| * coeff[own]
-    //   rhs[nei] -= corr[f] * γ_f * |S_f| * coeff[nei]
-    // The correction is zero for uncorrected via the default implicitCorrection() implementation,
-    // so the if-guard skips unnecessary work and allocation.
-    if (faceNormalGradient.hasImplicitCorrection())
-    {
-        SurfaceField<ValueType> corrField(
-            exec, "snGradCorr", mesh, createCalculatedBCs<SurfaceBoundary<ValueType>>(mesh)
-        );
-        faceNormalGradient.implicitCorrection(phi, corrField);
-
-        const auto corrV = corrField.internalVector().view();
-        auto rhs = ls.rhs().view();
-
-        parallelFor(
-            exec,
-            {0, nInternalFaces},
-            NEON_LAMBDA(const localIdx facei) {
-                auto corrFlux = corrV[facei] * gammaV[facei] * magFaceArea[facei];
-                auto own = ownV[facei];
-                auto nei = neiV[facei];
-                Kokkos::atomic_add(&rhs[own], corrFlux * coeff[own]);
-                Kokkos::atomic_sub(&rhs[nei], corrFlux * coeff[nei]);
-            },
-            "computeLaplacianImplicitCorrection"
-        );
-    }
 }
 
 #define NN_DECLARE_COMPUTE_IMP_LAP(TYPENAME)                                                                                                                      \
     template void computeLaplacianIntImpl<                                                                                                                        \
         TYPENAME>(la::LinearSystem<TYPENAME>&, const SurfaceField<scalar>&, const VolumeField<TYPENAME>&, const dsl::Coeff, const FaceNormalGradient<TYPENAME>&); \
     template void computeLaplacianBoundImpl<                                                                                                                      \
+        TYPENAME>(la::LinearSystem<TYPENAME>&, const SurfaceField<scalar>&, const VolumeField<TYPENAME>&, const dsl::Coeff, const FaceNormalGradient<TYPENAME>&); \
+    template void computeLaplacianNonOrthCorrImpl<                                                                                                                \
         TYPENAME>(la::LinearSystem<TYPENAME>&, const SurfaceField<scalar>&, const VolumeField<TYPENAME>&, const dsl::Coeff, const FaceNormalGradient<TYPENAME>&)
 
 NN_DECLARE_COMPUTE_IMP_LAP(scalar);

--- a/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
@@ -139,11 +139,41 @@ void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
 }
 
 
-void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
-    [[maybe_unused]] const Executor& exec, [[maybe_unused]] SurfaceField<Vec3>& nonOrthDeltaCoeffs
+void BasicGeometryScheme::updateNonOrthCorrectionVec3s(
+    const Executor& exec, SurfaceField<Vec3>& nonOrthCorrectionVec3s
 )
 {
-    NF_ERROR_EXIT("Not implemented");
+    const auto [owners, neighbors] = views(mesh_.faceOwners(), mesh_.faceNeighbors());
+
+    const auto [cellCenters, faceNormals, faceAreas] =
+        views(mesh_.cellCenters(), mesh_.faceNormals(), mesh_.faceAreas());
+
+    const auto [corrVec, corrVecB] = views(
+        nonOrthCorrectionVec3s.internalVector(), nonOrthCorrectionVec3s.boundaryData().value()
+    );
+
+    const auto nInternalFaces = mesh_.nInternalFaces();
+    const auto nBoundaryFaces = mesh_.nBoundaryFaces();
+
+    parallelFor(
+        exec,
+        {0, nInternalFaces},
+        NEON_LAMBDA(const localIdx facei) {
+            Vec3 delta = cellCenters[neighbors[facei]] - cellCenters[owners[facei]];
+            Vec3 n = (1.0 / faceAreas[facei]) * faceNormals[facei];
+            scalar orthoDist = n & delta;
+            scalar nonOrthDeltaCoeff = 1.0 / std::max(orthoDist, scalar(0.05) * mag(delta));
+            corrVec[facei] = n - delta * nonOrthDeltaCoeff;
+        },
+        "basicGeometricScheme::updateNonOrthCorrectionVec3sInternal"
+    );
+
+    parallelFor(
+        exec,
+        {0, nBoundaryFaces},
+        NEON_LAMBDA(const localIdx bfi) { corrVecB[bfi] = zero<Vec3>(); },
+        "basicGeometricScheme::updateNonOrthCorrectionVec3sBoundary"
+    );
 }
 
 } // namespace NeoN

--- a/src/finiteVolume/cellCentred/stencil/geometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/geometryScheme.cpp
@@ -113,7 +113,7 @@ void GeometryScheme::update()
                 kernel_->updateWeights(exec, weights_);
                 kernel_->updateDeltaCoeffs(exec, deltaCoeffs_);
                 kernel_->updateNonOrthDeltaCoeffs(exec, nonOrthDeltaCoeffs_);
-                // kernel_->updateNonOrthCorrectionVec3s(exec, nonOrthCorrectionVec3s_);
+                kernel_->updateNonOrthCorrectionVec3s(exec, nonOrthCorrectionVec3s_);
             },
             exec_
         );

--- a/test/finiteVolume/cellCentred/faceNormalGradient/CMakeLists.txt
+++ b/test/finiteVolume/cellCentred/faceNormalGradient/CMakeLists.txt
@@ -3,3 +3,5 @@
 # SPDX-License-Identifier: Unlicense
 
 neon_unit_test(uncorrected)
+neon_unit_test(corrected)
+neon_unit_test(limitedCorrected)

--- a/test/finiteVolume/cellCentred/faceNormalGradient/corrected.cpp
+++ b/test/finiteVolume/cellCentred/faceNormalGradient/corrected.cpp
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
+                            // a custom main
+#include "catch2_common.hpp"
+
+#include "NeoN/NeoN.hpp"
+
+namespace fvcc = NeoN::finiteVolume::cellCentred;
+
+namespace NeoN
+{
+
+template<typename T>
+using I = std::initializer_list<T>;
+
+TEMPLATE_TEST_CASE("corrected", "[template]", NeoN::scalar)
+{
+    auto [execName, exec] = GENERATE(allAvailableExecutor());
+
+    const NeoN::localIdx nCells = 10;
+    // 1D uniform mesh is orthogonal, so corrVec = 0 everywhere
+    // Corrected result should be identical to uncorrected on this mesh
+    auto mesh = create1DUniformMesh(exec, nCells);
+    auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<TestType>>(mesh);
+
+    fvcc::SurfaceField<TestType> phif(exec, "phif", mesh, surfaceBCs);
+    fill(phif.internalVector(), zero<TestType>());
+
+    auto volumeBCs = fvcc::createCalculatedBCs<fvcc::VolumeBoundary<TestType>>(mesh);
+    fvcc::VolumeField<TestType> phi(exec, "phi", mesh, volumeBCs);
+    NeoN::parallelFor(
+        phi.internalVector(),
+        NEON_LAMBDA(const NeoN::localIdx i) { return scalar(i + 1) * one<TestType>(); }
+    );
+    phi.boundaryData().value() =
+        NeoN::Vector<TestType>(exec, {0.5 * one<TestType>(), 10.5 * one<TestType>()});
+
+    SECTION("Construct from TokenList" + execName)
+    {
+        NeoN::Input input = NeoN::TokenList({std::string("corrected")});
+        fvcc::FaceNormalGradient<TestType> corrected(exec, mesh, input);
+    }
+
+    SECTION("Construct from Dictionary" + execName)
+    {
+        NeoN::Input input = NeoN::Dictionary({{"faceNormalGradient", std::string("corrected")}});
+        fvcc::FaceNormalGradient<TestType> corrected(exec, mesh, input);
+    }
+
+    SECTION("faceNormalGrad equals uncorrected on orthogonal mesh" + execName)
+    {
+        // On orthogonal meshes corrVec = 0, so corrected == uncorrected
+        NeoN::Input input = NeoN::TokenList({std::string("corrected")});
+        fvcc::FaceNormalGradient<TestType> corrected(exec, mesh, input);
+        corrected.faceNormalGrad(phi, phif);
+
+        // internal faces
+        auto phifHost = phif.internalVector().copyToHost();
+        auto sPhif = phifHost.view();
+        for (NeoN::localIdx i = 0; i < nCells - 1; i++)
+        {
+            REQUIRE(
+                NeoN::mag(sPhif[i] - 10.0 * one<TestType>()) == Catch::Approx(0.0).margin(1e-8)
+            );
+        }
+        // boundary faces are now in boundaryData().value()
+        auto phifBHost = phif.boundaryData().value().copyToHost();
+        auto sPhifB = phifBHost.view();
+        // left boundary (bfi=0): gradient is -10.0
+        REQUIRE(NeoN::mag(sPhifB[0] + 10.0 * one<TestType>()) == Catch::Approx(0.0).margin(1e-8));
+        // right boundary (bfi=1): gradient is 10.0
+        REQUIRE(NeoN::mag(sPhifB[1] - 10.0 * one<TestType>()) == Catch::Approx(0.0).margin(1e-8));
+    }
+}
+}

--- a/test/finiteVolume/cellCentred/faceNormalGradient/limitedCorrected.cpp
+++ b/test/finiteVolume/cellCentred/faceNormalGradient/limitedCorrected.cpp
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
+                            // a custom main
+#include "catch2_common.hpp"
+
+#include "NeoN/NeoN.hpp"
+
+namespace fvcc = NeoN::finiteVolume::cellCentred;
+
+namespace NeoN
+{
+
+template<typename T>
+using I = std::initializer_list<T>;
+
+TEMPLATE_TEST_CASE("limitedCorrected", "[template]", NeoN::scalar)
+{
+    auto [execName, exec] = GENERATE(allAvailableExecutor());
+
+    const NeoN::localIdx nCells = 10;
+    // 1D uniform mesh is orthogonal, so corrVec = 0 everywhere
+    // LimitedCorrected result should be identical to uncorrected on this mesh
+    auto mesh = create1DUniformMesh(exec, nCells);
+    auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<TestType>>(mesh);
+
+    fvcc::SurfaceField<TestType> phif(exec, "phif", mesh, surfaceBCs);
+    fill(phif.internalVector(), zero<TestType>());
+
+    auto volumeBCs = fvcc::createCalculatedBCs<fvcc::VolumeBoundary<TestType>>(mesh);
+    fvcc::VolumeField<TestType> phi(exec, "phi", mesh, volumeBCs);
+    NeoN::parallelFor(
+        phi.internalVector(),
+        NEON_LAMBDA(const NeoN::localIdx i) { return scalar(i + 1) * one<TestType>(); }
+    );
+    phi.boundaryData().value() =
+        NeoN::Vector<TestType>(exec, {0.5 * one<TestType>(), 10.5 * one<TestType>()});
+
+    SECTION("Construct from TokenList with coefficient" + execName)
+    {
+        NeoN::Input input = NeoN::TokenList({std::string("limitedCorrected"), NeoN::scalar(0.333)});
+        fvcc::FaceNormalGradient<TestType> lc(exec, mesh, input);
+    }
+
+    SECTION("Construct from Dictionary with limitCoeff" + execName)
+    {
+        NeoN::Input input = NeoN::Dictionary(
+            {{"faceNormalGradient", std::string("limitedCorrected")},
+             {"limitCoeff", NeoN::scalar(0.333)}}
+        );
+        fvcc::FaceNormalGradient<TestType> lc(exec, mesh, input);
+    }
+
+    SECTION("faceNormalGrad equals uncorrected on orthogonal mesh" + execName)
+    {
+        // On orthogonal meshes corrVec = 0, so limitedCorrected == uncorrected
+        NeoN::Input input = NeoN::TokenList({std::string("limitedCorrected"), NeoN::scalar(0.333)});
+        fvcc::FaceNormalGradient<TestType> lc(exec, mesh, input);
+        lc.faceNormalGrad(phi, phif);
+
+        // internal faces
+        auto phifHost = phif.internalVector().copyToHost();
+        auto sPhif = phifHost.view();
+        for (NeoN::localIdx i = 0; i < nCells - 1; i++)
+        {
+            REQUIRE(
+                NeoN::mag(sPhif[i] - 10.0 * one<TestType>()) == Catch::Approx(0.0).margin(1e-8)
+            );
+        }
+        // boundary faces are now in boundaryData().value()
+        auto phifBHost = phif.boundaryData().value().copyToHost();
+        auto sPhifB = phifBHost.view();
+        // left boundary (bfi=0): gradient is -10.0
+        REQUIRE(NeoN::mag(sPhifB[0] + 10.0 * one<TestType>()) == Catch::Approx(0.0).margin(1e-8));
+        // right boundary (bfi=1): gradient is 10.0
+        REQUIRE(NeoN::mag(sPhifB[1] - 10.0 * one<TestType>()) == Catch::Approx(0.0).margin(1e-8));
+    }
+
+    SECTION("faceNormalGrad with full correction (limitCoeff=1) on orthogonal mesh" + execName)
+    {
+        // limitCoeff=1 behaves as full corrected — still equals uncorrected on orthogonal mesh
+        NeoN::Input input = NeoN::TokenList({std::string("limitedCorrected"), NeoN::scalar(1.0)});
+        fvcc::FaceNormalGradient<TestType> lc(exec, mesh, input);
+        lc.faceNormalGrad(phi, phif);
+
+        auto phifHost = phif.internalVector().copyToHost();
+        auto sPhif = phifHost.view();
+        for (NeoN::localIdx i = 0; i < nCells - 1; i++)
+        {
+            REQUIRE(
+                NeoN::mag(sPhif[i] - 10.0 * one<TestType>()) == Catch::Approx(0.0).margin(1e-8)
+            );
+        }
+    }
+}
+}

--- a/test/timeIntegration/ddtFluxCorr.cpp
+++ b/test/timeIntegration/ddtFluxCorr.cpp
@@ -80,8 +80,6 @@ TEST_CASE("timeIntegration: ddtPhiCorr on single-cell mesh", "[timeIntegration][
         // Helper: expected values for boundary faces (host-side)
         auto expectedFrom = [&](const SurfScalar& flux0Field)
         {
-
-            for (auto i = 0; i < mesh.nTotalFaces(); ++i)
             std::vector<Scalar> e(static_cast<size_t>(nBndFaces), 0.0);
             auto flux0FieldH = flux0Field.boundaryData().value().copyToHost();
             auto flux0FieldV = flux0FieldH.view();
@@ -110,13 +108,8 @@ TEST_CASE("timeIntegration: ddtPhiCorr on single-cell mesh", "[timeIntegration][
 
             NeoN::parallelFor(
                 exec,
-<<<<<<< HEAD
-                {size_t(0), mesh.nTotalFaces()},
-                NEON_LAMBDA(const NeoN::localIdx i) { flux0V2[i] = (sfV2[i] & uf0V2[i]); }
-=======
                 {size_t(0), static_cast<size_t>(nBndFaces)},
                 NEON_LAMBDA(const NeoN::localIdx i) { flux0BV2[i] = (sfV2[i] & uf0BV2[i]); }
->>>>>>> a744ac4b54 (make surface field contain only internal data)
             );
 
             flux.boundaryData().value() = flux0.boundaryData().value();
@@ -124,15 +117,9 @@ TEST_CASE("timeIntegration: ddtPhiCorr on single-cell mesh", "[timeIntegration][
             auto fluxCorr = fvcc::ddtFluxCorr(u, flux, dt, scheme);
             auto corrBH = fluxCorr.boundaryData().value().copyToHost();
 
-<<<<<<< HEAD
-            for (auto i = 0; i < mesh.nTotalFaces(); ++i)
-            {
-                REQUIRE(corrH.view()[i] == Catch::Approx(0.0).margin(1e-12));
-            }
-=======
-            for (NeoN::localIdx i = 0; i < nBndFaces; ++i)
+            for (NeoN::localIdx i = 0; i < nBndFaces; ++i) {
                 REQUIRE(corrBH.view()[i] == Catch::Approx(0.0).margin(1e-12));
->>>>>>> a744ac4b54 (make surface field contain only internal data)
+            }
         }
 
         // ─────────────────────────────────────────────
@@ -146,12 +133,7 @@ TEST_CASE("timeIntegration: ddtPhiCorr on single-cell mesh", "[timeIntegration][
             auto fluxCorr = fvcc::ddtFluxCorr(u, flux, dt, scheme);
             auto corrBH = fluxCorr.boundaryData().value().copyToHost();
 
-<<<<<<< HEAD
-            for (auto i = 0; i < mesh.nTotalFaces(); ++i)
-            {
-=======
-            for (NeoN::localIdx i = 0; i < nBndFaces; ++i)
->>>>>>> a744ac4b54 (make surface field contain only internal data)
+            for (NeoN::localIdx i = 0; i < nBndFaces; ++i) {
                 REQUIRE(
                     corrBH.view()[i]
                     == Catch::Approx(expected[static_cast<size_t>(i)]).margin(1e-12)

--- a/test/timeIntegration/ddtFluxCorr.cpp
+++ b/test/timeIntegration/ddtFluxCorr.cpp
@@ -117,7 +117,8 @@ TEST_CASE("timeIntegration: ddtPhiCorr on single-cell mesh", "[timeIntegration][
             auto fluxCorr = fvcc::ddtFluxCorr(u, flux, dt, scheme);
             auto corrBH = fluxCorr.boundaryData().value().copyToHost();
 
-            for (NeoN::localIdx i = 0; i < nBndFaces; ++i) {
+            for (NeoN::localIdx i = 0; i < nBndFaces; ++i)
+            {
                 REQUIRE(corrBH.view()[i] == Catch::Approx(0.0).margin(1e-12));
             }
         }
@@ -133,7 +134,8 @@ TEST_CASE("timeIntegration: ddtPhiCorr on single-cell mesh", "[timeIntegration][
             auto fluxCorr = fvcc::ddtFluxCorr(u, flux, dt, scheme);
             auto corrBH = fluxCorr.boundaryData().value().copyToHost();
 
-            for (NeoN::localIdx i = 0; i < nBndFaces; ++i) {
+            for (NeoN::localIdx i = 0; i < nBndFaces; ++i)
+            {
                 REQUIRE(
                     corrBH.view()[i]
                     == Catch::Approx(expected[static_cast<size_t>(i)]).margin(1e-12)


### PR DESCRIPTION
This PR adds corrected and limited-corrected face-normal gradient (snGrad) schemes for the cell-centred finite-volume stack, including deferred non-orthogonal corrections in the implicit Laplacian assembly, and updates geometry/stencil plumbing and tests to support these schemes.

Changes:

Introduces corrected and limitedCorrected faceNormalGradient schemes (with scalar implementations) and wires them into the build and runtime selection.
Extends GeometryScheme/BasicGeometryScheme to compute and expose a non-orthogonality correction vector field used by corrected snGrad variants.
Adds unit tests for the new schemes and cleans up/adjusts existing tests and operator code for updated surface/boundary handling.
