### PR TITLE
Add distributed Ginkgo solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Add experimental support for cell based assembly strategies [#471](https://github.com/exasim-project/NeoN/pull/471),[#517](https://github.com/exasim-project/NeoN/pull/517)
 - Add experimental support for COO and CSR Matrices [#486](https://github.com/exasim-project/NeoN/pull/486)
 - Add experimental umpire support [#455](https://github.com/exasim-project/NeoN/pull/455)
-- Add experimental MPI support [#519](https://github.com/exasim-project/NeoN/pull/519), [#520](https://github.com/exasim-project/NeoN/pull/520) [#512](https://github.com/exasim-project/NeoN/pull/512) [#525](https://github.com/exasim-project/NeoN/pull/525)
+- Add experimental MPI support [#519](https://github.com/exasim-project/NeoN/pull/519), [#520](https://github.com/exasim-project/NeoN/pull/520), [#512](https://github.com/exasim-project/NeoN/pull/512) [#525](https://github.com/exasim-project/NeoN/pull/525)
 - Add python bindings via nanobind [#382](https://github.com/exasim-project/NeoN/pull/382)
 - Correct the Ginkgo version to 2.0.0 (unreleased) [#493](https://github.com/exasim-project/NeoN/pull/493)
 - Add tensor and symmTensor primitives, Su type sourceTerm and passing of fields to BCs [#428](https://github.com/exasim-project/NeoN/pull/428)

--- a/ci/lrz-gitlab/build-and-test.sh
+++ b/ci/lrz-gitlab/build-and-test.sh
@@ -23,6 +23,7 @@ if [ "$GPU_VENDOR" == "nvidia" ]; then
     nvcc --version
 
     echo "=== Configuring, building, and testing NeoN on NVIDIA ==="
+    export CUDA_VISIBLE_DEVICES=0
     cmake --preset develop \
         -DCMAKE_CUDA_ARCHITECTURES=89 \
         -DNeoN_WITH_THREADS=OFF \

--- a/include/NeoN/dsl/expression.hpp
+++ b/include/NeoN/dsl/expression.hpp
@@ -8,6 +8,8 @@
 #include <vector>
 
 #include "NeoN/core/error.hpp"
+#include "NeoN/core/parallelAlgorithms.hpp"
+#include "NeoN/core/primitives/label.hpp"
 #include "NeoN/core/primitives/scalar.hpp"
 #include "NeoN/fields/field.hpp"
 #include "NeoN/linearAlgebra/cooSparsityPattern.hpp"
@@ -16,6 +18,9 @@
 #include "NeoN/linearAlgebra/linearSystem.hpp"
 #include "NeoN/dsl/spatialOperator.hpp"
 #include "NeoN/dsl/temporalOperator.hpp"
+#ifdef NF_WITH_MPI_SUPPORT
+#include "NeoN/core/mpi/environment.hpp"
+#endif
 
 #include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
 #include "NeoN/finiteVolume/cellCentred/fields/volumeField.hpp"
@@ -27,7 +32,64 @@ template<typename VectorType, typename IndexType>
 struct PostAssemblyBase
 {
     virtual ~PostAssemblyBase() = default;
-    virtual void operator()(la::LinearSystem<VectorType, la::CSRMatrix<VectorType, IndexType>>&) {};
+    virtual void
+    operator()(la::LinearSystem<VectorType, la::CSRMatrix<VectorType, IndexType>>&) const {};
+};
+
+/**
+ * @class SetReference
+ * @brief Post-assembly functor that pins one cell's value to a reference, removing the
+ *        constant null space that arises when all boundaries have Neumann (zero-gradient)
+ *        conditions on operators such as laplacian or div+laplacian.
+ *
+ * Modifies the assembled linear system in-place:
+ *   A[refCell, refCell] += A[refCell, refCell]   (doubles the diagonal)
+ *   rhs[refCell]        += A[refCell, refCell] * refValue
+ *
+ * For distributed systems only the rank that owns the reference cell (assumed to be
+ * rank 0 for local cell index 0) applies the modification; all other ranks skip it.
+ * For non-distributed systems every rank applies it independently (each holds a full copy).
+ */
+template<typename ValueType, typename IndexType = localIdx>
+class SetReference : public PostAssemblyBase<ValueType, IndexType>
+{
+public:
+
+    SetReference(localIdx refCell, ValueType refValue) : refCell_(refCell), refValue_(refValue) {}
+
+    void operator()(la::LinearSystem<ValueType, la::CSRMatrix<ValueType, IndexType>>& ls
+    ) const override
+    {
+#ifdef NF_WITH_MPI_SUPPORT
+        // For distributed systems, only the rank owning refCell applies the constraint.
+        // For non-distributed systems (each rank holds a full copy), every rank applies it.
+        if (!ls.commPattern().sendCounts.empty())
+        {
+            mpi::Environment mpiEnv;
+            if (mpiEnv.isInitialized() && mpiEnv.rank() != 0) return;
+        }
+#endif
+        auto lsView = ls.view();
+        const auto ma = ls.faceToMatrixAddress()->view(ls.matrix().sparsity()->rowOffs().view());
+        auto refVal = refValue_;
+        auto refCell = refCell_;
+        parallelFor(
+            ls.exec(),
+            {refCell, refCell + 1},
+            NEON_LAMBDA(const localIdx celli) {
+                auto dIdx = ma.diagIdx(celli);
+                auto diagVal = lsView.matrix.values[dIdx];
+                lsView.rhs[celli] += diagVal * refVal;
+                lsView.matrix.values[dIdx] += diagVal;
+            },
+            "SetReference"
+        );
+    }
+
+private:
+
+    localIdx refCell_;
+    ValueType refValue_;
 };
 
 
@@ -128,14 +190,14 @@ public:
 
     /** @brief construct a linear system and force assembly
      *
-     * @param ps a vector of functor performing transformation on the created linear system
+     * @param ps post-assembly functors applied to the system after assembly
      * @return the assembled linear system
      */
     la::LinearSystem<ValueType> assemble(
         const UnstructuredMesh& mesh,
         scalar t,
         scalar dt,
-        std::span<const PostAssemblyBase<ValueType, IndexType>> ps = {}
+        std::vector<const PostAssemblyBase<ValueType, IndexType>*> ps = {}
     ) const
     {
         auto ls = la::createEmptyLinearSystem<ValueType>(mesh);
@@ -145,22 +207,21 @@ public:
 
     /* @brief assemble into a given linear system
      *
-     * @param ps a vector of functor performing transformation on the created linear system
+     * @param ps post-assembly functors applied to the system after assembly
      */
     void assemble(
         scalar t,
         scalar dt,
         la::LinearSystem<ValueType>& ls,
-        std::span<const PostAssemblyBase<ValueType, IndexType>> ps = {}
+        std::vector<const PostAssemblyBase<ValueType, IndexType>*> ps = {}
     ) const
     {
         assembleSpatialOperator(ls);         // add spatial operator
         assembleTemporalOperator(ls, t, dt); // add temporal operators
 
-        // perform post assembly transformations
-        for (auto p : ps)
+        for (const auto* p : ps)
         {
-            p(ls);
+            (*p)(ls);
         }
     }
 

--- a/include/NeoN/dsl/expression.hpp
+++ b/include/NeoN/dsl/expression.hpp
@@ -49,6 +49,7 @@ struct PostAssemblyBase
  * For distributed systems only the rank that owns the reference cell (assumed to be
  * rank 0 for local cell index 0) applies the modification; all other ranks skip it.
  * For non-distributed systems every rank applies it independently (each holds a full copy).
+ * @TODO allow to set a refPoint instead of a refCell, make the refCell a global cellID
  */
 template<typename ValueType, typename IndexType = localIdx>
 class SetReference : public PostAssemblyBase<ValueType, IndexType>

--- a/include/NeoN/dsl/solver.hpp
+++ b/include/NeoN/dsl/solver.hpp
@@ -35,7 +35,7 @@ la::SolverStats iterativeSolveImpl(
     scalar dt,
     const Dictionary& fvSchemes,
     const Dictionary& fvSolution,
-    std::vector<PostAssemblyBase<typename VectorType::ElementType, IndexType>> ps
+    std::vector<const PostAssemblyBase<typename VectorType::ElementType, IndexType>*> ps = {}
 )
 {
     exp.read(fvSchemes);
@@ -67,7 +67,7 @@ la::SolverStats iterativeSolveImpl(
     scalar t,
     scalar dt,
     const Dictionary& fvSolution,
-    std::vector<PostAssemblyBase<typename VectorType::ElementType, IndexType>> ps
+    std::vector<const PostAssemblyBase<typename VectorType::ElementType, IndexType>*> ps = {}
 )
 {
     auto ls = exp.assemble(solution.mesh(), t, dt, ps);
@@ -107,7 +107,7 @@ la::SolverStats solve(
     scalar dt,
     const Dictionary& fvSchemes,
     const Dictionary& fvSolution,
-    std::vector<PostAssemblyBase<typename VectorType::ElementType, IndexType>> p = {}
+    std::vector<const PostAssemblyBase<typename VectorType::ElementType, IndexType>*> p = {}
 )
 {
     if (exp.temporalOperators().size() == 0 && exp.spatialOperators().size() == 0)

--- a/include/NeoN/finiteVolume/cellCentred/boundary/surface/processor.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/surface/processor.hpp
@@ -43,6 +43,7 @@ public:
     {
         detail::setProcBoundaryValue(domainVector, mesh_, this->range());
 #ifdef NF_WITH_MPI_SUPPORT
+        fence(domainVector.exec());
         const int neighborRank =
             static_cast<int>(mesh_.boundaryMesh().neighbourRankForRange(this->range()));
         domainVector.boundaryData().communicate(this->range(), neighborRank);

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/processor.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/processor.hpp
@@ -45,6 +45,7 @@ public:
     {
         detail::setProcBoundaryValue(domainVector, mesh_, this->range());
 #ifdef NF_WITH_MPI_SUPPORT
+        fence(domainVector.exec());
         const int neighborRank =
             static_cast<int>(mesh_.boundaryMesh().neighbourRankForRange(this->range()));
         domainVector.boundaryData().communicate(this->range(), neighborRank);

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp
@@ -81,6 +81,7 @@ public:
     virtual std::unique_ptr<GradOperatorFactory<Vec3>> clone() const override
     {
         NF_ERROR_EXIT("Not implemented");
+        return nullptr;
     };
 
 private:

--- a/include/NeoN/linearAlgebra/ginkgo.hpp
+++ b/include/NeoN/linearAlgebra/ginkgo.hpp
@@ -27,10 +27,54 @@ std::shared_ptr<gko::Executor> getGkoExecutor(Executor exec);
 
 gko::config::pnode parse(const Dictionary& dict);
 
-
 /** @brief create a ginkgo matrix by creating views */
 template<typename NeoNMatrixType>
 std::shared_ptr<const gko::LinOp> createGkoMtx(const NeoNMatrixType& mtx);
+
+template<typename T>
+gko::array<T> gkoArrayView(std::shared_ptr<const gko::Executor> exec, std::span<T> values)
+{
+    return gko::make_array_view(exec, values.size(), values.data());
+}
+
+/** @brief Non-owning mutable Dense view; 1 column for scalar*, 3 columns for Vec3* */
+template<typename T>
+std::shared_ptr<gko::matrix::Dense<scalar>>
+gkoVecView(std::shared_ptr<const gko::Executor> exec, T* ptr, localIdx s)
+{
+    constexpr std::size_t cols = std::is_same_v<T, Vec3> ? 3 : 1;
+    auto size = static_cast<std::size_t>(s);
+    return gko::share(gko::matrix::Dense<scalar>::create(
+        exec,
+        gko::dim<2> {size, cols},
+        gkoArrayView<scalar>(exec, std::span<scalar> {reinterpret_cast<scalar*>(ptr), cols * size}),
+        cols
+    ));
+}
+
+/** @brief Non-owning const Dense view; 1 column for scalar*, 3 columns for Vec3* */
+template<typename T>
+std::shared_ptr<const gko::matrix::Dense<scalar>>
+gkoVecView(std::shared_ptr<const gko::Executor> exec, const T* ptr, localIdx s)
+{
+    constexpr std::size_t cols = std::is_same_v<T, Vec3> ? 3 : 1;
+    auto size = static_cast<std::size_t>(s);
+    return gko::share(gko::matrix::Dense<scalar>::create_const(
+        exec,
+        gko::dim<2> {size, cols},
+        gko::array<scalar>::const_view(exec, cols * size, reinterpret_cast<const scalar*>(ptr)),
+        cols
+    ));
+}
+
+/** @brief retrieve a scalar value from a ginkgo dense matrix on any executor */
+template<typename InType>
+scalar retrieve(const InType& in)
+{
+    using vec = gko::matrix::Dense<scalar>;
+    auto host = vec::create(in->get_executor()->get_master(), gko::dim<2> {1});
+    return host->copy_from(in)->at(0);
+}
 
 class GinkgoSolver : public SolverFactory::template Register<GinkgoSolver>
 {
@@ -60,6 +104,22 @@ public:
 
     virtual SolverStats
     solve(const LinearSystem<Vec3, CSRMatrix<Vec3, localIdx>>& sys, Vector<Vec3>& x) const final;
+
+    virtual SolverStats solve(
+        const LinearSystem<scalar, CSRMatrix<scalar, localIdx>, COOMatrix<scalar, localIdx>, Vec3>&
+            sys,
+        Vector<Vec3>& x
+    ) const final;
+
+#ifdef NF_WITH_MPI_SUPPORT
+    virtual SolverStats solveDist(
+        const LinearSystem<scalar, CSRMatrix<scalar, localIdx>>& sys, Vector<scalar>& x
+    ) const final;
+
+    virtual SolverStats solveDist(
+        const LinearSystem<Vec3, CSRMatrix<Vec3, localIdx>>& sys, Vector<Vec3>& x
+    ) const final;
+#endif
 
     // TODO why use a smart pointer here?
     virtual std::unique_ptr<SolverFactory> clone() const final

--- a/include/NeoN/linearAlgebra/linearSystem.hpp
+++ b/include/NeoN/linearAlgebra/linearSystem.hpp
@@ -12,6 +12,9 @@
 #include "NeoN/linearAlgebra/csrSparsityPattern.hpp"
 #include "NeoN/linearAlgebra/meshIterationStrategies.hpp"
 #include "NeoN/linearAlgebra/faceToMatrixAddress.hpp"
+#ifdef NF_WITH_MPI_SUPPORT
+#include "NeoN/distributed/communicationPattern.hpp"
+#endif
 
 #include <string>
 
@@ -22,10 +25,10 @@ namespace NeoN::la
  * @struct LinearSystemView
  * @brief A view linear into a linear system's data.
  *
- * @tparam ValueType The value type of the linear system.
+ * @tparam RHSValueType The value type of the rhs/solution vectors.
  * @tparam MatrixViewType The type representing the matrix view
  */
-template<typename ValueType, typename MatrixViewType>
+template<typename RHSValueType, typename MatrixViewType>
 struct LinearSystemView
 {
     LinearSystemView() = default;
@@ -33,18 +36,18 @@ struct LinearSystemView
 
     LinearSystemView(
         MatrixViewType matrixView,
-        View<ValueType> rhsView,
+        View<RHSValueType> rhsView,
         MatrixViewType boundaryMatrixView,
-        View<ValueType> boundaryRhsView
+        View<RHSValueType> boundaryRhsView
     )
         : matrix(matrixView), rhs(rhsView), boundaryMatrix(boundaryMatrixView),
           boundaryRhs(boundaryRhsView) {};
 
     MatrixViewType matrix;
-    View<ValueType> rhs;
+    View<RHSValueType> rhs;
 
     MatrixViewType boundaryMatrix;
-    View<ValueType> boundaryRhs;
+    View<RHSValueType> boundaryRhs;
 };
 
 /**
@@ -54,13 +57,23 @@ struct LinearSystemView
  * The LinearSystem class provides functionality to store and manipulate a linear system of
  * equations. It supports the storage of the coefficient matrix and the right-hand side vector, as
  * well as the solution vector.
+ *
+ * @tparam MatrixValueType The value type of the system and boundary matrix coefficients.
+ * @tparam SystemMatrixType The sparse matrix type used for the system matrix (default:
+ * CSRMatrix<MatrixValueType, localIdx>).
+ * @tparam BoundaryMatrixType The sparse matrix type used for boundary and off-diagonal matrices
+ * (default: COOMatrix<MatrixValueType, localIdx>).
+ * @tparam RHSValueType The value type of the right-hand side and boundary rhs vectors. Defaults to
+ * MatrixValueType, but may differ (e.g. scalar matrix with Vec3 rhs for segregated vector solves).
  */
 template<
-    typename ValueType,
-    typename SystemMatrixType = CSRMatrix<ValueType, localIdx>,
-    typename BoundaryMatrixType = COOMatrix<ValueType, localIdx>>
+    typename MatrixValueType,
+    typename SystemMatrixType = CSRMatrix<MatrixValueType, localIdx>,
+    typename BoundaryMatrixType = COOMatrix<MatrixValueType, localIdx>,
+    typename RHSValueType = MatrixValueType>
 class LinearSystem :
-    public NeoN::SupportsCopyTo<LinearSystem<ValueType, SystemMatrixType, BoundaryMatrixType>>
+    public NeoN::SupportsCopyTo<
+        LinearSystem<MatrixValueType, SystemMatrixType, BoundaryMatrixType, RHSValueType>>
 {
 
     void validate()
@@ -88,10 +101,10 @@ public:
 
     LinearSystem(
         const SystemMatrixType& matrix,
-        const Vector<ValueType>& rhs,
+        const Vector<RHSValueType>& rhs,
         const BoundaryMatrixType& offDiagonalMatrix,
         const BoundaryMatrixType& boundaryMatrix,
-        const Vector<ValueType>& boundaryRhs,
+        const Vector<RHSValueType>& boundaryRhs,
         std::shared_ptr<MeshIterationStrategy> strategy = std::make_shared<FaceBasedIterator>()
     )
         : matrix_(matrix), rhs_(rhs), boundaryMatrix_(boundaryMatrix),
@@ -102,11 +115,26 @@ public:
         validate();
     }
 
+    LinearSystem(
+        const SystemMatrixType& matrix,
+        const Vector<RHSValueType>& rhs,
+        const BoundaryMatrixType& boundaryMatrix,
+        const Vector<RHSValueType>& boundaryRhs,
+        std::shared_ptr<MeshIterationStrategy> strategy = std::make_shared<FaceBasedIterator>()
+    )
+        : LinearSystem(
+            matrix, rhs, emptyMatrix(matrix.exec()), boundaryMatrix, boundaryRhs, strategy
+        )
+    {}
 
     LinearSystem(const LinearSystem& ls)
         : matrix_(ls.matrix_), rhs_(ls.rhs_), boundaryMatrix_(ls.boundaryMatrix_),
           offDiagonalMatrix_(ls.offDiagonalMatrix_), boundaryRhs_(ls.boundaryRhs_),
           meshIteratorContext_(ls.meshIteratorContext_)
+#ifdef NF_WITH_MPI_SUPPORT
+          ,
+          commPattern_(ls.commPattern_)
+#endif
     {
         validate();
     }
@@ -125,52 +153,56 @@ public:
 
     [[nodiscard]] const BoundaryMatrixType& boundaryMatrix() const { return boundaryMatrix_; }
 
-    [[nodiscard]] Vector<ValueType>& rhs() { return rhs_; }
+    [[nodiscard]] Vector<RHSValueType>& rhs() { return rhs_; }
 
-    [[nodiscard]] const Vector<ValueType>& rhs() const { return rhs_; }
+    [[nodiscard]] const Vector<RHSValueType>& rhs() const { return rhs_; }
 
-    [[nodiscard]] Vector<ValueType>& boundaryRhs() { return boundaryRhs_; }
+    [[nodiscard]] Vector<RHSValueType>& boundaryRhs() { return boundaryRhs_; }
 
-    [[nodiscard]] const Vector<ValueType>& boundaryRhs() const { return boundaryRhs_; }
+    [[nodiscard]] const Vector<RHSValueType>& boundaryRhs() const { return boundaryRhs_; }
 
-    [[nodiscard]] LinearSystem<ValueType, SystemMatrixType, BoundaryMatrixType>
+    [[nodiscard]] LinearSystem<MatrixValueType, SystemMatrixType, BoundaryMatrixType, RHSValueType>
     copyToExecutor(Executor exec) const override
     {
-        return {
+        LinearSystem<MatrixValueType, SystemMatrixType, BoundaryMatrixType, RHSValueType> ls {
             matrix_.copyToExecutor(exec),
             rhs_.copyToExecutor(exec),
             offDiagonalMatrix_.copyToExecutor(exec),
             boundaryMatrix_.copyToExecutor(exec),
             boundaryRhs_.copyToExecutor(exec)
         };
+#ifdef NF_WITH_MPI_SUPPORT
+        ls.commPattern_ = commPattern_;
+#endif
+        return ls;
     }
 
     void reset()
     {
-        fill(matrix_.values(), zero<ValueType>());
-        fill(rhs_, zero<ValueType>());
-        fill(boundaryMatrix_.values(), zero<ValueType>());
-        fill(boundaryRhs_, zero<ValueType>());
-        fill(offDiagonalMatrix_.values(), zero<ValueType>());
+        fill(matrix_.values(), zero<MatrixValueType>());
+        fill(rhs_, zero<RHSValueType>());
+        fill(boundaryMatrix_.values(), zero<MatrixValueType>());
+        fill(boundaryRhs_, zero<RHSValueType>());
+        fill(offDiagonalMatrix_.values(), zero<MatrixValueType>());
     }
 
     [[nodiscard]] LinearSystemView<
-        ValueType,
+        RHSValueType,
         MatrixView<
-            ValueType,
+            MatrixValueType,
             SparsityView<typename SystemMatrixType::MatrixSparsityType::SparsityIndexType>>>
     view() && = delete;
 
     [[nodiscard]] LinearSystemView<
-        ValueType,
+        RHSValueType,
         MatrixView<
-            ValueType,
+            MatrixValueType,
             SparsityView<typename SystemMatrixType::MatrixSparsityType::SparsityIndexType>>>
     view() const&& = delete;
 
     [[nodiscard]] LinearSystemView<
-        ValueType,
-        MatrixView<ValueType, SparsityView<LinearSystemIndexType>>>
+        RHSValueType,
+        MatrixView<MatrixValueType, SparsityView<LinearSystemIndexType>>>
     view() &
     {
         return {matrix_.view(), rhs_.view(), boundaryMatrix_.view(), boundaryRhs_.view()};
@@ -181,9 +213,14 @@ public:
         return matrix_.faceToMatrixAddress();
     }
 
+#ifdef NF_WITH_MPI_SUPPORT
+    [[nodiscard]] const CommunicationPattern& commPattern() const { return commPattern_; }
+    [[nodiscard]] CommunicationPattern& commPattern() { return commPattern_; }
+#endif
+
     [[nodiscard]] LinearSystemView<
-        const ValueType,
-        const MatrixView<ValueType, SparsityView<const LinearSystemIndexType>>>
+        const RHSValueType,
+        const MatrixView<MatrixValueType, SparsityView<const LinearSystemIndexType>>>
     view() const&
     {
         return {matrix_.view(), rhs_.view(), boundaryMatrix_.view(), boundaryRhs_.view()};
@@ -195,10 +232,19 @@ public:
 
 private:
 
+    static BoundaryMatrixType emptyMatrix(const Executor& exec)
+    {
+        using IndexType = typename BoundaryMatrixType::MatrixSparsityType::SparsityIndexType;
+        auto sp = std::make_shared<const typename BoundaryMatrixType::MatrixSparsityType>(
+            Vector<IndexType>(exec, 0), Vector<IndexType>(exec, 0), Dimensions {0, 0}
+        );
+        return BoundaryMatrixType(Vector<MatrixValueType>(exec, 0, zero<MatrixValueType>()), sp);
+    }
+
     // internal values
     SystemMatrixType matrix_;
 
-    Vector<ValueType> rhs_;
+    Vector<RHSValueType> rhs_;
 
     // boundary values
     BoundaryMatrixType boundaryMatrix_;
@@ -207,11 +253,15 @@ private:
     // eg on processor boundaries
     BoundaryMatrixType offDiagonalMatrix_;
 
-    Vector<ValueType> boundaryRhs_;
+    Vector<RHSValueType> boundaryRhs_;
 
     Dictionary auxiliaryCoefficients_;
 
     std::shared_ptr<MeshIteratorContext> meshIteratorContext_ = nullptr;
+
+#ifdef NF_WITH_MPI_SUPPORT
+    CommunicationPattern commPattern_;
+#endif
 };
 
 /*@brief helper function that creates a zero initialised linear system based on a given mesh
@@ -235,12 +285,36 @@ LinearSystem<ValueType, SystemMatrixType, BoundaryMatrixType> createEmptyLinearS
     const auto nProcFaces = static_cast<localIdx>(mesh.nProcBoundaryFaces());
     using IndexType = typename BoundaryMatrixType::MatrixSparsityType::SparsityIndexType;
 
-    auto offDiagSp =
-        createOffDiagonalSparsityPattern<typename BoundaryMatrixType::MatrixSparsityType>(
-            mesh, *mi
-        );
+    Vector<IndexType> offDiagColIdxs(exec, nProcFaces, 0);
+    Vector<IndexType> offDiagRowIdxs(exec, nProcFaces, 0);
 
-    return {
+#ifdef NF_WITH_MPI_SUPPORT
+    auto commPattern = computeCommunicationPattern(mesh);
+    if (nProcFaces > 0)
+    {
+        const localIdx nBoundaryFaces = static_cast<localIdx>(mesh.nBoundaryFaces());
+        const auto faceOwnersH = mesh.boundaryMesh().faceOwners().copyToHost();
+        const auto faceOwnersV = faceOwnersH.view();
+        Vector<IndexType> rowH(SerialExecutor {}, nProcFaces, 0);
+        Vector<IndexType> colH(SerialExecutor {}, nProcFaces, 0);
+        auto rowHV = rowH.view();
+        auto colHV = colH.view();
+        const auto globalOffset = static_cast<IndexType>(mesh.globalOffset());
+        for (localIdx i = 0; i < nProcFaces; ++i)
+        {
+            rowHV[i] = faceOwnersV[nBoundaryFaces + i] + globalOffset;
+            colHV[i] = static_cast<IndexType>(commPattern.recvIdx[static_cast<std::size_t>(i)]);
+        }
+        offDiagRowIdxs = rowH.copyToExecutor(exec);
+        offDiagColIdxs = colH.copyToExecutor(exec);
+    }
+#endif
+
+    auto offDiagSp = std::make_shared<const typename BoundaryMatrixType::MatrixSparsityType>(
+        std::move(offDiagColIdxs), std::move(offDiagRowIdxs), Dimensions {nCells, nCells}
+    );
+
+    LinearSystem<ValueType, SystemMatrixType, BoundaryMatrixType> ls {
         SystemMatrixType(Vector<ValueType>(sp->exec(), sp->nnz(), zero<ValueType>()), sp, mi),
         Vector<ValueType>(sp->exec(), sp->rows(), zero<ValueType>()),
         BoundaryMatrixType(Vector<ValueType>(exec, nProcFaces, zero<ValueType>()), offDiagSp),
@@ -248,6 +322,12 @@ LinearSystem<ValueType, SystemMatrixType, BoundaryMatrixType> createEmptyLinearS
         Vector<ValueType>(bSp->exec(), bSp->nnz(), zero<ValueType>()),
         strategy
     };
+
+#ifdef NF_WITH_MPI_SUPPORT
+    ls.commPattern() = std::move(commPattern);
+#endif
+
+    return ls;
 }
 
 /** @brief for testing purposes, this function reverses boundary contributions previously applied to

--- a/include/NeoN/linearAlgebra/meshIterationStrategies.hpp
+++ b/include/NeoN/linearAlgebra/meshIterationStrategies.hpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "NeoN/core/segmentedVector.hpp"
 
@@ -101,6 +102,41 @@ public:
      */
     struct CellBasedData
     {
+        CellBasedData() = default;
+
+        /** @brief Construct from pre-computed connectivity arrays.
+         *
+         * A user-declared constructor is required (rather than relying on
+         * aggregate initialisation) because @c std::make_shared builds the
+         * object through @c std::construct_at, which performs parenthesised
+         * placement-new: @c new(p)\ CellBasedData(args...). Parenthesised
+         * initialisation of aggregates (C++20 P0960) is not implemented by the
+         * CUDA 12.4 nvcc/EDG front-end, so @c make_shared<CellBasedData>(...)
+         * fails there with "no instance of constructor ... matches".
+         *
+         * The container parameters are templated so the constructor adapts to
+         * however the connectivity arrays are spelled at the call site
+         * (@c Vector<localIdx> or @c Vector<label>), avoiding a brittle exact
+         * type match across NeoN revisions.
+         */
+        template<
+            typename CellFaces,
+            typename FaceNeighbour,
+            typename FaceSign,
+            typename MatrixColumnIdx>
+        CellBasedData(
+            localIdx size_,
+            CellFaces&& cellFaces_,
+            FaceNeighbour&& faceNeighbour_,
+            FaceSign&& faceSign_,
+            MatrixColumnIdx&& matrixColumnIdx_
+        )
+            : size(size_), cellFaces(std::forward<CellFaces>(cellFaces_)),
+              faceNeighbour(std::forward<FaceNeighbour>(faceNeighbour_)),
+              faceSign(std::forward<FaceSign>(faceSign_)),
+              matrixColumnIdx(std::forward<MatrixColumnIdx>(matrixColumnIdx_))
+        {}
+
         localIdx size; ///< Number of cells.
 
         /** @brief Cell-to-face stencil; segments correspond to cells, values are face indices. */

--- a/include/NeoN/linearAlgebra/meshIterationStrategies.hpp
+++ b/include/NeoN/linearAlgebra/meshIterationStrategies.hpp
@@ -125,16 +125,16 @@ public:
             typename FaceSign,
             typename MatrixColumnIdx>
         CellBasedData(
-            localIdx size_,
-            CellFaces&& cellFaces_,
-            FaceNeighbour&& faceNeighbour_,
-            FaceSign&& faceSign_,
-            MatrixColumnIdx&& matrixColumnIdx_
+            localIdx sizeIn,
+            CellFaces&& cellFacesIn,
+            FaceNeighbour&& faceNeighbourIn,
+            FaceSign&& faceSignIn,
+            MatrixColumnIdx&& matrixColumnIdxIn
         )
-            : size(size_), cellFaces(std::forward<CellFaces>(cellFaces_)),
-              faceNeighbour(std::forward<FaceNeighbour>(faceNeighbour_)),
-              faceSign(std::forward<FaceSign>(faceSign_)),
-              matrixColumnIdx(std::forward<MatrixColumnIdx>(matrixColumnIdx_))
+            : size(sizeIn), cellFaces(std::forward<CellFaces>(cellFacesIn)),
+              faceNeighbour(std::forward<FaceNeighbour>(faceNeighbourIn)),
+              faceSign(std::forward<FaceSign>(faceSignIn)),
+              matrixColumnIdx(std::forward<MatrixColumnIdx>(matrixColumnIdxIn))
         {}
 
         localIdx size; ///< Number of cells.

--- a/include/NeoN/linearAlgebra/solver.hpp
+++ b/include/NeoN/linearAlgebra/solver.hpp
@@ -58,6 +58,27 @@ public:
     virtual SolverStats
     solve(const LinearSystem<Vec3, CSRMatrix<Vec3, localIdx>>&, Vector<Vec3>&) const = 0;
 
+    virtual SolverStats
+    solve(const LinearSystem<scalar, CSRMatrix<scalar, localIdx>, COOMatrix<scalar, localIdx>, Vec3>&, Vector<Vec3>&)
+        const
+    {
+        NF_THROW("solve(scalar matrix, Vec3 rhs) not implemented for this solver");
+    }
+
+#ifdef NF_WITH_MPI_SUPPORT
+    virtual SolverStats
+    solveDist(const LinearSystem<scalar, CSRMatrix<scalar, localIdx>>&, Vector<scalar>&) const
+    {
+        NF_THROW("solveDist not implemented for this solver");
+    }
+
+    virtual SolverStats
+    solveDist(const LinearSystem<Vec3, CSRMatrix<Vec3, localIdx>>&, Vector<Vec3>&) const
+    {
+        NF_THROW("solveDist not implemented for this solver");
+    }
+#endif
+
     // Pure virtual function for cloning
     virtual std::unique_ptr<SolverFactory> clone() const = 0;
 
@@ -86,11 +107,26 @@ public:
     SolverStats
     solve(const LinearSystem<scalar, CSRMatrix<scalar, localIdx>>& ls, Vector<scalar>& field) const
     {
+#ifdef NF_WITH_MPI_SUPPORT
+        if (!ls.commPattern().sendCounts.empty()) return solverInstance_->solveDist(ls, field);
+#endif
         return solverInstance_->solve(ls, field);
     }
 
     SolverStats
     solve(const LinearSystem<Vec3, CSRMatrix<Vec3, localIdx>>& ls, Vector<Vec3>& field) const
+    {
+#ifdef NF_WITH_MPI_SUPPORT
+        if (!ls.commPattern().sendCounts.empty()) return solverInstance_->solveDist(ls, field);
+#endif
+        return solverInstance_->solve(ls, field);
+    }
+
+    SolverStats solve(
+        const LinearSystem<scalar, CSRMatrix<scalar, localIdx>, COOMatrix<scalar, localIdx>, Vec3>&
+            ls,
+        Vector<Vec3>& field
+    ) const
     {
         return solverInstance_->solve(ls, field);
     }

--- a/include/NeoN/linearAlgebra/solver.hpp
+++ b/include/NeoN/linearAlgebra/solver.hpp
@@ -122,12 +122,24 @@ public:
         return solverInstance_->solve(ls, field);
     }
 
+    /// @brief Solve a system with a scalar matrix and Vec3 right-hand side.
+    /// @note This overload is **local-only**: it does not dispatch to solveDist and must not be
+    ///       called on a distributed LinearSystem (one whose commPattern has non-empty sendCounts).
+    ///       If distributed support is needed, add a solveDist virtual to SolverFactory and
+    ///       implement it in every backend.
     SolverStats solve(
         const LinearSystem<scalar, CSRMatrix<scalar, localIdx>, COOMatrix<scalar, localIdx>, Vec3>&
             ls,
         Vector<Vec3>& field
     ) const
     {
+#ifdef NF_WITH_MPI_SUPPORT
+        NF_ASSERT(
+            ls.commPattern().sendCounts.empty(),
+            "solve(scalar matrix, Vec3 rhs) does not support distributed systems. "
+            "Add a solveDist overload to SolverFactory to enable this."
+        );
+#endif
         return solverInstance_->solve(ls, field);
     }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,7 +39,7 @@ target_sources(
           "executor/serialExecutor.cpp"
           "linearAlgebra/utilities.cpp"
           "linearAlgebra/matrix.cpp"
-          "linearAlgebra/ginkgo.cpp"
+          "linearAlgebra/ginkgo/ginkgo.cpp"
           "linearAlgebra/faceToMatrixAddress.cpp"
           "linearAlgebra/cooSparsityPattern.cpp"
           "linearAlgebra/csrSparsityPattern.cpp"
@@ -72,8 +72,10 @@ target_sources(
 
 if(NeoN_WITH_MPI)
   target_sources(
-    NeoN PRIVATE "core/mpi/halfDuplexCommBuffer.cpp" "mesh/unstructured/communicator.cpp"
-                 "mesh/unstructured/distributedUnstructuredMesh.cpp")
+    NeoN
+    PRIVATE "core/mpi/halfDuplexCommBuffer.cpp" "mesh/unstructured/communicator.cpp"
+            "mesh/unstructured/distributedUnstructuredMesh.cpp"
+            "linearAlgebra/ginkgo/ginkgoDistributed.cpp" "linearAlgebra/ginkgo/ginkgoL1Stop.cpp")
 endif()
 
 if(NeoN_BUILD_PYTHON_BINDINGS)

--- a/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
@@ -157,7 +157,8 @@ void BasicGeometryScheme::updateDeltaCoeffs(
         views(mesh_.faceOwners(), mesh_.faceNeighbors(), mesh_.boundaryMesh().faceOwners());
 
 
-    const auto [faceCenters, cellCenters] = views(mesh_.faceCenters(), mesh_.cellCenters());
+    const auto [faceCenters, cellCenters] =
+        views(mesh_.boundaryMesh().faceCenters(), mesh_.cellCenters());
 
     auto deltaCoeff = deltaCoeffs.internalVector().view();
     auto deltaCoeffB = deltaCoeffs.boundaryData().value().view();
@@ -180,8 +181,8 @@ void BasicGeometryScheme::updateDeltaCoeffs(
         NEON_LAMBDA(const localIdx bfi) {
             auto own = surfFaceCells[bfi];
             // TODO Issue #515
-            Vec3 cellToCellDist = faceCenters[nInternalFaces + bfi] - cellCenters[own];
-            deltaCoeffB[bfi] = 1.0 / std::max(mag(cellToCellDist), scalar(ROOTVSMALL));
+            Vec3 cellToFaceDist = faceCenters[bfi] - cellCenters[own];
+            deltaCoeffB[bfi] = 1.0 / std::max(mag(cellToFaceDist), scalar(ROOTVSMALL));
         },
         "basicGeometricScheme::updateDeltaCoeffsBoundary"
     );

--- a/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
@@ -237,17 +237,19 @@ void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
     const auto nProcBoundaryFaces = mesh_.nProcBoundaryFaces();
     if (nProcBoundaryFaces > 0)
     {
-        const auto bFaceCenters = mesh_.boundaryMesh().faceCenters().view();
-        const auto bFaceNormals = mesh_.boundaryMesh().faceNormals().view();
-        const auto bFaceAreas = mesh_.boundaryMesh().faceAreas().view();
         const auto dNei = exchangeProcOwnerDistance(exec, mesh_);
         const auto dNeiView = dNei.view();
+        const auto [bFaceNormals, bFaceArea, bFaceCenters] = views(
+            mesh_.boundaryMesh().faceNormals(),
+            mesh_.boundaryMesh().faceAreas(),
+            mesh_.boundaryMesh().faceCenters()
+        );
         parallelFor(
             exec,
             {0, nProcBoundaryFaces},
             NEON_LAMBDA(const localIdx procFacei) {
                 const localIdx bfi = nBoundaryFaces + procFacei;
-                const Vec3 n = (1.0 / bFaceAreas[bfi]) * bFaceNormals[bfi];
+                const Vec3 n = (1.0 / bFaceArea[bfi]) * bFaceNormals[bfi];
                 const Vec3 co = cellCenters[surfFaceCells[bfi]];
                 const scalar dOwn = std::abs(n & (bFaceCenters[bfi] - co));
                 nonOrthDeltaCoeffB[bfi] =

--- a/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
@@ -147,6 +147,34 @@ void BasicGeometryScheme::updateWeights(const Executor& exec, SurfaceField<scala
         NEON_LAMBDA(const localIdx bfi) { weightB[bfi] = 1.0; },
         "basicGeometricScheme::updateWeightsBoundary"
     );
+#ifdef NF_WITH_MPI_SUPPORT
+    const auto nBoundaryFaces = mesh_.nBoundaryFaces();
+    const auto nProcBoundaryFaces = mesh_.nProcBoundaryFaces();
+    if (nProcBoundaryFaces > 0)
+    {
+        const auto surfFaceCells = mesh_.boundaryMesh().faceOwners().view();
+        const auto bFaceCenters = mesh_.boundaryMesh().faceCenters().view();
+        const auto bFaceNormals = mesh_.boundaryMesh().faceNormals().view();
+        const auto bFaceAreas = mesh_.boundaryMesh().faceAreas().view();
+        // dNei[procFacei] == |n & (Cf - Cnei)| received from the neighbouring rank
+        const auto dNei = exchangeProcOwnerDistance(exec, mesh_);
+        const auto dNeiView = dNei.view();
+        parallelFor(
+            exec,
+            {0, nProcBoundaryFaces},
+            NEON_LAMBDA(const localIdx procFacei) {
+                const localIdx bfi = nBoundaryFaces + procFacei;
+                const Vec3 n = (1.0 / bFaceAreas[bfi]) * bFaceNormals[bfi];
+                const Vec3 co = cellCenters[surfFaceCells[bfi]];
+                const scalar dOwn = std::abs(n & (bFaceCenters[bfi] - co));
+                const scalar dNeiF = dNeiView[procFacei];
+                const scalar sum = dOwn + dNeiF;
+                weightB[bfi] = (sum > ROOTVSMALL) ? dNeiF / sum : 0.5;
+            },
+            "basicGeometricScheme::updateWeightsProcBoundary"
+        );
+    }
+#endif
 }
 
 void BasicGeometryScheme::updateDeltaCoeffs(

--- a/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
@@ -169,7 +169,7 @@ void BasicGeometryScheme::updateDeltaCoeffs(
         {0, nInternalFaces},
         NEON_LAMBDA(const localIdx facei) {
             Vec3 cellToCellDist = cellCenters[neighbors[facei]] - cellCenters[owners[facei]];
-            deltaCoeff[facei] = 1.0 / mag(cellToCellDist);
+            deltaCoeff[facei] = 1.0 / std::max(mag(cellToCellDist), scalar(ROOTVSMALL));
         },
         "basicGeometricScheme::updateDeltaCoeffsInternal"
     );
@@ -181,7 +181,7 @@ void BasicGeometryScheme::updateDeltaCoeffs(
             auto own = surfFaceCells[bfi];
             // TODO Issue #515
             Vec3 cellToCellDist = faceCenters[nInternalFaces + bfi] - cellCenters[own];
-            deltaCoeffB[bfi] = 1.0 / mag(cellToCellDist);
+            deltaCoeffB[bfi] = 1.0 / std::max(mag(cellToCellDist), scalar(ROOTVSMALL));
         },
         "basicGeometricScheme::updateDeltaCoeffsBoundary"
     );

--- a/src/linearAlgebra/ginkgo/ginkgo.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgo.cpp
@@ -170,41 +170,12 @@ label computeNRows(const LinearSystem<scalar, CSRMatrix<scalar, localIdx>>& sys)
     return sys.rhs().size();
 }
 
-/*@brief create a array non const view into data given by ptr*/
-template<typename T>
-gko::array<T> gkoArrayView(std::shared_ptr<const gko::Executor> exec, std::span<T> values)
-{
-    return gko::make_array_view(exec, values.size(), values.data());
-}
-
 /*@brief create a new array by copying from view into ptr*/
 template<typename T>
 auto gkoCopyArray(std::shared_ptr<const gko::Executor> exec, std::span<T> values)
 {
     return gko::make_const_array_view(exec, values.size(), values.data()).copy_to_array();
 }
-
-
-/*@brief create a dense non const view into data given by ptr*/
-std::shared_ptr<gko::matrix::Dense<scalar>>
-gkoVecView(std::shared_ptr<const gko::Executor> exec, scalar* ptr, localIdx s)
-{
-    auto size = static_cast<std::size_t>(s);
-    return gko::share(gko::matrix::Dense<scalar>::create(
-        exec, gko::dim<2> {size, 1}, gkoArrayView(exec, std::span {ptr, size}), 1
-    ));
-}
-
-/*@brief create a dense const view into data given by ptr*/
-std::shared_ptr<const gko::matrix::Dense<scalar>>
-gkoVecView(std::shared_ptr<const gko::Executor> exec, const scalar* ptr, localIdx s)
-{
-    auto size = static_cast<std::size_t>(s);
-    return gko::share(gko::matrix::Dense<scalar>::create_const(
-        exec, gko::dim<2> {size, 1}, gko::array<scalar>::const_view(exec, size, ptr), 1
-    ));
-}
-
 
 /* @brief create a ginkgo csr matrix by creating views into Csr<scalar> avoiding copies */
 template<typename IndexType>
@@ -288,19 +259,12 @@ std::shared_ptr<const gko::LinOp> createGkoMtx(const NeoNMatrixType& mtx)
     return createGkoMtxImpl(exec, mtx);
 }
 
-/*@brief helper function to get a scalar dense value from a device back to the host*/
-template<typename InType>
-scalar retrieve(const InType& in)
-{
-    using vec = gko::matrix::Dense<scalar>;
-    auto host = vec::create(in->get_executor()->get_master(), gko::dim<2> {1});
-    return host->copy_from(in)->at(0);
-};
 
+template<typename VectorType>
 SolverStatsEntry solve_impl(
     std::shared_ptr<const gko::Executor> exec,
-    const Vector<scalar>& rhs,
-    Vector<scalar>& xIn,
+    const VectorType& rhs,
+    VectorType& xIn,
     std::shared_ptr<const gko::LinOp> mtx,
     std::unique_ptr<gko::LinOp> solver
 )
@@ -313,12 +277,10 @@ SolverStatsEntry solve_impl(
     const auto b = gkoVecView(exec, rhs.data(), nrows);
     auto x = gkoVecView(exec, xIn.data(), nrows);
 
-    // create a copy of rhs so that we can inline compute
-    // the residual
-    auto rhsCopy = Vector<scalar>(rhs);
+    // copy of rhs to compute the initial residual inline
+    auto rhsCopy = VectorType(rhs);
     auto res = gkoVecView(exec, rhsCopy.data(), nrows);
 
-    // compute Ax-b -> res
     auto one = gko::initialize<vec>({1.0}, exec);
     auto neg_one = gko::initialize<vec>({-1.0}, exec);
     mtx->apply(one, x, neg_one, res);
@@ -332,18 +294,16 @@ SolverStatsEntry solve_impl(
     solver->add_logger(logger);
     solver->apply(b, x);
 
-    // since we work on a copy we need to copy back
     scalar finalResNorm = retrieve(gko::as<vec>(logger->get_residual_norm()));
-
     auto numIter = label(logger->get_num_iterations());
     exec->synchronize();
+
     auto endEval = std::chrono::steady_clock::now();
     auto duration =
         static_cast<scalar>(
             std::chrono::duration_cast<std::chrono::microseconds>(endEval - startEval).count()
         )
         / 1000.0;
-
     return {numIter, initResNorm, finalResNorm, duration};
 }
 
@@ -422,6 +382,36 @@ GinkgoSolver::solve(const LinearSystem<Vec3, CSRMatrix<Vec3, localIdx>>& sys, Ve
     }
 }
 
+
+template<unsigned int I>
+void solveVec3RhsComponent(
+    const Vector<Vec3>& rhs,
+    Vector<Vec3>& x,
+    std::shared_ptr<const gko::Executor> exec,
+    std::shared_ptr<const gko::LinOpFactory> factory,
+    std::shared_ptr<const gko::LinOp> gkoMtx,
+    SolverStats& stats
+)
+{
+    auto rhsComp = getComponent<I>(rhs);
+    auto xcopy = getComponent<I>(x);
+    auto solver = factory->generate(gkoMtx);
+    stats.entries.push_back(solve_impl(exec, rhsComp, xcopy, gkoMtx, std::move(solver)));
+    setComponent<I>(xcopy, x);
+}
+
+SolverStats GinkgoSolver::solve(
+    const LinearSystem<scalar, CSRMatrix<scalar, localIdx>, COOMatrix<scalar, localIdx>, Vec3>& sys,
+    Vector<Vec3>& x
+) const
+{
+    auto stats = SolverStats {};
+    auto gkoMtx = createGkoMtx(sys.matrix());
+    solveVec3RhsComponent<0>(sys.rhs(), x, gkoExec_, factory_, gkoMtx, stats);
+    solveVec3RhsComponent<1>(sys.rhs(), x, gkoExec_, factory_, gkoMtx, stats);
+    solveVec3RhsComponent<2>(sys.rhs(), x, gkoExec_, factory_, gkoMtx, stats);
+    return stats;
+}
 
 template std::shared_ptr<const gko::LinOp>
 createGkoMtx<CSRMatrix<scalar, localIdx>>(const CSRMatrix<scalar, localIdx>&);

--- a/src/linearAlgebra/ginkgo/ginkgoDistributed.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgoDistributed.cpp
@@ -239,8 +239,9 @@ void solveComponentDist(auto& sys, auto& x, auto& exec, auto& factory, auto& sta
     auto nonLocalMtx = COOMatrix<scalar, localIdx> {nonLocalValues, nonLocalSparsity};
 
     const CommunicationPattern& commPattern = sys.commPattern();
-    bool forceHostBuffer = false;
-    auto comm = gko::experimental::mpi::communicator(commPattern.env.comm(), forceHostBuffer);
+    auto comm = gko::experimental::mpi::communicator(
+        commPattern.env.comm(), !commPattern.env.gpuAwareMpi()
+    );
     auto gkoMtx = createGkoMtxDist(exec, comm, mtx, nonLocalMtx, commPattern);
     auto solver = factory->generate(gkoMtx);
     stats.entries.push_back(solve_impl_dist(exec, comm, rhs, xcopy, gkoMtx, std::move(solver)));
@@ -251,9 +252,10 @@ SolverStats GinkgoSolver::solveDist(
     const LinearSystem<scalar, CSRMatrix<scalar, localIdx>>& sys, Vector<scalar>& x
 ) const
 {
-    bool forceHostBuffer = false;
     const CommunicationPattern& commPattern = sys.commPattern();
-    auto comm = gko::experimental::mpi::communicator(commPattern.env.comm(), forceHostBuffer);
+    auto comm = gko::experimental::mpi::communicator(
+        commPattern.env.comm(), !commPattern.env.gpuAwareMpi()
+    );
     auto gkoMtx =
         createGkoMtxDist(gkoExec_, comm, sys.matrix(), sys.offDiagonalMatrix(), commPattern);
     auto solver = factory_->generate(gkoMtx);

--- a/src/linearAlgebra/ginkgo/ginkgoDistributed.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgoDistributed.cpp
@@ -207,7 +207,13 @@ SolverStatsEntry solve_impl_dist(
     solver->add_logger(logger);
     solver->apply(b, x);
 
-    scalar finalResNorm = retrieve(gko::as<vec>(logger->get_residual_norm()));
+    auto rhsCopyFinal = Vector<scalar>(rhs);
+    auto resFinal = gkoVecViewDist(exec, comm, rhsCopyFinal.data(), nrows);
+    mtx->apply(one, x, neg_one, resFinal);
+    auto finalNormVec = gko::initialize<vec>({0.0}, exec);
+    gko::as<dist_vec>(resFinal)->compute_norm2(finalNormVec);
+    scalar finalResNorm = retrieve(finalNormVec);
+
     auto numIter = label(logger->get_num_iterations());
     exec->synchronize();
     auto endEval = std::chrono::steady_clock::now();

--- a/src/linearAlgebra/ginkgo/ginkgoDistributed.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgoDistributed.cpp
@@ -111,51 +111,46 @@ std::shared_ptr<const gko::LinOp> createGkoMtxDist(
         exec, partition, comm.rank(), recv_connections
     );
 
+    // numNonLocalElements: unique remote columns (used as the COO column dimension).
+    // nNonLocalNnz: one entry per processor face (used as the COO nnz).
+    // These differ when a local cell couples to the same remote cell via >1 face.
     const auto numNonLocalElements = imap.get_non_local_size();
+    const auto nNonLocalNnz = static_cast<gko::size_type>(bmtx.values().size());
 
-    auto non_loc_vals = gko::array<scalar>::const_view(
-        exec, static_cast<gko::size_type>(numNonLocalElements), bmtx.values().data()
-    );
+    auto non_loc_vals = gko::array<scalar>::const_view(exec, nNonLocalNnz, bmtx.values().data());
     // rowIdxs() holds global row indices; convert to local (subtract this rank's global offset).
     const auto globalOffset = static_cast<IndexType>(partition->get_range_bounds()[comm.rank()]);
-    gko::array<IndexType> non_loc_row {exec, static_cast<gko::size_type>(numNonLocalElements)};
+    gko::array<IndexType> non_loc_row {exec, nNonLocalNnz};
     {
         auto host = exec->get_master();
         auto srcView = gko::array<IndexType>::const_view(
-            exec,
-            static_cast<gko::size_type>(numNonLocalElements),
-            bmtx.sparsity()->rowIdxs().data()
+            exec, nNonLocalNnz, bmtx.sparsity()->rowIdxs().data()
         );
         auto srcArr = srcView.copy_to_array();
         srcArr.set_executor(host);
-        gko::array<IndexType> hostRow {host, static_cast<gko::size_type>(numNonLocalElements)};
+        gko::array<IndexType> hostRow {host, nNonLocalNnz};
         const auto* srcPtr = srcArr.get_const_data();
         auto* dstPtr = hostRow.get_data();
-        for (gko::size_type i = 0; i < static_cast<gko::size_type>(numNonLocalElements); ++i)
+        for (gko::size_type i = 0; i < nNonLocalNnz; ++i)
             dstPtr[i] = static_cast<IndexType>(srcPtr[i]) - globalOffset;
         non_loc_row = std::move(hostRow);
         non_loc_row.set_executor(exec);
     }
 
-    // Cast colIdxs (global neighbor indices, int32) to int64 for index_map::map_to_local
-    gko::array<global_index_type> non_loc_col {
-        exec, static_cast<gko::size_type>(numNonLocalElements)
-    };
+    // Cast colIdxs (global neighbour indices, int32) to int64 for index_map::map_to_local.
+    // imap deduplicates: multiple faces to the same remote cell map to the same local column.
+    gko::array<global_index_type> non_loc_col {exec, nNonLocalNnz};
     {
         auto host = exec->get_master();
         auto srcView = gko::array<IndexType>::const_view(
-            exec,
-            static_cast<gko::size_type>(numNonLocalElements),
-            bmtx.sparsity()->colIdxs().data()
+            exec, nNonLocalNnz, bmtx.sparsity()->colIdxs().data()
         );
         auto srcArr = srcView.copy_to_array();
         srcArr.set_executor(host);
-        gko::array<global_index_type> hostCol {
-            host, static_cast<gko::size_type>(numNonLocalElements)
-        };
+        gko::array<global_index_type> hostCol {host, nNonLocalNnz};
         const auto* srcPtr = srcArr.get_const_data();
         auto* dstPtr = hostCol.get_data();
-        for (gko::size_type i = 0; i < static_cast<gko::size_type>(numNonLocalElements); ++i)
+        for (gko::size_type i = 0; i < nNonLocalNnz; ++i)
             dstPtr[i] = static_cast<global_index_type>(srcPtr[i]);
         non_loc_col = std::move(hostCol);
         non_loc_col.set_executor(exec);

--- a/src/linearAlgebra/ginkgo/ginkgoDistributed.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgoDistributed.cpp
@@ -119,7 +119,11 @@ std::shared_ptr<const gko::LinOp> createGkoMtxDist(
 
     auto non_loc_vals = gko::array<scalar>::const_view(exec, nNonLocalNnz, bmtx.values().data());
     // rowIdxs() holds global row indices; convert to local (subtract this rank's global offset).
-    const auto globalOffset = static_cast<IndexType>(partition->get_range_bounds()[comm.rank()]);
+    // get_range_bounds() points into the partition's executor memory (device memory when `exec`
+    // is a GPU executor), so it must NOT be indexed directly on the host — doing so dereferences
+    // a device pointer and segfaults on CUDA. Pull the single value off the device safely.
+    const auto globalOffset =
+        static_cast<IndexType>(exec->copy_val_to_host(partition->get_range_bounds() + comm.rank()));
     gko::array<IndexType> non_loc_row {exec, nNonLocalNnz};
     {
         auto host = exec->get_master();

--- a/src/linearAlgebra/ginkgo/ginkgoDistributed.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgoDistributed.cpp
@@ -1,0 +1,277 @@
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#if NF_WITH_GINKGO
+#ifdef NF_WITH_MPI_SUPPORT
+
+#include "NeoN/linearAlgebra/ginkgo.hpp"
+#include "NeoN/distributed/communicationPattern.hpp"
+#include "NeoN/core/vector/vectorFreeFunctions.hpp"
+
+namespace NeoN::la::ginkgo
+{
+
+std::shared_ptr<gko::LinOp> gkoVecViewDist(
+    std::shared_ptr<const gko::Executor> exec,
+    const gko::experimental::mpi::communicator& comm,
+    scalar* ptr,
+    localIdx s
+)
+{
+    using dist_vec = gko::experimental::distributed::Vector<scalar>;
+    using vec = gko::matrix::Dense<scalar>;
+    auto size = static_cast<std::size_t>(s);
+    return gko::share(dist_vec::create(
+        exec,
+        comm,
+        vec::create(exec, gko::dim<2> {size, 1}, gko::array<scalar>::view(exec, size, ptr), 1)
+    ));
+}
+
+std::shared_ptr<const gko::LinOp> gkoConstVecViewDist(
+    std::shared_ptr<const gko::Executor> exec,
+    const gko::experimental::mpi::communicator& comm,
+    const scalar* ptr,
+    localIdx s
+)
+{
+    using dist_vec = gko::experimental::distributed::Vector<scalar>;
+    using vec = gko::matrix::Dense<scalar>;
+    auto size = static_cast<std::size_t>(s);
+    return gko::share(dist_vec::create_const(
+        exec,
+        comm,
+        vec::create_const(
+            exec, gko::dim<2> {size, 1}, gko::array<scalar>::const_view(exec, size, ptr), 1
+        )
+    ));
+}
+
+template<typename IndexType>
+std::shared_ptr<const gko::LinOp> createGkoMtxDist(
+    std::shared_ptr<const gko::Executor> exec,
+    const gko::experimental::mpi::communicator& comm,
+    const CSRMatrix<scalar, IndexType>& mtx,
+    const COOMatrix<scalar, IndexType>& bmtx,
+    const CommunicationPattern& commPattern
+)
+{
+    using global_index_type = gko::int64;
+    using dist_mtx = gko::experimental::distributed::Matrix<scalar, label, global_index_type>;
+
+    auto vals = gko::array<scalar>::const_view(
+        exec, static_cast<gko::size_type>(mtx.values().size()), mtx.values().data()
+    );
+    auto col = gko::array<IndexType>::const_view(
+        exec,
+        static_cast<gko::size_type>(mtx.sparsity()->colIdxs().size()),
+        mtx.sparsity()->colIdxs().data()
+    );
+    auto row = gko::array<IndexType>::const_view(
+        exec,
+        static_cast<gko::size_type>(mtx.sparsity()->rowOffs().size()),
+        mtx.sparsity()->rowOffs().data()
+    );
+
+    auto nrows = static_cast<gko::size_type>(mtx.sparsity()->rows());
+
+    auto partition = gko::share(
+        gko::experimental::distributed::build_partition_from_local_size<label, global_index_type>(
+            exec, comm, nrows
+        )
+    );
+
+    std::shared_ptr<const gko::LinOp> localMtx =
+        gko::share(gko::matrix::Csr<scalar, IndexType>::create_const(
+            exec, gko::dim<2> {nrows, nrows}, std::move(vals), std::move(col), std::move(row)
+        ));
+
+    // recv_connections: global cell indices of neighbor cells (stored in bmtx colIdxs),
+    // cast to int64 as required by gko::experimental::distributed::index_map.
+    const auto& bmtxColIdxs = bmtx.sparsity()->colIdxs();
+    const auto nRecv = static_cast<gko::size_type>(bmtxColIdxs.size());
+
+    gko::array<global_index_type> recv_connections {exec, nRecv};
+    {
+        auto host = exec->get_master();
+        auto srcView = gko::array<IndexType>::const_view(exec, nRecv, bmtxColIdxs.data());
+        auto srcArr = srcView.copy_to_array();
+        srcArr.set_executor(host);
+        gko::array<global_index_type> hostRecv {host, nRecv};
+        const auto* srcPtr = srcArr.get_const_data();
+        auto* dstPtr = hostRecv.get_data();
+        for (gko::size_type i = 0; i < nRecv; ++i)
+            dstPtr[i] = static_cast<global_index_type>(srcPtr[i]);
+        recv_connections = std::move(hostRecv);
+        recv_connections.set_executor(exec);
+    }
+
+    auto imap = gko::experimental::distributed::index_map<label, global_index_type>(
+        exec, partition, comm.rank(), recv_connections
+    );
+
+    const auto numNonLocalElements = imap.get_non_local_size();
+
+    auto non_loc_vals = gko::array<scalar>::const_view(
+        exec, static_cast<gko::size_type>(numNonLocalElements), bmtx.values().data()
+    );
+    // rowIdxs() holds global row indices; convert to local (subtract this rank's global offset).
+    const auto globalOffset = static_cast<IndexType>(partition->get_range_bounds()[comm.rank()]);
+    gko::array<IndexType> non_loc_row {exec, static_cast<gko::size_type>(numNonLocalElements)};
+    {
+        auto host = exec->get_master();
+        auto srcView = gko::array<IndexType>::const_view(
+            exec,
+            static_cast<gko::size_type>(numNonLocalElements),
+            bmtx.sparsity()->rowIdxs().data()
+        );
+        auto srcArr = srcView.copy_to_array();
+        srcArr.set_executor(host);
+        gko::array<IndexType> hostRow {host, static_cast<gko::size_type>(numNonLocalElements)};
+        const auto* srcPtr = srcArr.get_const_data();
+        auto* dstPtr = hostRow.get_data();
+        for (gko::size_type i = 0; i < static_cast<gko::size_type>(numNonLocalElements); ++i)
+            dstPtr[i] = static_cast<IndexType>(srcPtr[i]) - globalOffset;
+        non_loc_row = std::move(hostRow);
+        non_loc_row.set_executor(exec);
+    }
+
+    // Cast colIdxs (global neighbor indices, int32) to int64 for index_map::map_to_local
+    gko::array<global_index_type> non_loc_col {
+        exec, static_cast<gko::size_type>(numNonLocalElements)
+    };
+    {
+        auto host = exec->get_master();
+        auto srcView = gko::array<IndexType>::const_view(
+            exec,
+            static_cast<gko::size_type>(numNonLocalElements),
+            bmtx.sparsity()->colIdxs().data()
+        );
+        auto srcArr = srcView.copy_to_array();
+        srcArr.set_executor(host);
+        gko::array<global_index_type> hostCol {
+            host, static_cast<gko::size_type>(numNonLocalElements)
+        };
+        const auto* srcPtr = srcArr.get_const_data();
+        auto* dstPtr = hostCol.get_data();
+        for (gko::size_type i = 0; i < static_cast<gko::size_type>(numNonLocalElements); ++i)
+            dstPtr[i] = static_cast<global_index_type>(srcPtr[i]);
+        non_loc_col = std::move(hostCol);
+        non_loc_col.set_executor(exec);
+    }
+
+    auto comp_non_loc_col =
+        imap.map_to_local(non_loc_col, gko::experimental::distributed::index_space::non_local);
+
+    auto nonLocalMtx = gko::share(gko::matrix::Coo<scalar, IndexType>::create_const(
+                                      exec,
+                                      gko::dim<2> {nrows, numNonLocalElements},
+                                      std::move(non_loc_vals),
+                                      comp_non_loc_col.as_const_view(),
+                                      non_loc_row.as_const_view()
+    )
+                                      ->clone());
+
+    return gko::share(dist_mtx::create(
+        exec, comm, imap, std::const_pointer_cast<gko::LinOp>(localMtx), nonLocalMtx
+    ));
+}
+
+SolverStatsEntry solve_impl_dist(
+    std::shared_ptr<const gko::Executor> exec,
+    const gko::experimental::mpi::communicator& comm,
+    const Vector<scalar>& rhs,
+    Vector<scalar>& xIn,
+    std::shared_ptr<const gko::LinOp> mtx,
+    std::unique_ptr<gko::LinOp> solver
+)
+{
+    exec->synchronize();
+    auto startEval = std::chrono::steady_clock::now();
+    using vec = gko::matrix::Dense<scalar>;
+    label nrows = rhs.size();
+
+    const auto b = gkoConstVecViewDist(exec, comm, rhs.data(), nrows);
+    auto x = gkoVecViewDist(exec, comm, xIn.data(), nrows);
+
+    auto rhsCopy = Vector<scalar>(rhs);
+    auto res = gkoVecViewDist(exec, comm, rhsCopy.data(), nrows);
+
+    auto one = gko::initialize<vec>({1.0}, exec);
+    auto neg_one = gko::initialize<vec>({-1.0}, exec);
+    mtx->apply(one, x, neg_one, res);
+
+    auto init = gko::initialize<vec>({0.0}, exec);
+    using dist_vec = gko::experimental::distributed::Vector<scalar>;
+    gko::as<dist_vec>(res)->compute_norm2(init);
+    scalar initResNorm = retrieve(init);
+
+    std::shared_ptr<const gko::log::Convergence<scalar>> logger =
+        gko::log::Convergence<scalar>::create();
+    solver->add_logger(logger);
+    solver->apply(b, x);
+
+    scalar finalResNorm = retrieve(gko::as<vec>(logger->get_residual_norm()));
+    auto numIter = label(logger->get_num_iterations());
+    exec->synchronize();
+    auto endEval = std::chrono::steady_clock::now();
+    auto duration =
+        static_cast<scalar>(
+            std::chrono::duration_cast<std::chrono::microseconds>(endEval - startEval).count()
+        )
+        / 1000.0;
+
+    return {numIter, initResNorm, finalResNorm, duration};
+}
+
+template<unsigned int I>
+void solveComponentDist(auto& sys, auto& x, auto& exec, auto& factory, auto& stats)
+{
+    auto rhs = getComponent<I>(sys.rhs());
+    auto xcopy = getComponent<I>(x);
+    auto values = getComponent<I>(sys.matrix().values());
+    auto sparsity = sys.matrix().sparsity();
+    auto mtx = CSRMatrix<scalar, localIdx> {values, sparsity};
+
+    auto nonLocalValues = getComponent<I>(sys.offDiagonalMatrix().values());
+    auto nonLocalSparsity = sys.offDiagonalMatrix().sparsity();
+    auto nonLocalMtx = COOMatrix<scalar, localIdx> {nonLocalValues, nonLocalSparsity};
+
+    const CommunicationPattern& commPattern = sys.commPattern();
+    bool forceHostBuffer = false;
+    auto comm = gko::experimental::mpi::communicator(commPattern.env.comm(), forceHostBuffer);
+    auto gkoMtx = createGkoMtxDist(exec, comm, mtx, nonLocalMtx, commPattern);
+    auto solver = factory->generate(gkoMtx);
+    stats.entries.push_back(solve_impl_dist(exec, comm, rhs, xcopy, gkoMtx, std::move(solver)));
+    setComponent<I>(xcopy, x);
+}
+
+SolverStats GinkgoSolver::solveDist(
+    const LinearSystem<scalar, CSRMatrix<scalar, localIdx>>& sys, Vector<scalar>& x
+) const
+{
+    bool forceHostBuffer = false;
+    const CommunicationPattern& commPattern = sys.commPattern();
+    auto comm = gko::experimental::mpi::communicator(commPattern.env.comm(), forceHostBuffer);
+    auto gkoMtx =
+        createGkoMtxDist(gkoExec_, comm, sys.matrix(), sys.offDiagonalMatrix(), commPattern);
+    auto solver = factory_->generate(gkoMtx);
+    return {solve_impl_dist(gkoExec_, comm, sys.rhs(), x, gkoMtx, std::move(solver))};
+}
+
+SolverStats GinkgoSolver::solveDist(
+    const LinearSystem<Vec3, CSRMatrix<Vec3, localIdx>>& sys, Vector<Vec3>& x
+) const
+{
+    auto stats = SolverStats {};
+    solveComponentDist<0>(sys, x, gkoExec_, factory_, stats);
+    solveComponentDist<1>(sys, x, gkoExec_, factory_, stats);
+    solveComponentDist<2>(sys, x, gkoExec_, factory_, stats);
+    return stats;
+}
+
+}
+
+#endif // NF_WITH_MPI_SUPPORT
+#endif // NF_WITH_GINKGO

--- a/src/linearAlgebra/ginkgo/ginkgoL1Stop.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgoL1Stop.cpp
@@ -1,0 +1,434 @@
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#include "NeoN/linearAlgebra/ginkgo.hpp"
+
+namespace NeoN::la::ginkgo
+{
+
+#if NF_WITH_GINKGO
+
+class StoppingCriterion
+{
+    using vec = gko::matrix::Dense<scalar>;
+    using mtx = gko::matrix::Csr<scalar>;
+    using val_array = gko::array<scalar>;
+    using idx_array = gko::array<localIdx>;
+
+    using dist_vec = gko::experimental::distributed::Vector<scalar>;
+
+    class DistStoppingCriterion :
+        public gko::EnablePolymorphicObject<DistStoppingCriterion, gko::stop::Criterion>
+    {
+        friend class gko::EnablePolymorphicObject<DistStoppingCriterion, gko::stop::Criterion>;
+        using Criterion = gko::stop::Criterion;
+
+    public:
+
+        GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
+        {
+            /**
+             * Boolean set by the user to stop the iteration process
+             */
+            // TODO check why GKO_FACTORY_PARAMETER_SCALAR does not work
+            scalar GKO_FACTORY_PARAMETER(absolute_tolerance, 1.0e-6);
+
+            scalar GKO_FACTORY_PARAMETER(relative_tolerance, 0.0);
+
+            localIdx GKO_FACTORY_PARAMETER(minIter, 0);
+
+            localIdx GKO_FACTORY_PARAMETER(maxIter, 0);
+
+            localIdx GKO_FACTORY_PARAMETER(frequency, 1);
+
+            std::add_pointer<localIdx>::type GKO_FACTORY_PARAMETER_SCALAR(iter, NULL);
+
+            std::add_pointer<scalar>::type GKO_FACTORY_PARAMETER_SCALAR(time, NULL);
+
+            std::add_pointer<scalar>::type GKO_FACTORY_PARAMETER_SCALAR(residual_norm, NULL);
+
+            std::shared_ptr<vec> GKO_FACTORY_PARAMETER_SCALAR(residual_norms, {});
+
+            std::add_pointer<scalar>::type GKO_FACTORY_PARAMETER_SCALAR(init_residual_norm, NULL);
+
+            localIdx GKO_FACTORY_PARAMETER(verbose, 0);
+
+            bool GKO_FACTORY_PARAMETER(export_res, false);
+
+            std::shared_ptr<const gko::LinOp> GKO_FACTORY_PARAMETER(gkomatrix, {});
+
+            std::shared_ptr<dist_vec> GKO_FACTORY_PARAMETER(x, {});
+
+            std::shared_ptr<dist_vec> GKO_FACTORY_PARAMETER(b, {});
+        };
+
+        GKO_ENABLE_CRITERION_FACTORY(DistStoppingCriterion, parameters, Factory);
+
+        GKO_ENABLE_BUILD_METHOD(Factory);
+
+        /* Compute the SpMV of A with x_ref, where x_ref is a vector containing
+         * the average of x in every row. This is needed to initialise the
+         * normfactor in the first iteration.
+         *  */
+        void compute_Axref_dist(
+            size_t global_size,
+            size_t local_size,
+            std::shared_ptr<const gko::Executor> device_exec,
+            std::shared_ptr<const gko::LinOp> gkomatrix,
+            std::shared_ptr<const dist_vec> x,
+            std::shared_ptr<dist_vec> res
+        ) const;
+
+        /* Compute the normfactor ie || Ax - x* || + || b - x* ||
+         * or rewritten as || r - ( b - x* ) || + || (b - x*) ||
+         *  */
+        scalar compute_normfactor_dist(
+            std::shared_ptr<const gko::Executor> device_exec,
+            const dist_vec* r,
+            std::shared_ptr<const gko::LinOp> gkomatrix,
+            std::shared_ptr<const dist_vec> x,
+            std::shared_ptr<const dist_vec> b
+        ) const;
+
+        /* Implementation of the residual norm check
+         *  */
+        bool check_impl(
+            gko::uint8 stoppingId,
+            bool setFinalized,
+            gko::array<gko::stopping_status>* stop_status,
+            bool* one_changed,
+            const Criterion::Updater& updater
+        ) override;
+
+
+        explicit DistStoppingCriterion(std::shared_ptr<const gko::Executor> exec)
+            : EnablePolymorphicObject<DistStoppingCriterion, Criterion>(std::move(exec))
+        {}
+
+        explicit DistStoppingCriterion(const Factory* factory, const gko::stop::CriterionArgs&)
+
+            : EnablePolymorphicObject<DistStoppingCriterion, Criterion>(factory->get_executor()),
+              parameters_ {factory->get_parameters()}
+        {}
+
+        void set_eval_norm_factor(bool eval_norm_factor) { eval_norm_factor_ = eval_norm_factor; }
+
+        mutable bool first_iter_ = true;
+
+        mutable scalar norm_factor_ = 1;
+
+        mutable bool eval_norm_factor_ = true;
+
+        mutable std::vector<scalar> res_norms_ {};
+    };
+
+    mutable localIdx maxIter_;
+
+    const localIdx minIter_;
+
+    const scalar tolerance_;
+
+    const scalar relTol_;
+
+    const scalar res_norm_eval_;
+
+    const localIdx norm_eval_limit_;
+
+    const localIdx frequency_;
+
+    const scalar relaxationFactor_;
+
+    const bool adapt_minIter_;
+
+    const std::shared_ptr<vec> normalised_res_norms_;
+
+    mutable scalar init_normalised_res_norm_;
+
+    mutable scalar normalised_res_norm_;
+
+    mutable localIdx iter_;
+
+    mutable scalar time_;
+
+public:
+
+    StoppingCriterion(const Dictionary& controlDict)
+        : maxIter_(controlDict.get<localIdx>("maxIter", 1000)),
+          minIter_(controlDict.get<localIdx>("minIter", 0)),
+          tolerance_(controlDict.get<scalar>("tolerance", 1e-6)),
+          relTol_(controlDict.get<scalar>("relTol", 1e-6)),
+          res_norm_eval_(controlDict.get<scalar>("resNormEval", 0.1)),
+          norm_eval_limit_(controlDict.get<localIdx>("normEvalLimit", 100)),
+          frequency_(controlDict.get<localIdx>("evalFrequency", 1)),
+          relaxationFactor_(controlDict.get<scalar>("relaxationFactor", 0.6)),
+          adapt_minIter_(controlDict.get<bool>("adaptMinIter", true)),
+          normalised_res_norms_(gko::share(vec::create(
+              gko::ReferenceExecutor::create(),
+              gko::dim<2> {static_cast<gko::dim<2>::dimension_type>(maxIter_), 1}
+          ))),
+          init_normalised_res_norm_(0), normalised_res_norm_(0), iter_(0), time_(0)
+    {
+        normalised_res_norms_->fill(0.0);
+        if (controlDict.get<std::string>("solver") == "GKOBiCGStab") maxIter_ *= 2;
+    }
+
+    std::shared_ptr<const gko::stop::CriterionFactory> build_dist_stopping_criterion(
+        std::shared_ptr<gko::Executor> device_exec,
+        std::shared_ptr<const gko::LinOp> gkomatrix,
+        std::shared_ptr<dist_vec> x,
+        std::shared_ptr<dist_vec> b,
+        label verbose,
+        bool export_res,
+        label prev_solve_iters,
+        scalar prev_rel_cost
+    ) const
+    {
+        std::string frequencyMode = "optimizer";
+        label minIter = minIter_;
+        label frequency = frequency_;
+        // in case of export_res all residuals need to be computed
+        if (!export_res)
+        {
+            if (prev_solve_iters > 0 && adapt_minIter_ && prev_rel_cost > 0)
+            {
+                minIter = prev_solve_iters * relaxationFactor_;
+                if (frequencyMode == "optimizer")
+                {
+                    auto alpha =
+                        sqrt(1.0 / (prev_solve_iters * (1.0 - relaxationFactor_)) * prev_rel_cost);
+                    frequency = std::min(norm_eval_limit_, std::max(1, localIdx(1 / alpha)));
+                }
+                if (frequencyMode == "relative")
+                {
+                    frequency = localIdx(prev_solve_iters * 0.075) + 1;
+                }
+            }
+        }
+
+        std::string msg = "\nCreating stopping criterion\n\tminIter: " + std::to_string(minIter)
+                        + "\n\tfrequency: " + std::to_string(frequency) + "\n\tprev_solve_iters: "
+                        + std::to_string(prev_solve_iters) + "\n\tadapt_minIter:  "
+                        + std::to_string(adapt_minIter_) + "\n\tprev_rel_cost: ";
+
+        NeoN::Logging::info(msg);
+
+        return DistStoppingCriterion::build()
+            .with_absolute_tolerance(tolerance_)
+            .with_relative_tolerance(relTol_)
+            .with_minIter(minIter)
+            .with_maxIter(maxIter_)
+            .with_frequency(frequency)
+            .with_verbose(verbose)
+            .with_export_res(export_res)
+            .with_init_residual_norm(&init_normalised_res_norm_)
+            .with_residual_norm(&normalised_res_norm_)
+            .with_residual_norms(normalised_res_norms_)
+            .with_iter(&iter_)
+            .with_time(&time_)
+            .with_gkomatrix(gkomatrix)
+            .with_x(x)
+            .with_b(b)
+            .on(device_exec);
+    }
+
+    scalar get_init_res_norm() const { return init_normalised_res_norm_; }
+
+    scalar get_res_norm() const { return normalised_res_norm_; }
+
+    std::shared_ptr<vec> get_res_norms() const { return normalised_res_norms_; }
+
+    label get_is_final() const { return relTol_ == 0.0; }
+
+    label get_num_iters() const { return iter_; }
+
+    scalar get_res_norm_time() const { return time_; }
+};
+
+
+void StoppingCriterion::DistStoppingCriterion::compute_Axref_dist(
+    size_t global_size,
+    size_t local_size,
+    std::shared_ptr<const gko::Executor> device_exec,
+    std::shared_ptr<const gko::LinOp> gkomatrix,
+    std::shared_ptr<const dist_vec> x,
+    std::shared_ptr<dist_vec> res
+) const
+{
+    auto xAvg = gko::initialize<gko::matrix::Dense<scalar>>(1, {0}, device_exec);
+    x->compute_mean(xAvg.get());
+
+    auto xAvg_host = gko::initialize<gko::matrix::Dense<scalar>>(1, {0}, device_exec->get_master());
+    xAvg->move_to(xAvg_host);
+    auto xAvg_vec = gko::share(dist_vec::create(
+        device_exec,
+        x->get_communicator(),
+        gko::dim<2> {global_size, 1},
+        gko::dim<2> {local_size, 1}
+    ));
+    xAvg_vec->fill(xAvg_host->at(0));
+
+    gkomatrix->apply(xAvg_vec.get(), res.get());
+}
+
+scalar StoppingCriterion::DistStoppingCriterion::compute_normfactor_dist(
+    std::shared_ptr<const gko::Executor> device_exec,
+    const dist_vec* r,
+    std::shared_ptr<const gko::LinOp> gkomatrix,
+    std::shared_ptr<const dist_vec> x,
+    std::shared_ptr<const dist_vec> b
+) const
+{
+    // TODO store colA vector
+    auto comm = x->get_communicator();
+
+    gko::dim<2> local_size = x->get_local_vector()->get_size();
+    gko::dim<2> global_size = x->get_size();
+
+    auto Axref = gko::share(dist_vec::create(device_exec, comm, global_size, local_size));
+    Axref->fill(0.0);
+
+    auto start_axref = std::chrono::steady_clock::now();
+    compute_Axref_dist(global_size[0], local_size[0], device_exec, gkomatrix, x, Axref);
+    auto end_axref = std::chrono::steady_clock::now();
+    auto delta_t_axref =
+        std::chrono::duration_cast<std::chrono::microseconds>(end_axref - start_axref).count()
+        / 1.0;
+    // std::cout << __FILE__ << " delta_t_axref " << delta_t_axref << " [mu
+    // s]\n";
+
+    auto unity = gko::initialize<gko::matrix::Dense<scalar>>(1, {1.0}, device_exec);
+
+    auto b_sub_xstar = b->clone();
+    b_sub_xstar->sub_scaled(unity.get(), Axref.get());
+
+    auto norm_part2 = b_sub_xstar->compute_absolute();
+
+    b_sub_xstar->sub_scaled(unity.get(), r);
+
+    b_sub_xstar->compute_absolute_inplace();
+    b_sub_xstar->add_scaled(unity.get(), norm_part2.get());
+
+    auto res = vec::create(device_exec, gko::dim<2> {1});
+    b_sub_xstar->compute_norm1(res.get());
+
+    auto res_host = vec::create(device_exec->get_master(), gko::dim<2> {1});
+    res_host->copy_from(res.get());
+
+    return res_host->get_values()[0] + ROOTVSMALL;
+}
+
+bool StoppingCriterion::DistStoppingCriterion::check_impl(
+    gko::uint8 stoppingId,
+    bool setFinalized,
+    gko::array<gko::stopping_status>* stop_status,
+    bool* one_changed,
+    const Criterion::Updater& updater
+)
+{
+    // Dont check residual norm before minIter is reached
+    if (*(parameters_.iter) > 0 && *(parameters_.iter) < parameters_.minIter)
+    {
+        *(parameters_.iter) += 1;
+        return false;
+    }
+
+    // Only check residual for every frequency iteration
+    if (*(parameters_.iter) % parameters_.frequency != 0)
+    {
+        *(parameters_.iter) += 1;
+        return false;
+    }
+
+    auto start_eval = std::chrono::steady_clock::now();
+    const auto exec = this->get_executor();
+
+    std::shared_ptr<dist_vec> dense_r_vec;
+    // multigrid does not set residual for out iterations
+    if (updater.residual_ == nullptr)
+    {
+        dense_r_vec = parameters_.b->clone();
+
+        auto one {gko::initialize<gko::matrix::Dense<scalar>>({1}, exec)};
+        auto neg_one {gko::initialize<gko::matrix::Dense<scalar>>({-1}, exec)};
+        parameters_.gkomatrix->apply(neg_one, updater.solution_, one, dense_r_vec);
+    }
+
+    const dist_vec* dense_r =
+        (updater.residual_ == nullptr) ? dense_r_vec.get() : gko::as<dist_vec>(updater.residual_);
+
+    auto norm1 = vec::create(exec, gko::dim<2> {1});
+    dense_r->compute_norm1(norm1.get());
+    auto norm1_host = vec::create(exec->get_master(), gko::dim<2> {1});
+    norm1_host->copy_from(norm1.get());
+    scalar residual_norm = norm1_host->at(0);
+    // if (residual_norm != residual_norm) {
+    //     NF_
+    //     FatalErrorInFunction
+    //         << " Problem with residual norm detected: " << residual_norm
+    //         << exit(FatalError);
+    // }
+
+    bool result = false;
+
+    // Store initial residual
+    if (*(parameters_.iter) == 0)
+    {
+        //
+        if (eval_norm_factor_)
+        {
+            norm_factor_ = compute_normfactor_dist(
+                exec, dense_r, parameters_.gkomatrix, parameters_.x, parameters_.b
+            );
+        }
+
+        *(parameters_.init_residual_norm) = residual_norm / norm_factor_;
+    }
+
+    residual_norm /= norm_factor_;
+
+
+    if (parameters_.export_res)
+    {
+        parameters_.residual_norms->at(*(parameters_.iter)) = residual_norm;
+    }
+
+    *(parameters_.residual_norm) = residual_norm;
+
+    scalar init_residual = *(parameters_.init_residual_norm);
+
+    // stop if maximum number of iterations was reached
+    if (*(parameters_.iter) >= parameters_.maxIter)
+    {
+        result = true;
+    }
+    // check if absolute tolerance is hit
+    if (residual_norm < parameters_.absolute_tolerance)
+    {
+        result = true;
+    }
+    // check if relative tolerance is hit
+    if (parameters_.relative_tolerance > 0
+        && residual_norm < parameters_.relative_tolerance * init_residual)
+    {
+        result = true;
+    }
+
+    if (result)
+    {
+        this->set_all_statuses(stoppingId, setFinalized, stop_status);
+        *one_changed = true;
+    }
+
+    *(parameters_.iter) += 1;
+
+    auto end_eval = std::chrono::steady_clock::now();
+    *(parameters_.time) =
+        std::chrono::duration_cast<std::chrono::microseconds>(end_eval - start_eval).count() / 1.0;
+    // std::cout << __FILE__ << "time " << *(parameters_.time) << " [mu s]\n";
+    return result;
+}
+
+#endif
+
+} // namespace Foam

--- a/test/distributed/operator.cpp
+++ b/test/distributed/operator.cpp
@@ -12,7 +12,7 @@ using Catch::randomizeVector;
 namespace NeoN
 {
 
-auto generateInput = [](std::string scheme, std::string post)
+auto GENERATE_INPUT = [](std::string scheme, std::string post)
 {
     auto constructDiv = [](auto post) { return "div(phi" + post + ",U" + post + ")"; };
     auto constructGamma = [](auto post) { return "laplacian(gamma" + post + ",U" + post + ")"; };
@@ -38,15 +38,15 @@ TEST_CASE("Distributed Operator")
 
     auto [execName, exec] = GENERATE(allAvailableExecutor());
 
-    auto input = generateInput("upwind", "");
-    auto inputPart = generateInput("upwind", "Part");
+    auto input = GENERATE_INPUT("upwind", "");
+    auto inputPart = GENERATE_INPUT("upwind", "Part");
 
     auto nCells = 12;
     auto meshGlobal = create1DUniformMesh(exec, nCells);
     auto mesh = create1DUniformMesh(exec, nCells);
 
     auto volBCs = fvcc::createCalculatedBCs<fvcc::VolumeBoundary<scalar>>(mesh);
-    auto U = finiteVolume::cellCentred::VolumeField<scalar>(
+    auto u = finiteVolume::cellCentred::VolumeField<scalar>(
         exec, "U", mesh, Vector<scalar>(exec, nCells, 2.0 * one<scalar>()), volBCs
     );
     auto p = finiteVolume::cellCentred::VolumeField<scalar>(
@@ -54,7 +54,7 @@ TEST_CASE("Distributed Operator")
     );
 
     srand(42);
-    randomizeVector(U);
+    randomizeVector(u);
     randomizeVector(p);
 
     auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<scalar>>(mesh);
@@ -67,7 +67,7 @@ TEST_CASE("Distributed Operator")
     fill(gamma.internalVector(), 2.0);
 
     // assembly on global mesh
-    auto expr = dsl::imp::div(phi, U) - dsl::imp::laplacian(gamma, U);
+    auto expr = dsl::imp::div(phi, u) - dsl::imp::laplacian(gamma, u);
     expr.read(input);
     dsl::SetReference<scalar, localIdx> setRef(0, 0.0);
     auto ls = expr.assemble(mesh, 1.0, 1.0, {&setRef});
@@ -75,7 +75,7 @@ TEST_CASE("Distributed Operator")
     NeoN::mpi::Environment mpiEnviron;
     auto meshPart = create1DUniformMeshPart(exec, meshGlobal.nCells() / mpiEnviron.sizeRank());
 
-    auto uPart = detail::oneDPartitionField(U, meshPart, mpiEnviron);
+    auto uPart = detail::oneDPartitionField(u, meshPart, mpiEnviron);
     auto pPart = detail::oneDPartitionField(p, meshPart, mpiEnviron);
     auto phiPart = detail::oneDPartitionField(phi, meshPart, mpiEnviron);
     auto gammaPart = detail::oneDPartitionField(gamma, meshPart, mpiEnviron);

--- a/test/distributed/operator.cpp
+++ b/test/distributed/operator.cpp
@@ -12,7 +12,7 @@ using Catch::randomizeVector;
 namespace NeoN
 {
 
-auto GENERATE_INPUT = [](std::string scheme, std::string post)
+auto generateInput = [](std::string scheme, std::string post)
 {
     auto constructDiv = [](auto post) { return "div(phi" + post + ",U" + post + ")"; };
     auto constructGamma = [](auto post) { return "laplacian(gamma" + post + ",U" + post + ")"; };
@@ -38,15 +38,15 @@ TEST_CASE("Distributed Operator")
 
     auto [execName, exec] = GENERATE(allAvailableExecutor());
 
-    auto input = GENERATE_INPUT("upwind", "");
-    auto inputPart = GENERATE_INPUT("upwind", "Part");
+    auto input = generateInput("upwind", "");
+    auto inputPart = generateInput("upwind", "Part");
 
     auto nCells = 12;
     auto meshGlobal = create1DUniformMesh(exec, nCells);
     auto mesh = create1DUniformMesh(exec, nCells);
 
     auto volBCs = fvcc::createCalculatedBCs<fvcc::VolumeBoundary<scalar>>(mesh);
-    auto u = finiteVolume::cellCentred::VolumeField<scalar>(
+    auto U = finiteVolume::cellCentred::VolumeField<scalar>(
         exec, "U", mesh, Vector<scalar>(exec, nCells, 2.0 * one<scalar>()), volBCs
     );
     auto p = finiteVolume::cellCentred::VolumeField<scalar>(
@@ -54,7 +54,7 @@ TEST_CASE("Distributed Operator")
     );
 
     srand(42);
-    randomizeVector(u);
+    randomizeVector(U);
     randomizeVector(p);
 
     auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<scalar>>(mesh);
@@ -67,14 +67,16 @@ TEST_CASE("Distributed Operator")
     fill(gamma.internalVector(), 2.0);
 
     // assembly on global mesh
-    auto expr = dsl::imp::div(phi, u) - dsl::imp::laplacian(gamma, u);
+    auto expr = dsl::imp::div(phi, U) - dsl::imp::laplacian(gamma, U);
     expr.read(input);
-    auto ls = expr.assemble(mesh, 1.0, 1.0);
+    dsl::SetReference<scalar, localIdx> setRef(0, 0.0);
+    auto ls = expr.assemble(mesh, 1.0, 1.0, {&setRef});
 
     NeoN::mpi::Environment mpiEnviron;
     auto meshPart = create1DUniformMeshPart(exec, meshGlobal.nCells() / mpiEnviron.sizeRank());
 
-    auto uPart = detail::oneDPartitionField(u, meshPart, mpiEnviron);
+    auto uPart = detail::oneDPartitionField(U, meshPart, mpiEnviron);
+    auto pPart = detail::oneDPartitionField(p, meshPart, mpiEnviron);
     auto phiPart = detail::oneDPartitionField(phi, meshPart, mpiEnviron);
     auto gammaPart = detail::oneDPartitionField(gamma, meshPart, mpiEnviron);
 
@@ -82,7 +84,7 @@ TEST_CASE("Distributed Operator")
 
     exprDist.read(inputPart);
 
-    auto lsDst = exprDist.assemble(meshPart, 1.0, 1.0);
+    auto lsDst = exprDist.assemble(meshPart, 1.0, 1.0, {&setRef});
 
     fill(ls.rhs(), 2.0);
     fill(lsDst.rhs(), 2.0);
@@ -157,8 +159,8 @@ TEST_CASE("Distributed Operator")
 #if NF_WITH_GINKGO
     Dictionary solverDict {
         {{"solver", std::string {"Ginkgo"}},
-         {"type", "solver::Cg"},
-         {"criteria", Dictionary {{{"iteration", 3}, {"relative_residual_norm", 1e-7}}}}}
+         {"type", "solver::Gmres"},
+         {"criteria", Dictionary {{{"iteration", 200}, {"relative_residual_norm", 1e-7}}}}}
     };
 
     auto solver = NeoN::la::Solver(exec, solverDict);
@@ -171,14 +173,23 @@ TEST_CASE("Distributed Operator")
     auto solverStats = solver.solve(ls, x);
     auto solverStatsDist = solver.solve(lsDst, xPart);
 
-    auto [numIterDist, initResNormDist, finalResNormDist, solveTimeDist] =
-        solverStatsDist.entries[0];
-    auto [numIter, initResNorm, finalResNorm, solveTime] = solverStats.entries[0];
+    scalar finalResNorm = solverStats.entries[0].finalResNorm;
+    scalar finalResNormDist = solverStatsDist.entries[0].finalResNorm;
 
-    // TODO: add solution and residual norm checks once MPI-distributed Ginkgo solve is supported.
-    // The local solver operates per-rank; a global distributed solve requires MPI communication
-    // during CG iterations which is not yet implemented.
-    REQUIRE(numIterDist != 0);
+    REQUIRE(finalResNormDist == Catch::Approx(finalResNorm).margin(1e-6));
+
+    SECTION_IF(mpiEnviron.rank() == 0, "Correct solution on rank 0")
+    {
+        REQUIRE_THAT(xPart, Equals(take(x, {0, 4}), Approx {1e-4}));
+    }
+    SECTION_IF(mpiEnviron.rank() == 1, "Correct solution on rank 1")
+    {
+        REQUIRE_THAT(xPart, Equals(take(x, {4, 8}), Approx {1e-4}));
+    }
+    SECTION_IF(mpiEnviron.rank() == 2, "Correct solution on rank 2")
+    {
+        REQUIRE_THAT(xPart, Equals(take(x, {8, 12}), Approx {1e-4}));
+    }
 #endif
 }
 

--- a/test/linearAlgebra/ginkgo.cpp
+++ b/test/linearAlgebra/ginkgo.cpp
@@ -90,6 +90,60 @@ TEST_CASE("Dictionary Parsing - Ginkgo")
     }
 }
 
+TEST_CASE("gkoVecView - Ginkgo")
+{
+    NeoN::Executor exec = NeoN::SerialExecutor {};
+    auto gkoExec = NeoN::la::ginkgo::getGkoExecutor(exec);
+
+    SECTION("scalar mutable: 1-column non-owning Dense")
+    {
+        localIdx n = 4;
+        Vector<scalar> v(exec, {1.0, 2.0, 3.0, 4.0});
+        auto dense = NeoN::la::ginkgo::gkoVecView(gkoExec, v.data(), n);
+
+        CHECK(dense->get_size()[0] == static_cast<gko::size_type>(n));
+        CHECK(dense->get_size()[1] == gko::size_type {1});
+        CHECK(dense->get_stride() == gko::size_type {1});
+        CHECK(dense->get_values() == v.data());
+    }
+
+    SECTION("scalar const: 1-column non-owning Dense")
+    {
+        localIdx n = 4;
+        const Vector<scalar> v(exec, {1.0, 2.0, 3.0, 4.0});
+        auto dense = NeoN::la::ginkgo::gkoVecView(gkoExec, v.data(), n);
+
+        CHECK(dense->get_size()[0] == static_cast<gko::size_type>(n));
+        CHECK(dense->get_size()[1] == gko::size_type {1});
+        CHECK(dense->get_stride() == gko::size_type {1});
+        CHECK(dense->get_const_values() == v.data());
+    }
+
+    SECTION("Vec3 mutable: 3-column non-owning Dense")
+    {
+        localIdx n = 3;
+        Vector<Vec3> v(exec, {{1.0, 2.0, 3.0}, {4.0, 5.0, 6.0}, {7.0, 8.0, 9.0}});
+        auto dense = NeoN::la::ginkgo::gkoVecView(gkoExec, v.data(), n);
+
+        CHECK(dense->get_size()[0] == static_cast<gko::size_type>(n));
+        CHECK(dense->get_size()[1] == gko::size_type {3});
+        CHECK(dense->get_stride() == gko::size_type {3});
+        CHECK(dense->get_values() == reinterpret_cast<scalar*>(v.data()));
+    }
+
+    SECTION("Vec3 const: 3-column non-owning Dense")
+    {
+        localIdx n = 3;
+        const Vector<Vec3> v(exec, {{1.0, 2.0, 3.0}, {4.0, 5.0, 6.0}, {7.0, 8.0, 9.0}});
+        auto dense = NeoN::la::ginkgo::gkoVecView(gkoExec, v.data(), n);
+
+        CHECK(dense->get_size()[0] == static_cast<gko::size_type>(n));
+        CHECK(dense->get_size()[1] == gko::size_type {3});
+        CHECK(dense->get_stride() == gko::size_type {3});
+        CHECK(dense->get_const_values() == reinterpret_cast<const scalar*>(v.data()));
+    }
+}
+
 TEST_CASE("MatrixConversion - Ginkgo")
 {
     auto [execName, exec] = GENERATE(allAvailableExecutor());
@@ -268,6 +322,50 @@ TEST_CASE("MatrixAssembly - Ginkgo")
                 REQUIRE(initResNorm == Catch::Approx(6.4807406984).margin(1e-8));
                 REQUIRE(finalResNorm < 1.0e-04);
             }
+        }
+
+        SECTION("Solve linear system wo boundary scalar with multiple rhs " + execName)
+        {
+            Vector<scalar> values(exec, {1.0, -0.1, -0.1, 1.0, -0.1, -0.1, 1.0});
+            CSRMatrix<scalar, localIdx> csrMatrix(values, sparsity);
+            Vector<Vec3> rhs(exec, {{1.0, 1.0, 1.0}, {2.0, 2.0, 2.0}, {3.0, 3.0, 3.0}});
+
+            Vector<scalar> bValues(exec, {});
+            COOMatrix<scalar, localIdx> bCsrMatrix(bValues, bSparsity);
+            Vector<Vec3> bRhs(exec, {});
+
+            auto linearSystem = LinearSystem<
+                scalar,
+                NeoN::la::CSRMatrix<scalar, NeoN::localIdx>,
+                NeoN::la::COOMatrix<scalar, NeoN::localIdx>,
+                NeoN::Vec3>(csrMatrix, rhs, bCsrMatrix, bRhs);
+
+            Vector<Vec3> x(exec, {{0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}});
+
+            Dictionary solverDict {
+                {{"solver", std::string {"Ginkgo"}},
+                 {"type", "solver::Cg"},
+                 {"criteria", Dictionary {{{"iteration", 3}, {"relative_residual_norm", 1e-7}}}}}
+            };
+
+            // Create solver
+            auto solver = NeoN::la::Solver(exec, solverDict);
+
+            // Solve system
+            auto solverStats = solver.solve(linearSystem, x);
+            auto [numIter, initResNorm, finalResNorm, solveTime] = solverStats.entries[0];
+
+            auto hostX = x.copyToHost();
+            auto hostXS = hostX.view();
+            for (int c = 0; c < 3; ++c)
+            {
+                REQUIRE((hostXS[0][c]) == Catch::Approx(1.24489796).margin(1e-8));
+                REQUIRE((hostXS[1][c]) == Catch::Approx(2.44897959).margin(1e-8));
+                REQUIRE((hostXS[2][c]) == Catch::Approx(3.24489796).margin(1e-8));
+            }
+            REQUIRE(numIter == 3);
+            REQUIRE(initResNorm == Catch::Approx(3.741657386).margin(1e-8));
+            REQUIRE(finalResNorm < 1.0e-04);
         }
     }
 }


### PR DESCRIPTION
Adds distributed (MPI) Ginkgo solver support to NeoN. The LinearSystem template is extended so the RHS value type can differ from the matrix value type, and it now carries a CommunicationPattern under MPI; Solver::solve dispatches to new solveDist overloads when a non-empty pattern is present. A new ginkgoDistributed.cpp builds a Ginkgo distributed matrix/vector from the local CSR plus the off-diagonal COO and runs scalar (and per-component Vec3) distributed solves. A SetReference post-assembly DSL functor is added to pin a reference cell so pure-Neumann systems are nonsingular, and the distributed operator test now validates the distributed solve against a global one.

## Changes:

- Add distributed Ginkgo matrix assembly + scalar/Vec3 solveDist paths, gated on NF_WITH_GINKGO and NF_WITH_MPI_SUPPORT.
- Generalize LinearSystem with a separate RHSValueType and store/copy a CommunicationPattern; rebuild off-diagonal sparsity in createEmptyLinearSystem from the communication pattern.
- Add SetReference post-assembly hook (pointer-based ps API across Expression/solver) and rework Ginkgo helpers (gkoVecView, retrieve) into the header; also add a (currently unused) StoppingCriterion/DistStoppingCriterion source file.
