### PR TITLE
Fix/comm pattern audit

### DIFF
--- a/include/NeoN/distributed/communicationPattern.hpp
+++ b/include/NeoN/distributed/communicationPattern.hpp
@@ -47,6 +47,27 @@ struct CommunicationPattern
 
     /** @brief MPI environment captured at pattern-construction time. */
     mpi::Environment env;
+
+    /** @brief Set by `computeCommunicationPattern` after an `MPI_Allreduce`
+     *  so every rank in the job agrees on the dispatch decision.  True iff
+     *  the mesh used to build this pattern was a partition (some rank in
+     *  the job has processor faces), false for non-partitioned meshes
+     *  (e.g. a per-rank full copy of the global mesh used for sanity checks).
+     */
+    bool isPartitioned = false;
+
+    /** @brief Whether the owning LinearSystem participates in a distributed solve.
+     *
+     *  Authoritative dispatch question for solvers and post-assembly functors.
+     *  Crucially, NOT equivalent to:
+     *   - "this rank has processor faces" — would deadlock against peers when
+     *     an irregular Scotch partition gives this rank an island bounded only
+     *     by physical patches;
+     *   - "the job runs multi-rank" — a multi-rank job can carry a
+     *     non-partitioned LinearSystem (e.g. a sanity-check copy of the global
+     *     mesh held by every rank) that must be solved locally.
+     */
+    bool isDistributed() const { return isPartitioned; }
 };
 
 /**

--- a/include/NeoN/dsl/expression.hpp
+++ b/include/NeoN/dsl/expression.hpp
@@ -63,8 +63,15 @@ public:
     {
 #ifdef NF_WITH_MPI_SUPPORT
         // For distributed systems, only the rank owning refCell applies the constraint.
-        // For non-distributed systems (each rank holds a full copy), every rank applies it.
-        if (!ls.commPattern().sendCounts.empty())
+        // For serial / single-rank runs every rank trivially applies it.
+        // Dispatch on isDistributed() (sizeRank > 1), NOT on sendCounts.empty(): a rank
+        // with no processor faces still participates in a distributed job and must take
+        // the same branch as its peers.
+        // TODO refCell_ is currently a *local* cell index assumed to live on rank 0.
+        //      For Scotch-style decompositions this maps to an arbitrary original-mesh
+        //      cell. Once globalCellId is plumbed through the mesh, gate this on
+        //      "rank that owns the global refCell" instead of hard-coded rank 0.
+        if (ls.commPattern().isDistributed())
         {
             mpi::Environment mpiEnv;
             if (mpiEnv.isInitialized() && mpiEnv.rank() != 0) return;

--- a/include/NeoN/fields/boundaryData.hpp
+++ b/include/NeoN/fields/boundaryData.hpp
@@ -15,6 +15,7 @@
 #ifdef NF_WITH_MPI_SUPPORT
 #include <mpi.h>
 #include <optional>
+#include <unordered_map>
 #include "NeoN/core/mpi/environment.hpp"
 #include "NeoN/core/mpi/operators.hpp"
 #include "NeoN/core/parallelAlgorithms.hpp"
@@ -233,6 +234,25 @@ public:
             static_cast<mpi_label_t>(patchSize) * static_cast<mpi_label_t>(sizeof(ValueType));
         const auto neighborRankLabel = static_cast<mpi_label_t>(neighborRank);
 
+        // Disambiguate sends/recvs for multiple proc patches that share the same
+        // neighbour rank. The tag is a per-(neighbour-rank) sequence number that
+        // restarts at 0 on every waitAll(). A *per-neighbour* counter — not a
+        // global one — is necessary: a global counter desynchronises across ranks
+        // whenever the two sides have unequal traffic to OTHER peers between
+        // calls to the same neighbour.
+        //
+        // Correctness contract: within a single correctBoundaryConditions() pass,
+        // this rank and the neighbour must walk processor patches between THIS
+        // pair in the same canonical order. True today because both sides use
+        // OpenFOAM's lduInterfacePtrsList walk via meshAdapter; if a future
+        // adapter reorders patches independently per rank within a pair, this
+        // scheme silently matches messages to the wrong patch.
+        //
+        // TODO replace with a stable patch-pair-id sourced from BoundaryMesh once
+        //      processor-patch identity is plumbed through (see commPattern audit
+        //      REVIEW_2.md N-H4).
+        const int tag = perNeighbourTagCounter_[neighborRank]++;
+
         const bool useGpuPath = mpiEnv.gpuAwareMpi() && std::holds_alternative<GPUExecutor>(exec_);
 
         MPI_Request sendReq, recvReq;
@@ -243,7 +263,7 @@ public:
                 reinterpret_cast<const char*>(value_.data() + rangeStart),
                 byteCount,
                 neighborRankLabel,
-                0,
+                tag,
                 mpiEnv.comm(),
                 &sendReq
             );
@@ -251,7 +271,7 @@ public:
                 reinterpret_cast<char*>(buf.deviceRecvBuf->data()),
                 byteCount,
                 neighborRankLabel,
-                0,
+                tag,
                 mpiEnv.comm(),
                 &recvReq
             );
@@ -262,12 +282,14 @@ public:
             buf.sendBuf.resize(static_cast<std::size_t>(patchSize));
             buf.recvBuf.resize(static_cast<std::size_t>(patchSize));
             for (localIdx k = 0; k < patchSize; k++)
+            {
                 buf.sendBuf[static_cast<std::size_t>(k)] = valH.view()[rangeStart + k];
+            }
             mpi::isend<char>(
                 reinterpret_cast<const char*>(buf.sendBuf.data()),
                 byteCount,
                 neighborRankLabel,
-                0,
+                tag,
                 mpiEnv.comm(),
                 &sendReq
             );
@@ -275,7 +297,7 @@ public:
                 reinterpret_cast<char*>(buf.recvBuf.data()),
                 byteCount,
                 neighborRankLabel,
-                0,
+                tag,
                 mpiEnv.comm(),
                 &recvReq
             );
@@ -336,6 +358,7 @@ public:
         requests_.clear();
         communicating_ = false;
         commBuffers_.clear();
+        perNeighbourTagCounter_.clear();
 #endif
     }
 
@@ -376,6 +399,8 @@ private:
     mutable std::vector<CommBuffer>
         commBuffers_; ///< Send/recv staging buffers for pending requests.
     mutable bool communicating_ = false;
+    mutable std::unordered_map<int, int>
+        perNeighbourTagCounter_; ///< Tag = call index per neighbour rank; reset by waitAll().
 #endif
 };
 

--- a/include/NeoN/linearAlgebra/solver.hpp
+++ b/include/NeoN/linearAlgebra/solver.hpp
@@ -108,7 +108,10 @@ public:
     solve(const LinearSystem<scalar, CSRMatrix<scalar, localIdx>>& ls, Vector<scalar>& field) const
     {
 #ifdef NF_WITH_MPI_SUPPORT
-        if (!ls.commPattern().sendCounts.empty()) return solverInstance_->solveDist(ls, field);
+        // Dispatch based on whether the job runs distributed (sizeRank > 1), NOT on
+        // whether this rank has non-empty sendCounts: a rank without processor faces
+        // must still join the distributed collectives or the job deadlocks.
+        if (ls.commPattern().isDistributed()) return solverInstance_->solveDist(ls, field);
 #endif
         return solverInstance_->solve(ls, field);
     }
@@ -117,14 +120,14 @@ public:
     solve(const LinearSystem<Vec3, CSRMatrix<Vec3, localIdx>>& ls, Vector<Vec3>& field) const
     {
 #ifdef NF_WITH_MPI_SUPPORT
-        if (!ls.commPattern().sendCounts.empty()) return solverInstance_->solveDist(ls, field);
+        if (ls.commPattern().isDistributed()) return solverInstance_->solveDist(ls, field);
 #endif
         return solverInstance_->solve(ls, field);
     }
 
     /// @brief Solve a system with a scalar matrix and Vec3 right-hand side.
     /// @note This overload is **local-only**: it does not dispatch to solveDist and must not be
-    ///       called on a distributed LinearSystem (one whose commPattern has non-empty sendCounts).
+    ///       called on a distributed LinearSystem (one whose commPattern reports isDistributed()).
     ///       If distributed support is needed, add a solveDist virtual to SolverFactory and
     ///       implement it in every backend.
     SolverStats solve(
@@ -135,7 +138,7 @@ public:
     {
 #ifdef NF_WITH_MPI_SUPPORT
         NF_ASSERT(
-            ls.commPattern().sendCounts.empty(),
+            !ls.commPattern().isDistributed(),
             "solve(scalar matrix, Vec3 rhs) does not support distributed systems. "
             "Add a solveDist overload to SolverFactory to enable this."
         );

--- a/include/NeoN/mesh/unstructured/communicator.hpp
+++ b/include/NeoN/mesh/unstructured/communicator.hpp
@@ -42,6 +42,20 @@ using CommMap = std::vector<RankCommMap>;
 /**
  * @class Communicator
  * @brief Manages communication between ranks in a parallel environment.
+ *
+ * @note **Roadmap stub.** As of 2026-05, this class is the intended canonical
+ *       halo-exchange API for the upcoming unification of NeoN's distributed
+ *       communication paths. It is currently *not wired into production code*:
+ *       field halo exchange runs through `BoundaryData::communicate` (per-patch
+ *       Isend/Irecv) and linear-system metadata runs through
+ *       `computeCommunicationPattern` (MPI_Alltoallv). Both paths will be
+ *       retired in favour of a `Communicator` built once per mesh partition
+ *       and reused across solves and field updates.
+ *
+ *       Do not delete this class without first deleting the corresponding
+ *       roadmap item; see `.planning/quick/20260528-comm-pattern-audit/REVIEW_2.md`
+ *       findings N-H1 and N-H5.
+ *
  * The Communicator class provides functionality to manage communication of field data exchange
  * between MPI ranks for unstructured meshes. The class maintains an MPI environment and maps for
  * rank-specific send and receive operations.

--- a/src/mesh/unstructured/distributedUnstructuredMesh.cpp
+++ b/src/mesh/unstructured/distributedUnstructuredMesh.cpp
@@ -140,9 +140,39 @@ UnstructuredMesh create1DUniformMeshPart(const Executor exec, const localIdx nCe
 CommunicationPattern computeCommunicationPattern(const UnstructuredMesh& mesh)
 {
     mpi::Environment mpiEnviron;
+
+    // Agree across the job on whether this LinearSystem should dispatch to the
+    // distributed solver path. Local presence of processor faces is not enough:
+    // an irregular partition can leave a rank with only physical boundaries
+    // (isPartitioned still true), while a multi-rank job may also carry a
+    // non-partitioned LinearSystem built from a per-rank full copy of the mesh
+    // (isPartitioned false). One MPI_Allreduce per pattern construction; the
+    // pattern is built once per LinearSystem, not per solve, so the overhead is
+    // negligible compared to the deadlocks the agreement prevents.
+    //
+    // Many serial unit tests call this path without ever initialising MPI; skip
+    // the collective in that case (the local fast path below handles them).
+    bool patternIsPartitioned = false;
+    if (mpiEnviron.isInitialized())
+    {
+        int localHasProcFaces = mesh.boundaryMesh().isDistributed() ? 1 : 0;
+        int anyHasProcFaces = 0;
+        MPI_Allreduce(&localHasProcFaces, &anyHasProcFaces, 1, MPI_INT, MPI_LOR, mpiEnviron.comm());
+        patternIsPartitioned = (anyHasProcFaces != 0);
+    }
+
     if (!mesh.boundaryMesh().isDistributed())
     {
-        return {};
+        // Either a single-rank build, or a multi-rank build holding a non-partitioned
+        // mesh (sanity-check copy), or — in the rare Scotch corner case — a rank
+        // whose partition is bounded entirely by physical patches. The dispatch
+        // decision differs between the latter two, so isPartitioned (set above
+        // via Allreduce) discriminates them; sendCounts/recvIdx remain empty on
+        // this rank in either case.
+        CommunicationPattern empty;
+        empty.env = mpiEnviron;
+        empty.isPartitioned = patternIsPartitioned;
+        return empty;
     }
 
     auto sendCounts = std::vector<int>(static_cast<std::size_t>(mpiEnviron.sizeRank() + 1), 0);
@@ -210,7 +240,13 @@ CommunicationPattern computeCommunicationPattern(const UnstructuredMesh& mesh)
     );
 
     std::vector<localIdx> boundaryMapVector;
-    return CommunicationPattern {sendCounts, recvIdx, boundaryMapVector, mpiEnviron};
+    return CommunicationPattern {
+        sendCounts,
+        recvIdx,
+        boundaryMapVector,
+        mpiEnviron,
+        /*isPartitioned=*/true
+    };
 }
 
 } // namespace NeoN

--- a/test/distributed/operator.cpp
+++ b/test/distributed/operator.cpp
@@ -157,6 +157,12 @@ TEST_CASE("Distributed Operator")
     }
 
 #if NF_WITH_GINKGO
+    // [T2] End-to-end regression: solver.solve(lsDst, xPart) only enters the
+    // distributed Ginkgo path if Solver::solve dispatches via
+    // commPattern.isDistributed(). Comparing the partitioned solution against
+    // the canonical local solution catches any drift in the dispatch logic
+    // (see commPattern audit N-H2), the off-diagonal sparsity construction,
+    // or the recvIdx contract between ranks.
     Dictionary solverDict {
         {{"solver", std::string {"Ginkgo"}},
          {"type", "solver::Gmres"},

--- a/test/distributed/partitioning.cpp
+++ b/test/distributed/partitioning.cpp
@@ -76,6 +76,124 @@ TEST_CASE("Distributed")
             REQUIRE(commPattern.sendCounts == sendCountsExp);
             REQUIRE(commPattern.recvIdx == recvIdxExp);
         }
+
+        // [T1] Regression test for commPattern audit N-H2: isDistributed() must be the
+        // authoritative dispatch question, returning true on every rank of a multi-rank
+        // job — independent of whether the local sendCounts/recvIdx are non-empty.
+        // Previously the dispatch used `!sendCounts.empty()`, which silently returned
+        // false on any rank that happened to have no processor faces, deadlocking the
+        // job when peers entered distributed collectives that this rank never joined.
+        SECTION("isDistributed() agrees across ranks " + execName)
+        {
+            const int local = commPattern.isDistributed() ? 1 : 0;
+            int globalAnd = 0;
+            int globalOr = 0;
+            MPI_Allreduce(&local, &globalAnd, 1, MPI_INT, MPI_BAND, mpiEnviron.comm());
+            MPI_Allreduce(&local, &globalOr, 1, MPI_INT, MPI_BOR, mpiEnviron.comm());
+            // Every rank must answer the same question identically.
+            REQUIRE(globalAnd == globalOr);
+            // On a 3-rank job, every rank must dispatch to the distributed path.
+            REQUIRE(local == 1);
+        }
+
+        // [T1.b] Pattern with no local proc faces but `isPartitioned` set must
+        // still dispatch to the distributed path. This simulates the rare Scotch
+        // corner case where a rank's partition is bounded entirely by physical
+        // patches; that rank still has to enter every distributed collective its
+        // peers do, otherwise the job deadlocks. `isPartitioned` is the
+        // dispatch-determining bit, set globally via MPI_Allreduce in
+        // `computeCommunicationPattern` so that all ranks agree.
+        SECTION(
+            "isDistributed() true for partitioned pattern with empty local sendCounts " + execName
+        )
+        {
+            CommunicationPattern empty;
+            empty.env = mpiEnviron;
+            empty.isPartitioned = true; // as if computeCommunicationPattern set it
+            REQUIRE(empty.sendCounts.empty());
+            REQUIRE(empty.recvIdx.empty());
+            REQUIRE(empty.isDistributed() == true);
+        }
+
+        // [T1.c] A default-constructed pattern (no Allreduce, no mesh hint) is
+        // treated as non-distributed. This corresponds to a multi-rank job
+        // carrying a LinearSystem built from a per-rank full copy of the global
+        // mesh (e.g. the canonical local `ls` used as a sanity-check baseline
+        // against `lsDst` in the operator test): every rank must take the local
+        // solve branch.
+        SECTION("isDistributed() false for default-constructed pattern " + execName)
+        {
+            CommunicationPattern defaulted;
+            REQUIRE(defaulted.isDistributed() == false);
+        }
+
+        // [T3] Symmetric round-trip via the pattern: every value in recvIdx on this
+        // rank must equal a value the neighbour sent. We re-send the global cell
+        // indices that we shipped originally and confirm receivers get back what we
+        // claimed to send. Together with the rank-by-rank recvIdx assertions above,
+        // this catches one-side malformed patterns.
+        SECTION("Pattern round-trips global cell ids " + execName)
+        {
+            const int nRanks = mpiEnviron.sizeRank();
+            const auto globalOffset = static_cast<int>(meshPart.globalOffset());
+
+            // sendCounts[0..nRanks) are face counts per destination rank.
+            std::vector<int> sendCounts(
+                commPattern.sendCounts.begin(), commPattern.sendCounts.begin() + nRanks
+            );
+            std::vector<int> sdispl(nRanks, 0);
+            for (int r = 1; r < nRanks; ++r)
+            {
+                sdispl[r] = sdispl[r - 1] + sendCounts[r - 1];
+            }
+            const int totalSend = sdispl.back() + sendCounts.back();
+
+            // Build the send buffer in the SAME ordering the pattern uses
+            // internally: walk proc faces in patch order, dispatched by neighbour
+            // rank. Each rank announces "I am sending you my global cell id X".
+            std::vector<int> sendBuf(totalSend, 0);
+            const auto& neighbourRanks = meshPart.boundaryMesh().neighbourRank();
+            const auto& offsets = meshPart.boundaryMesh().offset();
+            const auto nInner = meshPart.boundaryMesh().nBoundaries()
+                              - meshPart.boundaryMesh().nProcBoundaryPatches();
+            const auto faceCellsH = meshPart.boundaryMesh().faceOwners().copyToHost();
+            const auto procStart = offsets[static_cast<std::size_t>(nInner)];
+            std::vector<int> cursor(nRanks, 0);
+            for (std::size_t i = 0; i < neighbourRanks.size(); ++i)
+            {
+                const int dst = static_cast<int>(neighbourRanks[i]);
+                const auto patchStart = offsets[static_cast<std::size_t>(nInner + i)];
+                const auto patchEnd = offsets[static_cast<std::size_t>(nInner + i + 1)];
+                for (auto k = patchStart; k < patchEnd; ++k)
+                {
+                    const int slot = sdispl[dst] + cursor[dst]++;
+                    sendBuf[slot] = static_cast<int>(faceCellsH.view()[k]) + globalOffset;
+                }
+            }
+
+            std::vector<int> recvCounts(nRanks, 0);
+            mpi::allToAll<int>(sendCounts.data(), 1, recvCounts.data(), 1, mpiEnviron.comm());
+            std::vector<int> rdispl(nRanks, 0);
+            for (int r = 1; r < nRanks; ++r)
+            {
+                rdispl[r] = rdispl[r - 1] + recvCounts[r - 1];
+            }
+            const int totalRecv = rdispl.back() + recvCounts.back();
+            std::vector<int> recvBuf(totalRecv, 0);
+            mpi::allToAllV<int>(
+                sendBuf.data(),
+                sendCounts.data(),
+                sdispl.data(),
+                recvBuf.data(),
+                recvCounts.data(),
+                rdispl.data(),
+                mpiEnviron.comm()
+            );
+
+            // The reconstructed recv buffer must equal the pattern's stored recvIdx,
+            // proving that what the neighbour announces matches what we recorded.
+            REQUIRE(recvBuf == commPattern.recvIdx);
+        }
     }
 
     auto mesh = create1DUniformMesh(exec, nCells);


### PR DESCRIPTION
Some improvements/fixes to the communication pattern. 
Still open to fix in a seperate branch:
### H3. `MPI_Scan` global numbering scheme is **incompatible** with OpenFOAM's Scotch output
[unstructuredMesh.cpp:19-34](../../../src/NeoN/src/mesh/unstructured/unstructuredMesh.cpp#L19-L34)

The "global cell index" semantics baked into `recvIdx` is:
```
global_id = local_cell_index_on_this_rank + sum(local_nCells of all ranks with lower rank)
```

This holds **only if** rank R's local cells correspond to a contiguous global cell range,
ordered by rank. That happens to be true for the canonical OF `decomposePar -decompositionMethod simple` AND for the toy `create1DUniformMeshPart`. It is **not** true
for Scotch — Scotch produces a graph partitioning where each rank's local cells were
arbitrarily-numbered global cells in the original mesh; the mapping is recorded in
`constant/cellProcAddressing`, which NeoFOAM currently **does not read**.

Right now this works because:
- The "global ID" is purely internal — NeoN never round-trips it back to OF
- Both sides of every proc patch agree on the convention
  (`local_neighbour_owner + neighbour_globalOffset`), so the index exchange is self-consistent.

It will silently break the moment any of these new requirements land:
1. **Reconstruct fields back to OF for post-processing** — `reconstructPar` needs the
   addressing files, and NeoN's "global IDs" do not match OF's.
2. **Read OF fields that were created against the original addressing** (e.g. initial
   conditions, checkpoints). Today this works only because every rank reads its own
   processor directory; if you move to "single-file mesh, per-rank slicing" (per the
   roadmap), the addressing has to be honoured.
3. **Coupling to other OF code paths that exchange data via global IDs** (e.g. AMI,
   overset, FSI).
4. **The new mesh format reusing Scotch via libscotch directly** — Scotch returns a `part`
   array (cell → rank), not a renumbering. The user of that array has to apply a
   permutation, store it, and use it for any cross-domain communication. If NeoN keeps
   inventing its own contiguous IDs via `MPI_Scan`, the per-cell identity is lost the
   moment cells leave NeoN.

**This is the central architectural issue** for the roadmap the user described.
Decomposition-time addressing has to become a first-class concept in NeoN before any
of the new mesh-format work begins, otherwise the new format will be designed around an
inconsistent contract.

**Recommendation**: introduce an explicit `globalCellId` field on `UnstructuredMesh` (or
`BoundaryMesh`) that is **provided** by the mesh-reader/decomposer, not invented by
`MPI_Scan`. Default it to `local + MPI_Scan(localNCells)` for backward compatibility, but
let the OF reader populate it from `cellProcAddressing` once that file is read.
`computeCommunicationPattern` and `computeGlobalOffset` then consume that field instead
of synthesising indices.
