### PR TITLE
Add copyTo Mixin

### DIFF
--- a/include/NeoN/core/copyTo.hpp
+++ b/include/NeoN/core/copyTo.hpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "NeoN/core/executor/executor.hpp"
+
+namespace NeoN
+{
+
+/**
+ * @class SupportsCopyTo
+ * @brief MixinClass signaling copyTo is supported
+ *
+ *  Requires copyToExecutor to be implemented, provides a copyToHost for free
+ */
+template<typename HostType>
+class SupportsCopyTo
+{
+
+public:
+
+    virtual ~SupportsCopyTo() = default;
+
+    [[nodiscard]] virtual HostType copyToExecutor(Executor exec) const = 0;
+
+    [[nodiscard]] HostType copyToHost() const { return copyToExecutor(SerialExecutor()); }
+};
+
+}

--- a/include/NeoN/core/segmentedVector.hpp
+++ b/include/NeoN/core/segmentedVector.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "NeoN/core/view.hpp"
+#include "NeoN/core/copyTo.hpp"
 #include "NeoN/core/parallelAlgorithms.hpp"
 #include "NeoN/core/primitives/label.hpp"
 #include "NeoN/core/vector/vector.hpp"
@@ -127,7 +128,7 @@ public:
  * @ingroup Vectors
  */
 template<typename ValueType, typename IndexType>
-class SegmentedVector
+class SegmentedVector : public SupportsCopyTo<SegmentedVector<ValueType, IndexType>>
 {
 public:
 
@@ -186,14 +187,11 @@ public:
      */
     localIdx numSegments() const { return segments_.size() - 1; }
 
-    /**
-     * @brief Returns a copy of the segmentedVector on the host
-     * @return copy of the segmentedVector on the host
-     */
-    SegmentedVector<ValueType, IndexType> copyToHost() const
+    [[nodiscard]] SegmentedVector<ValueType, IndexType> copyToExecutor(Executor exec) const override
     {
-        SegmentedVector<ValueType, IndexType> result(values_.copyToHost(), segments_.copyToHost());
-        return result;
+        return SegmentedVector<ValueType, IndexType>(
+            values_.copyToExecutor(exec), segments_.copyToExecutor(exec)
+        );
     }
 
 

--- a/include/NeoN/linearAlgebra/cooSparsityPattern.hpp
+++ b/include/NeoN/linearAlgebra/cooSparsityPattern.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "NeoN/core/copyTo.hpp"
 #include "NeoN/core/vector/vector.hpp"
 #include "NeoN/linearAlgebra/sparsityView.hpp"
 #include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
@@ -19,7 +20,7 @@ namespace NeoN::la
  * of sparsity patterns from a given unstructured mesh
  */
 template<typename IndexType>
-class CooSparsityPattern
+class CooSparsityPattern : public NeoN::SupportsCopyTo<CooSparsityPattern<IndexType>>
 {
 
     void validate() const;
@@ -33,22 +34,12 @@ public:
 
     CooSparsityPattern(Vector<IndexType>&& colIdx, Vector<IndexType>&& rowIdxs, Dimensions dim);
 
-    [[nodiscard]] CooSparsityPattern copyToHost() const
-    {
-        return CooSparsityPattern<IndexType>(
-            colIdxs_.copyToExecutor(SerialExecutor()),
-            rowIdxs_.copyToExecutor(SerialExecutor()),
-            dimensions_
-        );
-    }
-
-    [[nodiscard]] CooSparsityPattern copyToExecutor(Executor dstExec) const
+    [[nodiscard]] CooSparsityPattern copyToExecutor(Executor dstExec) const override
     {
         return CooSparsityPattern<IndexType>(
             colIdxs_.copyToExecutor(dstExec), rowIdxs_.copyToExecutor(dstExec), dimensions_
         );
     }
-
 
     ~CooSparsityPattern() = default;
 

--- a/include/NeoN/linearAlgebra/csrSparsityPattern.hpp
+++ b/include/NeoN/linearAlgebra/csrSparsityPattern.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "NeoN/core/copyTo.hpp"
 #include "NeoN/core/vector/vector.hpp"
 #include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
 #include "NeoN/linearAlgebra/sparsityView.hpp"
@@ -18,7 +19,7 @@ namespace NeoN::la
  * of sparsity patterns from a given unstructured mesh
  */
 template<typename IndexType>
-class CsrSparsityPattern
+class CsrSparsityPattern : public NeoN::SupportsCopyTo<CsrSparsityPattern<IndexType>>
 {
 
     void validate() const;
@@ -32,22 +33,12 @@ public:
 
     CsrSparsityPattern(Vector<IndexType>&& colIdx, Vector<IndexType>&& rowOffs, Dimensions dim);
 
-    [[nodiscard]] CsrSparsityPattern copyToHost() const
-    {
-        return CsrSparsityPattern<IndexType>(
-            colIdxs_.copyToExecutor(SerialExecutor()),
-            rowOffs_.copyToExecutor(SerialExecutor()),
-            dimensions_
-        );
-    }
-
-    [[nodiscard]] CsrSparsityPattern copyToExecutor(Executor dstExec) const
+    [[nodiscard]] CsrSparsityPattern copyToExecutor(Executor dstExec) const override
     {
         return CsrSparsityPattern<IndexType>(
             colIdxs_.copyToExecutor(dstExec), rowOffs_.copyToExecutor(dstExec), dimensions_
         );
     }
-
 
     ~CsrSparsityPattern() = default;
 

--- a/include/NeoN/linearAlgebra/faceToMatrixAddress.hpp
+++ b/include/NeoN/linearAlgebra/faceToMatrixAddress.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "NeoN/core/array.hpp"
+#include "NeoN/core/copyTo.hpp"
 #include "NeoN/linearAlgebra/cooSparsityPattern.hpp"
 #include "NeoN/linearAlgebra/csrSparsityPattern.hpp"
 #include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
@@ -70,7 +71,7 @@ struct FaceToMatrixView
  * the Matrix, not by this class; this class only borrows a view of the row offsets.
  *
  */
-class FaceToMatrixAddress
+class FaceToMatrixAddress : public NeoN::SupportsCopyTo<FaceToMatrixAddress>
 {
     void validate() const;
 
@@ -112,7 +113,7 @@ public:
     FaceToMatrixAddress(const FaceToMatrixAddress& mi);
 
 
-    FaceToMatrixAddress copyToExecutor(Executor dstExec) const
+    [[nodiscard]] FaceToMatrixAddress copyToExecutor(Executor dstExec) const override
     {
         return {
             ownerOffset_.copyToExecutor(dstExec),

--- a/include/NeoN/linearAlgebra/linearSystem.hpp
+++ b/include/NeoN/linearAlgebra/linearSystem.hpp
@@ -6,6 +6,7 @@
 
 #include "NeoN/core/vector/vector.hpp"
 #include "NeoN/core/dictionary.hpp"
+#include "NeoN/core/copyTo.hpp"
 #include "NeoN/linearAlgebra/matrix.hpp"
 #include "NeoN/linearAlgebra/cooSparsityPattern.hpp"
 #include "NeoN/linearAlgebra/csrSparsityPattern.hpp"
@@ -58,7 +59,8 @@ template<
     typename ValueType,
     typename SystemMatrixType = CSRMatrix<ValueType, localIdx>,
     typename BoundaryMatrixType = COOMatrix<ValueType, localIdx>>
-class LinearSystem
+class LinearSystem :
+    public NeoN::SupportsCopyTo<LinearSystem<ValueType, SystemMatrixType, BoundaryMatrixType>>
 {
 
     void validate()
@@ -123,13 +125,14 @@ public:
 
     [[nodiscard]] const Vector<ValueType>& boundaryRhs() const { return boundaryRhs_; }
 
-    [[nodiscard]] LinearSystem<ValueType, SystemMatrixType, BoundaryMatrixType> copyToHost() const
+    [[nodiscard]] LinearSystem<ValueType, SystemMatrixType, BoundaryMatrixType>
+    copyToExecutor(Executor exec) const override
     {
         return {
-            matrix_.copyToHost(),
-            rhs_.copyToHost(),
-            boundaryMatrix_.copyToHost(),
-            boundaryRhs_.copyToHost()
+            matrix_.copyToExecutor(exec),
+            rhs_.copyToExecutor(exec),
+            boundaryMatrix_.copyToExecutor(exec),
+            boundaryRhs_.copyToExecutor(exec)
         };
     }
 

--- a/include/NeoN/linearAlgebra/matrix.hpp
+++ b/include/NeoN/linearAlgebra/matrix.hpp
@@ -67,7 +67,7 @@ struct MatrixView
  * @tparam IndexType The index type of the rows and columns.
  */
 template<typename ValueType, typename SparsityType>
-class Matrix
+class Matrix : public NeoN::SupportsCopyTo<Matrix<ValueType, SparsityType>>
 {
 
     void validate()
@@ -192,21 +192,7 @@ public:
      * @param dstExec The destination executor.
      * @return A copy of the matrix on the destination executor.
      */
-    [[nodiscard]] Matrix<ValueType, SparsityType> copyToExecutor(Executor dstExec) const
-    {
-        if (dstExec == values_.exec())
-        {
-            return *this;
-        }
-        return {
-            values_.copyToExecutor(dstExec),
-            std::make_shared<const SparsityType>(this->sparsityPattern_->copyToExecutor(dstExec)),
-            (faceToMatrixAddress_) ? std::make_shared<const FaceToMatrixAddress>(
-                this->faceToMatrixAddress_->copyToExecutor(dstExec)
-            )
-                                   : nullptr
-        };
-    }
+    [[nodiscard]] Matrix<ValueType, SparsityType> copyToExecutor(Executor dstExec) const override;
 
     /**
      * @brief Get a reference to column indices vector.
@@ -220,28 +206,6 @@ public:
     [[nodiscard]] std::shared_ptr<const FaceToMatrixAddress> faceToMatrixAddress() const
     {
         return faceToMatrixAddress_;
-    }
-
-    /**
-     * @brief Copy the matrix to the host.
-     * @return A copy of the matrix on the host.
-     */
-    [[nodiscard]] Matrix<ValueType, SparsityType> copyToHost() const
-    {
-        if constexpr (std::is_same_v<typename SparsityType::SparsityIndexType, localIdx>)
-        {
-            if (faceToMatrixAddress_)
-            {
-                auto hostSp = std::make_shared<const SparsityType>(sparsityPattern_->copyToHost());
-                auto hostFtma = std::make_shared<const FaceToMatrixAddress>(
-                    faceToMatrixAddress_->ownerOffset().copyToHost(),
-                    faceToMatrixAddress_->neighbourOffset().copyToHost(),
-                    faceToMatrixAddress_->diagOffset().copyToHost()
-                );
-                return {values_.copyToHost(), hostSp, hostFtma};
-            }
-        }
-        return copyToExecutor(SerialExecutor());
     }
 
     /**

--- a/src/finiteVolume/cellCentred/stencil/cellToFaceStencil.cpp
+++ b/src/finiteVolume/cellCentred/stencil/cellToFaceStencil.cpp
@@ -41,13 +41,13 @@ SegmentedVector<localIdx, localIdx> CellToFaceStencil::computeInternalStencil() 
         {0, nInternalFaces},
         NEON_LAMBDA(const localIdx facei) {
             localIdx owner = faceOwners[facei];
-            localIdx neighbour = faceNeighbors[facei];
+            localIdx neigh = faceNeighbors[facei];
 
             const auto segIdxOwn = Kokkos::atomic_fetch_inc(&nFacesPerCellView[owner]);
             const auto segIdxNei = Kokkos::atomic_fetch_inc(&nFacesPerCellView[neighbour]);
 
             auto segOwn = segment[owner] + segIdxOwn;
-            auto segNei = segment[neighbour] + segIdxNei;
+            auto segNei = segment[neigh] + segIdxNei;
 
             stencilValues[segOwn] = facei;
             stencilValues[segNei] = facei;

--- a/src/finiteVolume/cellCentred/stencil/cellToFaceStencil.cpp
+++ b/src/finiteVolume/cellCentred/stencil/cellToFaceStencil.cpp
@@ -44,7 +44,7 @@ SegmentedVector<localIdx, localIdx> CellToFaceStencil::computeInternalStencil() 
             localIdx neigh = faceNeighbors[facei];
 
             const auto segIdxOwn = Kokkos::atomic_fetch_inc(&nFacesPerCellView[owner]);
-            const auto segIdxNei = Kokkos::atomic_fetch_inc(&nFacesPerCellView[neighbour]);
+            const auto segIdxNei = Kokkos::atomic_fetch_inc(&nFacesPerCellView[neigh]);
 
             auto segOwn = segment[owner] + segIdxOwn;
             auto segNei = segment[neigh] + segIdxNei;

--- a/src/linearAlgebra/matrix.cpp
+++ b/src/linearAlgebra/matrix.cpp
@@ -37,6 +37,25 @@ Vector<ValueType> Matrix<ValueType, SparsityType>::diag() const
 }
 
 
+template<typename ValueType, typename SparsityType>
+Matrix<ValueType, SparsityType> Matrix<ValueType, SparsityType>::copyToExecutor(Executor dstExec
+) const
+{
+    if (dstExec == values_.exec())
+    {
+        return *this;
+    }
+    return {
+        values_.copyToExecutor(dstExec),
+        std::make_shared<const SparsityType>(this->sparsityPattern_->copyToExecutor(dstExec)),
+        (faceToMatrixAddress_) ? std::make_shared<const FaceToMatrixAddress>(
+            this->faceToMatrixAddress_->copyToExecutor(dstExec)
+        )
+                               : nullptr
+    };
+}
+
+
 // Free functions
 
 template<typename ValueType, typename IndexType>
@@ -246,12 +265,13 @@ void scaledInverseDiag(
     );
 }
 
-#define NN_DECLARE_CSRMATRIX(VALUETYPE, INTEGERTYPE)                                               \
+#define NN_DECLARE_MATRIX(VALUETYPE, INTEGERTYPE)                                                  \
     template class Matrix<VALUETYPE, la::CsrSparsityPattern<INTEGERTYPE>>;                         \
+    template class Matrix<VALUETYPE, la::CooSparsityPattern<INTEGERTYPE>>;                         \
     template Vector<VALUETYPE>                                                                     \
     upper<VALUETYPE, INTEGERTYPE>(const CSRMatrix<VALUETYPE, INTEGERTYPE>&)
 
-NN_DECLARE_CSRMATRIX(scalar, localIdx);
-NN_DECLARE_CSRMATRIX(Vec3, int);
+NN_DECLARE_MATRIX(scalar, localIdx);
+NN_DECLARE_MATRIX(Vec3, localIdx);
 
 }


### PR DESCRIPTION
# Motivation

This PR introduces a SupportsCopyTo mixin to standardize “copy-to-executor/host” functionality and applies it to SegmentedVector, aiming to make host/device copies more uniform across core containers. This also gives a copyToHost implementation for "free".

Changes:

Added include/NeoN/core/copyTo.hpp defining SupportsCopyTo (requires copyToExecutor, provides copyToHost).
Updated SegmentedVector to inherit from SupportsCopyTo and implemented copyToExecutor.
Minor variable rename in CellToFaceStencil::computeInternalStencil().
