### PR TITLE
Implement cell based operator div and laplacian operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Version 0.3.0 (unreleased)
 ## Features
 - Add corrected and limited-corrected face-normal gradient schemes [#514](https://github.com/exasim-project/NeoN/pull/514)
-- Add experimental support for cell based assembly strategies [#471](https://github.com/exasim-project/NeoN/pull/471)
+- Add experimental support for cell based assembly strategies [#471](https://github.com/exasim-project/NeoN/pull/471),[#517](https://github.com/exasim-project/NeoN/pull/517)
 - Add experimental support for COO and CSR Matrices [#486](https://github.com/exasim-project/NeoN/pull/486)
 - Add experimental umpire support [#455](https://github.com/exasim-project/NeoN/pull/455)
 - Add python bindings via nanobind [#382](https://github.com/exasim-project/NeoN/pull/382)

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp
@@ -14,30 +14,6 @@
 namespace NeoN::finiteVolume::cellCentred
 {
 
-
-template<typename ValueType>
-void computeDivExp(
-    const SurfaceField<scalar>& faceFlux,
-    const VolumeField<ValueType>& phi,
-    const SurfaceInterpolation<ValueType>& surfInterp,
-    Vector<ValueType>& divPhi,
-    const dsl::Coeff operatorScaling
-);
-
-#define NN_DEFINE_IMPLICIT_DIV_IMPL(FUNCTION)                                                      \
-    template<typename ValueType>                                                                   \
-    void FUNCTION(                                                                                 \
-        la::LinearSystem<ValueType>& ls,                                                           \
-        const SurfaceField<scalar>& faceFlux,                                                      \
-        const VolumeField<ValueType>& phi,                                                         \
-        const SurfaceField<scalar>& weights,                                                       \
-        const dsl::Coeff operatorScaling                                                           \
-    )
-
-NN_DEFINE_IMPLICIT_DIV_IMPL(computeDivIntImp);
-NN_DEFINE_IMPLICIT_DIV_IMPL(computeDivIntCellBasedImp);
-NN_DEFINE_IMPLICIT_DIV_IMPL(computeDivBoundImp);
-
 /* @brief
  *
  */
@@ -61,60 +37,25 @@ public:
     virtual VolumeField<ValueType>
     div(const SurfaceField<scalar>& faceFlux,
         const VolumeField<ValueType>& phi,
-        const dsl::Coeff operatorScaling) const override
-    {
-        std::string name = "div(" + faceFlux.name + "," + phi.name + ")";
-        VolumeField<ValueType> divPhi(
-            this->exec_,
-            name,
-            this->mesh_,
-            createCalculatedBCs<VolumeBoundary<ValueType>>(this->mesh_)
-        );
-        NeoN::fill(divPhi.internalVector(), zero<ValueType>());
-        NeoN::fill(divPhi.boundaryData().value(), zero<ValueType>());
-        computeDivExp<ValueType>(
-            faceFlux, phi, surfaceInterpolation_, divPhi.internalVector(), operatorScaling
-        );
-        return divPhi;
-    };
+        const dsl::Coeff operatorScaling) const override;
 
     virtual void
     div(VolumeField<ValueType>& divPhi,
         const SurfaceField<scalar>& faceFlux,
         const VolumeField<ValueType>& phi,
-        const dsl::Coeff operatorScaling) const override
-    {
-        computeDivExp<ValueType>(
-            faceFlux, phi, surfaceInterpolation_, divPhi.internalVector(), operatorScaling
-        );
-    }
+        const dsl::Coeff operatorScaling) const override;
 
     virtual void
     div(Vector<ValueType>& divPhi,
         const SurfaceField<scalar>& faceFlux,
         const VolumeField<ValueType>& phi,
-        const dsl::Coeff operatorScaling) const override
-    {
-        computeDivExp<ValueType>(faceFlux, phi, surfaceInterpolation_, divPhi, operatorScaling);
-    };
+        const dsl::Coeff operatorScaling) const override;
 
     virtual void
     div(la::LinearSystem<ValueType>& ls,
         const SurfaceField<scalar>& faceFlux,
         const VolumeField<ValueType>& phi,
-        const dsl::Coeff operatorScaling) const override
-    {
-        const auto weights = surfaceInterpolation_.weight(faceFlux, phi);
-        if (dynamic_cast<const la::CellBasedIterator*>(ls.getMeshIterator()->get().get())
-            != nullptr)
-        {
-        }
-        else
-        {
-            computeDivIntImp(ls, faceFlux, phi, weights, operatorScaling);
-        }
-        computeDivBoundImp(ls, faceFlux, phi, weights, operatorScaling);
-    };
+        const dsl::Coeff operatorScaling) const override;
 
     std::unique_ptr<DivOperatorFactory<ValueType>> clone() const override
     {

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp
@@ -14,6 +14,7 @@
 namespace NeoN::finiteVolume::cellCentred
 {
 
+
 template<typename ValueType>
 void computeDivExp(
     const SurfaceField<scalar>& faceFlux,
@@ -23,23 +24,19 @@ void computeDivExp(
     const dsl::Coeff operatorScaling
 );
 
-template<typename ValueType>
-void computeDivIntImp(
-    la::LinearSystem<ValueType>& ls,
-    const SurfaceField<scalar>& faceFlux,
-    const VolumeField<ValueType>& phi,
-    const SurfaceField<scalar>& weights,
-    const dsl::Coeff operatorScaling
-);
+#define NN_DEFINE_IMPLICIT_DIV_IMPL(FUNCTION)                                                      \
+    template<typename ValueType>                                                                   \
+    void FUNCTION(                                                                                 \
+        la::LinearSystem<ValueType>& ls,                                                           \
+        const SurfaceField<scalar>& faceFlux,                                                      \
+        const VolumeField<ValueType>& phi,                                                         \
+        const SurfaceField<scalar>& weights,                                                       \
+        const dsl::Coeff operatorScaling                                                           \
+    )
 
-template<typename ValueType>
-void computeDivBoundImp(
-    la::LinearSystem<ValueType>& ls,
-    const SurfaceField<scalar>& faceFlux,
-    const VolumeField<ValueType>& phi,
-    const SurfaceField<scalar>& weights,
-    const dsl::Coeff operatorScaling
-);
+NN_DEFINE_IMPLICIT_DIV_IMPL(computeDivIntImp);
+NN_DEFINE_IMPLICIT_DIV_IMPL(computeDivIntCellBasedImp);
+NN_DEFINE_IMPLICIT_DIV_IMPL(computeDivBoundImp);
 
 /* @brief
  *
@@ -107,13 +104,15 @@ public:
         const VolumeField<ValueType>& phi,
         const dsl::Coeff operatorScaling) const override
     {
+        const auto weights = surfaceInterpolation_.weight(faceFlux, phi);
         if (dynamic_cast<const la::CellBasedIterator*>(ls.getMeshIterator()->get().get())
             != nullptr)
         {
-            NF_ERROR_EXIT("CellBased iteration not implemented");
         }
-        const auto weights = surfaceInterpolation_.weight(faceFlux, phi);
-        computeDivIntImp(ls, faceFlux, phi, weights, operatorScaling);
+        else
+        {
+            computeDivIntImp(ls, faceFlux, phi, weights, operatorScaling);
+        }
         computeDivBoundImp(ls, faceFlux, phi, weights, operatorScaling);
     };
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp
@@ -10,44 +10,18 @@
 #include "NeoN/finiteVolume/cellCentred/operators/laplacianOperator.hpp"
 #include "NeoN/finiteVolume/cellCentred/interpolation/surfaceInterpolation.hpp"
 #include "NeoN/finiteVolume/cellCentred/faceNormalGradient/faceNormalGradient.hpp"
+#include "NeoN/linearAlgebra/meshIterationStrategies.hpp"
 
 namespace NeoN::finiteVolume::cellCentred
 {
 
 template<typename ValueType>
 void computeLaplacianExp(
-    const FaceNormalGradient<ValueType>&,
-    const SurfaceField<scalar>&,
-    const VolumeField<ValueType>&,
-    Vector<ValueType>&,
-    const dsl::Coeff
-);
-
-template<typename ValueType>
-void computeLaplacianIntImpl(
-    la::LinearSystem<ValueType>& ls,
+    const FaceNormalGradient<ValueType>& faceNormalGradient,
     const SurfaceField<scalar>& gamma,
     const VolumeField<ValueType>& phi,
-    const dsl::Coeff operatorScaling,
-    const FaceNormalGradient<ValueType>& faceNormalGradient
-);
-
-template<typename ValueType>
-void computeLaplacianBoundImpl(
-    la::LinearSystem<ValueType>& ls,
-    const SurfaceField<scalar>& gamma,
-    const VolumeField<ValueType>& phi,
-    const dsl::Coeff operatorScaling,
-    const FaceNormalGradient<ValueType>& faceNormalGradient
-);
-
-template<typename ValueType>
-void computeLaplacianNonOrthCorrImpl(
-    la::LinearSystem<ValueType>& ls,
-    const SurfaceField<scalar>& gamma,
-    const VolumeField<ValueType>& phi,
-    const dsl::Coeff coeff,
-    const FaceNormalGradient<ValueType>& faceNormalGradient
+    Vector<ValueType>& lapPhi,
+    const dsl::Coeff operatorScaling
 );
 
 template<typename ValueType>
@@ -74,53 +48,25 @@ public:
         const SurfaceField<scalar>& gamma,
         const VolumeField<ValueType>& phi,
         const dsl::Coeff coeff
-    ) override
-    {
-        computeLaplacianExp<ValueType>(
-            faceNormalGradient_, gamma, phi, lapPhi.internalVector(), coeff
-        );
-    };
+    ) override;
 
     virtual VolumeField<ValueType> laplacian(
         const SurfaceField<scalar>& gamma, const VolumeField<ValueType>& phi, const dsl::Coeff coeff
-    ) const override
-    {
-        std::string name = "laplacian(" + gamma.name + "," + phi.name + ")";
-        VolumeField<ValueType> lapPhi(
-            this->exec_,
-            name,
-            this->mesh_,
-            createCalculatedBCs<VolumeBoundary<ValueType>>(this->mesh_)
-        );
-        NeoN::fill(lapPhi.internalVector(), zero<ValueType>());
-        NeoN::fill(lapPhi.boundaryData().value(), zero<ValueType>());
-        computeLaplacianExp<ValueType>(
-            faceNormalGradient_, gamma, phi, lapPhi.internalVector(), coeff
-        );
-        return lapPhi;
-    };
+    ) const override;
 
     virtual void laplacian(
         Vector<ValueType>& lapPhi,
         const SurfaceField<scalar>& gamma,
         const VolumeField<ValueType>& phi,
         const dsl::Coeff coeff
-    ) override
-    {
-        computeLaplacianExp<ValueType>(faceNormalGradient_, gamma, phi, lapPhi, coeff);
-    };
+    ) override;
 
     virtual void laplacian(
         la::LinearSystem<ValueType>& ls,
         const SurfaceField<scalar>& gamma,
         const VolumeField<ValueType>& phi,
         const dsl::Coeff coeff
-    ) override
-    {
-        computeLaplacianIntImpl(ls, gamma, phi, coeff, faceNormalGradient_);
-        computeLaplacianBoundImpl(ls, gamma, phi, coeff, faceNormalGradient_);
-        computeLaplacianNonOrthCorrImpl(ls, gamma, phi, coeff, faceNormalGradient_);
-    };
+    ) override;
 
     std::unique_ptr<LaplacianOperatorFactory<ValueType>> clone() const override
     {

--- a/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
@@ -263,7 +263,6 @@ void computeDivIntCellBasedImp(
     const dsl::Coeff coeff
 )
 {
-    const auto& mesh = phi.mesh();
     const auto exec = phi.exec();
 
     const auto ma = ls.faceToMatrixAddress()->view(ls.matrix().sparsity()->rowOffs().view());

--- a/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
@@ -127,18 +127,6 @@ void computeDivExp(
     );
 }
 
-#define NF_DECLARE_COMPUTE_EXP_DIV(TYPENAME)                                                       \
-    template void computeDivExp<TYPENAME>(                                                         \
-        const SurfaceField<scalar>&,                                                               \
-        const VolumeField<TYPENAME>&,                                                              \
-        const SurfaceInterpolation<TYPENAME>&,                                                     \
-        Vector<TYPENAME>&,                                                                         \
-        const dsl::Coeff                                                                           \
-    )
-
-NF_DECLARE_COMPUTE_EXP_DIV(scalar);
-NF_DECLARE_COMPUTE_EXP_DIV(Vec3);
-
 template<typename ValueType>
 void computeDivBoundImp(
     la::LinearSystem<ValueType>& ls,
@@ -275,40 +263,128 @@ void computeDivIntCellBasedImp(
     const dsl::Coeff coeff
 )
 {
-    const UnstructuredMesh& mesh = phi.mesh();
-    const auto nInternalFaces = mesh.nInternalFaces();
+    const auto& mesh = phi.mesh();
     const auto exec = phi.exec();
 
     const auto ma = ls.faceToMatrixAddress()->view(ls.matrix().sparsity()->rowOffs().view());
+    auto iterator = std::dynamic_pointer_cast<la::CellBasedIterator>(ls.getMeshIterator()->get());
 
-    const auto [fluxV, weightsV, ownV, neiV, surfFaceCells] = views(
-        faceFlux.internalVector(),
-        weights.internalVector(),
-        mesh.faceOwners(),
-        mesh.faceNeighbors(),
-        mesh.boundaryMesh().faceOwners()
-    );
+    const auto [fluxV, weightsV] = views(faceFlux.internalVector(), weights.internalVector());
+
+    auto cellBasedData = iterator->getCellBasedData();
+    auto [cellFacesValues, cellFacesSegments] = cellBasedData->cellFaces.views();
+    auto faceSignV = cellBasedData->faceSign.view();
+    auto matrixColumnIdxV = cellBasedData->matrixColumnIdx.view();
+
     auto values = ls.matrix().values().view();
+
+    parallelFor(
+        exec,
+        {0, iterator->size()},
+        NEON_LAMBDA(const localIdx celli) {
+            auto diagValue = zero<ValueType>();
+            const auto numFaces = cellFacesSegments[celli + 1] - cellFacesSegments[celli];
+            const auto startIdx = cellFacesSegments[celli];
+            const auto cellCoeff = coeff[celli];
+
+            for (localIdx i = 0; i < numFaces; ++i)
+            {
+                const auto faceIdx = cellFacesValues[startIdx + i];
+                const auto sign = faceSignV[startIdx + i];
+                const auto flux = fluxV[faceIdx];
+                const auto w = weightsV[faceIdx];
+
+                ValueType offDiag;
+                ValueType diagContrib;
+                if (sign > 0) // this cell is the owner: upper-triangle entry
+                {
+                    offDiag = flux * (1.0 - w) * cellCoeff * one<ValueType>();
+                    diagContrib = flux * w * cellCoeff * one<ValueType>();
+                }
+                else // this cell is the neighbor: lower-triangle entry
+                {
+                    offDiag = -flux * w * cellCoeff * one<ValueType>();
+                    diagContrib = -flux * (1.0 - w) * cellCoeff * one<ValueType>();
+                }
+
+                values[matrixColumnIdxV[startIdx + i]] += offDiag;
+                diagValue += diagContrib;
+            }
+
+            values[ma.diagIdx(celli)] += diagValue;
+        },
+        "fusedKernelCellBased::cellLoop"
+    );
 }
 
-#define NN_DECLARE_COMPUTE_IMP_DIV(TYPENAME)                                                       \
-    template void computeDivIntImp<TYPENAME>(                                                      \
-        la::LinearSystem<TYPENAME>&,                                                               \
-        const SurfaceField<scalar>&,                                                               \
-        const VolumeField<TYPENAME>&,                                                              \
-        const SurfaceField<scalar>&,                                                               \
-        const dsl::Coeff                                                                           \
-    );                                                                                             \
-    template void computeDivBoundImp<TYPENAME>(                                                    \
-        la::LinearSystem<TYPENAME>&,                                                               \
-        const SurfaceField<scalar>&,                                                               \
-        const VolumeField<TYPENAME>&,                                                              \
-        const SurfaceField<scalar>&,                                                               \
-        const dsl::Coeff                                                                           \
-    )
+template<typename ValueType>
+VolumeField<ValueType> GaussGreenDiv<ValueType>::div(
+    const SurfaceField<scalar>& faceFlux,
+    const VolumeField<ValueType>& phi,
+    const dsl::Coeff operatorScaling
+) const
+{
+    std::string name = "div(" + faceFlux.name + "," + phi.name + ")";
+    VolumeField<ValueType> divPhi(
+        this->exec_, name, this->mesh_, createCalculatedBCs<VolumeBoundary<ValueType>>(this->mesh_)
+    );
+    NeoN::fill(divPhi.internalVector(), zero<ValueType>());
+    NeoN::fill(divPhi.boundaryData().value(), zero<ValueType>());
+    computeDivExp<ValueType>(
+        faceFlux, phi, surfaceInterpolation_, divPhi.internalVector(), operatorScaling
+    );
+    return divPhi;
+}
 
-NN_DECLARE_COMPUTE_IMP_DIV(scalar);
-NN_DECLARE_COMPUTE_IMP_DIV(Vec3);
+template<typename ValueType>
+void GaussGreenDiv<ValueType>::div(
+    VolumeField<ValueType>& divPhi,
+    const SurfaceField<scalar>& faceFlux,
+    const VolumeField<ValueType>& phi,
+    const dsl::Coeff operatorScaling
+) const
+{
+    computeDivExp<ValueType>(
+        faceFlux, phi, surfaceInterpolation_, divPhi.internalVector(), operatorScaling
+    );
+}
+
+template<typename ValueType>
+void GaussGreenDiv<ValueType>::div(
+    Vector<ValueType>& divPhi,
+    const SurfaceField<scalar>& faceFlux,
+    const VolumeField<ValueType>& phi,
+    const dsl::Coeff operatorScaling
+) const
+{
+    computeDivExp<ValueType>(faceFlux, phi, surfaceInterpolation_, divPhi, operatorScaling);
+}
+
+template<typename ValueType>
+void GaussGreenDiv<ValueType>::div(
+    la::LinearSystem<ValueType>& ls,
+    const SurfaceField<scalar>& faceFlux,
+    const VolumeField<ValueType>& phi,
+    const dsl::Coeff operatorScaling
+) const
+{
+    const auto weights = surfaceInterpolation_.weight(faceFlux, phi);
+    if (auto* cellIter = dynamic_cast<la::CellBasedIterator*>(ls.getMeshIterator()->get().get()))
+    {
+        if (!cellIter->getCellBasedData())
+        {
+            cellIter->setComputeCellBasedData(
+                phi.mesh(), ls.matrix().sparsity(), ls.faceToMatrixAddress()
+            );
+        }
+        computeDivIntCellBasedImp(ls, faceFlux, phi, weights, operatorScaling);
+    }
+    else
+    {
+        computeDivIntImp(ls, faceFlux, phi, weights, operatorScaling);
+    }
+    computeDivBoundImp(ls, faceFlux, phi, weights, operatorScaling);
+}
 
 template class GaussGreenDiv<scalar>;
 template class GaussGreenDiv<Vec3>;

--- a/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
@@ -266,6 +266,31 @@ void computeDivIntImp(
     );
 };
 
+template<typename ValueType>
+void computeDivIntCellBasedImp(
+    la::LinearSystem<ValueType>& ls,
+    const SurfaceField<scalar>& faceFlux,
+    const VolumeField<ValueType>& phi,
+    const SurfaceField<scalar>& weights,
+    const dsl::Coeff coeff
+)
+{
+    const UnstructuredMesh& mesh = phi.mesh();
+    const auto nInternalFaces = mesh.nInternalFaces();
+    const auto exec = phi.exec();
+
+    const auto ma = ls.faceToMatrixAddress()->view(ls.matrix().sparsity()->rowOffs().view());
+
+    const auto [fluxV, weightsV, ownV, neiV, surfFaceCells] = views(
+        faceFlux.internalVector(),
+        weights.internalVector(),
+        mesh.faceOwners(),
+        mesh.faceNeighbors(),
+        mesh.boundaryMesh().faceOwners()
+    );
+    auto values = ls.matrix().values().view();
+}
+
 #define NN_DECLARE_COMPUTE_IMP_DIV(TYPENAME)                                                       \
     template void computeDivIntImp<TYPENAME>(                                                      \
         la::LinearSystem<TYPENAME>&,                                                               \

--- a/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
@@ -79,19 +79,6 @@ void computeLaplacianExp(
     );
 }
 
-#define NF_DECLARE_COMPUTE_EXP_LAP(TYPENAME)                                                       \
-    template void computeLaplacianExp<TYPENAME>(                                                   \
-        const FaceNormalGradient<TYPENAME>&,                                                       \
-        const SurfaceField<scalar>&,                                                               \
-        const VolumeField<TYPENAME>&,                                                              \
-        Vector<TYPENAME>&,                                                                         \
-        const dsl::Coeff                                                                           \
-    )
-
-NF_DECLARE_COMPUTE_EXP_LAP(scalar);
-NF_DECLARE_COMPUTE_EXP_LAP(Vec3);
-
-
 template<typename ValueType>
 void computeLaplacianBoundImpl(
     la::LinearSystem<ValueType>& ls,
@@ -261,16 +248,119 @@ void computeLaplacianIntImpl(
     );
 }
 
-#define NN_DECLARE_COMPUTE_IMP_LAP(TYPENAME)                                                                                                                      \
-    template void computeLaplacianIntImpl<                                                                                                                        \
-        TYPENAME>(la::LinearSystem<TYPENAME>&, const SurfaceField<scalar>&, const VolumeField<TYPENAME>&, const dsl::Coeff, const FaceNormalGradient<TYPENAME>&); \
-    template void computeLaplacianBoundImpl<                                                                                                                      \
-        TYPENAME>(la::LinearSystem<TYPENAME>&, const SurfaceField<scalar>&, const VolumeField<TYPENAME>&, const dsl::Coeff, const FaceNormalGradient<TYPENAME>&); \
-    template void computeLaplacianNonOrthCorrImpl<                                                                                                                \
-        TYPENAME>(la::LinearSystem<TYPENAME>&, const SurfaceField<scalar>&, const VolumeField<TYPENAME>&, const dsl::Coeff, const FaceNormalGradient<TYPENAME>&)
+template<typename ValueType>
+void computeLaplacianIntCellBasedImpl(
+    la::LinearSystem<ValueType>& ls,
+    const SurfaceField<scalar>& gamma,
+    const VolumeField<ValueType>& phi,
+    const dsl::Coeff coeff,
+    const FaceNormalGradient<ValueType>& faceNormalGradient
+)
+{
+    const UnstructuredMesh& mesh = phi.mesh();
+    const auto exec = phi.exec();
 
-NN_DECLARE_COMPUTE_IMP_LAP(scalar);
-NN_DECLARE_COMPUTE_IMP_LAP(Vec3);
+    const auto ma = ls.faceToMatrixAddress()->view(ls.matrix().sparsity()->rowOffs().view());
+    auto iterator = std::dynamic_pointer_cast<la::CellBasedIterator>(ls.getMeshIterator()->get());
+
+    const auto [gammaV, deltaCoeffs, magFaceArea] = views(
+        gamma.internalVector(), faceNormalGradient.deltaCoeffs().internalVector(), mesh.faceAreas()
+    );
+
+    auto cellBasedData = iterator->getCellBasedData();
+    auto [cellFacesValues, cellFacesSegments] = cellBasedData->cellFaces.views();
+    auto matrixColumnIdxV = cellBasedData->matrixColumnIdx.view();
+
+    auto values = ls.matrix().values().view();
+
+    parallelFor(
+        exec,
+        {0, iterator->size()},
+        NEON_LAMBDA(const localIdx celli) {
+            auto diagValue = zero<ValueType>();
+            const auto numFaces = cellFacesSegments[celli + 1] - cellFacesSegments[celli];
+            const auto startIdx = cellFacesSegments[celli];
+            const auto cellCoeff = coeff[celli];
+
+            for (localIdx i = 0; i < numFaces; ++i)
+            {
+                const auto faceIdx = cellFacesValues[startIdx + i];
+                // Laplacian is symmetric: flux contribution is identical for owner and neighbor
+                const auto offDiag = deltaCoeffs[faceIdx] * gammaV[faceIdx] * magFaceArea[faceIdx]
+                                   * cellCoeff * one<ValueType>();
+
+                values[matrixColumnIdxV[startIdx + i]] += offDiag;
+                diagValue -= offDiag;
+            }
+
+            values[ma.diagIdx(celli)] += diagValue;
+        },
+        "cellBasedLaplacian::cellLoop"
+    );
+}
+
+template<typename ValueType>
+void GaussGreenLaplacian<ValueType>::laplacian(
+    VolumeField<ValueType>& lapPhi,
+    const SurfaceField<scalar>& gamma,
+    const VolumeField<ValueType>& phi,
+    const dsl::Coeff coeff
+)
+{
+    computeLaplacianExp<ValueType>(faceNormalGradient_, gamma, phi, lapPhi.internalVector(), coeff);
+}
+
+template<typename ValueType>
+VolumeField<ValueType> GaussGreenLaplacian<ValueType>::laplacian(
+    const SurfaceField<scalar>& gamma, const VolumeField<ValueType>& phi, const dsl::Coeff coeff
+) const
+{
+    std::string name = "laplacian(" + gamma.name + "," + phi.name + ")";
+    VolumeField<ValueType> lapPhi(
+        this->exec_, name, this->mesh_, createCalculatedBCs<VolumeBoundary<ValueType>>(this->mesh_)
+    );
+    NeoN::fill(lapPhi.internalVector(), zero<ValueType>());
+    NeoN::fill(lapPhi.boundaryData().value(), zero<ValueType>());
+    computeLaplacianExp<ValueType>(faceNormalGradient_, gamma, phi, lapPhi.internalVector(), coeff);
+    return lapPhi;
+}
+
+template<typename ValueType>
+void GaussGreenLaplacian<ValueType>::laplacian(
+    Vector<ValueType>& lapPhi,
+    const SurfaceField<scalar>& gamma,
+    const VolumeField<ValueType>& phi,
+    const dsl::Coeff coeff
+)
+{
+    computeLaplacianExp<ValueType>(faceNormalGradient_, gamma, phi, lapPhi, coeff);
+}
+
+template<typename ValueType>
+void GaussGreenLaplacian<ValueType>::laplacian(
+    la::LinearSystem<ValueType>& ls,
+    const SurfaceField<scalar>& gamma,
+    const VolumeField<ValueType>& phi,
+    const dsl::Coeff coeff
+)
+{
+    if (auto* cellIter = dynamic_cast<la::CellBasedIterator*>(ls.getMeshIterator()->get().get()))
+    {
+        if (!cellIter->getCellBasedData())
+        {
+            cellIter->setComputeCellBasedData(
+                phi.mesh(), ls.matrix().sparsity(), ls.faceToMatrixAddress()
+            );
+        }
+        computeLaplacianIntCellBasedImpl(ls, gamma, phi, coeff, faceNormalGradient_);
+    }
+    else
+    {
+        computeLaplacianIntImpl(ls, gamma, phi, coeff, faceNormalGradient_);
+    }
+    computeLaplacianBoundImpl(ls, gamma, phi, coeff, faceNormalGradient_);
+    computeLaplacianNonOrthCorrImpl(ls, gamma, phi, coeff, faceNormalGradient_);
+};
 
 template class GaussGreenLaplacian<scalar>;
 template class GaussGreenLaplacian<Vec3>;

--- a/test/catch2/catch2_common.hpp
+++ b/test/catch2/catch2_common.hpp
@@ -292,4 +292,27 @@ struct StringMaker<NeoN::Vector<T>>
     }
 };
 
+template<typename VectorValueType>
+void randomizeVector(NeoN::Vector<VectorValueType>& a)
+{
+    std::random_device rd;  // Will be used to obtain a seed for the random number engine
+    std::mt19937 gen(rd()); // Standard mersenne_twister_engine seeded with rd()
+    std::uniform_real_distribution<> dis(1.0, 2.0);
+
+    auto b = a.copyToHost();
+    auto bV = b.view();
+
+    for (int i = 0; i < b.size(); i++)
+    {
+        bV[i] = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
+    }
+    auto c = b.copyToExecutor(a.exec());
+    a = c;
+}
+
+template<typename VectorValueType>
+void randomizeVector(fvcc::VolumeField<VectorValueType>& a)
+{
+    randomizeVector(a.internalVector());
+}
 } // namespace Catch

--- a/test/dsl/common.hpp
+++ b/test/dsl/common.hpp
@@ -285,28 +285,3 @@ ValueType getRhs(const la::LinearSystem<ValueType, la::CSRMatrix<ValueType, loca
     auto hostLs = ls.copyToHost();
     return hostLs.rhs().view()[0];
 }
-
-
-template<typename VectorValueType>
-void randomizeVector(NeoN::Vector<VectorValueType>& a)
-{
-    // std::random_device rd;  // Will be used to obtain a seed for the random number engine
-    // std::mt19937 gen(rd()); // Standard mersenne_twister_engine seeded with rd()
-    // std::uniform_real_distribution<> dis(1.0, 2.0);
-
-    auto b = a.copyToHost();
-    auto bV = b.view();
-
-    for (int i = 0; i < b.size(); i++)
-    {
-        bV[i] = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
-    }
-    auto c = b.copyToExecutor(a.exec());
-    a = c;
-}
-
-template<typename VectorValueType>
-void randomizeVector(fvcc::VolumeField<VectorValueType>& a)
-{
-    randomizeVector(a.internalVector());
-}

--- a/test/finiteVolume/cellCentred/operator/gaussGreenDiv.cpp
+++ b/test/finiteVolume/cellCentred/operator/gaussGreenDiv.cpp
@@ -193,7 +193,9 @@ TEST_CASE("DivOperator implicit boundary contributions are accumulated")
     }
 }
 
-TEST_CASE("Face based and cellbased iteration give same results")
+TEMPLATE_TEST_CASE(
+    "Face based and cellbased iteration give same results", "[template]", NeoN::scalar
+)
 {
     auto [execName, exec] = GENERATE(allAvailableExecutor());
 
@@ -212,10 +214,19 @@ TEST_CASE("Face based and cellbased iteration give same results")
     auto cellIterator = std::make_shared<NeoN::la::CellBasedIterator>();
     auto lsCellBased = NeoN::la::createEmptyLinearSystem<NeoN::scalar>(mesh, cellIterator);
 
+    auto volumeBCs = fvcc::createCalculatedBCs<fvcc::VolumeBoundary<TestType>>(mesh);
+    fvcc::VolumeField<TestType> phi(exec, "sf", mesh, volumeBCs);
+    Catch::randomizeVector(phi);
+    phi.correctBoundaryConditions();
+
     dsl::SpatialOperator divOp = dsl::imp::div(faceFlux, phi);
     divOp.read(input);
     divOp.implicitOperation(lsFaceBased);
     divOp.implicitOperation(lsCellBased);
+
+    REQUIRE_THAT(
+        lsFaceBased.matrix().values(), Equals(lsCellBased.matrix().values(), Approx {1e-12})
+    );
 }
 
 } // namespace NeoN

--- a/test/finiteVolume/cellCentred/operator/gaussGreenDiv.cpp
+++ b/test/finiteVolume/cellCentred/operator/gaussGreenDiv.cpp
@@ -193,4 +193,29 @@ TEST_CASE("DivOperator implicit boundary contributions are accumulated")
     }
 }
 
+TEST_CASE("Face based and cellbased iteration give same results")
+{
+    auto [execName, exec] = GENERATE(allAvailableExecutor());
+
+    const localIdx nCells = 10;
+    auto mesh = create1DUniformMesh(exec, nCells);
+    auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<NeoN::scalar>>(mesh);
+
+    fvcc::SurfaceField<NeoN::scalar> faceFlux(exec, "sf", mesh, surfaceBCs);
+    fill(faceFlux.internalVector(), 1.0);
+    fill(faceFlux.boundaryData().value(), 1.0);
+
+    Input input = TokenList({std::string("Gauss"), std::string("linear")});
+
+    auto lsFaceBased = NeoN::la::createEmptyLinearSystem<NeoN::scalar>(mesh);
+
+    auto cellIterator = std::make_shared<NeoN::la::CellBasedIterator>();
+    auto lsCellBased = NeoN::la::createEmptyLinearSystem<NeoN::scalar>(mesh, cellIterator);
+
+    dsl::SpatialOperator divOp = dsl::imp::div(faceFlux, phi);
+    divOp.read(input);
+    divOp.implicitOperation(lsFaceBased);
+    divOp.implicitOperation(lsCellBased);
+}
+
 } // namespace NeoN

--- a/test/finiteVolume/cellCentred/operator/laplacianOperator.cpp
+++ b/test/finiteVolume/cellCentred/operator/laplacianOperator.cpp
@@ -232,4 +232,41 @@ TEMPLATE_TEST_CASE("laplacianOperator boundary contributions are accumulated", "
     }
 }
 
+TEMPLATE_TEST_CASE(
+    "Face based and cellbased iteration give same results", "[template]", NeoN::scalar
+)
+{
+    auto [execName, exec] = GENERATE(allAvailableExecutor());
+
+    const localIdx nCells = 10;
+    auto mesh = create1DUniformMesh(exec, nCells);
+
+    auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<scalar>>(mesh);
+    fvcc::SurfaceField<scalar> gamma(exec, "gamma", mesh, surfaceBCs);
+    fill(gamma.internalVector(), 1.0);
+    fill(gamma.boundaryData().value(), 1.0);
+
+    auto volumeBCs = fvcc::createCalculatedBCs<fvcc::VolumeBoundary<TestType>>(mesh);
+    fvcc::VolumeField<TestType> phi(exec, "phi", mesh, volumeBCs);
+    Catch::randomizeVector(phi);
+    phi.correctBoundaryConditions();
+
+    Input input =
+        TokenList({std::string("Gauss"), std::string("linear"), std::string("uncorrected")});
+
+    auto lsFaceBased = la::createEmptyLinearSystem<TestType>(mesh);
+
+    auto cellIterator = std::make_shared<la::CellBasedIterator>();
+    auto lsCellBased = la::createEmptyLinearSystem<TestType>(mesh, cellIterator);
+
+    dsl::SpatialOperator lapOp = dsl::imp::laplacian(gamma, phi);
+    lapOp.read(input);
+    lapOp.implicitOperation(lsFaceBased);
+    lapOp.implicitOperation(lsCellBased);
+
+    REQUIRE_THAT(
+        lsFaceBased.matrix().values(), Equals(lsCellBased.matrix().values(), Approx {1e-12})
+    );
+}
+
 } // namespace NeoN


### PR DESCRIPTION
# Pull request overview
Implements a cell-based mesh iteration strategy for Gauss-Green divergence and laplacian implicit assembly, and adds tests to ensure face-based vs cell-based assembly produce identical matrix coefficients.

## Changes:

Add cell-based internal assembly kernels for GaussGreenDiv and GaussGreenLaplacian, selected via the linear system’s mesh iterator strategy.
Add regression tests comparing face-based vs cell-based assembled matrix values for div and laplacian.
Move/relocate test randomization helpers (from test/dsl/common.hpp into Catch2 common utilities).
