### PR TITLE
Add foamGlobalCellIds to UnstructuredMesh for OF round-trip identity

### DIFF
--- a/include/NeoN/mesh/unstructured/unstructuredMesh.hpp
+++ b/include/NeoN/mesh/unstructured/unstructuredMesh.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include "Kokkos_Sort.hpp"
 
 #include "NeoN/core/dictionary.hpp"
@@ -55,7 +57,8 @@ public:
         scalarVector faceAreas,
         labelVector faceOwners,
         labelVector faceNeighbors,
-        BoundaryMesh boundaryMesh
+        BoundaryMesh boundaryMesh,
+        std::vector<localIdx> foamGlobalCellIds = {}
     );
 
     /**
@@ -71,6 +74,14 @@ public:
      * @param faceOwners The list of labels of face owner cells.
      * @param faceNeighbors The list of labels of face neighbor cells.
      * @param boundaryMesh The boundary mesh.
+     * @param foamGlobalCellIds Optional. For each local cell, the global cell ID in
+     *        the **original** undecomposed OpenFOAM mesh (the contents of OF's
+     *        `constant/polyMesh/cellProcAddressing`). Empty if no OF addressing
+     *        is available (default, e.g. for purely synthetic meshes); in that
+     *        case OF-round-tripping APIs return empty / no-op.  Does not affect
+     *        any NeoN-internal global numbering used for linear solver assembly
+     *        or halo communication (those still use `globalOffset()`-based
+     *        contiguous IDs derived from an MPI_Scan of local cell counts).
      */
     UnstructuredMesh(
         vectorVector points,
@@ -81,7 +92,8 @@ public:
         scalarVector faceAreas,
         labelVector faceOwners,
         labelVector faceNeighbors,
-        BoundaryMesh boundaryMesh
+        BoundaryMesh boundaryMesh,
+        std::vector<localIdx> foamGlobalCellIds = {}
     );
 
     /**
@@ -198,6 +210,32 @@ public:
     localIdx globalOffset() const;
 
     /**
+     * @brief Per-local-cell global cell ID in the original undecomposed OpenFOAM mesh.
+     *
+     * Populated from OpenFOAM's `constant/polyMesh/cellProcAddressing` by the
+     * NeoFOAM mesh adapter when reading a decomposed case. Empty when no OF
+     * addressing is available (purely synthetic meshes, single-rank runs without
+     * a polyMesh on disk).
+     *
+     * **Not** used by NeoN's internal halo communication or by Ginkgo's
+     * distributed linear-algebra path: both of those operate on the contiguous
+     * MPI_Scan-based numbering exposed via `globalOffset()`. `foamGlobalCellIds`
+     * exists so that future code paths can round-trip cell identity back to OF
+     * (reconstruction, checkpoint loading, AMI/overset coupling).
+     *
+     * @return The OF-original global cell IDs, or an empty vector if not available.
+     */
+    const std::vector<localIdx>& foamGlobalCellIds() const;
+
+    /**
+     * @brief Whether OpenFOAM `cellProcAddressing` is available for this mesh.
+     *
+     * Equivalent to `!foamGlobalCellIds().empty()`. Use as a guard in code that
+     * relies on OF-round-trip identity.
+     */
+    bool hasFoamAddressing() const;
+
+    /**
      * @brief Get the boundary mesh.
      *
      * @return The boundary mesh.
@@ -292,6 +330,14 @@ private:
 
     //
     localIdx globalOffset_;
+
+    /**
+     * @brief OF-original global cell IDs per local cell.
+     *
+     * Populated from `cellProcAddressing` by the NeoFOAM mesh adapter when
+     * reading a decomposed OF case; empty otherwise. See `foamGlobalCellIds()`.
+     */
+    std::vector<localIdx> foamGlobalCellIds_;
 
     /**
      * @brief Stencil data base.

--- a/src/mesh/unstructured/unstructuredMesh.cpp
+++ b/src/mesh/unstructured/unstructuredMesh.cpp
@@ -44,14 +44,22 @@ UnstructuredMesh::UnstructuredMesh(
     scalarVector faceAreas,
     labelVector faceOwners,
     labelVector faceNeighbors,
-    BoundaryMesh boundaryMesh
+    BoundaryMesh boundaryMesh,
+    std::vector<localIdx> foamGlobalCellIds
 )
     : exec_(exec), points_(points), cellVolumes_(cellVolumes), cellCenters_(cellCenters),
       faceNormals_(faceNormals), faceCenters_(faceCenters), faceAreas_(faceAreas),
       faceOwners_(faceOwners), faceNeighbors_(faceNeighbors), nCells_(cellVolumes.size()),
       nInternalFaces_(faceNeighbors.size()), boundaryMesh_(boundaryMesh),
-      globalOffset_(computeGlobalOffset(boundaryMesh, cellVolumes.size())), stencilDataBase_()
-{}
+      globalOffset_(computeGlobalOffset(boundaryMesh, cellVolumes.size())),
+      foamGlobalCellIds_(std::move(foamGlobalCellIds)), stencilDataBase_()
+{
+    NF_ASSERT(
+        foamGlobalCellIds_.empty()
+            || foamGlobalCellIds_.size() == static_cast<std::size_t>(nCells_),
+        "foamGlobalCellIds size must match nCells when provided."
+    );
+}
 
 UnstructuredMesh::UnstructuredMesh(
     vectorVector points,
@@ -62,7 +70,8 @@ UnstructuredMesh::UnstructuredMesh(
     scalarVector faceAreas,
     labelVector faceOwners,
     labelVector faceNeighbors,
-    BoundaryMesh boundaryMesh
+    BoundaryMesh boundaryMesh,
+    std::vector<localIdx> foamGlobalCellIds
 )
     : UnstructuredMesh(
         faceOwners.exec(),
@@ -74,7 +83,8 @@ UnstructuredMesh::UnstructuredMesh(
         faceAreas,
         faceOwners,
         faceNeighbors,
-        boundaryMesh
+        boundaryMesh,
+        std::move(foamGlobalCellIds)
     )
 {}
 
@@ -127,6 +137,13 @@ localIdx UnstructuredMesh::nTotalFaces() const
 }
 
 localIdx UnstructuredMesh::globalOffset() const { return globalOffset_; }
+
+const std::vector<localIdx>& UnstructuredMesh::foamGlobalCellIds() const
+{
+    return foamGlobalCellIds_;
+}
+
+bool UnstructuredMesh::hasFoamAddressing() const { return !foamGlobalCellIds_.empty(); }
 
 const BoundaryMesh& UnstructuredMesh::boundaryMesh() const { return boundaryMesh_; }
 

--- a/test/mesh/unstructured/unstructuredMesh.cpp
+++ b/test/mesh/unstructured/unstructuredMesh.cpp
@@ -362,4 +362,51 @@ TEST_CASE("Unstructured Mesh")
             REQUIRE(hostFaceCenters.view()[f][2] == Catch::Approx(zmax).margin(1e-10));
         }
     }
+
+    // Default-constructed meshes (synthetic uniform meshes from create*UniformMesh
+    // helpers) carry no OpenFOAM addressing — `foamGlobalCellIds()` returns an
+    // empty vector and `hasFoamAddressing()` returns false.
+    SECTION("Synthetic meshes carry no foam addressing " + execName)
+    {
+        auto mesh = NeoN::create1DUniformMesh(exec, 4);
+        REQUIRE_FALSE(mesh.hasFoamAddressing());
+        REQUIRE(mesh.foamGlobalCellIds().empty());
+    }
+
+    // When `foamGlobalCellIds` is provided to the constructor, the mesh exposes
+    // it verbatim through the accessor. This is the contract the NeoFOAM mesh
+    // adapter relies on after reading `cellProcAddressing` from disk.
+    //
+    // Crucially, populating `foamGlobalCellIds` must NOT change the values
+    // returned by `globalOffset()` — that field continues to come from the
+    // MPI_Scan-based contiguous numbering and is what Ginkgo and the halo
+    // communication path consume.
+    SECTION("Constructor stores foamGlobalCellIds verbatim " + execName)
+    {
+        const std::vector<NeoN::localIdx> cyclicIds {0, 3, 6, 9};
+        const NeoN::localIdx nCells = static_cast<NeoN::localIdx>(cyclicIds.size());
+
+        // Re-use the generated 1D mesh's geometry / boundary mesh so we only
+        // have to construct one new top-level UnstructuredMesh wired with the
+        // addressing vector.
+        auto reference = NeoN::create1DUniformMesh(exec, nCells);
+        NeoN::UnstructuredMesh meshWithAddressing(
+            exec,
+            reference.points(),
+            reference.cellVolumes(),
+            reference.cellCenters(),
+            reference.faceNormals(),
+            reference.faceCenters(),
+            reference.faceAreas(),
+            reference.faceOwners(),
+            reference.faceNeighbors(),
+            NeoN::BoundaryMesh(reference.boundaryMesh()),
+            cyclicIds
+        );
+
+        REQUIRE(meshWithAddressing.hasFoamAddressing());
+        REQUIRE(meshWithAddressing.foamGlobalCellIds() == cyclicIds);
+        // The MPI_Scan-based offset is independent of the OF-addressing field.
+        REQUIRE(meshWithAddressing.globalOffset() == reference.globalOffset());
+    }
 }


### PR DESCRIPTION
## Summary

Adds a new `foamGlobalCellIds` field on `UnstructuredMesh` that records, for
each local cell, the cell's global ID in the **original undecomposed
OpenFOAM mesh** (the contents of OF's `constant/polyMesh/cellProcAddressing`).

This is the data needed for `reconstructPar`, checkpoint loading, and any
OF-side coupling (AMI, overset, FSI) to round-trip cell identity correctly
on non-`simple` decompositions. NeoFOAM populates it in a companion PR.

## Motivation — commPattern audit finding H3

Today NeoN synthesises a per-rank "global cell ID" as
`localId + MPI_Scan(localNCells)`. That formula is correct for OpenFOAM's
canonical `simple` decomposition, but **wrong for Scotch and cyclic**: those
decomposers assign each rank a non-contiguous, arbitrarily-permuted subset
of the original-mesh cell IDs, recorded in `cellProcAddressing`.

Right now NeoN never round-trips its synthetic IDs back to OF, so the
mismatch is invisible. The first time a downstream tool needs to map a
NeoN cell back to its OF identity (reconstruction, checkpoint, overlap
detection), the answer is silently wrong. See REVIEW.md H3.

## What changes

```
include/NeoN/mesh/unstructured/unstructuredMesh.hpp
src/mesh/unstructured/unstructuredMesh.cpp
test/mesh/unstructured/unstructuredMesh.cpp
```

- New optional constructor parameter `std::vector<localIdx> foamGlobalCellIds`
  on both `UnstructuredMesh` constructors. Default `{}`.
- New accessors:
  - `const std::vector<localIdx>& foamGlobalCellIds() const`
  - `bool hasFoamAddressing() const`
- Constructor asserts that, when non-empty, `foamGlobalCellIds.size() == nCells`.
- All existing constructor call sites (`createSingleCellMesh`,
  `create1DUniformMesh`, `create2DUniformMesh`, `create3DUniformMesh`,
  `create1DUniformMeshPart`) pick up the default and remain unchanged.

## Design choice — dual-vector, not single-vector

The audit originally recommended one field that defaults to `MPI_Scan`
and is overwritten by OF addressing when available, with
`computeCommunicationPattern` routed through that field.

That conflicts with Ginkgo. Today `createGkoMtxDist` uses
`build_partition_from_local_size`, which assumes contiguous per-rank
global ID ranges (`[scan, scan + localSize)`). Feeding it OF
addressing IDs from a non-contiguous decomposition (e.g. cyclic:
`{0, 3, 6, …}` on rank 0) would invalidate the partition's range
bounds and corrupt the distributed solve.

This PR therefore takes the dual-vector route:

- `globalOffset_` (existing, MPI_Scan-based, contiguous) — keeps feeding
  `computeCommunicationPattern`, `setOffDiagonalSparsityPatternImpl`,
  `createEmptyLinearSystem`, and Ginkgo's partition. **No behaviour
  change**. No NeoN test expectations had to be updated.
- `foamGlobalCellIds_` (new, OF-original IDs) — informational. Empty
  unless an OF reader explicitly populates it. Available for future
  reconstruction / checkpoint / coupling code.

The follow-up PR that unifies the two numbering schemes will need to
switch Ginkgo to `build_from_mapping` (mapping-based partition), at
which point the dual layout collapses back into a single field.

## Test plan

- [x] `neon_test_unstructuredMesh` covers two new sections:
      `Synthetic meshes carry no foam addressing` and
      `Constructor stores foamGlobalCellIds verbatim`. 252 assertions.
- [x] Full NeoN ctest suite (63/63) green locally with `develop` preset.
- [x] All existing `create*UniformMesh*` helpers still compile and
      behave identically (verified by the rest of the suite).
- [x] MPI tests `partitioning`, `operator`, `coNum_distributed`,
      `communicator` unchanged.

## Out of scope (follow-ups)

- Reader for `faceProcAddressing` / `pointProcAddressing` (same pattern,
  separate fields).
- Any consumer code that actually uses `foamGlobalCellIds` (reconstruction,
  checkpoint loading) — this PR exposes the data only.
- Migrating Ginkgo to `build_from_mapping` so the OF IDs can drive the
  distributed solve directly.
- 64-bit `globalIdx` (audit H2) — still a separate concern.

## Companion PR

The NeoFOAM mesh adapter PR that actually reads `cellProcAddressing` and
populates this field is shipped alongside: NeoFOAM#<PR> on
`fix/global-addressing`.
