### PR TITLE
Fix the issue of duplicated boundary mesh data in unstructured mesh

### DIFF
--- a/include/NeoN/finiteVolume/cellCentred/operators/ddtFluxCorr.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/ddtFluxCorr.hpp
@@ -64,11 +64,13 @@ inline void ddtFluxCorrBDF1Kernel(
     auto [outBV, flux0BV, uf0BV] = views(
         fluxCorr.boundaryData().value(), flux0.boundaryData().value(), uf0.boundaryData().value()
     );
+    const auto bFaceNormals = mesh.boundaryMesh().faceNormals().view();
     parallelFor(
         exec,
         {size_t(0), static_cast<size_t>(nBoundaryFaces)},
         NEON_LAMBDA(const localIdx bfi) {
-            const auto d = (SfV[nInternalFaces + bfi] & uf0BV[bfi]);
+            // const auto d = (SfV[nInternalFaces + bfi] & uf0BV[bfi]);
+            const auto d = (bFaceNormals[bfi] & uf0BV[bfi]);
             const auto corr = flux0BV[bfi] - d;
             const scalar limiter = ddtFluxCorrLimiter(mag(flux0BV[bfi]), mag(corr));
             outBV[bfi] = limiter * a1 * corr;
@@ -132,15 +134,18 @@ inline void ddtFluxCorrBDF2Kernel(
         auto flux00BV = flux00.boundaryData().value().view();
         auto uf0BV = uf0.boundaryData().value().view();
         auto uf00BV = uf00.boundaryData().value().view();
-        auto SfV = mesh.faceNormals().view();
+        // auto SfV = mesh.faceNormals().view();
+        const auto bFaceNormals = mesh.boundaryMesh().faceNormals().view();
         parallelFor(
             exec,
             {size_t(0), static_cast<size_t>(nBoundaryFaces)},
             NEON_LAMBDA(const localIdx bfi) {
-                const auto d1 = (SfV[nInternalFaces + bfi] & uf0BV[bfi]);
+                // const auto d1 = (SfV[nInternalFaces + bfi] & uf0BV[bfi]);
+                const auto d1 = (bFaceNormals[bfi] & uf0BV[bfi]);
                 const auto corr1 = flux0BV[bfi] - d1;
 
-                const auto d2 = (SfV[nInternalFaces + bfi] & uf00BV[bfi]);
+                // const auto d2 = (SfV[nInternalFaces + bfi] & uf00BV[bfi]);
+                const auto d2 = (bFaceNormals[bfi] & uf00BV[bfi]);
                 const auto corr2 = flux00BV[bfi] - d2;
 
                 const scalar limiter1 = ddtFluxCorrLimiter(mag(flux0BV[bfi]), mag(corr1));

--- a/include/NeoN/finiteVolume/cellCentred/operators/ddtFluxCorr.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/ddtFluxCorr.hpp
@@ -69,7 +69,6 @@ inline void ddtFluxCorrBDF1Kernel(
         exec,
         {size_t(0), static_cast<size_t>(nBoundaryFaces)},
         NEON_LAMBDA(const localIdx bfi) {
-            // const auto d = (SfV[nInternalFaces + bfi] & uf0BV[bfi]);
             const auto d = (bFaceNormals[bfi] & uf0BV[bfi]);
             const auto corr = flux0BV[bfi] - d;
             const scalar limiter = ddtFluxCorrLimiter(mag(flux0BV[bfi]), mag(corr));
@@ -134,17 +133,14 @@ inline void ddtFluxCorrBDF2Kernel(
         auto flux00BV = flux00.boundaryData().value().view();
         auto uf0BV = uf0.boundaryData().value().view();
         auto uf00BV = uf00.boundaryData().value().view();
-        // auto SfV = mesh.faceNormals().view();
         const auto bFaceNormals = mesh.boundaryMesh().faceNormals().view();
         parallelFor(
             exec,
             {size_t(0), static_cast<size_t>(nBoundaryFaces)},
             NEON_LAMBDA(const localIdx bfi) {
-                // const auto d1 = (SfV[nInternalFaces + bfi] & uf0BV[bfi]);
                 const auto d1 = (bFaceNormals[bfi] & uf0BV[bfi]);
                 const auto corr1 = flux0BV[bfi] - d1;
 
-                // const auto d2 = (SfV[nInternalFaces + bfi] & uf00BV[bfi]);
                 const auto d2 = (bFaceNormals[bfi] & uf00BV[bfi]);
                 const auto corr2 = flux00BV[bfi] - d2;
 

--- a/include/NeoN/mesh/unstructured/uniformMeshDataGenerator.hpp
+++ b/include/NeoN/mesh/unstructured/uniformMeshDataGenerator.hpp
@@ -54,12 +54,12 @@ struct CellData
 
 /** @brief Face geometric and topological data for internal mesh faces
  *
- * Stores face areas, centroids, magnitudes, and owner-neighbour connectivity
+ * Stores face normals, centroids, magnitudes, and owner-neighbour connectivity
  * for all internal faces of a structured 3D uniform mesh.
  */
 struct FaceData
 {
-    std::vector<Vec3> areas;
+    std::vector<Vec3> normals;
     std::vector<Vec3> centers;
     std::vector<scalar> magnitudes;
     std::vector<label> owner;
@@ -88,7 +88,7 @@ CellData generateCellData(const MeshParams& p);
 
 /** @brief Generate internal face data for a 3D uniform mesh
  *
- * Constructs face areas, centers, magnitudes, and owner/neighbour connectivity
+ * Constructs face normals, centers, magnitudes, and owner/neighbour connectivity
  * for all internal faces in x-, y-, and z-directions.
  *
  * Face ordering:

--- a/include/NeoN/mesh/unstructured/uniformMeshDataGenerator.hpp
+++ b/include/NeoN/mesh/unstructured/uniformMeshDataGenerator.hpp
@@ -61,7 +61,7 @@ struct FaceData
 {
     std::vector<Vec3> normals;
     std::vector<Vec3> centers;
-    std::vector<scalar> magnitudes;
+    std::vector<scalar> areas;
     std::vector<label> owner;
     std::vector<label> neighbour;
 };

--- a/src/finiteVolume/cellCentred/operators/gaussGreenGrad.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenGrad.cpp
@@ -70,7 +70,6 @@ void computeGrad(
         {0, nBoundaryFaces},
         NEON_LAMBDA(const localIdx bfi) {
             auto own = boundaryFaceOwners[bfi];
-            // Vec3 valueOwn = faceNormals[nInternalFaces + bfi] * surfPhifB[bfi];
             Vec3 valueOwn = bFaceNormals[bfi] * surfPhifB[bfi];
             Kokkos::atomic_add(&surfGradPhi[own], valueOwn);
         },
@@ -298,8 +297,6 @@ void computeGradTensor(
         {0, nBnd},
         NEON_LAMBDA(const localIdx bi) {
             const auto o = bFaceCells[bi];
-            // TODO Issue #515
-            // const Vec3 sf = SfAll[nInt + bi];
             const Vec3 sf = bFaceNormals[bi];
             const Vec3 faceU = ufBound[bi];
             for (size_t row = 0; row < 3; ++row)

--- a/src/finiteVolume/cellCentred/operators/gaussGreenGrad.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenGrad.cpp
@@ -33,7 +33,7 @@ void computeGrad(
 
     auto surfGradPhi = out.view();
 
-    const auto [boundaryFaceOwners, faceOwners, faceNeighbors, faceAreaS, surfV] = views(
+    const auto [boundaryFaceOwners, faceOwners, faceNeighbors, faceNormals, surfV] = views(
         mesh.boundaryMesh().faceOwners(),
         mesh.faceOwners(),
         mesh.faceNeighbors(),
@@ -56,7 +56,7 @@ void computeGrad(
         exec,
         {0, nInternalFaces},
         NEON_LAMBDA(const localIdx i) {
-            Vec3 flux = faceAreaS[i] * surfPhif[i];
+            Vec3 flux = faceNormals[i] * surfPhif[i];
             Kokkos::atomic_add(&surfGradPhi[faceOwners[i]], flux);    // +S_f * φ_f
             Kokkos::atomic_sub(&surfGradPhi[faceNeighbors[i]], flux); // −S_f * φ_f
         },
@@ -64,12 +64,14 @@ void computeGrad(
     );
 
     // Boundary faces: only the owner cell is on this rank.
+    const auto bFaceNormals = mesh.boundaryMesh().faceNormals().view();
     parallelFor(
         exec,
         {0, nBoundaryFaces},
         NEON_LAMBDA(const localIdx bfi) {
             auto own = boundaryFaceOwners[bfi];
-            Vec3 valueOwn = faceAreaS[nInternalFaces + bfi] * surfPhifB[bfi];
+            // Vec3 valueOwn = faceNormals[nInternalFaces + bfi] * surfPhifB[bfi];
+            Vec3 valueOwn = bFaceNormals[bfi] * surfPhifB[bfi];
             Kokkos::atomic_add(&surfGradPhi[own], valueOwn);
         },
         "computeGradBoundary"
@@ -290,13 +292,15 @@ void computeGradTensor(
         "computeGradTensorInternal"
     );
 
+    const auto bFaceNormals = mesh.boundaryMesh().faceNormals().view();
     parallelFor(
         exec,
         {0, nBnd},
         NEON_LAMBDA(const localIdx bi) {
             const auto o = bFaceCells[bi];
             // TODO Issue #515
-            const Vec3 sf = SfAll[nInt + bi];
+            // const Vec3 sf = SfAll[nInt + bi];
+            const Vec3 sf = bFaceNormals[bi];
             const Vec3 faceU = ufBound[bi];
             for (size_t row = 0; row < 3; ++row)
             {

--- a/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
@@ -68,8 +68,6 @@ void computeLaplacianExp(
         {0, nBoundaryFaces},
         NEON_LAMBDA(const localIdx bfi) {
             auto own = boundaryFaceOwners[bfi];
-            // TODO Issue #515 faceAreas should not contain boundary data
-            // ValueType valueOwn = faceAreas[nInternalFaces + bfi] * fnGradB[bfi];
             ValueType valueOwn = bFaceAreas[bfi] * fnGradB[bfi];
             Kokkos::atomic_add(&result[own], valueOwn);
         },
@@ -176,8 +174,6 @@ void computeLaplacianBoundImpl(
 
             auto refValFrac = valueFraction[bfi];
             auto refGradFrac = 1.0 - refValFrac;
-            // TODO Issue #515 magFaceArea should not contain boundary data
-            // auto flux = bGammaV[bfi] * magFaceArea[nInternalFaces + bfi];
             auto flux = bGammaV[bfi] * bFaceAreas[bfi];
             auto fluxContrib =
                 flux * ownRowCoeff * refValFrac * bDeltaCoeffs[bfi] * one<ValueType>();

--- a/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
@@ -25,7 +25,7 @@ void computeLaplacianExp(
     const auto [owners, neighbors, boundaryFaceOwners] =
         views(mesh.faceOwners(), mesh.faceNeighbors(), mesh.boundaryMesh().faceOwners());
 
-    const auto [result, faceArea, fnGrad, vol] =
+    const auto [result, faceAreas, fnGrad, vol] =
         views(lapPhi, mesh.faceAreas(), faceNormalGrad.internalVector(), mesh.cellVolumes());
     const auto fnGradB = faceNormalGrad.boundaryData().value().view();
 
@@ -47,7 +47,7 @@ void computeLaplacianExp(
         exec,
         {0, nInternalFaces},
         NEON_LAMBDA(const localIdx i) {
-            ValueType flux = faceArea[i] * fnGrad[i];
+            ValueType flux = faceAreas[i] * fnGrad[i];
             Kokkos::atomic_add(
                 &result[owners[i]], flux
             ); // +|S_f| * fnGrad (outward gradient from owner)
@@ -61,14 +61,16 @@ void computeLaplacianExp(
     // Physical (non-proc) boundary faces: only the owner cell is on this rank.
     // For non-proc patches, OpenFOAM's full face index and NeoN's compressed
     // index agree (empty patches like defaultFaces have size()==0 in fvPatch),
-    // so faceArea[i] = mesh.magFaceAreas()[i] is correct here.
+    // so faceAreas[i] = mesh.magFaceAreas()[i] is correct here.
+    const auto bFaceAreas = mesh.boundaryMesh().faceAreas().view();
     parallelFor(
         exec,
         {0, nBoundaryFaces},
         NEON_LAMBDA(const localIdx bfi) {
             auto own = boundaryFaceOwners[bfi];
-            // TODO Issue #515 faceArea should not contain boundary data
-            ValueType valueOwn = faceArea[nInternalFaces + bfi] * fnGradB[bfi];
+            // TODO Issue #515 faceAreas should not contain boundary data
+            // ValueType valueOwn = faceAreas[nInternalFaces + bfi] * fnGradB[bfi];
+            ValueType valueOwn = bFaceAreas[bfi] * fnGradB[bfi];
             Kokkos::atomic_add(&result[own], valueOwn);
         },
         "computeLaplacianExplicitBoundary"
@@ -163,6 +165,7 @@ void computeLaplacianBoundImpl(
 
     const auto nInternalFaces = mesh.nInternalFaces();
     const auto nBoundaryFaces = mesh.nBoundaryFaces();
+    const auto bFaceAreas = mesh.boundaryMesh().faceAreas().view();
     parallelFor(
         exec,
         {0, nBoundaryFaces},
@@ -174,7 +177,8 @@ void computeLaplacianBoundImpl(
             auto refValFrac = valueFraction[bfi];
             auto refGradFrac = 1.0 - refValFrac;
             // TODO Issue #515 magFaceArea should not contain boundary data
-            auto flux = bGammaV[bfi] * magFaceArea[nInternalFaces + bfi];
+            // auto flux = bGammaV[bfi] * magFaceArea[nInternalFaces + bfi];
+            auto flux = bGammaV[bfi] * bFaceAreas[bfi];
             auto fluxContrib =
                 flux * ownRowCoeff * refValFrac * bDeltaCoeffs[bfi] * one<ValueType>();
 

--- a/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
@@ -253,9 +253,7 @@ void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
         {0, mesh_.nBoundaryFaces()},
         NEON_LAMBDA(const localIdx bfi) {
             auto own = surfFaceCells[bfi];
-            // TODO Issue #515
             Vec3 cellToCellDist = bFaceCenters[bfi] - cellCenters[own];
-            // Vec3 faceNormal = 1 / faceAreas[nInternalFaces + bfi] * bFaceNormals[bfi];
             Vec3 faceNormal = 1 / bFaceAreas[bfi] * bFaceNormals[bfi];
             scalar orthoDist = faceNormal & cellToCellDist;
             nonOrthDeltaCoeffB[bfi] = 1.0 / std::max(orthoDist, 0.05 * mag(cellToCellDist));

--- a/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
@@ -224,7 +224,7 @@ void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
         views(mesh_.faceOwners(), mesh_.faceNeighbors(), mesh_.boundaryMesh().faceOwners());
 
 
-    const auto [faceCenters, cellCenters, faceAreaVec3, faceArea] =
+    const auto [faceCenters, cellCenters, faceNormals, faceArea] =
         views(mesh_.faceCenters(), mesh_.cellCenters(), mesh_.faceNormals(), mesh_.faceAreas());
 
     auto nonOrthDeltaCoeff = nonOrthDeltaCoeffs.internalVector().view();
@@ -238,7 +238,7 @@ void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
         {0, nInternalFaces},
         NEON_LAMBDA(const localIdx facei) {
             Vec3 cellToCellDist = cellCenters[neighbors[facei]] - cellCenters[owners[facei]];
-            Vec3 faceNormal = 1 / faceArea[facei] * faceAreaVec3[facei];
+            Vec3 faceNormal = 1 / faceArea[facei] * faceNormals[facei];
             scalar orthoDist = faceNormal & cellToCellDist;
             nonOrthDeltaCoeff[facei] = 1.0 / std::max(orthoDist, 0.05 * mag(cellToCellDist));
         },
@@ -246,16 +246,15 @@ void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
     );
 
     const auto bFaceCenters = mesh_.boundaryMesh().faceCenters().view();
+    const auto bFaceNormals = mesh_.boundaryMesh().faceNormals().view();
     parallelFor(
         exec,
         {0, mesh_.nBoundaryFaces()},
         NEON_LAMBDA(const localIdx bfi) {
             auto own = surfFaceCells[bfi];
             // TODO Issue #515
-            // Vec3 cellToCellDist = faceCenters[nInternalFaces + bfi] - cellCenters[own];
             Vec3 cellToCellDist = bFaceCenters[bfi] - cellCenters[own];
-            Vec3 faceNormal =
-                1 / faceArea[nInternalFaces + bfi] * faceAreaVec3[nInternalFaces + bfi];
+            Vec3 faceNormal = 1 / faceArea[nInternalFaces + bfi] * bFaceNormals[bfi];
             scalar orthoDist = faceNormal & cellToCellDist;
             nonOrthDeltaCoeffB[bfi] = 1.0 / std::max(orthoDist, 0.05 * mag(cellToCellDist));
         },

--- a/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
@@ -224,7 +224,7 @@ void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
         views(mesh_.faceOwners(), mesh_.faceNeighbors(), mesh_.boundaryMesh().faceOwners());
 
 
-    const auto [faceCenters, cellCenters, faceNormals, faceArea] =
+    const auto [faceCenters, cellCenters, faceNormals, faceAreas] =
         views(mesh_.faceCenters(), mesh_.cellCenters(), mesh_.faceNormals(), mesh_.faceAreas());
 
     auto nonOrthDeltaCoeff = nonOrthDeltaCoeffs.internalVector().view();
@@ -238,7 +238,7 @@ void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
         {0, nInternalFaces},
         NEON_LAMBDA(const localIdx facei) {
             Vec3 cellToCellDist = cellCenters[neighbors[facei]] - cellCenters[owners[facei]];
-            Vec3 faceNormal = 1 / faceArea[facei] * faceNormals[facei];
+            Vec3 faceNormal = 1 / faceAreas[facei] * faceNormals[facei];
             scalar orthoDist = faceNormal & cellToCellDist;
             nonOrthDeltaCoeff[facei] = 1.0 / std::max(orthoDist, 0.05 * mag(cellToCellDist));
         },
@@ -247,6 +247,7 @@ void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
 
     const auto bFaceCenters = mesh_.boundaryMesh().faceCenters().view();
     const auto bFaceNormals = mesh_.boundaryMesh().faceNormals().view();
+    const auto bFaceAreas = mesh_.boundaryMesh().faceAreas().view();
     parallelFor(
         exec,
         {0, mesh_.nBoundaryFaces()},
@@ -254,7 +255,8 @@ void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
             auto own = surfFaceCells[bfi];
             // TODO Issue #515
             Vec3 cellToCellDist = bFaceCenters[bfi] - cellCenters[own];
-            Vec3 faceNormal = 1 / faceArea[nInternalFaces + bfi] * bFaceNormals[bfi];
+            // Vec3 faceNormal = 1 / faceAreas[nInternalFaces + bfi] * bFaceNormals[bfi];
+            Vec3 faceNormal = 1 / bFaceAreas[bfi] * bFaceNormals[bfi];
             scalar orthoDist = faceNormal & cellToCellDist;
             nonOrthDeltaCoeffB[bfi] = 1.0 / std::max(orthoDist, 0.05 * mag(cellToCellDist));
         },

--- a/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
@@ -185,7 +185,7 @@ void BasicGeometryScheme::updateDeltaCoeffs(
         views(mesh_.faceOwners(), mesh_.faceNeighbors(), mesh_.boundaryMesh().faceOwners());
 
 
-    const auto [faceCenters, cellCenters] =
+    const auto [bFaceCenters, cellCenters] =
         views(mesh_.boundaryMesh().faceCenters(), mesh_.cellCenters());
 
     auto deltaCoeff = deltaCoeffs.internalVector().view();
@@ -208,8 +208,7 @@ void BasicGeometryScheme::updateDeltaCoeffs(
         {0, mesh_.nBoundaryFaces()},
         NEON_LAMBDA(const localIdx bfi) {
             auto own = surfFaceCells[bfi];
-            // TODO Issue #515
-            Vec3 cellToFaceDist = faceCenters[bfi] - cellCenters[own];
+            Vec3 cellToFaceDist = bFaceCenters[bfi] - cellCenters[own];
             deltaCoeffB[bfi] = 1.0 / std::max(mag(cellToFaceDist), scalar(ROOTVSMALL));
         },
         "basicGeometricScheme::updateDeltaCoeffsBoundary"
@@ -246,13 +245,15 @@ void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
         "basicGeometricScheme::updateNonOrthDeltaCoeffsInternal"
     );
 
+    const auto bFaceCenters = mesh_.boundaryMesh().faceCenters().view();
     parallelFor(
         exec,
         {0, mesh_.nBoundaryFaces()},
         NEON_LAMBDA(const localIdx bfi) {
             auto own = surfFaceCells[bfi];
             // TODO Issue #515
-            Vec3 cellToCellDist = faceCenters[nInternalFaces + bfi] - cellCenters[own];
+            // Vec3 cellToCellDist = faceCenters[nInternalFaces + bfi] - cellCenters[own];
+            Vec3 cellToCellDist = bFaceCenters[bfi] - cellCenters[own];
             Vec3 faceNormal =
                 1 / faceArea[nInternalFaces + bfi] * faceAreaVec3[nInternalFaces + bfi];
             scalar orthoDist = faceNormal & cellToCellDist;

--- a/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/basicGeometryScheme.cpp
@@ -238,8 +238,8 @@ void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
         {0, nInternalFaces},
         NEON_LAMBDA(const localIdx facei) {
             Vec3 cellToCellDist = cellCenters[neighbors[facei]] - cellCenters[owners[facei]];
-            Vec3 faceNormal = 1 / faceAreas[facei] * faceNormals[facei];
-            scalar orthoDist = faceNormal & cellToCellDist;
+            Vec3 faceUnitNormal = 1 / faceAreas[facei] * faceNormals[facei];
+            scalar orthoDist = faceUnitNormal & cellToCellDist;
             nonOrthDeltaCoeff[facei] = 1.0 / std::max(orthoDist, 0.05 * mag(cellToCellDist));
         },
         "basicGeometricScheme::updateNonOrthDeltaCoeffsInternal"
@@ -254,8 +254,8 @@ void BasicGeometryScheme::updateNonOrthDeltaCoeffs(
         NEON_LAMBDA(const localIdx bfi) {
             auto own = surfFaceCells[bfi];
             Vec3 cellToCellDist = bFaceCenters[bfi] - cellCenters[own];
-            Vec3 faceNormal = 1 / bFaceAreas[bfi] * bFaceNormals[bfi];
-            scalar orthoDist = faceNormal & cellToCellDist;
+            Vec3 bFaceUnitNormal = 1 / bFaceAreas[bfi] * bFaceNormals[bfi];
+            scalar orthoDist = bFaceUnitNormal & cellToCellDist;
             nonOrthDeltaCoeffB[bfi] = 1.0 / std::max(orthoDist, 0.05 * mag(cellToCellDist));
         },
         "basicGeometricScheme::updateNonOrthDeltaCoeffsBoundary"

--- a/src/mesh/unstructured/distributedUnstructuredMesh.cpp
+++ b/src/mesh/unstructured/distributedUnstructuredMesh.cpp
@@ -93,7 +93,7 @@ UnstructuredMesh create1DUniformMeshPart(const Executor exec, const localIdx nCe
 
     // For the last rank, the baseMesh boundary faces need to be physically swapped so
     // that regular (xmax) comes before the proc face in the internal face arrays.
-    auto faceCentersH = baseMesh.faceCenters().copyToHost();
+    /* auto faceCentersH = baseMesh.faceCenters().copyToHost();
     auto faceNormalsH = baseMesh.faceNormals().copyToHost();
     if (isLast)
     {
@@ -119,6 +119,20 @@ UnstructuredMesh create1DUniformMeshPart(const Executor exec, const localIdx nCe
         faceCentersPart,
         faceAreasPart,
         faceOwnersPart,
+        baseMesh.faceNeighbors(),
+        std::move(boundaryMesh)
+    );
+    */
+
+    UnstructuredMesh mesh(
+        exec,
+        baseMesh.points(),
+        baseMesh.cellVolumes(),
+        baseMesh.cellCenters(),
+        baseMesh.faceNormals(),
+        baseMesh.faceCenters(),
+        baseMesh.faceAreas(),
+        baseMesh.faceOwners(),
         baseMesh.faceNeighbors(),
         std::move(boundaryMesh)
     );

--- a/src/mesh/unstructured/distributedUnstructuredMesh.cpp
+++ b/src/mesh/unstructured/distributedUnstructuredMesh.cpp
@@ -93,37 +93,6 @@ UnstructuredMesh create1DUniformMeshPart(const Executor exec, const localIdx nCe
 
     // For the last rank, the baseMesh boundary faces need to be physically swapped so
     // that regular (xmax) comes before the proc face in the internal face arrays.
-    /* auto faceCentersH = baseMesh.faceCenters().copyToHost();
-    auto faceNormalsH = baseMesh.faceNormals().copyToHost();
-    if (isLast)
-    {
-        const auto localCells = baseMesh.nCells();
-        std::swap(faceCentersH.view()[localCells - 1], faceCentersH.view()[localCells]);
-        faceNormalsH.view()[localCells - 1] = {1.0, 0.0, 0.0}; // xmax
-        faceNormalsH.view()[localCells] = {-1.0, 0.0, 0.0};    // proc left
-    }
-
-    const localIdx nFacesPart = baseMesh.nInternalFaces() + nRegularBoundary;
-
-    auto faceCentersPart = take(faceCentersH.copyToExecutor(exec), {0, nFacesPart});
-    auto faceNormalsPart = take(faceNormalsH.copyToExecutor(exec), {0, nFacesPart});
-    auto faceAreasPart = take(baseMesh.faceAreas(), {0, nFacesPart});
-    auto faceOwnersPart = take(baseMesh.faceOwners(), {0, nFacesPart});
-
-    UnstructuredMesh mesh(
-        exec,
-        baseMesh.points(),
-        baseMesh.cellVolumes(),
-        baseMesh.cellCenters(),
-        faceNormalsPart,
-        faceCentersPart,
-        faceAreasPart,
-        faceOwnersPart,
-        baseMesh.faceNeighbors(),
-        std::move(boundaryMesh)
-    );
-    */
-
     UnstructuredMesh mesh(
         exec,
         baseMesh.points(),

--- a/src/mesh/unstructured/uniformMeshDataGenerator.cpp
+++ b/src/mesh/unstructured/uniformMeshDataGenerator.cpp
@@ -164,7 +164,7 @@ BoundaryMesh generateBoundaryData(
 
         faces.normals[fi] = faceNormal;
         faces.centers[fi] = faceCentre;
-        faces.magnitudes[fi] = magA;
+        faces.areas[fi] = magA;
         faces.owner[fi] = ciLabel;
 
         bndFaceOwners[sz] = ciLabel;

--- a/src/mesh/unstructured/uniformMeshDataGenerator.cpp
+++ b/src/mesh/unstructured/uniformMeshDataGenerator.cpp
@@ -164,7 +164,7 @@ BoundaryMesh generateBoundaryData(
 
         // faces.normals[fi] = faceNormal;
         // faces.centers[fi] = faceCenter;
-        faces.areas[fi] = magA;
+        // faces.areas[fi] = magA;
         faces.owner[fi] = ciLabel;
 
         bndFaceOwners[sz] = ciLabel;

--- a/src/mesh/unstructured/uniformMeshDataGenerator.cpp
+++ b/src/mesh/unstructured/uniformMeshDataGenerator.cpp
@@ -53,7 +53,8 @@ generateInternalFaces(const MeshParams& p, const localIdx nInternalFaces, const 
     std::vector<Vec3> fAreas(static_cast<size_t>(nFaces));
     std::vector<Vec3> fCenters(static_cast<size_t>(nFaces));
     std::vector<scalar> fMag(static_cast<size_t>(nFaces));
-    std::vector<label> fOwner(static_cast<size_t>(nFaces));
+    // std::vector<label> fOwner(static_cast<size_t>(nFaces));
+    std::vector<label> fOwner(static_cast<size_t>(nInternalFaces));
     std::vector<label> fNeighbour(static_cast<size_t>(nInternalFaces));
 
     localIdx faceId = 0;
@@ -165,7 +166,7 @@ BoundaryMesh generateBoundaryData(
         // faces.normals[fi] = faceNormal;
         // faces.centers[fi] = faceCenter;
         // faces.areas[fi] = magA;
-        faces.owner[fi] = ciLabel;
+        // faces.owner[fi] = ciLabel;
 
         bndFaceOwners[sz] = ciLabel;
         bndFaceCenters[sz] = faceCenter;

--- a/src/mesh/unstructured/uniformMeshDataGenerator.cpp
+++ b/src/mesh/unstructured/uniformMeshDataGenerator.cpp
@@ -50,10 +50,9 @@ CellData generateCellData(const MeshParams& p)
 FaceData
 generateInternalFaces(const MeshParams& p, const localIdx nInternalFaces, const localIdx nFaces)
 {
-    std::vector<Vec3> fAreas(static_cast<size_t>(nFaces));
-    std::vector<Vec3> fCenters(static_cast<size_t>(nFaces));
-    std::vector<scalar> fMag(static_cast<size_t>(nFaces));
-    // std::vector<label> fOwner(static_cast<size_t>(nFaces));
+    std::vector<Vec3> fAreas(static_cast<size_t>(nInternalFaces));
+    std::vector<Vec3> fCenters(static_cast<size_t>(nInternalFaces));
+    std::vector<scalar> fMag(static_cast<size_t>(nInternalFaces));
     std::vector<label> fOwner(static_cast<size_t>(nInternalFaces));
     std::vector<label> fNeighbour(static_cast<size_t>(nInternalFaces));
 

--- a/src/mesh/unstructured/uniformMeshDataGenerator.cpp
+++ b/src/mesh/unstructured/uniformMeshDataGenerator.cpp
@@ -162,11 +162,6 @@ BoundaryMesh generateBoundaryData(
         Vec3 faceUnitNormal = faceNormal * (1.0 / magA);
         Vec3 delta = faceCenter - centers[ciSizeT];
 
-        // faces.normals[fi] = faceNormal;
-        // faces.centers[fi] = faceCenter;
-        // faces.areas[fi] = magA;
-        // faces.owner[fi] = ciLabel;
-
         bndFaceOwners[sz] = ciLabel;
         bndFaceCenters[sz] = faceCenter;
         bndCellCenters[sz] = centers[ciSizeT];

--- a/src/mesh/unstructured/uniformMeshDataGenerator.cpp
+++ b/src/mesh/unstructured/uniformMeshDataGenerator.cpp
@@ -162,7 +162,7 @@ BoundaryMesh generateBoundaryData(
         Vec3 faceUnitNormal = faceNormal * (1.0 / magA);
         Vec3 delta = faceCenter - centers[ciSizeT];
 
-        faces.normals[fi] = faceNormal;
+        // faces.normals[fi] = faceNormal;
         // faces.centers[fi] = faceCenter;
         faces.areas[fi] = magA;
         faces.owner[fi] = ciLabel;

--- a/src/mesh/unstructured/uniformMeshDataGenerator.cpp
+++ b/src/mesh/unstructured/uniformMeshDataGenerator.cpp
@@ -152,17 +152,17 @@ BoundaryMesh generateBoundaryData(
 
     localIdx faceId = nInternalFaces;
 
-    auto addBndFace = [&](localIdx bndId, localIdx ci, Vec3 area, Vec3 faceCentre)
+    auto addBndFace = [&](localIdx bndId, localIdx ci, Vec3 faceNormal, Vec3 faceCentre)
     {
         auto sz = static_cast<size_t>(bndId);
         auto fi = static_cast<size_t>(faceId);
         auto ciSizeT = static_cast<size_t>(ci);
         auto ciLabel = static_cast<label>(ci);
-        scalar magA = mag(area);
-        Vec3 normal = area * (1.0 / magA);
+        scalar magA = mag(faceNormal);
+        Vec3 faceUnitNormal = faceNormal * (1.0 / magA);
         Vec3 delta = faceCentre - centers[ciSizeT];
 
-        faces.areas[fi] = area;
+        faces.normals[fi] = faceNormal;
         faces.centers[fi] = faceCentre;
         faces.magnitudes[fi] = magA;
         faces.owner[fi] = ciLabel;
@@ -170,9 +170,9 @@ BoundaryMesh generateBoundaryData(
         bndFaceOwners[sz] = ciLabel;
         bndFaceCenters[sz] = faceCentre;
         bndCellCenters[sz] = centers[ciSizeT];
-        bndFaceNormals[sz] = area;
+        bndFaceNormals[sz] = faceNormal;
         bndFaceAreas[sz] = magA;
-        bndFaceUnitNormals[sz] = normal;
+        bndFaceUnitNormals[sz] = faceUnitNormal;
         bndDelta[sz] = delta;
         bndDeltaCoeffs[sz] = 1.0 / mag(delta);
     };

--- a/src/mesh/unstructured/uniformMeshDataGenerator.cpp
+++ b/src/mesh/unstructured/uniformMeshDataGenerator.cpp
@@ -152,7 +152,7 @@ BoundaryMesh generateBoundaryData(
 
     localIdx faceId = nInternalFaces;
 
-    auto addBndFace = [&](localIdx bndId, localIdx ci, Vec3 faceNormal, Vec3 faceCentre)
+    auto addBndFace = [&](localIdx bndId, localIdx ci, Vec3 faceNormal, Vec3 faceCenter)
     {
         auto sz = static_cast<size_t>(bndId);
         auto fi = static_cast<size_t>(faceId);
@@ -160,15 +160,15 @@ BoundaryMesh generateBoundaryData(
         auto ciLabel = static_cast<label>(ci);
         scalar magA = mag(faceNormal);
         Vec3 faceUnitNormal = faceNormal * (1.0 / magA);
-        Vec3 delta = faceCentre - centers[ciSizeT];
+        Vec3 delta = faceCenter - centers[ciSizeT];
 
         faces.normals[fi] = faceNormal;
-        faces.centers[fi] = faceCentre;
+        faces.centers[fi] = faceCenter;
         faces.areas[fi] = magA;
         faces.owner[fi] = ciLabel;
 
         bndFaceOwners[sz] = ciLabel;
-        bndFaceCenters[sz] = faceCentre;
+        bndFaceCenters[sz] = faceCenter;
         bndCellCenters[sz] = centers[ciSizeT];
         bndFaceNormals[sz] = faceNormal;
         bndFaceAreas[sz] = magA;

--- a/src/mesh/unstructured/uniformMeshDataGenerator.cpp
+++ b/src/mesh/unstructured/uniformMeshDataGenerator.cpp
@@ -163,7 +163,7 @@ BoundaryMesh generateBoundaryData(
         Vec3 delta = faceCenter - centers[ciSizeT];
 
         faces.normals[fi] = faceNormal;
-        faces.centers[fi] = faceCenter;
+        // faces.centers[fi] = faceCenter;
         faces.areas[fi] = magA;
         faces.owner[fi] = ciLabel;
 

--- a/src/mesh/unstructured/unstructuredMesh.cpp
+++ b/src/mesh/unstructured/unstructuredMesh.cpp
@@ -267,7 +267,7 @@ UnstructuredMesh create3DUniformMesh(
         vectorVector(exec, std::move(cellCenters)),
         {exec, std::move(faces.normals)},
         {exec, std::move(faces.centers)},
-        {exec, std::move(faces.magnitudes)},
+        {exec, std::move(faces.areas)},
         {exec, std::move(faces.owner)},
         labelVector(exec, std::move(faces.neighbour)),
         std::move(boundaryMesh)

--- a/src/mesh/unstructured/unstructuredMesh.cpp
+++ b/src/mesh/unstructured/unstructuredMesh.cpp
@@ -265,7 +265,7 @@ UnstructuredMesh create3DUniformMesh(
         vectorVector(exec, std::move(points)),
         scalarVector(exec, std::move(cellVolumes)),
         vectorVector(exec, std::move(cellCenters)),
-        {exec, std::move(faces.areas)},
+        {exec, std::move(faces.normals)},
         {exec, std::move(faces.centers)},
         {exec, std::move(faces.magnitudes)},
         {exec, std::move(faces.owner)},

--- a/test/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
+++ b/test/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
@@ -63,7 +63,7 @@ TEMPLATE_TEST_CASE("uncorrected", "[template]", NeoN::scalar, NeoN::Vec3)
         auto sPhifB = phifBHost.view();
         // left boundary (bfi=0): gradient is -10.0
         REQUIRE(NeoN::mag(sPhifB[0] + 10.0 * one<TestType>()) == Catch::Approx(0.0).margin(1e-8));
-        // right boundary (bfi=1): gradient is 10.0uncorrectr
+        // right boundary (bfi=1): gradient is 10.0
         REQUIRE(NeoN::mag(sPhifB[1] - 10.0 * one<TestType>()) == Catch::Approx(0.0).margin(1e-8));
     }
 }

--- a/test/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
+++ b/test/finiteVolume/cellCentred/faceNormalGradient/uncorrected.cpp
@@ -63,7 +63,7 @@ TEMPLATE_TEST_CASE("uncorrected", "[template]", NeoN::scalar, NeoN::Vec3)
         auto sPhifB = phifBHost.view();
         // left boundary (bfi=0): gradient is -10.0
         REQUIRE(NeoN::mag(sPhifB[0] + 10.0 * one<TestType>()) == Catch::Approx(0.0).margin(1e-8));
-        // right boundary (bfi=1): gradient is 10.0
+        // right boundary (bfi=1): gradient is 10.0uncorrectr
         REQUIRE(NeoN::mag(sPhifB[1] - 10.0 * one<TestType>()) == Catch::Approx(0.0).margin(1e-8));
     }
 }

--- a/test/mesh/unstructured/unstructuredMesh.cpp
+++ b/test/mesh/unstructured/unstructuredMesh.cpp
@@ -55,8 +55,8 @@ TEST_CASE("Unstructured Mesh")
         };
         REQUIRE_THAT(mesh.cellCenters(), Equals(cellCentersExp, Approx {1e-12}));
 
-        // Verify face owners (x-direction)
-        auto faceOwnerExp = std::vector<NeoN::label> {0, 1, 2, 0, 3};
+        // Verify owners of interior faces (x-direction)
+        auto faceOwnerExp = std::vector<NeoN::label> {0, 1, 2};
         REQUIRE_THAT(mesh.faceOwners(), Equals(faceOwnerExp, EqualInt()));
 
         // Verify face neighbours (x-direction)


### PR DESCRIPTION
Remove the storage of boundary mesh data below from unstructured mesh itself:
- boundary face normal vectors
- boundary face centers
- boundary face areas
- boundary face owners

Fix issue #492 
Fix issue #515 