### PR TITLE
Distributed Courant number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Add experimental support for cell based assembly strategies [#471](https://github.com/exasim-project/NeoN/pull/471),[#517](https://github.com/exasim-project/NeoN/pull/517)
 - Add experimental support for COO and CSR Matrices [#486](https://github.com/exasim-project/NeoN/pull/486)
 - Add experimental umpire support [#455](https://github.com/exasim-project/NeoN/pull/455)
-- Add experimental MPI support [#519](https://github.com/exasim-project/NeoN/pull/519), [#520](https://github.com/exasim-project/NeoN/pull/520) [#512](https://github.com/exasim-project/NeoN/pull/512)
+- Add experimental MPI support [#519](https://github.com/exasim-project/NeoN/pull/519), [#520](https://github.com/exasim-project/NeoN/pull/520) [#512](https://github.com/exasim-project/NeoN/pull/512) [#525](https://github.com/exasim-project/NeoN/pull/525)
 - Add python bindings via nanobind [#382](https://github.com/exasim-project/NeoN/pull/382)
 - Correct the Ginkgo version to 2.0.0 (unreleased) [#493](https://github.com/exasim-project/NeoN/pull/493)
 - Add tensor and symmTensor primitives, Su type sourceTerm and passing of fields to BCs [#428](https://github.com/exasim-project/NeoN/pull/428)

--- a/include/NeoN/distributed/partitioning.hpp
+++ b/include/NeoN/distributed/partitioning.hpp
@@ -85,6 +85,21 @@ oneDPartitionField(FieldType field, UnstructuredMesh& mesh, NeoN::mpi::Environme
             const localIdx gIdx = weightsHV[bcfacei] > 0 ? firstIdx + localSize : firstIdx - 1;
             retBdHV[bcfacei] = globalInternalHV[gIdx];
         }
+        // Copy physical boundary face values from the global field.
+        // First rank owns the leading global boundary faces; last rank owns the trailing ones.
+        if (nBoundaryFaces > 0)
+        {
+            const localIdx nGlobalBdFaces =
+                static_cast<localIdx>(field.boundaryData().value().size());
+            auto globalBdH = field.boundaryData().value().copyToHost();
+            const auto globalBdHV = globalBdH.view();
+            const bool isFirst = (mpiEnviron.rank() == 0);
+            for (localIdx bfi = 0; bfi < nBoundaryFaces; bfi++)
+            {
+                const localIdx globalBfi = isFirst ? bfi : (nGlobalBdFaces - nBoundaryFaces + bfi);
+                retBdHV[bfi] = globalBdHV[globalBfi];
+            }
+        }
         ret.boundaryData().value() = retBdH.copyToExecutor(field.exec());
     }
 

--- a/include/NeoN/distributed/partitioning.hpp
+++ b/include/NeoN/distributed/partitioning.hpp
@@ -93,6 +93,8 @@ oneDPartitionField(FieldType field, UnstructuredMesh& mesh, NeoN::mpi::Environme
 
 } // namespace detail
 
+using detail::oneDPartitionField;
+
 } // namespace NeoN
 
 #endif

--- a/src/finiteVolume/cellCentred/auxiliary/coNum.cpp
+++ b/src/finiteVolume/cellCentred/auxiliary/coNum.cpp
@@ -12,6 +12,10 @@
 #include "NeoN/finiteVolume/cellCentred/fields/surfaceField.hpp"
 #include "NeoN/finiteVolume/cellCentred/fields/volumeField.hpp"
 #include "NeoN/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp"
+#ifdef NF_WITH_MPI_SUPPORT
+#include "NeoN/core/mpi/environment.hpp"
+#include "NeoN/core/mpi/operators.hpp"
+#endif
 
 namespace NeoN::finiteVolume::cellCentred
 {
@@ -35,6 +39,7 @@ std::pair<scalar, scalar> computeCoNum(const SurfaceField<scalar>& faceFlux, con
     auto nInternalFaces = mesh.nInternalFaces();
     auto nBoundaryFaces = mesh.nBoundaryFaces();
 
+    auto nProcBoundaryFaces = mesh.nProcBoundaryFaces();
     scalar maxCoNum = std::numeric_limits<scalar>::lowest();
     scalar meanCoNum = 0.0;
     parallelFor(
@@ -50,7 +55,7 @@ std::pair<scalar, scalar> computeCoNum(const SurfaceField<scalar>& faceFlux, con
 
     parallelFor(
         exec,
-        {0, nBoundaryFaces},
+        {0, nBoundaryFaces + nProcBoundaryFaces},
         NEON_LAMBDA(const localIdx bfi) {
             auto own = boundaryFaceOwners[bfi];
             scalar flux = Kokkos::sqrt(bFaceFlux[bfi] * bFaceFlux[bfi]);
@@ -91,8 +96,20 @@ std::pair<scalar, scalar> computeCoNum(const SurfaceField<scalar>& faceFlux, con
         sumVol
     );
 
-    maxCoNum = maxReducer.reference() * 0.5 * dt;
-    meanCoNum = 0.5 * (sumPhi.reference() / sumVol.reference()) * dt;
+#ifdef NF_WITH_MPI_SUPPORT
+    if (mesh.boundaryMesh().isDistributed())
+    {
+        mpi::Environment env;
+        mpi::allReduce(maxValue, mpi::ReduceOp::Max, env.comm());
+        scalar sums[2] = {totalPhi, totalVol};
+        MPI_Allreduce(MPI_IN_PLACE, sums, 2, mpi::getType<scalar>(), MPI_SUM, env.comm());
+        totalPhi = sums[0];
+        totalVol = sums[1];
+    }
+#endif
+
+    maxCoNum = maxValue * 0.5 * dt;
+    meanCoNum = 0.5 * (totalPhi / totalVol) * dt;
 
     return {maxCoNum, meanCoNum};
 }

--- a/test/finiteVolume/cellCentred/auxiliary/CMakeLists.txt
+++ b/test/finiteVolume/cellCentred/auxiliary/CMakeLists.txt
@@ -3,3 +3,7 @@
 # SPDX-License-Identifier: Unlicense
 
 neon_unit_test(coNum)
+
+if(NeoN_WITH_MPI)
+  neon_unit_test(coNum_distributed MPI_SIZE 3)
+endif()

--- a/test/finiteVolume/cellCentred/auxiliary/coNum_distributed.cpp
+++ b/test/finiteVolume/cellCentred/auxiliary/coNum_distributed.cpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2025 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#include "catch2_common.hpp"
+
+#include "NeoN/NeoN.hpp"
+
+namespace fvcc = NeoN::finiteVolume::cellCentred;
+
+TEST_CASE("Distributed Courant Number")
+{
+    NeoN::mpi::Environment mpiEnviron;
+
+    auto [execName, exec] = GENERATE(allAvailableExecutor());
+
+    SECTION("distributed computeCoNum matches serial result on partitioned 1D mesh: " + execName)
+    {
+        const NeoN::localIdx nCells = 12; // 3 ranks × 4 cells each
+
+        // Serial reference: non-distributed global mesh, MPI allReduce block is skipped
+        auto meshGlobal = NeoN::create1DUniformMesh(exec, nCells);
+
+        std::vector<fvcc::SurfaceBoundary<NeoN::scalar>> bcsGlobal;
+        for (auto patchi : I<NeoN::localIdx> {0, 1})
+        {
+            NeoN::Dictionary dict;
+            dict.insert("type", std::string("fixedValue"));
+            dict.insert("fixedValue", 1.0);
+            bcsGlobal.push_back(fvcc::SurfaceBoundary<NeoN::scalar>(meshGlobal, dict, patchi));
+        }
+        fvcc::SurfaceField<NeoN::scalar> sfGlobal(exec, "sf", meshGlobal, bcsGlobal);
+        NeoN::fill(sfGlobal.internalVector(), 1.0);
+        sfGlobal.correctBoundaryConditions();
+
+        const auto [maxCoNumRef, meanCoNumRef] = fvcc::computeCoNum(sfGlobal, 0.01);
+
+        // Distributed: each rank owns nCells/sizeRank cells
+        auto meshPart = NeoN::create1DUniformMeshPart(exec, nCells / mpiEnviron.sizeRank());
+        auto sfPart = NeoN::oneDPartitionField(sfGlobal, meshPart, mpiEnviron);
+
+        const auto [maxCoNum, meanCoNum] = fvcc::computeCoNum(sfPart, 0.01);
+
+        REQUIRE(maxCoNum == Catch::Approx(maxCoNumRef));
+        REQUIRE(meanCoNum == Catch::Approx(meanCoNumRef));
+    }
+}


### PR DESCRIPTION
# Motivation

This PR extends the finite-volume cell-centred Courant number utility to produce consistent results on distributed meshes by including processor-boundary faces and performing MPI reductions, and adds a corresponding MPI unit test. taken from https://github.com/exasim-project/NeoN/pull/414.