### PR TITLE
Support AsssemblyType != ValueType for Vec3 fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,11 @@
 
 ### Misc
 - Include RHS / explicit source assembly [#539](https://github.com/exasim-project/NeoN/pull/539)
-- Bump Ginkgo to 1.11 and Kokkos 4.7.01 [#409](https://github.com/exasim-project/NeoN/pull/409)
 - Remove stencilDataBase [#416](https://github.com/exasim-project/NeoN/pull/416)
 - Added backward ddtScheme and scheme selection mechanism [#419](https://github.com/exasim-project/NeoN/pull/419)
+- Support AssemblyType != ValueType for Vec3 fields [#536](https://github.com/exasim-project/NeoN/pull/536)
 - Bump Kokkos to 5.0.2 [#476](https://github.com/exasim-project/NeoN/pull/476)
+- Bump Ginkgo to 1.11  [#409](https://github.com/exasim-project/NeoN/pull/409)
 
 ## Fixes
 - Fix distributed processor-face correctness: multi-patch (scotch) halo exchange, ddtFluxCorr proc-face correction, processor BC on coupled patches, and row-sorted non-local COO for correct CUDA distributed apply [#528](https://github.com/exasim-project/NeoN/pull/528)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Add experimental support for cell based assembly strategies [#471](https://github.com/exasim-project/NeoN/pull/471),[#517](https://github.com/exasim-project/NeoN/pull/517)
 - Add experimental support for COO and CSR Matrices [#486](https://github.com/exasim-project/NeoN/pull/486)
 - Add experimental umpire support [#455](https://github.com/exasim-project/NeoN/pull/455)
-- Add experimental MPI support [#519](https://github.com/exasim-project/NeoN/pull/519), [#520](https://github.com/exasim-project/NeoN/pull/520), [#512](https://github.com/exasim-project/NeoN/pull/512), [#525](https://github.com/exasim-project/NeoN/pull/525), [#531](https://github.com/exasim-project/NeoN/pull/531)
+- Add experimental MPI support [#519](https://github.com/exasim-project/NeoN/pull/519), [#520](https://github.com/exasim-project/NeoN/pull/520), [#512](https://github.com/exasim-project/NeoN/pull/512), [#525](https://github.com/exasim-project/NeoN/pull/525), [#531](https://github.com/exasim-project/NeoN/pull/531), [#522](https://github.com/exasim-project/NeoN/pull/522)
 - Add python bindings via nanobind [#382](https://github.com/exasim-project/NeoN/pull/382)
 - Correct the Ginkgo version to 2.0.0 (unreleased) [#493](https://github.com/exasim-project/NeoN/pull/493)
 - Add tensor and symmTensor primitives, Su type sourceTerm and passing of fields to BCs [#428](https://github.com/exasim-project/NeoN/pull/428)

--- a/benchmarks/distributed/common.cpp
+++ b/benchmarks/distributed/common.cpp
@@ -74,7 +74,7 @@ void runDistributedPoissonBenchmark(
         return fv;
     };
 
-    DYNAMIC_SECTION(sectionName + " - Poisson assemble")
+    DYNAMIC_SECTION(sectionName + " - Poisson assemble - face based")
     {
         auto ls = la::createEmptyLinearSystem<NeoN::scalar>(mesh);
         fvcc::SurfaceField<NeoN::scalar> phiHbyA(exec, "gamma", mesh, surfaceBCs);
@@ -91,6 +91,73 @@ void runDistributedPoissonBenchmark(
                     p.correctBoundaryConditions();
                     phiHbyA.correctBoundaryConditions();
                     expr.assemble(0.0, 1.0, ls);
+                    fence(exec);
+                    ls.reset();
+                    MPI_Barrier(MPI_COMM_WORLD);
+                }
+            );
+        };
+    }
+
+    DYNAMIC_SECTION(sectionName + " - Poisson assemble - cell based")
+    {
+        auto cellIterator = std::make_shared<NeoN::la::CellBasedIterator>();
+        auto ls = NeoN::la::createEmptyLinearSystem<NeoN::scalar>(mesh, cellIterator);
+
+        fvcc::SurfaceField<NeoN::scalar> phiHbyA(exec, "gamma", mesh, surfaceBCs);
+        NeoN::fill(phiHbyA.internalVector(), 1.0);
+        NeoN::dsl::Expression<NeoN::scalar> expr =
+            NeoN::dsl::imp::laplacian(gamma, p) - NeoN::dsl::exp::div(phiHbyA);
+        expr.read(fvSchemes());
+        BENCHMARK_ADVANCED(std::string(execName))(Catch::Benchmark::Chronometer meter)
+        {
+            MPI_Barrier(MPI_COMM_WORLD);
+            meter.measure(
+                [&]
+                {
+                    p.correctBoundaryConditions();
+                    phiHbyA.correctBoundaryConditions();
+                    expr.assemble(0.0, 1.0, ls);
+                    fence(exec);
+                    ls.reset();
+                    MPI_Barrier(MPI_COMM_WORLD);
+                }
+            );
+        };
+    }
+
+    DYNAMIC_SECTION(sectionName + " - Poisson assemble + Gko no solve")
+    {
+        auto ls = la::createEmptyLinearSystem<NeoN::scalar>(mesh);
+        fvcc::SurfaceField<NeoN::scalar> phiHbyA(exec, "gamma", mesh, surfaceBCs);
+        NeoN::fill(phiHbyA.internalVector(), 1.0);
+        NeoN::dsl::Expression<NeoN::scalar> expr =
+            NeoN::dsl::imp::laplacian(gamma, p) - NeoN::dsl::exp::div(phiHbyA);
+        expr.read(fvSchemes());
+
+        NeoN::Dictionary solverDict {
+            {{"solver", std::string {"Ginkgo"}},
+             {"type", "solver::Gmres"},
+             {"criteria", NeoN::Dictionary {{{"iteration", 0}, {"relative_residual_norm", 1.0}}}}}
+        };
+
+        auto solver = NeoN::la::Solver(exec, solverDict);
+        auto x = NeoN::Vector<NeoN::scalar>(exec, mesh.nCells());
+        NeoN::fill(x, 0.0);
+
+        BENCHMARK_ADVANCED(std::string(execName))(Catch::Benchmark::Chronometer meter)
+        {
+            MPI_Barrier(MPI_COMM_WORLD);
+            meter.measure(
+                [&]
+                {
+                    p.correctBoundaryConditions();
+                    phiHbyA.correctBoundaryConditions();
+
+                    auto solver = NeoN::la::Solver(exec, solverDict);
+                    expr.assemble(0.0, 1.0, ls);
+                    auto solverStats = solver.solve(ls, x);
+
                     fence(exec);
                     ls.reset();
                     MPI_Barrier(MPI_COMM_WORLD);
@@ -134,16 +201,49 @@ void runDistributedMomentumBenchmark(
                 {std::string("Gauss"), std::string("linear"), std::string("uncorrected")}
             )
         );
+        NeoN::Dictionary gradSchemes;
+        gradSchemes.insert(
+            "grad(p)", NeoN::TokenList({std::string("Gauss"), std::string("linear")})
+        );
         NeoN::Dictionary fv;
         fv.insert("divSchemes", divSchemes);
         fv.insert("laplacianSchemes", lapSchemes);
+        fv.insert("gradSchemes", gradSchemes);
         return fv;
     };
 
-    DYNAMIC_SECTION(sectionName + " - momentum assemble")
+    auto scalarVolumeBCs = createDistributedBCs<fvcc::VolumeBoundary<NeoN::scalar>>(mesh);
+    fvcc::VolumeField<NeoN::scalar> p(exec, "p", mesh, scalarVolumeBCs);
+    NeoN::fill(p.internalVector(), 1.0);
+    p.correctBoundaryConditions();
+
+    DYNAMIC_SECTION(sectionName + " - momentum assemble - face based")
     {
         auto ls = la::createEmptyLinearSystem<NeoN::Vec3>(mesh);
-        auto expr = NeoN::dsl::imp::div(phi, U) - NeoN::dsl::imp::laplacian(nu, U);
+        auto expr = NeoN::dsl::imp::div(phi, U) - NeoN::dsl::imp::laplacian(nu, U)
+                  + NeoN::dsl::exp::grad(p);
+        expr.read(fvSchemes());
+        BENCHMARK_ADVANCED(std::string(execName))(Catch::Benchmark::Chronometer meter)
+        {
+            MPI_Barrier(MPI_COMM_WORLD);
+            meter.measure(
+                [&]
+                {
+                    U.correctBoundaryConditions();
+                    expr.assemble(0.0, 1.0, ls);
+                    fence(exec);
+                    MPI_Barrier(MPI_COMM_WORLD);
+                }
+            );
+        };
+    }
+
+    DYNAMIC_SECTION(sectionName + " - momentum assemble - cell based")
+    {
+        auto cellIterator = std::make_shared<NeoN::la::CellBasedIterator>();
+        auto ls = NeoN::la::createEmptyLinearSystem<NeoN::Vec3>(mesh, cellIterator);
+        auto expr = NeoN::dsl::imp::div(phi, U) - NeoN::dsl::imp::laplacian(nu, U)
+                  + NeoN::dsl::exp::grad(p);
         expr.read(fvSchemes());
         BENCHMARK_ADVANCED(std::string(execName))(Catch::Benchmark::Chronometer meter)
         {
@@ -160,6 +260,7 @@ void runDistributedMomentumBenchmark(
         };
     }
 }
+
 
 #endif // NF_WITH_MPI_SUPPORT
 

--- a/benchmarks/distributed/common.cpp
+++ b/benchmarks/distributed/common.cpp
@@ -217,7 +217,7 @@ void runDistributedMomentumBenchmark(
     NeoN::fill(p.internalVector(), 1.0);
     p.correctBoundaryConditions();
 
-    DYNAMIC_SECTION(sectionName + " - momentum assemble - face based")
+    DYNAMIC_SECTION(sectionName + " - momentum assemble - face based - vec3")
     {
         auto ls = la::createEmptyLinearSystem<NeoN::Vec3>(mesh);
         auto expr = NeoN::dsl::imp::div(phi, U) - NeoN::dsl::imp::laplacian(nu, U)
@@ -238,7 +238,28 @@ void runDistributedMomentumBenchmark(
         };
     }
 
-    DYNAMIC_SECTION(sectionName + " - momentum assemble - cell based")
+    DYNAMIC_SECTION(sectionName + " - momentum assemble - face based - scalar")
+    {
+        auto ls = la::createEmptyLinearSystem<NeoN::scalar, NeoN::Vec3>(mesh);
+        auto expr = NeoN::dsl::imp::div(phi, U) - NeoN::dsl::imp::laplacian(nu, U)
+                  + NeoN::dsl::exp::grad(p);
+        expr.read(fvSchemes());
+        BENCHMARK_ADVANCED(std::string(execName))(Catch::Benchmark::Chronometer meter)
+        {
+            MPI_Barrier(MPI_COMM_WORLD);
+            meter.measure(
+                [&]
+                {
+                    U.correctBoundaryConditions();
+                    expr.assemble<NeoN::scalar>(0.0, 1.0, ls);
+                    fence(exec);
+                    MPI_Barrier(MPI_COMM_WORLD);
+                }
+            );
+        };
+    }
+
+    DYNAMIC_SECTION(sectionName + " - momentum assemble - cell based - Vec3")
     {
         auto cellIterator = std::make_shared<NeoN::la::CellBasedIterator>();
         auto ls = NeoN::la::createEmptyLinearSystem<NeoN::Vec3>(mesh, cellIterator);
@@ -259,6 +280,100 @@ void runDistributedMomentumBenchmark(
             );
         };
     }
+
+    DYNAMIC_SECTION(sectionName + " - momentum assemble + Gko no solve - scalar")
+    {
+        auto ls = la::createEmptyLinearSystem<NeoN::scalar, NeoN::Vec3>(mesh);
+        auto expr = NeoN::dsl::imp::div(phi, U) - NeoN::dsl::imp::laplacian(nu, U)
+                  + NeoN::dsl::exp::grad(p);
+        expr.read(fvSchemes());
+
+        NeoN::Dictionary solverDict {
+            {{"solver", std::string {"Ginkgo"}},
+             {"type", "solver::Gmres"},
+             {"criteria", NeoN::Dictionary {{{"iteration", 0}, {"relative_residual_norm", 1.0}}}}}
+        };
+
+        auto x = NeoN::Vector<NeoN::Vec3>(exec, mesh.nCells());
+        NeoN::fill(x, NeoN::zero<NeoN::Vec3>());
+
+        BENCHMARK_ADVANCED(std::string(execName))(Catch::Benchmark::Chronometer meter)
+        {
+            MPI_Barrier(MPI_COMM_WORLD);
+            meter.measure(
+                [&]
+                {
+                    U.correctBoundaryConditions();
+
+                    auto solver = NeoN::la::Solver(exec, solverDict);
+                    expr.assemble<NeoN::scalar>(0.0, 1.0, ls);
+                    auto solverStats = solver.solve(ls, x);
+
+                    fence(exec);
+                    ls.reset();
+                    MPI_Barrier(MPI_COMM_WORLD);
+                }
+            );
+        };
+    }
+
+    DYNAMIC_SECTION(sectionName + " - momentum assemble + Gko no solve - Vec3")
+    {
+        auto ls = la::createEmptyLinearSystem<NeoN::Vec3>(mesh);
+        auto expr = NeoN::dsl::imp::div(phi, U) - NeoN::dsl::imp::laplacian(nu, U)
+                  + NeoN::dsl::exp::grad(p);
+        expr.read(fvSchemes());
+
+        NeoN::Dictionary solverDict {
+            {{"solver", std::string {"Ginkgo"}},
+             {"type", "solver::Gmres"},
+             {"criteria", NeoN::Dictionary {{{"iteration", 0}, {"relative_residual_norm", 1.0}}}}}
+        };
+
+        auto x = NeoN::Vector<NeoN::Vec3>(exec, mesh.nCells());
+        NeoN::fill(x, NeoN::zero<NeoN::Vec3>());
+
+        BENCHMARK_ADVANCED(std::string(execName))(Catch::Benchmark::Chronometer meter)
+        {
+            MPI_Barrier(MPI_COMM_WORLD);
+            meter.measure(
+                [&]
+                {
+                    U.correctBoundaryConditions();
+
+                    auto solver = NeoN::la::Solver(exec, solverDict);
+                    expr.assemble<NeoN::Vec3>(0.0, 1.0, ls);
+                    auto solverStats = solver.solve(ls, x);
+
+                    fence(exec);
+                    ls.reset();
+                    MPI_Barrier(MPI_COMM_WORLD);
+                }
+            );
+        };
+    }
+
+    // DYNAMIC_SECTION(sectionName + " - momentum assemble - cell based - scalar")
+    // {
+    //     auto cellIterator = std::make_shared<NeoN::la::CellBasedIterator>();
+    //     auto ls = NeoN::la::createEmptyLinearSystem<NeoN::scalar, NeoN::Vec3>(mesh,
+    //     cellIterator); auto expr = NeoN::dsl::imp::div(phi, U) - NeoN::dsl::imp::laplacian(nu, U)
+    //       + NeoN::dsl::exp::grad(p);
+    //     expr.read(fvSchemes());
+    //     BENCHMARK_ADVANCED(std::string(execName))(Catch::Benchmark::Chronometer meter)
+    //     {
+    //         MPI_Barrier(MPI_COMM_WORLD);
+    //         meter.measure(
+    //             [&]
+    //             {
+    //                 U.correctBoundaryConditions();
+    //                 expr.assemble(0.0, 1.0, ls);
+    //                 fence(exec);
+    //                 MPI_Barrier(MPI_COMM_WORLD);
+    //             }
+    //         );
+    //     };
+    // }
 }
 
 

--- a/benchmarks/distributed/common.hpp
+++ b/benchmarks/distributed/common.hpp
@@ -27,6 +27,7 @@ std::pair<NeoN::localIdx, NeoN::localIdx> createStrongScalingSizeFromEnv();
  * processor patches - which BoundaryMesh stores after the regular patches -
  * receive a "processor" boundary condition so that halo values are exchanged
  * with the neighbouring rank during correctBoundaryConditions.
+ * TODO remove when PR528 is merged.
  */
 template<typename BoundaryType>
 std::vector<BoundaryType> createDistributedBCs(const NeoN::UnstructuredMesh& mesh)

--- a/include/NeoN/core/tokenList.hpp
+++ b/include/NeoN/core/tokenList.hpp
@@ -84,6 +84,12 @@ public:
     [[nodiscard]] size_t size() const;
 
     /**
+     * @brief Rewind the read cursor used by next<>() so the list can be
+     *        iterated again from the beginning.
+     */
+    void reset() const { nextIndex_ = 0; }
+
+    /**
      * @brief Retrieves the value associated with the given index, casting it to
      * the specified type.
      * @tparam T The type to cast the value to.

--- a/include/NeoN/dsl/ddt.hpp
+++ b/include/NeoN/dsl/ddt.hpp
@@ -27,7 +27,7 @@ public:
         NF_ERROR_EXIT("Not implemented");
     }
 
-    void implicitOperation(la::LinearSystem<scalar, localIdx>&, scalar, scalar) const
+    void implicitOperation(la::LinearSystem<scalar>&, scalar, scalar) const
     {
         NF_ERROR_EXIT("Not implemented");
     }

--- a/include/NeoN/dsl/expression.hpp
+++ b/include/NeoN/dsl/expression.hpp
@@ -240,7 +240,10 @@ public:
     }
 
     /*@brief subtract explicit source terms from the linear system rhs, scaled by cell volumes */
-    void assembleExplicitSource(la::LinearSystem<ValueType>& ls, const UnstructuredMesh& mesh) const
+    template<typename AssemblyType = ValueType>
+    void assembleExplicitSource(
+        la::LinearSystem<AssemblyType, ValueType>& ls, const UnstructuredMesh& mesh
+    ) const
     {
         auto expTmp = explicitOperation(static_cast<localIdx>(mesh.nCells()));
         auto [vol, expSource, rhs] = views(mesh.cellVolumes(), expTmp, ls.rhs());
@@ -273,15 +276,16 @@ public:
      *
      * @param ps post-assembly functors applied to the system after assembly
      */
+    template<typename AssemblyType = ValueType>
     void assemble(
         scalar t,
         scalar dt,
-        la::LinearSystem<ValueType>& ls,
+        la::LinearSystem<AssemblyType, ValueType>& ls,
         const UnstructuredMesh& mesh,
         std::vector<const PostAssemblyBase<ValueType, IndexType>*> ps = {}
     ) const
     {
-        assemble(t, dt, ls, ps);
+        assemble<AssemblyType>(t, dt, ls, ps);
         assembleExplicitSource(ls, mesh);
     }
 

--- a/include/NeoN/dsl/expression.hpp
+++ b/include/NeoN/dsl/expression.hpp
@@ -33,7 +33,8 @@ struct PostAssemblyBase
 {
     virtual ~PostAssemblyBase() = default;
     virtual void
-    operator()(la::LinearSystem<VectorType, la::CSRMatrix<VectorType, IndexType>>&) const {};
+    operator()(la::LinearSystem<VectorType, VectorType, la::CSRMatrix<VectorType, IndexType>>&)
+        const {};
 };
 
 /**
@@ -58,7 +59,7 @@ public:
 
     SetReference(localIdx refCell, ValueType refValue) : refCell_(refCell), refValue_(refValue) {}
 
-    void operator()(la::LinearSystem<ValueType, la::CSRMatrix<ValueType, IndexType>>& ls
+    void operator()(la::LinearSystem<ValueType, ValueType, la::CSRMatrix<ValueType, IndexType>>& ls
     ) const override
     {
 #ifdef NF_WITH_MPI_SUPPORT
@@ -163,8 +164,9 @@ public:
         return source;
     }
 
-    /*@brief compute matrix coefficients based on all spatial operators */
-    void assembleSpatialOperator(la::LinearSystem<ValueType>& ls) const
+    /** @brief compute matrix coefficients based on all spatial operators */
+    template<typename AssemblyType = ValueType>
+    void assembleSpatialOperator(la::LinearSystem<AssemblyType, ValueType>& ls) const
     {
         for (auto& op : spatialOperators_)
         {
@@ -175,10 +177,13 @@ public:
         }
     }
 
-    /*@brief compute matrix coefficients based on all temporal operators
+    /** @brief compute matrix coefficients based on all temporal operators
      * assemble directly into linear system
      */
-    void assembleTemporalOperator(la::LinearSystem<ValueType>& ls, scalar t, scalar dt) const
+    template<typename AssemblyType = ValueType>
+    void assembleTemporalOperator(
+        la::LinearSystem<AssemblyType, ValueType>& ls, scalar t, scalar dt
+    ) const
     {
         for (auto& op : temporalOperators_)
         {
@@ -206,15 +211,16 @@ public:
      * @param ps post-assembly functors applied to the system after assembly
      * @return the assembled linear system
      */
-    la::LinearSystem<ValueType> assemble(
+    template<typename AssemblyType = ValueType>
+    la::LinearSystem<AssemblyType, ValueType> assemble(
         const UnstructuredMesh& mesh,
         scalar t,
         scalar dt,
         std::vector<const PostAssemblyBase<ValueType, IndexType>*> ps = {}
     ) const
     {
-        auto ls = la::createEmptyLinearSystem<ValueType>(mesh);
-        assemble(t, dt, ls, mesh, ps);
+        auto ls = la::createEmptyLinearSystem<AssemblyType, ValueType>(mesh);
+        assemble<AssemblyType>(t, dt, ls, mesh, ps);
         return ls;
     }
 
@@ -238,19 +244,25 @@ public:
      *
      * @param ps post-assembly functors applied to the system after assembly
      */
+    template<typename AssemblyType = ValueType>
     void assemble(
         scalar t,
         scalar dt,
-        la::LinearSystem<ValueType>& ls,
+        la::LinearSystem<AssemblyType, ValueType>& ls,
         std::vector<const PostAssemblyBase<ValueType, IndexType>*> ps = {}
     ) const
     {
         assembleSpatialOperator(ls);         // add spatial operator
         assembleTemporalOperator(ls, t, dt); // add temporal operators
 
-        for (const auto* p : ps)
+        // Post-assembly functors operate on LinearSystem<ValueType, ValueType, ...>; they only
+        // apply when the matrix and RHS value types coincide (the default-AssemblyType path).
+        if constexpr (std::is_same_v<AssemblyType, ValueType>)
         {
-            (*p)(ls);
+            for (const auto* p : ps)
+            {
+                (*p)(ls);
+            }
         }
     }
 

--- a/include/NeoN/dsl/expression.hpp
+++ b/include/NeoN/dsl/expression.hpp
@@ -35,6 +35,16 @@ struct PostAssemblyBase
     virtual void
     operator()(la::LinearSystem<VectorType, VectorType, la::CSRMatrix<VectorType, IndexType>>&)
         const {};
+
+    /** @brief Apply to the segregated scalar-matrix / VectorType-rhs form (a scalar coefficient
+     *         matrix with a VectorType right-hand side). Default no-op; functors that support the
+     *         segregated form override this. A distinct name (rather than an operator() overload)
+     *         avoids colliding with the same-type signature when VectorType == scalar. */
+    virtual void applyScalarMatrix(la::LinearSystem<
+                                   scalar,
+                                   VectorType,
+                                   la::CSRMatrix<scalar, IndexType>,
+                                   la::COOMatrix<scalar, IndexType>>&) const {};
 };
 
 /**
@@ -61,6 +71,41 @@ public:
 
     void operator()(la::LinearSystem<ValueType, ValueType, la::CSRMatrix<ValueType, IndexType>>& ls
     ) const override
+    {
+#ifdef NF_WITH_MPI_SUPPORT
+        // For distributed systems, only the rank owning refCell applies the constraint.
+        // For non-distributed systems (each rank holds a full copy), every rank applies it.
+        if (!ls.commPattern().sendCounts.empty())
+        {
+            mpi::Environment mpiEnv;
+            if (mpiEnv.isInitialized() && mpiEnv.rank() != 0) return;
+        }
+#endif
+        auto lsView = ls.view();
+        const auto ma = ls.faceToMatrixAddress()->view(ls.matrix().sparsity()->rowOffs().view());
+        auto refVal = refValue_;
+        auto refCell = refCell_;
+        parallelFor(
+            ls.exec(),
+            {refCell, refCell + 1},
+            NEON_LAMBDA(const localIdx celli) {
+                auto dIdx = ma.diagIdx(celli);
+                auto diagVal = lsView.matrix.values[dIdx];
+                lsView.rhs[celli] += diagVal * refVal;
+                lsView.matrix.values[dIdx] += diagVal;
+            },
+            "SetReference"
+        );
+    }
+
+    /** @brief Segregated scalar-matrix / ValueType-rhs form. The scalar diagonal scales the
+     *         ValueType reference value (scalar * Vec3 broadcasts), so the same pin applies to
+     *         every component of the right-hand side. */
+    void applyScalarMatrix(la::LinearSystem<
+                           scalar,
+                           ValueType,
+                           la::CSRMatrix<scalar, IndexType>,
+                           la::COOMatrix<scalar, IndexType>>& ls) const override
     {
 #ifdef NF_WITH_MPI_SUPPORT
         // For distributed systems, only the rank owning refCell applies the constraint.
@@ -255,13 +300,20 @@ public:
         assembleSpatialOperator(ls);         // add spatial operator
         assembleTemporalOperator(ls, t, dt); // add temporal operators
 
-        // Post-assembly functors operate on LinearSystem<ValueType, ValueType, ...>; they only
-        // apply when the matrix and RHS value types coincide (the default-AssemblyType path).
+        // Post-assembly functors apply on the same-type form via operator(); the segregated
+        // scalar-matrix / ValueType-rhs form dispatches to applyScalarMatrix instead.
         if constexpr (std::is_same_v<AssemblyType, ValueType>)
         {
             for (const auto* p : ps)
             {
                 (*p)(ls);
+            }
+        }
+        else if constexpr (std::is_same_v<AssemblyType, scalar>)
+        {
+            for (const auto* p : ps)
+            {
+                p->applyScalarMatrix(ls);
             }
         }
     }

--- a/include/NeoN/dsl/solver.hpp
+++ b/include/NeoN/dsl/solver.hpp
@@ -27,9 +27,7 @@ namespace detail
 template<typename VectorType, typename IndexType>
 la::SolverStats iterativeSolveImpl(
     Expression<typename VectorType::ElementType>& exp,
-    la::LinearSystem<
-        typename VectorType::ElementType,
-        la::CSRMatrix<typename VectorType::ElementType, IndexType>>& ls,
+    la::LinearSystem<typename VectorType::ElementType>& ls,
     VectorType& solution,
     scalar t,
     scalar dt,

--- a/include/NeoN/dsl/spatialOperator.hpp
+++ b/include/NeoN/dsl/spatialOperator.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <concepts>
 
+#include "NeoN/core/error.hpp"
 #include "NeoN/core/primitives/scalar.hpp"
 #include "NeoN/core/primitives/vec3.hpp"
 #include "NeoN/core/vector/vector.hpp"
@@ -186,6 +187,16 @@ private:
             if constexpr (HasImplicitOperatorScalarMtx<ConcreteOperatorType>)
             {
                 concreteOp_.implicitOperation(ls);
+            }
+            else
+            {
+                // Reached only for an implicit operator that lacks the scalar-matrix
+                // (segregated vector-solve) overload. Silently skipping it would drop its
+                // contribution and yield a wrong system, so fail fast instead.
+                NF_ERROR_EXIT(
+                    "Operator '" << getName()
+                                 << "' does not support scalar-matrix (segregated) assembly."
+                );
             }
         }
 

--- a/include/NeoN/dsl/spatialOperator.hpp
+++ b/include/NeoN/dsl/spatialOperator.hpp
@@ -34,8 +34,20 @@ concept HasImplicitOperator = requires(T const t) {
     } -> std::same_as<void>; // Adjust return type and arguments as needed
 };
 
+/* @brief Concept satisfied when T can assemble into a LinearSystem whose matrix
+ *        coefficients are scalar while the RHS holds T's field value type
+ *        (segregated vector-solve form). Only meaningful when VectorValueType != scalar.
+ */
 template<typename T>
-concept IsSpatialOperator = HasExplicitOperator<T> || HasImplicitOperator<T>;
+concept HasImplicitOperatorScalarMtx = requires(T const t) {
+    {
+        t.implicitOperation(std::declval<la::LinearSystem<scalar, typename T::VectorValueType>&>())
+    } -> std::same_as<void>;
+};
+
+template<typename T>
+concept IsSpatialOperator =
+    HasExplicitOperator<T> || HasImplicitOperator<T> || HasImplicitOperatorScalarMtx<T>;
 
 /* @class SpatialOperator
  * @brief A class to represent an operator in NeoNs dsl
@@ -74,6 +86,17 @@ public:
 
     void implicitOperation(la::LinearSystem<ValueType>& ls) const { model_->implicitOperation(ls); }
 
+    /* @brief Implicit assembly into a scalar-matrix / ValueType-rhs linear system
+     *        (segregated vector-solve form). Disabled when ValueType == scalar to
+     *        avoid colliding with the same-type overload above.
+     */
+    template<typename U = ValueType>
+        requires(!std::is_same_v<U, scalar>)
+    void implicitOperation(la::LinearSystem<scalar, ValueType>& ls) const
+    {
+        model_->implicitOperationScalarMtx(ls);
+    }
+
     /* returns the fundamental type of an operator, ie explicit, implicit */
     Operator::Type getType() const { return model_->getType(); }
 
@@ -102,6 +125,12 @@ private:
         virtual void explicitOperation(Vector<ValueType>& source) const = 0;
 
         virtual void implicitOperation(la::LinearSystem<ValueType>& ls) const = 0;
+
+        /* @brief Implicit assembly into LinearSystem<scalar, ValueType> for the
+         *        scalar-matrix / ValueType-rhs (segregated vector-solve) form.
+         *        Concrete operators that don't support this form leave it as a no-op.
+         */
+        virtual void implicitOperationScalarMtx(la::LinearSystem<scalar, ValueType>& ls) const = 0;
 
         /* @brief Given an input this function reads required coeffs */
         virtual void read(const Input& input) = 0;
@@ -146,6 +175,15 @@ private:
         virtual void implicitOperation(la::LinearSystem<ValueType>& ls) const override
         {
             if constexpr (HasImplicitOperator<ConcreteOperatorType>)
+            {
+                concreteOp_.implicitOperation(ls);
+            }
+        }
+
+        virtual void implicitOperationScalarMtx(la::LinearSystem<scalar, ValueType>& ls
+        ) const override
+        {
+            if constexpr (HasImplicitOperatorScalarMtx<ConcreteOperatorType>)
             {
                 concreteOp_.implicitOperation(ls);
             }

--- a/include/NeoN/dsl/temporalOperator.hpp
+++ b/include/NeoN/dsl/temporalOperator.hpp
@@ -41,8 +41,24 @@ concept HasTemporalImplicitOperator = requires(T t) {
     } -> std::same_as<void>; // Adjust return type and arguments as needed
 };
 
+/* @brief Concept satisfied when T can assemble its temporal contribution into a
+ *        LinearSystem whose matrix coefficients are scalar while the RHS holds T's
+ *        field value type (segregated vector-solve form).
+ */
 template<typename T>
-concept HasTemporalOperator = HasTemporalExplicitOperator<T> || HasTemporalImplicitOperator<T>;
+concept HasTemporalImplicitOperatorScalarMtx = requires(T t) {
+    {
+        t.implicitOperation(
+            std::declval<la::LinearSystem<scalar, typename T::VectorValueType>&>(),
+            std::declval<NeoN::scalar>(),
+            std::declval<NeoN::scalar>()
+        )
+    } -> std::same_as<void>;
+};
+
+template<typename T>
+concept HasTemporalOperator = HasTemporalExplicitOperator<T> || HasTemporalImplicitOperator<T>
+                           || HasTemporalImplicitOperatorScalarMtx<T>;
 
 /* @class TemporalOperator
  * @brief A class to represent a TemporalOperator in NeoNs DSL
@@ -87,6 +103,17 @@ public:
         model_->implicitOperation(ls, t, dt);
     }
 
+    /* @brief Implicit temporal assembly into a scalar-matrix / ValueType-rhs linear system
+     *        (segregated vector-solve form). Disabled when ValueType == scalar to avoid
+     *        colliding with the same-type overload above.
+     */
+    template<typename U = ValueType>
+        requires(!std::is_same_v<U, scalar>)
+    void implicitOperation(la::LinearSystem<scalar, ValueType>& ls, scalar t, scalar dt) const
+    {
+        model_->implicitOperationScalarMtx(ls, t, dt);
+    }
+
     /* returns the fundamental type of an operator, ie explicit, implicit */
     Operator::Type getType() const { return model_->getType(); }
 
@@ -117,6 +144,14 @@ private:
         virtual void explicitOperation(Vector<ValueType>& source, scalar t, scalar dt) = 0;
 
         virtual void implicitOperation(la::LinearSystem<ValueType>& ls, scalar t, scalar dt) = 0;
+
+        /* @brief Temporal assembly into LinearSystem<scalar, ValueType> for the
+         *        scalar-matrix / ValueType-rhs (segregated vector-solve) form.
+         *        Concrete operators that don't support this form leave it as a no-op.
+         */
+        virtual void implicitOperationScalarMtx(
+            la::LinearSystem<scalar, ValueType>& ls, scalar t, scalar dt
+        ) = 0;
 
         /* @brief Given an input this function reads required properties */
         virtual void read(const Input& input) = 0;
@@ -170,6 +205,16 @@ private:
         implicitOperation(la::LinearSystem<ValueType>& ls, scalar t, scalar dt) override
         {
             if constexpr (HasTemporalImplicitOperator<ConcreteTemporalOperatorType>)
+            {
+                concreteOp_.implicitOperation(ls, t, dt);
+            }
+        }
+
+        virtual void implicitOperationScalarMtx(
+            la::LinearSystem<scalar, ValueType>& ls, scalar t, scalar dt
+        ) override
+        {
+            if constexpr (HasTemporalImplicitOperatorScalarMtx<ConcreteTemporalOperatorType>)
             {
                 concreteOp_.implicitOperation(ls, t, dt);
             }

--- a/include/NeoN/dsl/temporalOperator.hpp
+++ b/include/NeoN/dsl/temporalOperator.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <concepts>
 
+#include "NeoN/core/error.hpp"
 #include "NeoN/core/primitives/scalar.hpp"
 #include "NeoN/core/vector/vector.hpp"
 #include "NeoN/core/input.hpp"
@@ -217,6 +218,18 @@ private:
             if constexpr (HasTemporalImplicitOperatorScalarMtx<ConcreteTemporalOperatorType>)
             {
                 concreteOp_.implicitOperation(ls, t, dt);
+            }
+            else
+            {
+                // Reached only for an implicit temporal operator that lacks the scalar-matrix
+                // (segregated vector-solve) overload. Silently skipping it would drop its
+                // contribution (e.g. an implicit ddt term) and yield a wrong system, so fail
+                // fast instead.
+                NF_ERROR_EXIT(
+                    "Temporal operator '" << getName()
+                                          << "' does not support scalar-matrix (segregated) "
+                                             "assembly."
+                );
             }
         }
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/ddtOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/ddtOperator.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include "NeoN/core/vector/vector.hpp"
 #include "NeoN/core/executor/executor.hpp"
 #include "NeoN/core/input.hpp"
@@ -40,6 +42,19 @@ public:
     void bdf1Kernel(la::LinearSystem<ValueType>& ls, scalar t, scalar dt) const;
 
     void bdf2Kernel(la::LinearSystem<ValueType>& ls, scalar t, scalar dt) const;
+
+    /* @brief Implicit temporal assembly into a scalar-matrix / ValueType-rhs linear system
+     *        (segregated vector-solve form). Only present when ValueType != scalar; for scalar
+     *        fields the same-type overload above already covers LinearSystem<scalar, scalar>.
+     *        The scalar diagonal entry scales every rhs component equally.
+     */
+    template<typename F = ValueType>
+        requires(!std::is_same_v<F, scalar>)
+    void implicitOperation(la::LinearSystem<scalar, ValueType>& ls, scalar, scalar dt) const;
+
+    void bdf1KernelScalarMtx(la::LinearSystem<scalar, ValueType>& ls, scalar t, scalar dt) const;
+
+    void bdf2KernelScalarMtx(la::LinearSystem<scalar, ValueType>& ls, scalar t, scalar dt) const;
 
     DdtScheme scheme() const noexcept { return scheme_; }
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/divOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/divOperator.hpp
@@ -18,23 +18,25 @@ namespace NeoN::finiteVolume::cellCentred
 /* @class Factory class to create divergence operators by a given name using
  * using NeoNs runTimeFactory mechanism
  */
-template<typename ValueType>
+template<typename FieldValueType, typename AssemblyType = FieldValueType>
 class DivOperatorFactory :
     public RuntimeSelectionFactory<
-        DivOperatorFactory<ValueType>,
+        DivOperatorFactory<FieldValueType, AssemblyType>,
         Parameters<const Executor&, const UnstructuredMesh&, const Input&>>
 {
 
 public:
 
-    static std::unique_ptr<DivOperatorFactory<ValueType>>
+    static std::unique_ptr<DivOperatorFactory<FieldValueType, AssemblyType>>
     create(const Executor& exec, const UnstructuredMesh& uMesh, const Input& inputs)
     {
         std::string key = (std::holds_alternative<Dictionary>(inputs))
                             ? std::get<Dictionary>(inputs).get<std::string>("DivOperator")
                             : std::get<TokenList>(inputs).next<std::string>();
-        DivOperatorFactory<ValueType>::keyExistsOrError(key);
-        return DivOperatorFactory<ValueType>::table().at(key)(exec, uMesh, inputs);
+        DivOperatorFactory<FieldValueType, AssemblyType>::keyExistsOrError(key);
+        return DivOperatorFactory<FieldValueType, AssemblyType>::table().at(key)(
+            exec, uMesh, inputs
+        );
     }
 
     static std::string name() { return "DivOperatorFactory"; }
@@ -45,30 +47,30 @@ public:
     virtual ~DivOperatorFactory() {} // Virtual destructor
 
     virtual void
-    div(VolumeField<ValueType>& divPhi,
+    div(VolumeField<FieldValueType>& divPhi,
         const SurfaceField<scalar>& faceFlux,
-        const VolumeField<ValueType>& phi,
+        const VolumeField<FieldValueType>& phi,
         const dsl::Coeff operatorScaling) const = 0;
 
     virtual void
-    div(la::LinearSystem<ValueType>& ls,
+    div(la::LinearSystem<AssemblyType, FieldValueType>& ls,
         const SurfaceField<scalar>& faceFlux,
-        const VolumeField<ValueType>& phi,
+        const VolumeField<FieldValueType>& phi,
         const dsl::Coeff operatorScaling) const = 0;
 
     virtual void
-    div(Vector<ValueType>& divPhi,
+    div(Vector<FieldValueType>& divPhi,
         const SurfaceField<scalar>& faceFlux,
-        const VolumeField<ValueType>& phi,
+        const VolumeField<FieldValueType>& phi,
         const dsl::Coeff operatorScaling) const = 0;
 
-    virtual VolumeField<ValueType>
+    virtual VolumeField<FieldValueType>
     div(const SurfaceField<scalar>& faceFlux,
-        const VolumeField<ValueType>& phi,
+        const VolumeField<FieldValueType>& phi,
         const dsl::Coeff operatorScaling) const = 0;
 
     // Pure virtual function for cloning
-    virtual std::unique_ptr<DivOperatorFactory<ValueType>> clone() const = 0;
+    virtual std::unique_ptr<DivOperatorFactory<FieldValueType, AssemblyType>> clone() const = 0;
 
 protected:
 
@@ -77,93 +79,115 @@ protected:
     const UnstructuredMesh& mesh_;
 };
 
-template<typename ValueType>
-class DivOperator : public dsl::OperatorMixin<VolumeField<ValueType>>
+template<typename FieldValueType>
+class DivOperator : public dsl::OperatorMixin<VolumeField<FieldValueType>>
 {
 
 public:
 
-    using VectorValueType = ValueType;
+    using VectorValueType = FieldValueType;
 
     // copy constructor
     DivOperator(const DivOperator& divOp)
-        : dsl::OperatorMixin<VolumeField<ValueType>>(
+        : dsl::OperatorMixin<VolumeField<FieldValueType>>(
             divOp.exec_, divOp.coeffs_, divOp.field_, divOp.type_
         ),
           faceFlux_(divOp.faceFlux_),
-          divOperatorStrategy_(
-              divOp.divOperatorStrategy_ ? divOp.divOperatorStrategy_->clone() : nullptr
+          sameTypeStrategy_(divOp.sameTypeStrategy_ ? divOp.sameTypeStrategy_->clone() : nullptr),
+          scalarMtxStrategy_(
+              divOp.scalarMtxStrategy_ ? divOp.scalarMtxStrategy_->clone() : nullptr
           ) {};
 
     DivOperator(
         dsl::Operator::Type termType,
         const SurfaceField<scalar>& faceFlux,
-        const VolumeField<ValueType>& phi,
+        const VolumeField<FieldValueType>& phi,
         Input input
     )
-        : dsl::OperatorMixin<VolumeField<ValueType>>(phi.exec(), dsl::Coeff(1.0), phi, termType),
+        : dsl::OperatorMixin<VolumeField<FieldValueType>>(
+            phi.exec(), dsl::Coeff(1.0), phi, termType
+        ),
           faceFlux_(faceFlux),
-          divOperatorStrategy_(DivOperatorFactory<ValueType>::create(phi.exec(), phi.mesh(), input)
-          ) {};
-
-    DivOperator(
-        dsl::Operator::Type termType,
-        const SurfaceField<scalar>& faceFlux,
-        const VolumeField<ValueType>& phi,
-        std::unique_ptr<DivOperatorFactory<ValueType>> divOperatorStrategy
-    )
-        : dsl::OperatorMixin<VolumeField<scalar>>(phi.exec(), dsl::Coeff(1.0), phi, termType),
-          faceFlux_(faceFlux), divOperatorStrategy_(std::move(divOperatorStrategy)) {};
-
-    DivOperator(
-        dsl::Operator::Type termType,
-        const SurfaceField<scalar>& faceFlux,
-        const VolumeField<ValueType>& phi
-    )
-        : dsl::OperatorMixin<VolumeField<ValueType>>(phi.exec(), dsl::Coeff(1.0), phi, termType),
-          faceFlux_(faceFlux), divOperatorStrategy_(nullptr) {};
-
-
-    void explicitOperation(Vector<ValueType>& source) const
+          sameTypeStrategy_(DivOperatorFactory<FieldValueType, FieldValueType>::create(
+              phi.exec(), phi.mesh(), input
+          )),
+          scalarMtxStrategy_(nullptr)
     {
-        NF_ASSERT(divOperatorStrategy_, "DivOperatorStrategy not initialized");
-        auto tmpsource = Vector<ValueType>(source.exec(), source.size(), zero<ValueType>());
+        if constexpr (!std::is_same_v<FieldValueType, scalar>)
+        {
+            // The first create() consumed tokens; rewind the cursor so the second
+            // strategy can read the same scheme tokens from the start.
+            if (std::holds_alternative<NeoN::TokenList>(input))
+            {
+                std::get<NeoN::TokenList>(input).reset();
+            }
+            scalarMtxStrategy_ =
+                DivOperatorFactory<FieldValueType, scalar>::create(phi.exec(), phi.mesh(), input);
+        }
+    };
+
+    DivOperator(
+        dsl::Operator::Type termType,
+        const SurfaceField<scalar>& faceFlux,
+        const VolumeField<FieldValueType>& phi
+    )
+        : dsl::OperatorMixin<VolumeField<FieldValueType>>(
+            phi.exec(), dsl::Coeff(1.0), phi, termType
+        ),
+          faceFlux_(faceFlux), sameTypeStrategy_(nullptr), scalarMtxStrategy_(nullptr) {};
+
+
+    void explicitOperation(Vector<FieldValueType>& source) const
+    {
+        NF_ASSERT(sameTypeStrategy_, "DivOperatorStrategy not initialized");
+        auto tmpsource =
+            Vector<FieldValueType>(source.exec(), source.size(), zero<FieldValueType>());
         const auto operatorScaling = this->getCoefficient();
-        divOperatorStrategy_->div(tmpsource, faceFlux_, this->getVector(), operatorScaling);
+        sameTypeStrategy_->div(tmpsource, faceFlux_, this->getVector(), operatorScaling);
         source += tmpsource;
     }
 
-    void implicitOperation(la::LinearSystem<ValueType>& ls) const
+    void implicitOperation(la::LinearSystem<FieldValueType, FieldValueType>& ls) const
     {
-        NF_ASSERT(divOperatorStrategy_, "DivOperatorStrategy not initialized");
+        NF_ASSERT(sameTypeStrategy_, "DivOperatorStrategy not initialized");
         const auto operatorScaling = this->getCoefficient();
-        divOperatorStrategy_->div(ls, faceFlux_, this->getVector(), operatorScaling);
+        sameTypeStrategy_->div(ls, faceFlux_, this->getVector(), operatorScaling);
     }
 
-    [[deprecated("use explicit or implicit operation")]] void div(auto&&... args) const
+    /* @brief Implicit assembly into a scalar-matrix / FieldValueType-rhs linear system
+     *        (segregated vector-solve form). Only present when FieldValueType != scalar;
+     *        for scalar fields the same-type overload above already covers this signature.
+     */
+    template<typename F = FieldValueType>
+        requires(!std::is_same_v<F, scalar>)
+    void implicitOperation(la::LinearSystem<scalar, FieldValueType>& ls) const
     {
+        NF_ASSERT(scalarMtxStrategy_, "Scalar-matrix DivOperatorStrategy not initialized");
         const auto operatorScaling = this->getCoefficient();
-        divOperatorStrategy_->div(
-            std::forward<decltype(args)>(args)..., faceFlux_, this->getVector(), operatorScaling
-        );
+        scalarMtxStrategy_->div(ls, faceFlux_, this->getVector(), operatorScaling);
     }
 
     void read(const Input& input)
     {
         const UnstructuredMesh& mesh = this->getVector().mesh();
+        NeoN::TokenList tokens;
         if (std::holds_alternative<NeoN::Dictionary>(input))
         {
             auto dict = std::get<NeoN::Dictionary>(input);
             std::string schemeName = "div(" + faceFlux_.name + "," + this->getVector().name + ")";
-            auto tokens = dict.subDict("divSchemes").get<NeoN::TokenList>(schemeName);
-            divOperatorStrategy_ =
-                DivOperatorFactory<ValueType>::create(this->exec(), mesh, tokens);
+            tokens = dict.subDict("divSchemes").get<NeoN::TokenList>(schemeName);
         }
         else
         {
-            auto tokens = std::get<NeoN::TokenList>(input);
-            divOperatorStrategy_ =
-                DivOperatorFactory<ValueType>::create(this->exec(), mesh, tokens);
+            tokens = std::get<NeoN::TokenList>(input);
+        }
+        sameTypeStrategy_ =
+            DivOperatorFactory<FieldValueType, FieldValueType>::create(this->exec(), mesh, tokens);
+        if constexpr (!std::is_same_v<FieldValueType, scalar>)
+        {
+            tokens.reset();
+            scalarMtxStrategy_ =
+                DivOperatorFactory<FieldValueType, scalar>::create(this->exec(), mesh, tokens);
         }
     }
 
@@ -173,7 +197,10 @@ private:
 
     const SurfaceField<NeoN::scalar>& faceFlux_;
 
-    std::unique_ptr<DivOperatorFactory<ValueType>> divOperatorStrategy_;
+    std::unique_ptr<DivOperatorFactory<FieldValueType, FieldValueType>> sameTypeStrategy_;
+    // Only initialized when FieldValueType != scalar; used to assemble into a
+    // LinearSystem<scalar, FieldValueType> for segregated vector solves.
+    std::unique_ptr<DivOperatorFactory<FieldValueType, scalar>> scalarMtxStrategy_;
 };
 
 

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp
@@ -17,11 +17,13 @@ namespace NeoN::finiteVolume::cellCentred
 /* @brief
  *
  */
-template<typename ValueType>
+template<typename FieldValueType, typename AssemblyType = FieldValueType>
 class GaussGreenDiv :
-    public DivOperatorFactory<ValueType>::template Register<GaussGreenDiv<ValueType>>
+    public DivOperatorFactory<FieldValueType, AssemblyType>::template Register<
+        GaussGreenDiv<FieldValueType, AssemblyType>>
 {
-    using Base = DivOperatorFactory<ValueType>::template Register<GaussGreenDiv<ValueType>>;
+    using Base = DivOperatorFactory<FieldValueType, AssemblyType>::template Register<
+        GaussGreenDiv<FieldValueType, AssemblyType>>;
 
 public:
 
@@ -34,37 +36,37 @@ public:
     GaussGreenDiv(const Executor& exec, const UnstructuredMesh& mesh, const Input& inputs)
         : Base(exec, mesh), surfaceInterpolation_(exec, mesh, inputs) {};
 
-    virtual VolumeField<ValueType>
+    virtual VolumeField<FieldValueType>
     div(const SurfaceField<scalar>& faceFlux,
-        const VolumeField<ValueType>& phi,
+        const VolumeField<FieldValueType>& phi,
         const dsl::Coeff operatorScaling) const override;
 
     virtual void
-    div(VolumeField<ValueType>& divPhi,
+    div(VolumeField<FieldValueType>& divPhi,
         const SurfaceField<scalar>& faceFlux,
-        const VolumeField<ValueType>& phi,
+        const VolumeField<FieldValueType>& phi,
         const dsl::Coeff operatorScaling) const override;
 
     virtual void
-    div(Vector<ValueType>& divPhi,
+    div(Vector<FieldValueType>& divPhi,
         const SurfaceField<scalar>& faceFlux,
-        const VolumeField<ValueType>& phi,
+        const VolumeField<FieldValueType>& phi,
         const dsl::Coeff operatorScaling) const override;
 
     virtual void
-    div(la::LinearSystem<ValueType>& ls,
+    div(la::LinearSystem<AssemblyType, FieldValueType>& ls,
         const SurfaceField<scalar>& faceFlux,
-        const VolumeField<ValueType>& phi,
+        const VolumeField<FieldValueType>& phi,
         const dsl::Coeff operatorScaling) const override;
 
-    std::unique_ptr<DivOperatorFactory<ValueType>> clone() const override
+    std::unique_ptr<DivOperatorFactory<FieldValueType, AssemblyType>> clone() const override
     {
-        return std::make_unique<GaussGreenDiv<ValueType>>(*this);
+        return std::make_unique<GaussGreenDiv<FieldValueType, AssemblyType>>(*this);
     }
 
 private:
 
-    SurfaceInterpolation<ValueType> surfaceInterpolation_;
+    SurfaceInterpolation<FieldValueType> surfaceInterpolation_;
 };
 
 // Required on MSVC: without extern template, each TU (DLL and EXE) gets its own
@@ -72,5 +74,6 @@ private:
 // a different map than the one the test binary queries.
 extern template class GaussGreenDiv<scalar>;
 extern template class GaussGreenDiv<Vec3>;
+extern template class GaussGreenDiv<Vec3, scalar>;
 
 } // namespace NeoN

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp
@@ -16,12 +16,13 @@ namespace NeoN::finiteVolume::cellCentred
 {
 
 
-template<typename ValueType>
+template<typename FieldValueType, typename AssemblyType = FieldValueType>
 class GaussGreenLaplacian :
-    public LaplacianOperatorFactory<ValueType>::template Register<GaussGreenLaplacian<ValueType>>
+    public LaplacianOperatorFactory<FieldValueType, AssemblyType>::template Register<
+        GaussGreenLaplacian<FieldValueType, AssemblyType>>
 {
-    using Base =
-        LaplacianOperatorFactory<ValueType>::template Register<GaussGreenLaplacian<ValueType>>;
+    using Base = LaplacianOperatorFactory<FieldValueType, AssemblyType>::template Register<
+        GaussGreenLaplacian<FieldValueType, AssemblyType>>;
 
 public:
 
@@ -36,40 +37,42 @@ public:
           faceNormalGradient_(exec, mesh, inputs) {};
 
     virtual void laplacian(
-        VolumeField<ValueType>& lapPhi,
+        VolumeField<FieldValueType>& lapPhi,
         const SurfaceField<scalar>& gamma,
-        const VolumeField<ValueType>& phi,
+        const VolumeField<FieldValueType>& phi,
         const dsl::Coeff coeff
     ) override;
 
-    virtual VolumeField<ValueType> laplacian(
-        const SurfaceField<scalar>& gamma, const VolumeField<ValueType>& phi, const dsl::Coeff coeff
+    virtual VolumeField<FieldValueType> laplacian(
+        const SurfaceField<scalar>& gamma,
+        const VolumeField<FieldValueType>& phi,
+        const dsl::Coeff coeff
     ) const override;
 
     virtual void laplacian(
-        Vector<ValueType>& lapPhi,
+        Vector<FieldValueType>& lapPhi,
         const SurfaceField<scalar>& gamma,
-        const VolumeField<ValueType>& phi,
+        const VolumeField<FieldValueType>& phi,
         const dsl::Coeff coeff
     ) override;
 
     virtual void laplacian(
-        la::LinearSystem<ValueType>& ls,
+        la::LinearSystem<AssemblyType, FieldValueType>& ls,
         const SurfaceField<scalar>& gamma,
-        const VolumeField<ValueType>& phi,
+        const VolumeField<FieldValueType>& phi,
         const dsl::Coeff coeff
     ) override;
 
-    std::unique_ptr<LaplacianOperatorFactory<ValueType>> clone() const override
+    std::unique_ptr<LaplacianOperatorFactory<FieldValueType, AssemblyType>> clone() const override
     {
-        return std::make_unique<GaussGreenLaplacian<ValueType>>(*this);
+        return std::make_unique<GaussGreenLaplacian<FieldValueType, AssemblyType>>(*this);
     };
 
 private:
 
-    SurfaceInterpolation<ValueType> surfaceInterpolation_;
+    SurfaceInterpolation<FieldValueType> surfaceInterpolation_;
 
-    FaceNormalGradient<ValueType> faceNormalGradient_;
+    FaceNormalGradient<FieldValueType> faceNormalGradient_;
 };
 
 // Required on MSVC: without extern template, each TU (DLL and EXE) gets its own
@@ -77,5 +80,6 @@ private:
 // a different map than the one the test binary queries.
 extern template class GaussGreenLaplacian<scalar>;
 extern template class GaussGreenLaplacian<Vec3>;
+extern template class GaussGreenLaplacian<Vec3, scalar>;
 
 } // namespace NeoN

--- a/include/NeoN/finiteVolume/cellCentred/operators/laplacianOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/laplacianOperator.hpp
@@ -17,26 +17,28 @@
 namespace NeoN::finiteVolume::cellCentred
 {
 
-/* @class Factory class to create divergence operators by a given name using
+/* @class Factory class to create laplacian operators by a given name using
  * using NeoNs runTimeFactory mechanism
  */
-template<typename ValueType>
+template<typename FieldValueType, typename AssemblyType = FieldValueType>
 class LaplacianOperatorFactory :
     public RuntimeSelectionFactory<
-        LaplacianOperatorFactory<ValueType>,
+        LaplacianOperatorFactory<FieldValueType, AssemblyType>,
         Parameters<const Executor&, const UnstructuredMesh&, const Input&>>
 {
 
 public:
 
-    static std::unique_ptr<LaplacianOperatorFactory<ValueType>>
+    static std::unique_ptr<LaplacianOperatorFactory<FieldValueType, AssemblyType>>
     create(const Executor& exec, const UnstructuredMesh& mesh, const Input& inputs)
     {
         std::string key = (std::holds_alternative<Dictionary>(inputs))
                             ? std::get<Dictionary>(inputs).get<std::string>("LaplacianOperator")
                             : std::get<TokenList>(inputs).next<std::string>();
-        LaplacianOperatorFactory<ValueType>::keyExistsOrError(key);
-        return LaplacianOperatorFactory<ValueType>::table().at(key)(exec, mesh, inputs);
+        LaplacianOperatorFactory<FieldValueType, AssemblyType>::keyExistsOrError(key);
+        return LaplacianOperatorFactory<FieldValueType, AssemblyType>::table().at(key)(
+            exec, mesh, inputs
+        );
     }
 
     static std::string name() { return "LaplacianOperatorFactory"; }
@@ -47,34 +49,35 @@ public:
     virtual ~LaplacianOperatorFactory() {} // Virtual destructor
 
     virtual void laplacian(
-        VolumeField<ValueType>& lapPhi,
+        VolumeField<FieldValueType>& lapPhi,
         const SurfaceField<scalar>& gamma,
-        const VolumeField<ValueType>& phi,
+        const VolumeField<FieldValueType>& phi,
         const dsl::Coeff operatorScaling
     ) = 0;
 
-    virtual VolumeField<ValueType> laplacian(
+    virtual VolumeField<FieldValueType> laplacian(
         const SurfaceField<scalar>& gamma,
-        const VolumeField<ValueType>& phi,
+        const VolumeField<FieldValueType>& phi,
         const dsl::Coeff operatorScaling
     ) const = 0;
 
     virtual void laplacian(
-        Vector<ValueType>& lapPhi,
+        Vector<FieldValueType>& lapPhi,
         const SurfaceField<scalar>& gamma,
-        const VolumeField<ValueType>& phi,
+        const VolumeField<FieldValueType>& phi,
         const dsl::Coeff operatorScaling
     ) = 0;
 
     virtual void laplacian(
-        la::LinearSystem<ValueType>& ls,
+        la::LinearSystem<AssemblyType, FieldValueType>& ls,
         const SurfaceField<scalar>& gamma,
-        const VolumeField<ValueType>& phi,
+        const VolumeField<FieldValueType>& phi,
         const dsl::Coeff operatorScaling
     ) = 0;
 
     // Pure virtual function for cloning
-    virtual std::unique_ptr<LaplacianOperatorFactory<ValueType>> clone() const = 0;
+    virtual std::unique_ptr<LaplacianOperatorFactory<FieldValueType, AssemblyType>>
+    clone() const = 0;
 
 protected:
 
@@ -83,104 +86,118 @@ protected:
     const UnstructuredMesh& mesh_;
 };
 
-template<typename ValueType>
-class LaplacianOperator : public dsl::OperatorMixin<VolumeField<ValueType>>
+template<typename FieldValueType>
+class LaplacianOperator : public dsl::OperatorMixin<VolumeField<FieldValueType>>
 {
 
 public:
 
-    using VectorValueType = ValueType;
+    using VectorValueType = FieldValueType;
 
     // copy constructor
     LaplacianOperator(const LaplacianOperator& lapOp)
-        : dsl::OperatorMixin<VolumeField<ValueType>>(
+        : dsl::OperatorMixin<VolumeField<FieldValueType>>(
             lapOp.exec_, lapOp.coeffs_, lapOp.field_, lapOp.type_
         ),
           gamma_(lapOp.gamma_),
-          laplacianOperatorStrategy_(
-              lapOp.laplacianOperatorStrategy_ ? lapOp.laplacianOperatorStrategy_->clone() : nullptr
+          sameTypeStrategy_(lapOp.sameTypeStrategy_ ? lapOp.sameTypeStrategy_->clone() : nullptr),
+          scalarMtxStrategy_(
+              lapOp.scalarMtxStrategy_ ? lapOp.scalarMtxStrategy_->clone() : nullptr
           ) {};
 
     LaplacianOperator(
         dsl::Operator::Type termType,
         const SurfaceField<scalar>& gamma,
-        VolumeField<ValueType>& phi,
+        VolumeField<FieldValueType>& phi,
         Input input
     )
-        : dsl::OperatorMixin<VolumeField<ValueType>>(phi.exec(), dsl::Coeff(1.0), phi, termType),
+        : dsl::OperatorMixin<VolumeField<FieldValueType>>(
+            phi.exec(), dsl::Coeff(1.0), phi, termType
+        ),
           gamma_(gamma),
-          laplacianOperatorStrategy_(
-              LaplacianOperatorFactory<ValueType>::create(this->exec_, phi.mesh(), input)
-          ) {};
+          sameTypeStrategy_(LaplacianOperatorFactory<FieldValueType, FieldValueType>::create(
+              this->exec_, phi.mesh(), input
+          )),
+          scalarMtxStrategy_(nullptr)
+    {
+        if constexpr (!std::is_same_v<FieldValueType, scalar>)
+        {
+            // The first create() consumed tokens; rewind the cursor so the second
+            // strategy can read the same scheme tokens from the start.
+            if (std::holds_alternative<NeoN::TokenList>(input))
+            {
+                std::get<NeoN::TokenList>(input).reset();
+            }
+            scalarMtxStrategy_ = LaplacianOperatorFactory<FieldValueType, scalar>::create(
+                this->exec_, phi.mesh(), input
+            );
+        }
+    };
 
     LaplacianOperator(
         dsl::Operator::Type termType,
         const SurfaceField<scalar>& gamma,
-        VolumeField<ValueType>& phi,
-        std::unique_ptr<LaplacianOperatorFactory<ValueType>> laplacianOperatorStrategy
+        VolumeField<FieldValueType>& phi
     )
-        : dsl::OperatorMixin<VolumeField<ValueType>>(phi.exec(), dsl::Coeff(1.0), phi, termType),
-          gamma_(gamma), laplacianOperatorStrategy_(std::move(laplacianOperatorStrategy)) {};
-
-    LaplacianOperator(
-        dsl::Operator::Type termType, const SurfaceField<scalar>& gamma, VolumeField<ValueType>& phi
-    )
-        : dsl::OperatorMixin<VolumeField<ValueType>>(phi.exec(), dsl::Coeff(1.0), phi, termType),
-          gamma_(gamma), laplacianOperatorStrategy_(nullptr) {};
+        : dsl::OperatorMixin<VolumeField<FieldValueType>>(
+            phi.exec(), dsl::Coeff(1.0), phi, termType
+        ),
+          gamma_(gamma), sameTypeStrategy_(nullptr), scalarMtxStrategy_(nullptr) {};
 
 
-    void explicitOperation(Vector<ValueType>& source) const
+    void explicitOperation(Vector<FieldValueType>& source) const
     {
-        NF_ASSERT(laplacianOperatorStrategy_, "LaplacianOperatorStrategy not initialized");
+        NF_ASSERT(sameTypeStrategy_, "LaplacianOperatorStrategy not initialized");
         const auto operatorScaling = this->getCoefficient();
-        NeoN::Vector<ValueType> tmpsource(source.exec(), source.size(), zero<ValueType>());
-        laplacianOperatorStrategy_->laplacian(tmpsource, gamma_, this->field_, operatorScaling);
+        NeoN::Vector<FieldValueType> tmpsource(
+            source.exec(), source.size(), zero<FieldValueType>()
+        );
+        sameTypeStrategy_->laplacian(tmpsource, gamma_, this->field_, operatorScaling);
         source += tmpsource;
     }
 
-    void implicitOperation(la::LinearSystem<ValueType>& ls) const
+    void implicitOperation(la::LinearSystem<FieldValueType, FieldValueType>& ls) const
     {
-        NF_ASSERT(laplacianOperatorStrategy_, "LaplacianOperatorStrategy not initialized");
+        NF_ASSERT(sameTypeStrategy_, "LaplacianOperatorStrategy not initialized");
         const auto operatorScaling = this->getCoefficient();
-        laplacianOperatorStrategy_->laplacian(ls, gamma_, this->field_, operatorScaling);
+        sameTypeStrategy_->laplacian(ls, gamma_, this->field_, operatorScaling);
     }
 
-    [[deprecated("use explicit or implicit operation")]] void laplacian(VolumeField<scalar>& lapPhi)
+    /* @brief Implicit assembly into a scalar-matrix / FieldValueType-rhs linear system
+     *        (segregated vector-solve form). Only present when FieldValueType != scalar.
+     */
+    template<typename F = FieldValueType>
+        requires(!std::is_same_v<F, scalar>)
+    void implicitOperation(la::LinearSystem<scalar, FieldValueType>& ls) const
     {
+        NF_ASSERT(scalarMtxStrategy_, "Scalar-matrix LaplacianOperatorStrategy not initialized");
         const auto operatorScaling = this->getCoefficient();
-        laplacianOperatorStrategy_->laplacian(lapPhi, gamma_, this->getVector(), operatorScaling);
-    }
-
-    [[deprecated("use explicit or implicit operation")]] VolumeField<scalar> laplacian()
-    {
-        const auto operatorScaling = this->getCoefficient();
-        std::string name = "laplacian(" + gamma_.name + "," + this->field_.name + ")";
-        VolumeField<scalar> lapPhi(
-            this->exec_,
-            name,
-            this->field_.mesh(),
-            createCalculatedBCs<VolumeBoundary<scalar>>(this->field_.mesh())
-        );
-        laplacianOperatorStrategy_->laplacian(lapPhi, gamma_, this->field_, operatorScaling);
-        return lapPhi;
+        scalarMtxStrategy_->laplacian(ls, gamma_, this->field_, operatorScaling);
     }
 
     void read(const Input& input)
     {
         const UnstructuredMesh& mesh = this->field_.mesh();
+        NeoN::TokenList tokens;
         if (std::holds_alternative<NeoN::Dictionary>(input))
         {
             auto dict = std::get<NeoN::Dictionary>(input);
             std::string schemeName = "laplacian(" + gamma_.name + "," + this->field_.name + ")";
-            auto tokens = dict.subDict("laplacianSchemes").get<NeoN::TokenList>(schemeName);
-            laplacianOperatorStrategy_ =
-                LaplacianOperatorFactory<ValueType>::create(this->exec(), mesh, tokens);
+            tokens = dict.subDict("laplacianSchemes").get<NeoN::TokenList>(schemeName);
         }
         else
         {
-            auto tokens = std::get<NeoN::TokenList>(input);
-            laplacianOperatorStrategy_ =
-                LaplacianOperatorFactory<ValueType>::create(this->exec(), mesh, tokens);
+            tokens = std::get<NeoN::TokenList>(input);
+        }
+        sameTypeStrategy_ = LaplacianOperatorFactory<FieldValueType, FieldValueType>::create(
+            this->exec(), mesh, tokens
+        );
+        if constexpr (!std::is_same_v<FieldValueType, scalar>)
+        {
+            tokens.reset();
+            scalarMtxStrategy_ = LaplacianOperatorFactory<FieldValueType, scalar>::create(
+                this->exec(), mesh, tokens
+            );
         }
     }
 
@@ -190,7 +207,10 @@ private:
 
     const SurfaceField<scalar>& gamma_;
 
-    std::unique_ptr<LaplacianOperatorFactory<ValueType>> laplacianOperatorStrategy_;
+    std::unique_ptr<LaplacianOperatorFactory<FieldValueType, FieldValueType>> sameTypeStrategy_;
+    // Only initialized when FieldValueType != scalar; used to assemble into a
+    // LinearSystem<scalar, FieldValueType> for segregated vector solves.
+    std::unique_ptr<LaplacianOperatorFactory<FieldValueType, scalar>> scalarMtxStrategy_;
 };
 
 

--- a/include/NeoN/linearAlgebra/ginkgo.hpp
+++ b/include/NeoN/linearAlgebra/ginkgo.hpp
@@ -120,6 +120,12 @@ public:
     virtual SolverStats solveDist(
         const LinearSystem<Vec3, Vec3, CSRMatrix<Vec3, localIdx>>& sys, Vector<Vec3>& x
     ) const final;
+
+    virtual SolverStats solveDist(
+        const LinearSystem<scalar, Vec3, CSRMatrix<scalar, localIdx>, COOMatrix<scalar, localIdx>>&
+            sys,
+        Vector<Vec3>& x
+    ) const final;
 #endif
 
     // TODO why use a smart pointer here?

--- a/include/NeoN/linearAlgebra/ginkgo.hpp
+++ b/include/NeoN/linearAlgebra/ginkgo.hpp
@@ -99,25 +99,26 @@ public:
     static std::string schema() { return "none"; }
 
     virtual SolverStats solve(
-        const LinearSystem<scalar, CSRMatrix<scalar, localIdx>>& sys, Vector<scalar>& x
+        const LinearSystem<scalar, scalar, CSRMatrix<scalar, localIdx>>& sys, Vector<scalar>& x
     ) const final;
 
-    virtual SolverStats
-    solve(const LinearSystem<Vec3, CSRMatrix<Vec3, localIdx>>& sys, Vector<Vec3>& x) const final;
+    virtual SolverStats solve(
+        const LinearSystem<Vec3, Vec3, CSRMatrix<Vec3, localIdx>>& sys, Vector<Vec3>& x
+    ) const final;
 
     virtual SolverStats solve(
-        const LinearSystem<scalar, CSRMatrix<scalar, localIdx>, COOMatrix<scalar, localIdx>, Vec3>&
+        const LinearSystem<scalar, Vec3, CSRMatrix<scalar, localIdx>, COOMatrix<scalar, localIdx>>&
             sys,
         Vector<Vec3>& x
     ) const final;
 
 #ifdef NF_WITH_MPI_SUPPORT
     virtual SolverStats solveDist(
-        const LinearSystem<scalar, CSRMatrix<scalar, localIdx>>& sys, Vector<scalar>& x
+        const LinearSystem<scalar, scalar, CSRMatrix<scalar, localIdx>>& sys, Vector<scalar>& x
     ) const final;
 
     virtual SolverStats solveDist(
-        const LinearSystem<Vec3, CSRMatrix<Vec3, localIdx>>& sys, Vector<Vec3>& x
+        const LinearSystem<Vec3, Vec3, CSRMatrix<Vec3, localIdx>>& sys, Vector<Vec3>& x
     ) const final;
 #endif
 

--- a/include/NeoN/linearAlgebra/linearSystem.hpp
+++ b/include/NeoN/linearAlgebra/linearSystem.hpp
@@ -71,12 +71,12 @@ struct LinearSystemView
  */
 template<
     typename MatrixValueType,
+    typename RHSValueType = MatrixValueType,
     typename SystemMatrixType = CSRMatrix<MatrixValueType, localIdx>,
-    typename BoundaryMatrixType = COOMatrix<MatrixValueType, localIdx>,
-    typename RHSValueType = MatrixValueType>
+    typename BoundaryMatrixType = COOMatrix<MatrixValueType, localIdx>>
 class LinearSystem :
     public NeoN::SupportsCopyTo<
-        LinearSystem<MatrixValueType, SystemMatrixType, BoundaryMatrixType, RHSValueType>>
+        LinearSystem<MatrixValueType, RHSValueType, SystemMatrixType, BoundaryMatrixType>>
 {
 
     void validate()
@@ -164,16 +164,15 @@ public:
 
     [[nodiscard]] const Vector<RHSValueType>& boundaryRhs() const { return boundaryRhs_; }
 
-    [[nodiscard]] LinearSystem<MatrixValueType, SystemMatrixType, BoundaryMatrixType, RHSValueType>
+    [[nodiscard]] LinearSystem<MatrixValueType, RHSValueType, SystemMatrixType, BoundaryMatrixType>
     copyToExecutor(Executor exec) const override
     {
-        LinearSystem<MatrixValueType, SystemMatrixType, BoundaryMatrixType, RHSValueType> ls {
+        LinearSystem<MatrixValueType, RHSValueType, SystemMatrixType, BoundaryMatrixType> ls {
             matrix_.copyToExecutor(exec),
             rhs_.copyToExecutor(exec),
             offDiagonalMatrix_.copyToExecutor(exec),
             boundaryMatrix_.copyToExecutor(exec),
-            boundaryRhs_.copyToExecutor(exec),
-            offDiagonalMatrix_.copyToExecutor(exec)
+            boundaryRhs_.copyToExecutor(exec)
         };
 #ifdef NF_WITH_MPI_SUPPORT
         ls.commPattern_ = commPattern_;
@@ -272,9 +271,10 @@ private:
  */
 template<
     typename ValueType,
+    typename RHSValueType = ValueType,
     typename SystemMatrixType = CSRMatrix<ValueType, localIdx>,
     typename BoundaryMatrixType = COOMatrix<ValueType, localIdx>>
-LinearSystem<ValueType, SystemMatrixType, BoundaryMatrixType> createEmptyLinearSystem(
+LinearSystem<ValueType, RHSValueType, SystemMatrixType, BoundaryMatrixType> createEmptyLinearSystem(
     const UnstructuredMesh& mesh,
     std::shared_ptr<MeshIterationStrategy> strategy = std::make_shared<FaceBasedIterator>()
 )
@@ -335,13 +335,12 @@ LinearSystem<ValueType, SystemMatrixType, BoundaryMatrixType> createEmptyLinearS
         std::move(offDiagColIdxs), std::move(offDiagRowIdxs), Dimensions {nCells, nCells}
     );
 
-    LinearSystem<ValueType, SystemMatrixType, BoundaryMatrixType> ls {
+    LinearSystem<ValueType, RHSValueType, SystemMatrixType, BoundaryMatrixType> ls {
         SystemMatrixType(Vector<ValueType>(sp->exec(), sp->nnz(), zero<ValueType>()), sp, mi),
-        Vector<ValueType>(sp->exec(), sp->rows(), zero<ValueType>()),
+        Vector<RHSValueType>(sp->exec(), sp->rows(), zero<RHSValueType>()),
         BoundaryMatrixType(Vector<ValueType>(exec, nProcFaces, zero<ValueType>()), offDiagSp),
         BoundaryMatrixType(Vector<ValueType>(bSp->exec(), bSp->nnz(), zero<ValueType>()), bSp),
-        Vector<ValueType>(bSp->exec(), bSp->nnz(), zero<ValueType>()),
-        BoundaryMatrixType(Vector<ValueType>(exec, nProcFaces, zero<ValueType>()), offDiagSp),
+        Vector<RHSValueType>(bSp->exec(), bSp->nnz(), zero<RHSValueType>()),
         strategy
     };
 

--- a/include/NeoN/linearAlgebra/linearSystem.hpp
+++ b/include/NeoN/linearAlgebra/linearSystem.hpp
@@ -352,12 +352,24 @@ LinearSystem<ValueType, RHSValueType, SystemMatrixType, BoundaryMatrixType> crea
 }
 
 /** @brief for testing purposes, this function reverses boundary contributions previously applied to
- * the matrix diagonal and RHS for some operators (e.g., div). **/
-template<typename ValueType>
-inline la::LinearSystem<ValueType>
-removeBoundaryContributions(const la::LinearSystem<ValueType>& lsIn)
+ * the matrix diagonal and RHS for some operators (e.g., div).
+ *
+ * @note templated on the full LinearSystem parameter set so it also accepts the segregated
+ * vector-solve form (scalar matrix, Vec3 rhs): the scalar boundary diagonal is reversed on the
+ * scalar matrix while the rhs reversal uses the field (RHS) value type. **/
+template<
+    typename MatrixValueType,
+    typename RHSValueType,
+    typename SystemMatrixType,
+    typename BoundaryMatrixType>
+inline la::LinearSystem<MatrixValueType, RHSValueType, SystemMatrixType, BoundaryMatrixType>
+removeBoundaryContributions(
+    const la::LinearSystem<MatrixValueType, RHSValueType, SystemMatrixType, BoundaryMatrixType>&
+        lsIn
+)
 {
-    auto ls = la::LinearSystem<ValueType>(lsIn);
+    auto ls =
+        la::LinearSystem<MatrixValueType, RHSValueType, SystemMatrixType, BoundaryMatrixType>(lsIn);
     auto lsView = ls.view();
     auto& matrix = lsView.matrix;
     auto& rhs = lsView.rhs;

--- a/include/NeoN/linearAlgebra/linearSystem.hpp
+++ b/include/NeoN/linearAlgebra/linearSystem.hpp
@@ -62,12 +62,12 @@ struct LinearSystemView
  * well as the solution vector.
  *
  * @tparam MatrixValueType The value type of the system and boundary matrix coefficients.
+ * @tparam RHSValueType The value type of the right-hand side and boundary rhs vectors. Defaults to
+ * MatrixValueType, but may differ (e.g. scalar matrix with Vec3 rhs for segregated vector solves).
  * @tparam SystemMatrixType The sparse matrix type used for the system matrix (default:
  * CSRMatrix<MatrixValueType, localIdx>).
  * @tparam BoundaryMatrixType The sparse matrix type used for boundary and off-diagonal matrices
  * (default: COOMatrix<MatrixValueType, localIdx>).
- * @tparam RHSValueType The value type of the right-hand side and boundary rhs vectors. Defaults to
- * MatrixValueType, but may differ (e.g. scalar matrix with Vec3 rhs for segregated vector solves).
  */
 template<
     typename MatrixValueType,

--- a/include/NeoN/linearAlgebra/linearSystem.hpp
+++ b/include/NeoN/linearAlgebra/linearSystem.hpp
@@ -172,7 +172,8 @@ public:
             rhs_.copyToExecutor(exec),
             offDiagonalMatrix_.copyToExecutor(exec),
             boundaryMatrix_.copyToExecutor(exec),
-            boundaryRhs_.copyToExecutor(exec)
+            boundaryRhs_.copyToExecutor(exec),
+            offDiagonalMatrix_.copyToExecutor(exec)
         };
 #ifdef NF_WITH_MPI_SUPPORT
         ls.commPattern_ = commPattern_;
@@ -340,6 +341,7 @@ LinearSystem<ValueType, SystemMatrixType, BoundaryMatrixType> createEmptyLinearS
         BoundaryMatrixType(Vector<ValueType>(exec, nProcFaces, zero<ValueType>()), offDiagSp),
         BoundaryMatrixType(Vector<ValueType>(bSp->exec(), bSp->nnz(), zero<ValueType>()), bSp),
         Vector<ValueType>(bSp->exec(), bSp->nnz(), zero<ValueType>()),
+        BoundaryMatrixType(Vector<ValueType>(exec, nProcFaces, zero<ValueType>()), offDiagSp),
         strategy
     };
 

--- a/include/NeoN/linearAlgebra/matrix.hpp
+++ b/include/NeoN/linearAlgebra/matrix.hpp
@@ -290,6 +290,20 @@ void scaledInverseDiag(
     Vector<scalar>& out
 );
 
+/** @brief scalar-matrix variant of scaledInverseDiag for the segregated vector-solve form
+ * @note used when a vector field is assembled into a scalar coefficient matrix; the scalar
+ * diagonal is shared across all field components, so no per-component selection is needed
+ */
+[[nodiscard]] Vector<scalar>
+scaledInverseDiag(const CSRMatrix<scalar, localIdx>&, const FaceToMatrixAddress& mi, const Vector<scalar>&);
+
+void scaledInverseDiag(
+    const CSRMatrix<scalar, localIdx>& mtx,
+    const FaceToMatrixAddress& mi,
+    const Vector<scalar>& a,
+    Vector<scalar>& out
+);
+
 /* @brief given Matrix<Vec3> this function returns a component Matrix<scalar>*/
 template<unsigned int I>
 [[nodiscard]] auto getComponent(const CSRMatrix<Vec3, localIdx>& in)
@@ -317,6 +331,23 @@ void negLUx(
  */
 void scaledInvDiagNegLUx(
     const CSRMatrix<Vec3, localIdx>& mtx,
+    const Vector<Vec3>& a,
+    const Vector<Vec3>& b,
+    const Vector<scalar>& vol,
+    Vector<scalar>& rAU,
+    Vector<Vec3>& out
+);
+
+/** @brief scalar-matrix / Vec3-rhs variant of scaledInvDiagNegLUx
+ *
+ * Mirrors the Vec3-matrix overload but for a scalar coefficient matrix assembled from a
+ * vector field (segregated vector-solve form). The scalar diagonal/off-diagonal entries
+ * scale all three rhs components equally.
+ *
+ * @notes explicitly sets out values to zero
+ */
+void scaledInvDiagNegLUx(
+    const CSRMatrix<scalar, localIdx>& mtx,
     const Vector<Vec3>& a,
     const Vector<Vec3>& b,
     const Vector<scalar>& vol,

--- a/include/NeoN/linearAlgebra/petsc.hpp
+++ b/include/NeoN/linearAlgebra/petsc.hpp
@@ -77,8 +77,7 @@ public:
     }
 
 
-    virtual SolverStats
-    solve(const LinearSystem<scalar, localIdx>& sys, Vector<scalar>& x) const final
+    virtual SolverStats solve(const LinearSystem<scalar>& sys, Vector<scalar>& x) const final
     {
 
         Mat Amat;

--- a/include/NeoN/linearAlgebra/petscSolverContext.hpp
+++ b/include/NeoN/linearAlgebra/petscSolverContext.hpp
@@ -68,7 +68,7 @@ public:
     bool updated() const noexcept { return updated_; }
 
     //- Create auxiliary rows for calculation purposes
-    void initialize(const LinearSystem<scalar, localIdx>& sys)
+    void initialize(const LinearSystem<scalar>& sys)
     {
         std::size_t size = sys.matrix().values().size();
         std::size_t nrows = sys.rhs().size();

--- a/include/NeoN/linearAlgebra/solver.hpp
+++ b/include/NeoN/linearAlgebra/solver.hpp
@@ -53,13 +53,14 @@ public:
     SolverFactory(const Executor& exec) : exec_(exec) {};
 
     virtual SolverStats
-    solve(const LinearSystem<scalar, CSRMatrix<scalar, localIdx>>&, Vector<scalar>&) const = 0;
+    solve(const LinearSystem<scalar, scalar, CSRMatrix<scalar, localIdx>>&, Vector<scalar>&)
+        const = 0;
 
     virtual SolverStats
-    solve(const LinearSystem<Vec3, CSRMatrix<Vec3, localIdx>>&, Vector<Vec3>&) const = 0;
+    solve(const LinearSystem<Vec3, Vec3, CSRMatrix<Vec3, localIdx>>&, Vector<Vec3>&) const = 0;
 
     virtual SolverStats
-    solve(const LinearSystem<scalar, CSRMatrix<scalar, localIdx>, COOMatrix<scalar, localIdx>, Vec3>&, Vector<Vec3>&)
+    solve(const LinearSystem<scalar, Vec3, CSRMatrix<scalar, localIdx>, COOMatrix<scalar, localIdx>>&, Vector<Vec3>&)
         const
     {
         NF_THROW("solve(scalar matrix, Vec3 rhs) not implemented for this solver");
@@ -67,13 +68,14 @@ public:
 
 #ifdef NF_WITH_MPI_SUPPORT
     virtual SolverStats
-    solveDist(const LinearSystem<scalar, CSRMatrix<scalar, localIdx>>&, Vector<scalar>&) const
+    solveDist(const LinearSystem<scalar, scalar, CSRMatrix<scalar, localIdx>>&, Vector<scalar>&)
+        const
     {
         NF_THROW("solveDist not implemented for this solver");
     }
 
     virtual SolverStats
-    solveDist(const LinearSystem<Vec3, CSRMatrix<Vec3, localIdx>>&, Vector<Vec3>&) const
+    solveDist(const LinearSystem<Vec3, Vec3, CSRMatrix<Vec3, localIdx>>&, Vector<Vec3>&) const
     {
         NF_THROW("solveDist not implemented for this solver");
     }
@@ -104,8 +106,9 @@ public:
     Solver(const Executor& exec, const Dictionary& dict)
         : exec_(exec), solverInstance_(SolverFactory::create(exec, dict)) {};
 
-    SolverStats
-    solve(const LinearSystem<scalar, CSRMatrix<scalar, localIdx>>& ls, Vector<scalar>& field) const
+    SolverStats solve(
+        const LinearSystem<scalar, scalar, CSRMatrix<scalar, localIdx>>& ls, Vector<scalar>& field
+    ) const
     {
 #ifdef NF_WITH_MPI_SUPPORT
         if (!ls.commPattern().sendCounts.empty()) return solverInstance_->solveDist(ls, field);
@@ -114,7 +117,7 @@ public:
     }
 
     SolverStats
-    solve(const LinearSystem<Vec3, CSRMatrix<Vec3, localIdx>>& ls, Vector<Vec3>& field) const
+    solve(const LinearSystem<Vec3, Vec3, CSRMatrix<Vec3, localIdx>>& ls, Vector<Vec3>& field) const
     {
 #ifdef NF_WITH_MPI_SUPPORT
         if (!ls.commPattern().sendCounts.empty()) return solverInstance_->solveDist(ls, field);
@@ -128,7 +131,7 @@ public:
     ///       If distributed support is needed, add a solveDist virtual to SolverFactory and
     ///       implement it in every backend.
     SolverStats solve(
-        const LinearSystem<scalar, CSRMatrix<scalar, localIdx>, COOMatrix<scalar, localIdx>, Vec3>&
+        const LinearSystem<scalar, Vec3, CSRMatrix<scalar, localIdx>, COOMatrix<scalar, localIdx>>&
             ls,
         Vector<Vec3>& field
     ) const

--- a/include/NeoN/linearAlgebra/solver.hpp
+++ b/include/NeoN/linearAlgebra/solver.hpp
@@ -79,6 +79,13 @@ public:
     {
         NF_THROW("solveDist not implemented for this solver");
     }
+
+    virtual SolverStats
+    solveDist(const LinearSystem<scalar, Vec3, CSRMatrix<scalar, localIdx>, COOMatrix<scalar, localIdx>>&, Vector<Vec3>&)
+        const
+    {
+        NF_THROW("solveDist(scalar matrix, Vec3 rhs) not implemented for this solver");
+    }
 #endif
 
     // Pure virtual function for cloning
@@ -125,11 +132,9 @@ public:
         return solverInstance_->solve(ls, field);
     }
 
-    /// @brief Solve a system with a scalar matrix and Vec3 right-hand side.
-    /// @note This overload is **local-only**: it does not dispatch to solveDist and must not be
-    ///       called on a distributed LinearSystem (one whose commPattern has non-empty sendCounts).
-    ///       If distributed support is needed, add a solveDist virtual to SolverFactory and
-    ///       implement it in every backend.
+    /// @brief Solve a system with a scalar matrix and Vec3 right-hand side (segregated vector
+    ///        solve). Dispatches to the distributed backend when the linear system carries a
+    ///        non-empty communication pattern, otherwise solves locally.
     SolverStats solve(
         const LinearSystem<scalar, Vec3, CSRMatrix<scalar, localIdx>, COOMatrix<scalar, localIdx>>&
             ls,
@@ -137,11 +142,7 @@ public:
     ) const
     {
 #ifdef NF_WITH_MPI_SUPPORT
-        NF_ASSERT(
-            ls.commPattern().sendCounts.empty(),
-            "solve(scalar matrix, Vec3 rhs) does not support distributed systems. "
-            "Add a solveDist overload to SolverFactory to enable this."
-        );
+        if (!ls.commPattern().sendCounts.empty()) return solverInstance_->solveDist(ls, field);
 #endif
         return solverInstance_->solve(ls, field);
     }

--- a/include/NeoN/linearAlgebra/utilities.hpp
+++ b/include/NeoN/linearAlgebra/utilities.hpp
@@ -99,9 +99,12 @@ Vector<scalar> unpackMtxValues(
  * @param[in] x, initial guess vector x
  * @param[out]
  */
-template<typename MatrixType>
+template<typename MatrixType, typename ValueType = scalar>
 void computeResidual(
-    const MatrixType& mtx, const Vector<scalar>& b, const Vector<scalar>& x, Vector<scalar>& res
+    const MatrixType& mtx,
+    const Vector<ValueType>& b,
+    const Vector<ValueType>& x,
+    Vector<ValueType>& res
 );
 
 /**@brief given a set off row idx this function converts to rowOffsets

--- a/src/finiteVolume/cellCentred/operators/ddtOperator.cpp
+++ b/src/finiteVolume/cellCentred/operators/ddtOperator.cpp
@@ -109,6 +109,87 @@ void DdtOperator<ValueType>::implicitOperation(la::LinearSystem<ValueType>& ls, 
 }
 
 template<typename ValueType>
+void DdtOperator<ValueType>::bdf1KernelScalarMtx(
+    la::LinearSystem<scalar, ValueType>& ls, scalar, scalar dt
+) const
+{
+    const auto vol = this->getVector().mesh().cellVolumes().view();
+    const auto operatorScaling = this->getCoefficient();
+    const auto oldVector = oldTime(this->field_).internalVector().view();
+    auto [rhs, values] = views(ls.rhs(), ls.matrix().values());
+    const auto ma = ls.faceToMatrixAddress()->view(ls.matrix().sparsity()->rowOffs().view());
+
+    const scalar a0a1 = 1.0 / dt;
+
+    parallelFor(
+        ls.exec(),
+        {0, oldVector.size()},
+        NEON_LAMBDA(const localIdx celli) {
+            const auto commonCoef = operatorScaling[celli] * vol[celli];
+            // scalar diagonal coefficient shared across all rhs components
+            values[ma.diagIdx(celli)] += commonCoef * a0a1;
+            rhs[celli] += commonCoef * a0a1 * oldVector[celli];
+        },
+        "ddtOperator::implicitOperationScalarMtx<BDF1>"
+    );
+}
+
+template<typename ValueType>
+void DdtOperator<ValueType>::bdf2KernelScalarMtx(
+    la::LinearSystem<scalar, ValueType>& ls, scalar, scalar dt
+) const
+{
+    const auto vol = this->getVector().mesh().cellVolumes().view();
+    const auto operatorScaling = this->getCoefficient();
+    auto& old = oldTime(this->field_);
+    auto& oldOld = oldTime(old);
+    const auto [oldVector, oldOldVector] = views(old.internalVector(), oldOld.internalVector());
+    auto [rhs, values] = views(ls.rhs(), ls.matrix().values());
+
+    const auto ma = ls.faceToMatrixAddress()->view(ls.matrix().sparsity()->rowOffs().view());
+
+    const scalar a0 = 1.5 / dt;
+    const scalar a1 = 2.0 / dt;
+    const scalar a2 = -0.5 / dt;
+
+    parallelFor(
+        ls.exec(),
+        {0, oldVector.size()},
+        NEON_LAMBDA(const localIdx celli) {
+            const auto commonCoef = operatorScaling[celli] * vol[celli];
+            // scalar diagonal coefficient shared across all rhs components
+            values[ma.diagIdx(celli)] += commonCoef * a0;
+            rhs[celli] +=
+                commonCoef * a1 * oldVector[celli] + commonCoef * a2 * oldOldVector[celli];
+        },
+        "ddtOperator::implicitOperationScalarMtx<BDF2>"
+    );
+}
+
+template<typename ValueType>
+template<typename F>
+    requires(!std::is_same_v<F, scalar>)
+void DdtOperator<ValueType>::implicitOperation(
+    la::LinearSystem<scalar, ValueType>& ls, scalar t, scalar dt
+) const
+{
+    const int level = oldTimeLevel(this->field_);
+
+    if (scheme_ == DdtScheme::BDF1)
+    {
+        bdf1KernelScalarMtx(ls, t, dt);
+    }
+    else if (level < 2)
+    {
+        bdf1KernelScalarMtx(ls, t, dt); // startup step
+    }
+    else
+    {
+        bdf2KernelScalarMtx(ls, t, dt);
+    }
+}
+
+template<typename ValueType>
 void DdtOperator<ValueType>::read(const Input& input)
 {
     if (!std::holds_alternative<NeoN::Dictionary>(input))
@@ -157,5 +238,11 @@ void DdtOperator<ValueType>::read(const Input& input)
 // instantiate the template class
 template class DdtOperator<scalar>;
 template class DdtOperator<Vec3>;
+
+// The scalar-matrix implicitOperation is a constrained member template (disabled for scalar
+// fields), so it is not covered by the class instantiation above; instantiate it explicitly
+// for the Vec3 segregated vector-solve form.
+template void
+DdtOperator<Vec3>::implicitOperation<Vec3>(la::LinearSystem<scalar, Vec3>&, scalar, scalar) const;
 
 };

--- a/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenDiv.cpp
@@ -127,11 +127,11 @@ void computeDivExp(
     );
 }
 
-template<typename ValueType>
+template<typename FieldValueType, typename AssemblyType = FieldValueType>
 void computeDivProcBoundImpl(
-    la::LinearSystem<ValueType>& ls,
+    la::LinearSystem<AssemblyType, FieldValueType>& ls,
     const SurfaceField<scalar>& faceFlux,
-    const VolumeField<ValueType>& phi,
+    const VolumeField<FieldValueType>& phi,
     const SurfaceField<scalar>& weights,
     const dsl::Coeff coeff
 )
@@ -175,12 +175,12 @@ void computeDivProcBoundImpl(
             auto sign = isOwnerFace ? scalar(-1) : scalar(1);
 
             auto weight = isOwnerFace ? bWeightsV[bcfacei] : (scalar(1) - bWeightsV[bcfacei]);
-            auto fluxContrib = sign * weight * bFluxV[bcfacei] * ownCoeff * one<ValueType>();
+            auto fluxContrib = sign * weight * bFluxV[bcfacei] * ownCoeff * one<AssemblyType>();
 
             Kokkos::atomic_sub(&values[ma.diagIdx(cell)], fluxContrib);
             bndDiagValues[bcfacei] += fluxContrib;
             auto valueOff =
-                -sign * (scalar(1) - weight) * bFluxV[bcfacei] * ownCoeff * one<ValueType>();
+                -sign * (scalar(1) - weight) * bFluxV[bcfacei] * ownCoeff * one<AssemblyType>();
             bValues[procFacei] += valueOff;
         },
         "computeProcInterfaceGaussGreenDivCoefficients"
@@ -188,11 +188,11 @@ void computeDivProcBoundImpl(
 }
 
 
-template<typename ValueType>
+template<typename FieldValueType, typename AssemblyType = FieldValueType>
 void computeDivBoundImpl(
-    la::LinearSystem<ValueType>& ls,
+    la::LinearSystem<AssemblyType, FieldValueType>& ls,
     const SurfaceField<scalar>& faceFlux,
-    const VolumeField<ValueType>& phi,
+    const VolumeField<FieldValueType>& phi,
     const SurfaceField<scalar>& weights,
     const dsl::Coeff operatorScaling
 )
@@ -232,7 +232,7 @@ void computeDivBoundImpl(
             auto refGradFrac = 1.0 - refValFrac;
 
             auto flux =
-                bFaceFluxV[bfi] * -bweights[bfi] * ownCoeff * refGradFrac * one<ValueType>();
+                bFaceFluxV[bfi] * -bweights[bfi] * ownCoeff * refGradFrac * one<AssemblyType>();
 
             // since upper triangular value is "outside" of system matrix
             // it is stored separately in bMatrix
@@ -257,11 +257,11 @@ void computeDivBoundImpl(
 }
 
 
-template<typename ValueType>
+template<typename FieldValueType, typename AssemblyType = FieldValueType>
 void computeDivIntImp(
-    la::LinearSystem<ValueType>& ls,
+    la::LinearSystem<AssemblyType, FieldValueType>& ls,
     const SurfaceField<scalar>& faceFlux,
-    const VolumeField<ValueType>& phi,
+    const VolumeField<FieldValueType>& phi,
     const SurfaceField<scalar>& weights,
     const dsl::Coeff coeff
 )
@@ -300,8 +300,8 @@ void computeDivIntImp(
             // Decompose face flux via linear interpolation:
             //   ownFluxContrib = w * F_f     — part attributed to the owner cell value
             //   neiFluxContrib = (1-w) * F_f — part attributed to the neighbor cell value
-            auto ownFluxContrib = -fluxV[facei] * weightsV[facei] * one<ValueType>();
-            auto neiFluxContrib = +fluxV[facei] * (1.0 - weightsV[facei]) * one<ValueType>();
+            auto ownFluxContrib = -fluxV[facei] * weightsV[facei] * one<AssemblyType>();
+            auto neiFluxContrib = +fluxV[facei] * (1.0 - weightsV[facei]) * one<AssemblyType>();
 
             // triangular coefficients - neighbor -> lower, owner -> upper
             values[ma.lowerIdx(neiRow, facei)] += ownFluxContrib * neiCoeff;
@@ -315,11 +315,11 @@ void computeDivIntImp(
     );
 };
 
-template<typename ValueType>
+template<typename FieldValueType, typename AssemblyType = FieldValueType>
 void computeDivIntCellBasedImp(
-    la::LinearSystem<ValueType>& ls,
+    la::LinearSystem<AssemblyType, FieldValueType>& ls,
     const SurfaceField<scalar>& faceFlux,
-    const VolumeField<ValueType>& phi,
+    const VolumeField<FieldValueType>& phi,
     const SurfaceField<scalar>& weights,
     const dsl::Coeff coeff
 )
@@ -342,7 +342,7 @@ void computeDivIntCellBasedImp(
         exec,
         {0, iterator->size()},
         NEON_LAMBDA(const localIdx celli) {
-            auto diagValue = zero<ValueType>();
+            auto diagValue = zero<AssemblyType>();
             const auto numFaces = cellFacesSegments[celli + 1] - cellFacesSegments[celli];
             const auto startIdx = cellFacesSegments[celli];
             const auto cellCoeff = coeff[celli];
@@ -354,17 +354,17 @@ void computeDivIntCellBasedImp(
                 const auto flux = fluxV[faceIdx];
                 const auto w = weightsV[faceIdx];
 
-                ValueType offDiag;
-                ValueType diagContrib;
+                AssemblyType offDiag;
+                AssemblyType diagContrib;
                 if (sign > 0) // this cell is the owner: upper-triangle entry
                 {
-                    offDiag = flux * (1.0 - w) * cellCoeff * one<ValueType>();
-                    diagContrib = flux * w * cellCoeff * one<ValueType>();
+                    offDiag = flux * (1.0 - w) * cellCoeff * one<AssemblyType>();
+                    diagContrib = flux * w * cellCoeff * one<AssemblyType>();
                 }
                 else // this cell is the neighbor: lower-triangle entry
                 {
-                    offDiag = -flux * w * cellCoeff * one<ValueType>();
-                    diagContrib = -flux * (1.0 - w) * cellCoeff * one<ValueType>();
+                    offDiag = -flux * w * cellCoeff * one<AssemblyType>();
+                    diagContrib = -flux * (1.0 - w) * cellCoeff * one<AssemblyType>();
                 }
 
                 values[matrixColumnIdxV[startIdx + i]] += offDiag;
@@ -377,54 +377,57 @@ void computeDivIntCellBasedImp(
     );
 }
 
-template<typename ValueType>
-VolumeField<ValueType> GaussGreenDiv<ValueType>::div(
+template<typename FieldValueType, typename AssemblyType>
+VolumeField<FieldValueType> GaussGreenDiv<FieldValueType, AssemblyType>::div(
     const SurfaceField<scalar>& faceFlux,
-    const VolumeField<ValueType>& phi,
+    const VolumeField<FieldValueType>& phi,
     const dsl::Coeff operatorScaling
 ) const
 {
     std::string name = "div(" + faceFlux.name + "," + phi.name + ")";
-    VolumeField<ValueType> divPhi(
-        this->exec_, name, this->mesh_, createCalculatedBCs<VolumeBoundary<ValueType>>(this->mesh_)
+    VolumeField<FieldValueType> divPhi(
+        this->exec_,
+        name,
+        this->mesh_,
+        createCalculatedBCs<VolumeBoundary<FieldValueType>>(this->mesh_)
     );
-    NeoN::fill(divPhi.internalVector(), zero<ValueType>());
-    NeoN::fill(divPhi.boundaryData().value(), zero<ValueType>());
-    computeDivExp<ValueType>(
+    NeoN::fill(divPhi.internalVector(), zero<FieldValueType>());
+    NeoN::fill(divPhi.boundaryData().value(), zero<FieldValueType>());
+    computeDivExp<FieldValueType>(
         faceFlux, phi, surfaceInterpolation_, divPhi.internalVector(), operatorScaling
     );
     return divPhi;
 }
 
-template<typename ValueType>
-void GaussGreenDiv<ValueType>::div(
-    VolumeField<ValueType>& divPhi,
+template<typename FieldValueType, typename AssemblyType>
+void GaussGreenDiv<FieldValueType, AssemblyType>::div(
+    VolumeField<FieldValueType>& divPhi,
     const SurfaceField<scalar>& faceFlux,
-    const VolumeField<ValueType>& phi,
+    const VolumeField<FieldValueType>& phi,
     const dsl::Coeff operatorScaling
 ) const
 {
-    computeDivExp<ValueType>(
+    computeDivExp<FieldValueType>(
         faceFlux, phi, surfaceInterpolation_, divPhi.internalVector(), operatorScaling
     );
 }
 
-template<typename ValueType>
-void GaussGreenDiv<ValueType>::div(
-    Vector<ValueType>& divPhi,
+template<typename FieldValueType, typename AssemblyType>
+void GaussGreenDiv<FieldValueType, AssemblyType>::div(
+    Vector<FieldValueType>& divPhi,
     const SurfaceField<scalar>& faceFlux,
-    const VolumeField<ValueType>& phi,
+    const VolumeField<FieldValueType>& phi,
     const dsl::Coeff operatorScaling
 ) const
 {
-    computeDivExp<ValueType>(faceFlux, phi, surfaceInterpolation_, divPhi, operatorScaling);
+    computeDivExp<FieldValueType>(faceFlux, phi, surfaceInterpolation_, divPhi, operatorScaling);
 }
 
-template<typename ValueType>
-void GaussGreenDiv<ValueType>::div(
-    la::LinearSystem<ValueType>& ls,
+template<typename FieldValueType, typename AssemblyType>
+void GaussGreenDiv<FieldValueType, AssemblyType>::div(
+    la::LinearSystem<AssemblyType, FieldValueType>& ls,
     const SurfaceField<scalar>& faceFlux,
-    const VolumeField<ValueType>& phi,
+    const VolumeField<FieldValueType>& phi,
     const dsl::Coeff operatorScaling
 ) const
 {
@@ -450,5 +453,6 @@ void GaussGreenDiv<ValueType>::div(
 
 template class GaussGreenDiv<scalar>;
 template class GaussGreenDiv<Vec3>;
+template class GaussGreenDiv<Vec3, scalar>;
 
 };

--- a/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
@@ -82,13 +82,13 @@ void computeLaplacianExp(
     );
 }
 
-template<typename ValueType>
+template<typename FieldValueType, typename AssemblyType = FieldValueType>
 void computeLaplacianProcBoundImpl(
-    la::LinearSystem<ValueType>& ls,
+    la::LinearSystem<AssemblyType, FieldValueType>& ls,
     const SurfaceField<scalar>& gamma,
-    const VolumeField<ValueType>& phi,
+    const VolumeField<FieldValueType>& phi,
     const dsl::Coeff coeff,
-    const FaceNormalGradient<ValueType>& faceNormalGradient
+    const FaceNormalGradient<FieldValueType>& faceNormalGradient
 )
 {
     const auto exec = phi.exec();
@@ -99,12 +99,13 @@ void computeLaplacianProcBoundImpl(
     if (nProcBoundaryFaces == 0) return;
     const auto ma = ls.faceToMatrixAddress()->view(ls.matrix().sparsity()->rowOffs().view());
 
-    const auto [bGammaV, bDeltaCoeffs, surfFaceCells] = views(
+    const auto [bGammaV, bDeltaCoeffs, boundaryFaceOwner] = views(
         gamma.boundaryData().value(),
         faceNormalGradient.deltaCoeffs().boundaryData().value(),
         mesh.boundaryMesh().faceOwners()
     );
     const auto bcMagSf = mesh.boundaryMesh().faceAreas().view();
+
     auto bValues = ls.offDiagonalMatrix().values().view();
     // boundaryMatrix records the diagonal contribution so removeBoundaryContributions can reverse
     // it (proc slots live at [nBoundaryFaces, nBoundaryFaces + nProcBoundaryFaces)).
@@ -117,11 +118,11 @@ void computeLaplacianProcBoundImpl(
         {0, nProcBoundaryFaces},
         NEON_LAMBDA(const localIdx procFacei) {
             auto bcfacei = nBoundaryFaces + procFacei;
-            auto cell = surfFaceCells[bcfacei];
+            auto cell = boundaryFaceOwner[bcfacei];
             auto ownCoeff = coeff[cell];
 
             auto flux = bGammaV[bcfacei] * bcMagSf[bcfacei] * bDeltaCoeffs[bcfacei];
-            auto value = flux * ownCoeff * one<ValueType>();
+            auto value = flux * ownCoeff * one<AssemblyType>();
 
             Kokkos::atomic_sub(&values[ma.diagIdx(cell)], value);
             bValues[procFacei] += value;
@@ -132,13 +133,13 @@ void computeLaplacianProcBoundImpl(
 }
 
 
-template<typename ValueType>
+template<typename FieldValueType, typename AssemblyType = FieldValueType>
 void computeLaplacianBoundImpl(
-    la::LinearSystem<ValueType>& ls,
+    la::LinearSystem<AssemblyType, FieldValueType>& ls,
     const SurfaceField<scalar>& gamma,
-    const VolumeField<ValueType>& phi,
+    const VolumeField<FieldValueType>& phi,
     const dsl::Coeff operatorScaling,
-    const FaceNormalGradient<ValueType>& faceNormalGradient
+    const FaceNormalGradient<FieldValueType>& faceNormalGradient
 )
 {
     const auto exec = phi.exec();
@@ -179,7 +180,7 @@ void computeLaplacianBoundImpl(
             auto refGradFrac = 1.0 - refValFrac;
             auto flux = bGammaV[bfi] * bFaceAreas[bfi];
             auto fluxContrib =
-                flux * ownRowCoeff * refValFrac * bDeltaCoeffs[bfi] * one<ValueType>();
+                flux * ownRowCoeff * refValFrac * bDeltaCoeffs[bfi] * one<AssemblyType>();
 
             bValues[bfi] += fluxContrib;
             Kokkos::atomic_sub(&values[ma.diagIdx(ownRow)], fluxContrib);
@@ -194,13 +195,13 @@ void computeLaplacianBoundImpl(
     );
 }
 
-template<typename ValueType>
+template<typename FieldValueType, typename AssemblyType = FieldValueType>
 void computeLaplacianNonOrthCorrImpl(
-    la::LinearSystem<ValueType>& ls,
+    la::LinearSystem<AssemblyType, FieldValueType>& ls,
     const SurfaceField<scalar>& gamma,
-    const VolumeField<ValueType>& phi,
+    const VolumeField<FieldValueType>& phi,
     const dsl::Coeff coeff,
-    const FaceNormalGradient<ValueType>& faceNormalGradient
+    const FaceNormalGradient<FieldValueType>& faceNormalGradient
 )
 {
     if (!faceNormalGradient.hasImplicitCorrection()) return;
@@ -212,8 +213,8 @@ void computeLaplacianNonOrthCorrImpl(
     const auto [ownV, neiV] = views(mesh.faceOwners(), mesh.faceNeighbors());
     const auto [gammaV, magFaceArea] = views(gamma.internalVector(), mesh.faceAreas());
 
-    SurfaceField<ValueType> corrField(
-        exec, "snGradCorr", mesh, createCalculatedBCs<SurfaceBoundary<ValueType>>(mesh)
+    SurfaceField<FieldValueType> corrField(
+        exec, "snGradCorr", mesh, createCalculatedBCs<SurfaceBoundary<FieldValueType>>(mesh)
     );
     faceNormalGradient.implicitCorrection(phi, corrField);
 
@@ -237,13 +238,13 @@ void computeLaplacianNonOrthCorrImpl(
     );
 }
 
-template<typename ValueType>
+template<typename FieldValueType, typename AssemblyType = FieldValueType>
 void computeLaplacianIntImpl(
-    la::LinearSystem<ValueType>& ls,
+    la::LinearSystem<AssemblyType, FieldValueType>& ls,
     const SurfaceField<scalar>& gamma,
-    const VolumeField<ValueType>& phi,
+    const VolumeField<FieldValueType>& phi,
     const dsl::Coeff coeff,
-    const FaceNormalGradient<ValueType>& faceNormalGradient
+    const FaceNormalGradient<FieldValueType>& faceNormalGradient
 )
 {
     const UnstructuredMesh& mesh = phi.mesh();
@@ -277,7 +278,8 @@ void computeLaplacianIntImpl(
             // The Laplacian is symmetric — the same flux value enters both owner and neighbour rows
             // with opposite signs (diffusion out of one cell = diffusion into the other).
             // S_f points from owner to neighbour by construction.
-            auto flux = deltaCoeffs[facei] * gammaV[facei] * magFaceArea[facei] * one<ValueType>();
+            auto flux =
+                deltaCoeffs[facei] * gammaV[facei] * magFaceArea[facei] * one<AssemblyType>();
 
             // triangular coefficients - neighbour -> lower, owner -> upper
             values[ma.lowerIdx(neiRow, facei)] += flux * neiCoeff;
@@ -291,13 +293,13 @@ void computeLaplacianIntImpl(
     );
 }
 
-template<typename ValueType>
+template<typename FieldValueType, typename AssemblyType = FieldValueType>
 void computeLaplacianIntCellBasedImpl(
-    la::LinearSystem<ValueType>& ls,
+    la::LinearSystem<AssemblyType, FieldValueType>& ls,
     const SurfaceField<scalar>& gamma,
-    const VolumeField<ValueType>& phi,
+    const VolumeField<FieldValueType>& phi,
     const dsl::Coeff coeff,
-    const FaceNormalGradient<ValueType>& faceNormalGradient
+    const FaceNormalGradient<FieldValueType>& faceNormalGradient
 )
 {
     const UnstructuredMesh& mesh = phi.mesh();
@@ -320,7 +322,7 @@ void computeLaplacianIntCellBasedImpl(
         exec,
         {0, iterator->size()},
         NEON_LAMBDA(const localIdx celli) {
-            auto diagValue = zero<ValueType>();
+            auto diagValue = zero<AssemblyType>();
             const auto numFaces = cellFacesSegments[celli + 1] - cellFacesSegments[celli];
             const auto startIdx = cellFacesSegments[celli];
             const auto cellCoeff = coeff[celli];
@@ -330,7 +332,7 @@ void computeLaplacianIntCellBasedImpl(
                 const auto faceIdx = cellFacesValues[startIdx + i];
                 // Laplacian is symmetric: flux contribution is identical for owner and neighbor
                 const auto offDiag = deltaCoeffs[faceIdx] * gammaV[faceIdx] * magFaceArea[faceIdx]
-                                   * cellCoeff * one<ValueType>();
+                                   * cellCoeff * one<AssemblyType>();
 
                 values[matrixColumnIdxV[startIdx + i]] += offDiag;
                 diagValue -= offDiag;
@@ -342,48 +344,57 @@ void computeLaplacianIntCellBasedImpl(
     );
 }
 
-template<typename ValueType>
-void GaussGreenLaplacian<ValueType>::laplacian(
-    VolumeField<ValueType>& lapPhi,
+template<typename FieldValueType, typename AssemblyType>
+void GaussGreenLaplacian<FieldValueType, AssemblyType>::laplacian(
+    VolumeField<FieldValueType>& lapPhi,
     const SurfaceField<scalar>& gamma,
-    const VolumeField<ValueType>& phi,
+    const VolumeField<FieldValueType>& phi,
     const dsl::Coeff coeff
 )
 {
-    computeLaplacianExp<ValueType>(faceNormalGradient_, gamma, phi, lapPhi.internalVector(), coeff);
+    computeLaplacianExp<FieldValueType>(
+        faceNormalGradient_, gamma, phi, lapPhi.internalVector(), coeff
+    );
 }
 
-template<typename ValueType>
-VolumeField<ValueType> GaussGreenLaplacian<ValueType>::laplacian(
-    const SurfaceField<scalar>& gamma, const VolumeField<ValueType>& phi, const dsl::Coeff coeff
+template<typename FieldValueType, typename AssemblyType>
+VolumeField<FieldValueType> GaussGreenLaplacian<FieldValueType, AssemblyType>::laplacian(
+    const SurfaceField<scalar>& gamma,
+    const VolumeField<FieldValueType>& phi,
+    const dsl::Coeff coeff
 ) const
 {
     std::string name = "laplacian(" + gamma.name + "," + phi.name + ")";
-    VolumeField<ValueType> lapPhi(
-        this->exec_, name, this->mesh_, createCalculatedBCs<VolumeBoundary<ValueType>>(this->mesh_)
+    VolumeField<FieldValueType> lapPhi(
+        this->exec_,
+        name,
+        this->mesh_,
+        createCalculatedBCs<VolumeBoundary<FieldValueType>>(this->mesh_)
     );
-    NeoN::fill(lapPhi.internalVector(), zero<ValueType>());
-    NeoN::fill(lapPhi.boundaryData().value(), zero<ValueType>());
-    computeLaplacianExp<ValueType>(faceNormalGradient_, gamma, phi, lapPhi.internalVector(), coeff);
+    NeoN::fill(lapPhi.internalVector(), zero<FieldValueType>());
+    NeoN::fill(lapPhi.boundaryData().value(), zero<FieldValueType>());
+    computeLaplacianExp<FieldValueType>(
+        faceNormalGradient_, gamma, phi, lapPhi.internalVector(), coeff
+    );
     return lapPhi;
 }
 
-template<typename ValueType>
-void GaussGreenLaplacian<ValueType>::laplacian(
-    Vector<ValueType>& lapPhi,
+template<typename FieldValueType, typename AssemblyType>
+void GaussGreenLaplacian<FieldValueType, AssemblyType>::laplacian(
+    Vector<FieldValueType>& lapPhi,
     const SurfaceField<scalar>& gamma,
-    const VolumeField<ValueType>& phi,
+    const VolumeField<FieldValueType>& phi,
     const dsl::Coeff coeff
 )
 {
-    computeLaplacianExp<ValueType>(faceNormalGradient_, gamma, phi, lapPhi, coeff);
+    computeLaplacianExp<FieldValueType>(faceNormalGradient_, gamma, phi, lapPhi, coeff);
 }
 
-template<typename ValueType>
-void GaussGreenLaplacian<ValueType>::laplacian(
-    la::LinearSystem<ValueType>& ls,
+template<typename FieldValueType, typename AssemblyType>
+void GaussGreenLaplacian<FieldValueType, AssemblyType>::laplacian(
+    la::LinearSystem<AssemblyType, FieldValueType>& ls,
     const SurfaceField<scalar>& gamma,
-    const VolumeField<ValueType>& phi,
+    const VolumeField<FieldValueType>& phi,
     const dsl::Coeff coeff
 )
 {
@@ -409,5 +420,6 @@ void GaussGreenLaplacian<ValueType>::laplacian(
 
 template class GaussGreenLaplacian<scalar>;
 template class GaussGreenLaplacian<Vec3>;
+template class GaussGreenLaplacian<Vec3, scalar>;
 
 };

--- a/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
@@ -99,13 +99,12 @@ void computeLaplacianProcBoundImpl(
     if (nProcBoundaryFaces == 0) return;
     const auto ma = ls.faceToMatrixAddress()->view(ls.matrix().sparsity()->rowOffs().view());
 
-    const auto [bGammaV, bDeltaCoeffs, boundaryFaceOwner] = views(
+    const auto [bGammaV, bDeltaCoeffs, surfFaceCells] = views(
         gamma.boundaryData().value(),
         faceNormalGradient.deltaCoeffs().boundaryData().value(),
         mesh.boundaryMesh().faceOwners()
     );
     const auto bcMagSf = mesh.boundaryMesh().faceAreas().view();
-
     auto bValues = ls.offDiagonalMatrix().values().view();
     // boundaryMatrix records the diagonal contribution so removeBoundaryContributions can reverse
     // it (proc slots live at [nBoundaryFaces, nBoundaryFaces + nProcBoundaryFaces)).
@@ -118,7 +117,7 @@ void computeLaplacianProcBoundImpl(
         {0, nProcBoundaryFaces},
         NEON_LAMBDA(const localIdx procFacei) {
             auto bcfacei = nBoundaryFaces + procFacei;
-            auto cell = boundaryFaceOwner[bcfacei];
+            auto cell = surfFaceCells[bcfacei];
             auto ownCoeff = coeff[cell];
 
             auto flux = bGammaV[bcfacei] * bcMagSf[bcfacei] * bDeltaCoeffs[bcfacei];

--- a/src/linearAlgebra/ginkgo/ginkgo.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgo.cpp
@@ -167,12 +167,12 @@ std::shared_ptr<gko::Executor> NeoN::la::ginkgo::getGkoExecutor(NeoN::Executor e
 namespace NeoN::la::ginkgo
 {
 
-label computeNRows(const LinearSystem<Vec3, CSRMatrix<Vec3, localIdx>>& sys)
+label computeNRows(const LinearSystem<Vec3, Vec3, CSRMatrix<Vec3, localIdx>>& sys)
 {
     return 3 * sys.rhs().size();
 }
 
-label computeNRows(const LinearSystem<scalar, CSRMatrix<scalar, localIdx>>& sys)
+label computeNRows(const LinearSystem<scalar, scalar, CSRMatrix<scalar, localIdx>>& sys)
 {
     return sys.rhs().size();
 }
@@ -314,9 +314,59 @@ SolverStatsEntry solve_impl(
     return {numIter, initResNorm, finalResNorm, duration};
 }
 
+SolverStatsEntry solve_impl(
+    std::shared_ptr<const gko::Executor> exec,
+    const Vector<Vec3>& rhs,
+    Vector<Vec3>& xIn,
+    std::shared_ptr<const gko::LinOp> mtx,
+    std::unique_ptr<gko::LinOp> solver
+)
+{
+    exec->synchronize();
+    auto startEval = std::chrono::steady_clock::now();
+
+    using vec = gko::matrix::Dense<scalar>;
+    label nrows = rhs.size();
+    const auto b = gkoVecView(exec, rhs.data(), nrows);
+    auto x = gkoVecView(exec, xIn.data(), nrows);
+
+    // create a copy of rhs so that we can inline compute
+    // the residual
+    auto rhsCopy = Vector<Vec3>(rhs);
+    auto res = gkoVecView(exec, rhsCopy.data(), nrows);
+
+    // compute Ax-b -> res
+    auto one = gko::initialize<vec>({1.0}, exec);
+    auto neg_one = gko::initialize<vec>({-1.0}, exec);
+    mtx->apply(one, x, neg_one, res);
+
+    auto init = gko::initialize<vec>({0.0}, exec);
+    res->compute_norm2(init);
+    scalar initResNorm = retrieve(init);
+
+    std::shared_ptr<const gko::log::Convergence<scalar>> logger =
+        gko::log::Convergence<scalar>::create();
+    solver->add_logger(logger);
+    solver->apply(b, x);
+
+    // since we work on a copy we need to copy back
+    scalar finalResNorm = retrieve(gko::as<vec>(logger->get_residual_norm()));
+
+    auto numIter = label(logger->get_num_iterations());
+    exec->synchronize();
+    auto endEval = std::chrono::steady_clock::now();
+    auto duration =
+        static_cast<scalar>(
+            std::chrono::duration_cast<std::chrono::microseconds>(endEval - startEval).count()
+        )
+        / 1000.0;
+
+    return {numIter, initResNorm, finalResNorm, duration};
+}
+
 
 SolverStats GinkgoSolver::solve(
-    const LinearSystem<scalar, CSRMatrix<scalar, localIdx>>& sys, Vector<scalar>& x
+    const LinearSystem<scalar, scalar, CSRMatrix<scalar, localIdx>>& sys, Vector<scalar>& x
 ) const
 {
     auto gkoMtx = createGkoMtx(sys.matrix());
@@ -328,7 +378,7 @@ SolverStats GinkgoSolver::solve(
 template<typename IndexType>
 std::shared_ptr<const gko::matrix::Csr<scalar, IndexType>> createGkoMtxImpl(
     std::shared_ptr<const gko::Executor> exec,
-    const LinearSystem<Vec3, CSRMatrix<Vec3, IndexType>>& sys
+    const LinearSystem<Vec3, Vec3, CSRMatrix<Vec3, IndexType>>& sys
 )
 {
     // NOTE we get a const view of the system but need a non const view to vals and indices
@@ -363,8 +413,9 @@ void solveComponent(auto& sys, auto& x, auto& exec, auto& factory, auto& stats)
     setComponent<I>(xcopy, x);
 }
 
-SolverStats
-GinkgoSolver::solve(const LinearSystem<Vec3, CSRMatrix<Vec3, localIdx>>& sys, Vector<Vec3>& x) const
+SolverStats GinkgoSolver::solve(
+    const LinearSystem<Vec3, Vec3, CSRMatrix<Vec3, localIdx>>& sys, Vector<Vec3>& x
+) const
 {
     if (coupled_)
     {
@@ -408,7 +459,7 @@ void solveVec3RhsComponent(
 }
 
 SolverStats GinkgoSolver::solve(
-    const LinearSystem<scalar, CSRMatrix<scalar, localIdx>, COOMatrix<scalar, localIdx>, Vec3>& sys,
+    const LinearSystem<scalar, Vec3, CSRMatrix<scalar, localIdx>, COOMatrix<scalar, localIdx>>& sys,
     Vector<Vec3>& x
 ) const
 {

--- a/src/linearAlgebra/ginkgo/ginkgoDistributed.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgoDistributed.cpp
@@ -358,6 +358,7 @@ SolverStats GinkgoSolver::solveDist(
     auto gkoMtx =
         createGkoMtxDist(gkoExec_, comm, sys.matrix(), sys.offDiagonalMatrix(), commPattern);
 
+    // TODO here Ginkgos multiple RHS solver could be used
     auto stats = SolverStats {};
     solveVec3RhsComponentDist<0>(sys.rhs(), x, gkoExec_, comm, factory_, gkoMtx, stats);
     solveVec3RhsComponentDist<1>(sys.rhs(), x, gkoExec_, comm, factory_, gkoMtx, stats);

--- a/src/linearAlgebra/ginkgo/ginkgoDistributed.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgoDistributed.cpp
@@ -325,6 +325,46 @@ SolverStats GinkgoSolver::solveDist(
     return stats;
 }
 
+// Solve one Vec3 rhs component against a shared distributed scalar matrix (segregated form).
+template<unsigned int I>
+void solveVec3RhsComponentDist(
+    const Vector<Vec3>& rhs,
+    Vector<Vec3>& x,
+    std::shared_ptr<const gko::Executor> exec,
+    const gko::experimental::mpi::communicator& comm,
+    std::shared_ptr<const gko::LinOpFactory> factory,
+    std::shared_ptr<const gko::LinOp> gkoMtx,
+    SolverStats& stats
+)
+{
+    auto rhsComp = getComponent<I>(rhs);
+    auto xcopy = getComponent<I>(x);
+    auto solver = factory->generate(gkoMtx);
+    stats.entries.push_back(solve_impl_dist(exec, comm, rhsComp, xcopy, gkoMtx, std::move(solver)));
+    setComponent<I>(xcopy, x);
+}
+
+SolverStats GinkgoSolver::solveDist(
+    const LinearSystem<scalar, Vec3, CSRMatrix<scalar, localIdx>, COOMatrix<scalar, localIdx>>& sys,
+    Vector<Vec3>& x
+) const
+{
+    const CommunicationPattern& commPattern = sys.commPattern();
+    auto comm = gko::experimental::mpi::communicator(
+        commPattern.env.comm(), !commPattern.env.gpuAwareMpi()
+    );
+    // The matrix is already scalar and shared across all three components, so build the
+    // distributed operator once and reuse it for each Vec3 rhs component.
+    auto gkoMtx =
+        createGkoMtxDist(gkoExec_, comm, sys.matrix(), sys.offDiagonalMatrix(), commPattern);
+
+    auto stats = SolverStats {};
+    solveVec3RhsComponentDist<0>(sys.rhs(), x, gkoExec_, comm, factory_, gkoMtx, stats);
+    solveVec3RhsComponentDist<1>(sys.rhs(), x, gkoExec_, comm, factory_, gkoMtx, stats);
+    solveVec3RhsComponentDist<2>(sys.rhs(), x, gkoExec_, comm, factory_, gkoMtx, stats);
+    return stats;
+}
+
 }
 
 #endif // NF_WITH_MPI_SUPPORT

--- a/src/linearAlgebra/ginkgo/ginkgoDistributed.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgoDistributed.cpp
@@ -301,7 +301,7 @@ void solveComponentDist(auto& sys, auto& x, auto& exec, auto& factory, auto& sta
 }
 
 SolverStats GinkgoSolver::solveDist(
-    const LinearSystem<scalar, CSRMatrix<scalar, localIdx>>& sys, Vector<scalar>& x
+    const LinearSystem<scalar, scalar, CSRMatrix<scalar, localIdx>>& sys, Vector<scalar>& x
 ) const
 {
     const CommunicationPattern& commPattern = sys.commPattern();
@@ -315,7 +315,7 @@ SolverStats GinkgoSolver::solveDist(
 }
 
 SolverStats GinkgoSolver::solveDist(
-    const LinearSystem<Vec3, CSRMatrix<Vec3, localIdx>>& sys, Vector<Vec3>& x
+    const LinearSystem<Vec3, Vec3, CSRMatrix<Vec3, localIdx>>& sys, Vector<Vec3>& x
 ) const
 {
     auto stats = SolverStats {};

--- a/src/linearAlgebra/matrix.cpp
+++ b/src/linearAlgebra/matrix.cpp
@@ -200,6 +200,48 @@ void scaledInvDiagNegLUx(
     );
 }
 
+void scaledInvDiagNegLUx(
+    const CSRMatrix<scalar, localIdx>& mtx,
+    const Vector<Vec3>& a,
+    const Vector<Vec3>& b,
+    const Vector<scalar>& vol,
+    Vector<scalar>& rAU,
+    Vector<Vec3>& out
+)
+{
+    NF_ASSERT(mtx.nRows() == a.size(), "Dimension mismatch");
+    NF_ASSERT(mtx.nRows() == out.size(), "Dimension mismatch");
+
+    const auto [rowOffsV, colIdxV, matrixV, rAUV, volV, aV, bV] =
+        views(mtx.sparsity()->rowOffs(), mtx.sparsity()->colIdxs(), mtx.values(), rAU, vol, a, b);
+    auto outV = out.view();
+
+    parallelFor(
+        mtx.exec(),
+        {0, mtx.nRows()},
+        NEON_LAMBDA(const localIdx rowi) {
+            outV[rowi] = zero<Vec3>();
+            for (auto i = rowOffsV[rowi]; i < rowOffsV[rowi + 1]; i++)
+            {
+                auto colI = colIdxV[i];
+                if (rowi == colI)
+                {
+                    // scalar diagonal coefficient scales all components equally
+                    rAUV[rowi] = volV[rowi] / matrixV[i];
+                }
+                else
+                {
+                    // scalar * Vec3 broadcasts the off-diagonal coefficient to each component
+                    outV[rowi] -= matrixV[i] * aV[colI];
+                }
+            }
+
+            outV[rowi] += bV[rowi];
+            outV[rowi] *= rAUV[rowi] / volV[rowi];
+        }
+    );
+}
+
 
 Vector<scalar> scaledInverseDiag(const CSRMatrix<Vec3, localIdx>& mtx, const Vector<scalar>& a)
 {
@@ -261,6 +303,39 @@ void scaledInverseDiag(
         {0, mtx.nRows()},
         NEON_LAMBDA(const localIdx rowi) {
             outV[rowi] = aV[rowi] / matrixV[rowOffsV[rowi] + diaOffsV[rowi]][0];
+        }
+    );
+}
+
+Vector<scalar> scaledInverseDiag(
+    const CSRMatrix<scalar, localIdx>& mtx, const FaceToMatrixAddress& mi, const Vector<scalar>& a
+)
+{
+    auto diag = Vector<scalar>(mtx.exec(), mtx.nRows());
+    scaledInverseDiag(mtx, mi, a, diag);
+    return diag;
+}
+
+void scaledInverseDiag(
+    const CSRMatrix<scalar, localIdx>& mtx,
+    const FaceToMatrixAddress& mi,
+    const Vector<scalar>& a,
+    Vector<scalar>& out
+)
+{
+    NF_ASSERT(mtx.nRows() == a.size(), "Dimension mismatch");
+
+    auto [outV, rowOffsV, colIdxV, matrixV, aV] =
+        views(out, mtx.sparsity()->rowOffs(), mtx.sparsity()->colIdxs(), mtx.values(), a);
+
+    const auto diaOffsV = mi.diagOffset().view();
+
+    parallelFor(
+        mtx.exec(),
+        {0, mtx.nRows()},
+        NEON_LAMBDA(const localIdx rowi) {
+            // scalar diagonal coefficient: no per-component selection needed
+            outV[rowi] = aV[rowi] / matrixV[rowOffsV[rowi] + diaOffsV[rowi]];
         }
     );
 }

--- a/src/linearAlgebra/utilities.cpp
+++ b/src/linearAlgebra/utilities.cpp
@@ -161,9 +161,12 @@ void packVecValues(const Vector<scalar>& in, Vector<Vec3>& out)
     );
 }
 
-template<typename MatrixType>
+template<typename MatrixType, typename ValueType>
 void computeResidual(
-    const MatrixType& mtx, const Vector<scalar>& bV, const Vector<scalar>& xV, Vector<scalar>& resV
+    const MatrixType& mtx,
+    const Vector<ValueType>& bV,
+    const Vector<ValueType>& xV,
+    Vector<ValueType>& resV
 )
 {
     auto [res, b, x] = views(resV, bV, xV);
@@ -175,7 +178,9 @@ void computeResidual(
         NEON_LAMBDA(const localIdx rowi) {
             auto rowStart = sparsity.rowOffs[rowi];
             auto rowEnd = sparsity.rowOffs[rowi + 1];
-            scalar sum = 0.0;
+            // ValueType sum: scalar coeffs * Vec3 x broadcasts to each component for
+            // the segregated vector-solve form (scalar matrix, Vec3 rhs)
+            ValueType sum = zero<ValueType>();
             for (localIdx coli = rowStart; coli < rowEnd; coli++)
             {
                 sum += coeffs[coli] * x[sparsity.colIdxs[coli]];
@@ -186,9 +191,13 @@ void computeResidual(
     );
 }
 
-template void computeResidual<CSRMatrix<
-    scalar,
-    localIdx>>(const CSRMatrix<scalar, localIdx>&, const Vector<scalar>&, const Vector<scalar>&, Vector<scalar>&);
+template void computeResidual<
+    CSRMatrix<scalar, localIdx>,
+    scalar>(const CSRMatrix<scalar, localIdx>&, const Vector<scalar>&, const Vector<scalar>&, Vector<scalar>&);
+
+template void computeResidual<
+    CSRMatrix<scalar, localIdx>,
+    Vec3>(const CSRMatrix<scalar, localIdx>&, const Vector<Vec3>&, const Vector<Vec3>&, Vector<Vec3>&);
 
 template<typename IndexType>
 Vector<IndexType> rowsToRowOffs(const Vector<IndexType>& rows)

--- a/test/catch2/catch2_common.hpp
+++ b/test/catch2/catch2_common.hpp
@@ -304,7 +304,8 @@ void randomizeVector(NeoN::Vector<VectorValueType>& a)
 
     for (int i = 0; i < b.size(); i++)
     {
-        bV[i] = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
+        const auto val = static_cast<NeoN::scalar>(rand()) / static_cast<NeoN::scalar>(RAND_MAX);
+        bV[i] = NeoN::one<VectorValueType>() * val;
     }
     auto c = b.copyToExecutor(a.exec());
     a = c;

--- a/test/distributed/operator.cpp
+++ b/test/distributed/operator.cpp
@@ -349,4 +349,110 @@ TEST_CASE("Distributed Operator - vec3")
 #endif
 }
 
+// Validates the distributed scalar-matrix / Vec3-rhs solve (segregated vector solve):
+// GinkgoSolver::solveDist(LinearSystem<scalar, Vec3, ...>, Vector<Vec3>). The matrix
+// coefficients are scalar and shared across the three rhs components; the distributed
+// solution and per-component convergence must match the serial solve of the same global system.
+TEST_CASE("Distributed Operator - scalar matrix, Vec3 rhs")
+{
+    auto [execName, exec] = GENERATE(allAvailableExecutor());
+
+    auto input = generateInput("upwind", "");
+    auto inputPart = generateInput("upwind", "Part");
+
+    auto nCells = 12;
+    auto meshGlobal = create1DUniformMesh(exec, nCells);
+    auto mesh = create1DUniformMesh(exec, nCells);
+
+    auto volBCs = fvcc::createCalculatedBCs<fvcc::VolumeBoundary<Vec3>>(mesh);
+    auto U = finiteVolume::cellCentred::VolumeField<Vec3>(
+        exec, "U", mesh, Vector<Vec3>(exec, nCells, 2.0 * one<Vec3>()), volBCs
+    );
+    srand(42);
+    randomizeVector(U);
+
+    auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<scalar>>(mesh);
+    auto phi = finiteVolume::cellCentred::SurfaceField<scalar>(exec, "phi", mesh, surfaceBCs);
+    auto gamma = finiteVolume::cellCentred::SurfaceField<scalar>(exec, "gamma", mesh, surfaceBCs);
+    fill(phi.internalVector(), 1.0);
+    srand(42);
+    randomizeVector(phi.internalVector());
+    fill(gamma.internalVector(), 2.0);
+
+    // assemble into a scalar coefficient matrix with a Vec3 rhs (segregated vector-solve form).
+    // SetReference pins cell 0 to remove the constant null space; for scalar-matrix assembly the
+    // post-assembly functor is dispatched via PostAssemblyBase::applyScalarMatrix.
+    dsl::SetReference<Vec3, localIdx> setRef(0, zero<Vec3>());
+    auto expr = dsl::imp::div(phi, U) - dsl::imp::laplacian(gamma, U);
+    expr.read(input);
+    auto ls = expr.template assemble<scalar>(mesh, 1.0, 1.0, {&setRef});
+
+    NeoN::mpi::Environment mpiEnviron;
+    auto meshPart = create1DUniformMeshPart(exec, meshGlobal.nCells() / mpiEnviron.sizeRank());
+
+    auto uPart = detail::oneDPartitionField(U, meshPart, mpiEnviron);
+    auto phiPart = detail::oneDPartitionField(phi, meshPart, mpiEnviron);
+    auto gammaPart = detail::oneDPartitionField(gamma, meshPart, mpiEnviron);
+
+    auto exprDist = dsl::imp::div(phiPart, uPart) - dsl::imp::laplacian(gammaPart, uPart);
+    exprDist.read(inputPart);
+    auto lsDst = exprDist.template assemble<scalar>(meshPart, 1.0, 1.0, {&setRef});
+
+    fill(ls.rhs(), 2.0 * one<Vec3>());
+    fill(lsDst.rhs(), 2.0 * one<Vec3>());
+
+    // matrix coefficients are scalar while the rhs holds Vec3 values
+    static_assert(std::is_same_v<
+                  std::decay_t<decltype(lsDst.matrix().values())>,
+                  NeoN::Vector<NeoN::scalar>>);
+    static_assert(std::is_same_v<std::decay_t<decltype(lsDst.rhs())>, NeoN::Vector<NeoN::Vec3>>);
+
+#if NF_WITH_GINKGO
+    Dictionary solverDict {
+        {{"solver", std::string {"Ginkgo"}},
+         {"type", "solver::Gmres"},
+         {"criteria", Dictionary {{{"iteration", 200}, {"relative_residual_norm", 1e-7}}}}}
+    };
+
+    auto solver = NeoN::la::Solver(exec, solverDict);
+    auto x = Vector<Vec3>(exec, 12);
+    fill(x, zero<Vec3>());
+    auto xPart = Vector<Vec3>(exec, 4);
+    fill(xPart, zero<Vec3>());
+
+    // serial scalar-matrix solve on the global system (one scalar matrix, three rhs components)
+    auto solverStats = solver.solve(ls, x);
+    // distributed scalar-matrix solve -> GinkgoSolver::solveDist(scalar mtx, Vec3 rhs)
+    auto solverStatsDist = solver.solve(lsDst, xPart);
+
+    // one solve per velocity component (Ux, Uy, Uz) sharing the scalar matrix
+    REQUIRE(solverStats.entries.size() == 3);
+    REQUIRE(solverStatsDist.entries.size() == 3);
+
+    // distributed per-component convergence matches the serial reference (same arithmetic,
+    // partitioned vs global operator)
+    for (std::size_t i = 0; i < 3; ++i)
+    {
+        REQUIRE(
+            solverStatsDist.entries[i].finalResNorm
+            == Catch::Approx(solverStats.entries[i].finalResNorm).margin(1e-6)
+        );
+    }
+
+    // the distributed solution slice matches the serial global solution on every rank
+    SECTION_IF(mpiEnviron.rank() == 0, "Correct solution on rank 0")
+    {
+        REQUIRE_THAT(xPart, Equals(take(x, {0, 4}), Approx {1e-4}));
+    }
+    SECTION_IF(mpiEnviron.rank() == 1, "Correct solution on rank 1")
+    {
+        REQUIRE_THAT(xPart, Equals(take(x, {4, 8}), Approx {1e-4}));
+    }
+    SECTION_IF(mpiEnviron.rank() == 2, "Correct solution on rank 2")
+    {
+        REQUIRE_THAT(xPart, Equals(take(x, {8, 12}), Approx {1e-4}));
+    }
+#endif
+}
+
 }

--- a/test/distributed/operator.cpp
+++ b/test/distributed/operator.cpp
@@ -12,7 +12,7 @@ using Catch::randomizeVector;
 namespace NeoN
 {
 
-auto generateInput = [](std::string scheme, std::string post)
+auto GENERATE_INPUT = [](std::string scheme, std::string post)
 {
     auto constructDiv = [](auto post) { return "div(phi" + post + ",U" + post + ")"; };
     auto constructGamma = [](auto post) { return "laplacian(gamma" + post + ",U" + post + ")"; };
@@ -38,15 +38,15 @@ TEST_CASE("Distributed Operator - scalar")
 
     auto [execName, exec] = GENERATE(allAvailableExecutor());
 
-    auto input = generateInput("upwind", "");
-    auto inputPart = generateInput("upwind", "Part");
+    auto input = GENERATE_INPUT("upwind", "");
+    auto inputPart = GENERATE_INPUT("upwind", "Part");
 
     auto nCells = 12;
     auto meshGlobal = create1DUniformMesh(exec, nCells);
     auto mesh = create1DUniformMesh(exec, nCells);
 
     auto volBCs = fvcc::createCalculatedBCs<fvcc::VolumeBoundary<scalar>>(mesh);
-    auto U = finiteVolume::cellCentred::VolumeField<scalar>(
+    auto u = finiteVolume::cellCentred::VolumeField<scalar>(
         exec, "U", mesh, Vector<scalar>(exec, nCells, 2.0 * one<scalar>()), volBCs
     );
     auto p = finiteVolume::cellCentred::VolumeField<scalar>(
@@ -54,7 +54,7 @@ TEST_CASE("Distributed Operator - scalar")
     );
 
     srand(42);
-    randomizeVector(U);
+    randomizeVector(u);
     randomizeVector(p);
 
     auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<scalar>>(mesh);
@@ -67,7 +67,7 @@ TEST_CASE("Distributed Operator - scalar")
     fill(gamma.internalVector(), 2.0);
 
     // assembly on global mesh
-    auto expr = dsl::imp::div(phi, U) - dsl::imp::laplacian(gamma, U);
+    auto expr = dsl::imp::div(phi, u) - dsl::imp::laplacian(gamma, u);
     expr.read(input);
     dsl::SetReference<scalar, localIdx> setRef(0, 0.0);
     auto ls = expr.assemble(mesh, 1.0, 1.0, {&setRef});
@@ -75,7 +75,7 @@ TEST_CASE("Distributed Operator - scalar")
     NeoN::mpi::Environment mpiEnviron;
     auto meshPart = create1DUniformMeshPart(exec, meshGlobal.nCells() / mpiEnviron.sizeRank());
 
-    auto uPart = detail::oneDPartitionField(U, meshPart, mpiEnviron);
+    auto uPart = detail::oneDPartitionField(u, meshPart, mpiEnviron);
     auto pPart = detail::oneDPartitionField(p, meshPart, mpiEnviron);
     auto phiPart = detail::oneDPartitionField(phi, meshPart, mpiEnviron);
     auto gammaPart = detail::oneDPartitionField(gamma, meshPart, mpiEnviron);
@@ -199,20 +199,20 @@ TEST_CASE("Distributed Operator - vec3")
 
     auto [execName, exec] = GENERATE(allAvailableExecutor());
 
-    auto input = generateInput("upwind", "");
-    auto inputPart = generateInput("upwind", "Part");
+    auto input = GENERATE_INPUT("upwind", "");
+    auto inputPart = GENERATE_INPUT("upwind", "Part");
 
     auto nCells = 12;
     auto meshGlobal = create1DUniformMesh(exec, nCells);
     auto mesh = create1DUniformMesh(exec, nCells);
 
     auto volBCs = fvcc::createCalculatedBCs<fvcc::VolumeBoundary<Vec3>>(mesh);
-    auto U = finiteVolume::cellCentred::VolumeField<Vec3>(
+    auto u = finiteVolume::cellCentred::VolumeField<Vec3>(
         exec, "U", mesh, Vector<Vec3>(exec, nCells, 2.0 * one<Vec3>()), volBCs
     );
 
     srand(42);
-    randomizeVector(U);
+    randomizeVector(u);
 
     auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<scalar>>(mesh);
     auto phi = finiteVolume::cellCentred::SurfaceField<scalar>(exec, "phi", mesh, surfaceBCs);
@@ -224,7 +224,7 @@ TEST_CASE("Distributed Operator - vec3")
     fill(gamma.internalVector(), 2.0);
 
     // assembly on global mesh
-    auto expr = dsl::imp::div(phi, U) - dsl::imp::laplacian(gamma, U);
+    auto expr = dsl::imp::div(phi, u) - dsl::imp::laplacian(gamma, u);
     expr.read(input);
     dsl::SetReference<Vec3, localIdx> setRef(0, zero<Vec3>());
     auto ls = expr.assemble(mesh, 1.0, 1.0, {&setRef});
@@ -232,7 +232,7 @@ TEST_CASE("Distributed Operator - vec3")
     NeoN::mpi::Environment mpiEnviron;
     auto meshPart = create1DUniformMeshPart(exec, meshGlobal.nCells() / mpiEnviron.sizeRank());
 
-    auto uPart = detail::oneDPartitionField(U, meshPart, mpiEnviron);
+    auto uPart = detail::oneDPartitionField(u, meshPart, mpiEnviron);
     auto phiPart = detail::oneDPartitionField(phi, meshPart, mpiEnviron);
     auto gammaPart = detail::oneDPartitionField(gamma, meshPart, mpiEnviron);
 
@@ -357,19 +357,19 @@ TEST_CASE("Distributed Operator - scalar matrix, Vec3 rhs")
 {
     auto [execName, exec] = GENERATE(allAvailableExecutor());
 
-    auto input = generateInput("upwind", "");
-    auto inputPart = generateInput("upwind", "Part");
+    auto input = GENERATE_INPUT("upwind", "");
+    auto inputPart = GENERATE_INPUT("upwind", "Part");
 
     auto nCells = 12;
     auto meshGlobal = create1DUniformMesh(exec, nCells);
     auto mesh = create1DUniformMesh(exec, nCells);
 
     auto volBCs = fvcc::createCalculatedBCs<fvcc::VolumeBoundary<Vec3>>(mesh);
-    auto U = finiteVolume::cellCentred::VolumeField<Vec3>(
+    auto u = finiteVolume::cellCentred::VolumeField<Vec3>(
         exec, "U", mesh, Vector<Vec3>(exec, nCells, 2.0 * one<Vec3>()), volBCs
     );
     srand(42);
-    randomizeVector(U);
+    randomizeVector(u);
 
     auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<scalar>>(mesh);
     auto phi = finiteVolume::cellCentred::SurfaceField<scalar>(exec, "phi", mesh, surfaceBCs);
@@ -383,14 +383,14 @@ TEST_CASE("Distributed Operator - scalar matrix, Vec3 rhs")
     // SetReference pins cell 0 to remove the constant null space; for scalar-matrix assembly the
     // post-assembly functor is dispatched via PostAssemblyBase::applyScalarMatrix.
     dsl::SetReference<Vec3, localIdx> setRef(0, zero<Vec3>());
-    auto expr = dsl::imp::div(phi, U) - dsl::imp::laplacian(gamma, U);
+    auto expr = dsl::imp::div(phi, u) - dsl::imp::laplacian(gamma, u);
     expr.read(input);
     auto ls = expr.template assemble<scalar>(mesh, 1.0, 1.0, {&setRef});
 
     NeoN::mpi::Environment mpiEnviron;
     auto meshPart = create1DUniformMeshPart(exec, meshGlobal.nCells() / mpiEnviron.sizeRank());
 
-    auto uPart = detail::oneDPartitionField(U, meshPart, mpiEnviron);
+    auto uPart = detail::oneDPartitionField(u, meshPart, mpiEnviron);
     auto phiPart = detail::oneDPartitionField(phi, meshPart, mpiEnviron);
     auto gammaPart = detail::oneDPartitionField(gamma, meshPart, mpiEnviron);
 

--- a/test/distributed/operator.cpp
+++ b/test/distributed/operator.cpp
@@ -32,7 +32,7 @@ auto generateInput = [](std::string scheme, std::string post)
     };
 };
 
-TEST_CASE("Distributed Operator")
+TEST_CASE("Distributed Operator - scalar")
 {
     float epsilon = 1e-32;
 
@@ -169,6 +169,162 @@ TEST_CASE("Distributed Operator")
 
     auto xPart = Vector<scalar>(exec, 4);
     fill(xPart, 0.0);
+
+    auto solverStats = solver.solve(ls, x);
+    auto solverStatsDist = solver.solve(lsDst, xPart);
+
+    scalar finalResNorm = solverStats.entries[0].finalResNorm;
+    scalar finalResNormDist = solverStatsDist.entries[0].finalResNorm;
+
+    REQUIRE(finalResNormDist == Catch::Approx(finalResNorm).margin(1e-6));
+
+    SECTION_IF(mpiEnviron.rank() == 0, "Correct solution on rank 0")
+    {
+        REQUIRE_THAT(xPart, Equals(take(x, {0, 4}), Approx {1e-4}));
+    }
+    SECTION_IF(mpiEnviron.rank() == 1, "Correct solution on rank 1")
+    {
+        REQUIRE_THAT(xPart, Equals(take(x, {4, 8}), Approx {1e-4}));
+    }
+    SECTION_IF(mpiEnviron.rank() == 2, "Correct solution on rank 2")
+    {
+        REQUIRE_THAT(xPart, Equals(take(x, {8, 12}), Approx {1e-4}));
+    }
+#endif
+}
+
+TEST_CASE("Distributed Operator - vec3")
+{
+    float epsilon = 1e-32;
+
+    auto [execName, exec] = GENERATE(allAvailableExecutor());
+
+    auto input = generateInput("upwind", "");
+    auto inputPart = generateInput("upwind", "Part");
+
+    auto nCells = 12;
+    auto meshGlobal = create1DUniformMesh(exec, nCells);
+    auto mesh = create1DUniformMesh(exec, nCells);
+
+    auto volBCs = fvcc::createCalculatedBCs<fvcc::VolumeBoundary<Vec3>>(mesh);
+    auto U = finiteVolume::cellCentred::VolumeField<Vec3>(
+        exec, "U", mesh, Vector<Vec3>(exec, nCells, 2.0 * one<Vec3>()), volBCs
+    );
+
+    srand(42);
+    randomizeVector(U);
+
+    auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<scalar>>(mesh);
+    auto phi = finiteVolume::cellCentred::SurfaceField<scalar>(exec, "phi", mesh, surfaceBCs);
+    auto gamma = finiteVolume::cellCentred::SurfaceField<scalar>(exec, "gamma", mesh, surfaceBCs);
+
+    fill(phi.internalVector(), 1.0);
+    srand(42);
+    randomizeVector(phi.internalVector());
+    fill(gamma.internalVector(), 2.0);
+
+    // assembly on global mesh
+    auto expr = dsl::imp::div(phi, U) - dsl::imp::laplacian(gamma, U);
+    expr.read(input);
+    dsl::SetReference<Vec3, localIdx> setRef(0, zero<Vec3>());
+    auto ls = expr.assemble(mesh, 1.0, 1.0, {&setRef});
+
+    NeoN::mpi::Environment mpiEnviron;
+    auto meshPart = create1DUniformMeshPart(exec, meshGlobal.nCells() / mpiEnviron.sizeRank());
+
+    auto uPart = detail::oneDPartitionField(U, meshPart, mpiEnviron);
+    auto phiPart = detail::oneDPartitionField(phi, meshPart, mpiEnviron);
+    auto gammaPart = detail::oneDPartitionField(gamma, meshPart, mpiEnviron);
+
+    auto exprDist = dsl::imp::div(phiPart, uPart) - dsl::imp::laplacian(gammaPart, uPart);
+
+    exprDist.read(inputPart);
+
+    auto lsDst = exprDist.assemble(meshPart, 1.0, 1.0, {&setRef});
+
+    fill(ls.rhs(), 2.0 * one<Vec3>());
+    fill(lsDst.rhs(), 2.0 * one<Vec3>());
+
+    localIdx firstElement = 0;
+    localIdx lastElement = 0;
+    SECTION_IF(mpiEnviron.rank() == 0, "Correct mtx on rank 0")
+    {
+        lastElement = 10;
+        REQUIRE_THAT(
+            lsDst.matrix().values(), Equals(take(ls.matrix().values(), {firstElement, lastElement}))
+        );
+    }
+    SECTION_IF(mpiEnviron.rank() == 1, "Correct mtx on rank 1")
+    {
+        firstElement = 12;
+        lastElement = 22;
+        REQUIRE_THAT(
+            lsDst.matrix().values(), Equals(take(ls.matrix().values(), {firstElement, lastElement}))
+        );
+    }
+    SECTION_IF(mpiEnviron.rank() == 2, "Correct mtx on rank 2")
+    {
+        firstElement = 24;
+        lastElement = 34;
+        REQUIRE_THAT(
+            lsDst.matrix().values(), Equals(take(ls.matrix().values(), {firstElement, lastElement}))
+        );
+    }
+
+    // The global 12-cell 1D CSR matrix has 34 values (row 0: 2 entries, rows 1-10: 3 each,
+    // row 11: 2 entries). Proc-boundary off-diagonal entries sit at:
+    //   off(3,4)=global[10], off(4,3)=global[11], off(7,8)=global[22], off(8,7)=global[23].
+    // These are excluded from each rank's main matrix and stored in offDiagonalMatrix instead.
+    SECTION("Correct offDiagonalMatrix on partitioned mesh")
+    {
+        SECTION_IF(mpiEnviron.rank() == 0, "Rank 0 offDiagonalMatrix matches global off(3,4)")
+        {
+            REQUIRE_THAT(
+                lsDst.offDiagonalMatrix().values(), Equals(take(ls.matrix().values(), {10, 11}))
+            );
+            std::shared_ptr<const NeoN::la::CooSparsityPattern<localIdx>> cooSparsity =
+                lsDst.offDiagonalMatrix().sparsity();
+            REQUIRE_THAT(cooSparsity->rowIdxs(), Equals(I {3}, EqualInt()));
+            REQUIRE_THAT(cooSparsity->colIdxs(), Equals(I {4}, EqualInt()));
+        }
+        SECTION_IF(
+            mpiEnviron.rank() == 1, "Rank 1 offDiagonalMatrix matches global off(4,3) and off(7,8)"
+        )
+        {
+            auto globalHost = ls.matrix().values().copyToHost();
+            auto globalView = globalHost.view();
+            std::vector<Vec3> expected = {globalView[11], globalView[22]};
+            REQUIRE_THAT(lsDst.offDiagonalMatrix().values(), Equals(expected));
+            std::shared_ptr<const NeoN::la::CooSparsityPattern<localIdx>> cooSparsity =
+                lsDst.offDiagonalMatrix().sparsity();
+            REQUIRE_THAT(cooSparsity->rowIdxs(), Equals(I {4, 7}, EqualInt()));
+            REQUIRE_THAT(cooSparsity->colIdxs(), Equals(I {3, 8}, EqualInt()));
+        }
+        SECTION_IF(mpiEnviron.rank() == 2, "Rank 2 offDiagonalMatrix matches global off(8,7)")
+        {
+            REQUIRE_THAT(
+                lsDst.offDiagonalMatrix().values(), Equals(take(ls.matrix().values(), {23, 24}))
+            );
+            std::shared_ptr<const NeoN::la::CooSparsityPattern<localIdx>> cooSparsity =
+                lsDst.offDiagonalMatrix().sparsity();
+            REQUIRE_THAT(cooSparsity->rowIdxs(), Equals(I {8}, EqualInt()));
+            REQUIRE_THAT(cooSparsity->colIdxs(), Equals(I {7}, EqualInt()));
+        }
+    }
+
+#if NF_WITH_GINKGO
+    Dictionary solverDict {
+        {{"solver", std::string {"Ginkgo"}},
+         {"type", "solver::Gmres"},
+         {"criteria", Dictionary {{{"iteration", 200}, {"relative_residual_norm", 1e-7}}}}}
+    };
+
+    auto solver = NeoN::la::Solver(exec, solverDict);
+    auto x = Vector<Vec3>(exec, 12);
+    fill(x, zero<Vec3>());
+
+    auto xPart = Vector<Vec3>(exec, 4);
+    fill(xPart, zero<Vec3>());
 
     auto solverStats = solver.solve(ls, x);
     auto solverStatsDist = solver.solve(lsDst, xPart);

--- a/test/distributed/operator.cpp
+++ b/test/distributed/operator.cpp
@@ -12,7 +12,7 @@ using Catch::randomizeVector;
 namespace NeoN
 {
 
-auto GENERATE_INPUT = [](std::string scheme, std::string post)
+auto generateInput = [](std::string scheme, std::string post)
 {
     auto constructDiv = [](auto post) { return "div(phi" + post + ",U" + post + ")"; };
     auto constructGamma = [](auto post) { return "laplacian(gamma" + post + ",U" + post + ")"; };
@@ -38,15 +38,15 @@ TEST_CASE("Distributed Operator")
 
     auto [execName, exec] = GENERATE(allAvailableExecutor());
 
-    auto input = GENERATE_INPUT("upwind", "");
-    auto inputPart = GENERATE_INPUT("upwind", "Part");
+    auto input = generateInput("upwind", "");
+    auto inputPart = generateInput("upwind", "Part");
 
     auto nCells = 12;
     auto meshGlobal = create1DUniformMesh(exec, nCells);
     auto mesh = create1DUniformMesh(exec, nCells);
 
     auto volBCs = fvcc::createCalculatedBCs<fvcc::VolumeBoundary<scalar>>(mesh);
-    auto u = finiteVolume::cellCentred::VolumeField<scalar>(
+    auto U = finiteVolume::cellCentred::VolumeField<scalar>(
         exec, "U", mesh, Vector<scalar>(exec, nCells, 2.0 * one<scalar>()), volBCs
     );
     auto p = finiteVolume::cellCentred::VolumeField<scalar>(
@@ -54,7 +54,7 @@ TEST_CASE("Distributed Operator")
     );
 
     srand(42);
-    randomizeVector(u);
+    randomizeVector(U);
     randomizeVector(p);
 
     auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<scalar>>(mesh);
@@ -67,7 +67,7 @@ TEST_CASE("Distributed Operator")
     fill(gamma.internalVector(), 2.0);
 
     // assembly on global mesh
-    auto expr = dsl::imp::div(phi, u) - dsl::imp::laplacian(gamma, u);
+    auto expr = dsl::imp::div(phi, U) - dsl::imp::laplacian(gamma, U);
     expr.read(input);
     dsl::SetReference<scalar, localIdx> setRef(0, 0.0);
     auto ls = expr.assemble(mesh, 1.0, 1.0, {&setRef});
@@ -75,7 +75,7 @@ TEST_CASE("Distributed Operator")
     NeoN::mpi::Environment mpiEnviron;
     auto meshPart = create1DUniformMeshPart(exec, meshGlobal.nCells() / mpiEnviron.sizeRank());
 
-    auto uPart = detail::oneDPartitionField(u, meshPart, mpiEnviron);
+    auto uPart = detail::oneDPartitionField(U, meshPart, mpiEnviron);
     auto pPart = detail::oneDPartitionField(p, meshPart, mpiEnviron);
     auto phiPart = detail::oneDPartitionField(phi, meshPart, mpiEnviron);
     auto gammaPart = detail::oneDPartitionField(gamma, meshPart, mpiEnviron);

--- a/test/dsl/common.hpp
+++ b/test/dsl/common.hpp
@@ -174,8 +174,7 @@ public:
         );
     }
 
-    void implicitOperation(la::LinearSystem<ValueType, la::CSRMatrix<ValueType, localIdx>>& ls
-    ) const
+    void implicitOperation(la::LinearSystem<ValueType>& ls) const
     {
         auto values = ls.matrix().values().view();
         auto rhs = ls.rhs().view();
@@ -236,11 +235,7 @@ public:
         );
     }
 
-    void implicitOperation(
-        la::LinearSystem<ValueType, la::CSRMatrix<ValueType, localIdx>>& ls,
-        NeoN::scalar,
-        NeoN::scalar
-    )
+    void implicitOperation(la::LinearSystem<ValueType>& ls, NeoN::scalar, NeoN::scalar)
     {
         auto values = ls.matrix().values().view();
         auto rhs = ls.rhs().view();
@@ -273,14 +268,14 @@ ValueType getVector(const NeoN::Vector<ValueType>& source)
 }
 
 template<typename ValueType>
-ValueType getDiag(const la::LinearSystem<ValueType, la::CSRMatrix<ValueType, localIdx>>& ls)
+ValueType getDiag(const la::LinearSystem<ValueType>& ls)
 {
     auto hostLs = ls.copyToHost();
     return hostLs.matrix().values().view()[0];
 }
 
 template<typename ValueType>
-ValueType getRhs(const la::LinearSystem<ValueType, la::CSRMatrix<ValueType, localIdx>>& ls)
+ValueType getRhs(const la::LinearSystem<ValueType>& ls)
 {
     auto hostLs = ls.copyToHost();
     return hostLs.rhs().view()[0];

--- a/test/finiteVolume/cellCentred/operator/CMakeLists.txt
+++ b/test/finiteVolume/cellCentred/operator/CMakeLists.txt
@@ -5,4 +5,5 @@
 neon_unit_test(ddtOperator)
 neon_unit_test(laplacianOperator)
 neon_unit_test(gaussGreenDiv)
+neon_unit_test(gaussGreenDivLaplacian)
 neon_unit_test(sourceTerm)

--- a/test/finiteVolume/cellCentred/operator/gaussGreenDivLaplacian.cpp
+++ b/test/finiteVolume/cellCentred/operator/gaussGreenDivLaplacian.cpp
@@ -16,7 +16,7 @@ using Operator = NeoN::dsl::Operator;
 namespace NeoN
 {
 
-auto makeFvSchemes = []()
+auto MAKE_FV_SCHEMES = []()
 {
     NeoN::Dictionary fvSchemes;
     NeoN::Dictionary divSchemes;
@@ -47,7 +47,7 @@ TEMPLATE_TEST_CASE("Div + Laplacian Operator ", "[template]", NeoN::Vec3)
     NeoN::fill(phi.boundaryData().value(), NeoN::zero<TestType>());
     phi.correctBoundaryConditions();
 
-    auto fvSchemes = makeFvSchemes();
+    auto fvSchemes = MAKE_FV_SCHEMES();
 
     fvcc::SurfaceField<NeoN::scalar> faceFlux(exec, "faceFlux", mesh, surfaceBCs);
     NeoN::fill(faceFlux.internalVector(), 1.0);

--- a/test/finiteVolume/cellCentred/operator/gaussGreenDivLaplacian.cpp
+++ b/test/finiteVolume/cellCentred/operator/gaussGreenDivLaplacian.cpp
@@ -120,7 +120,7 @@ TEMPLATE_TEST_CASE("Div + Laplacian Operator ", "[template]", NeoN::Vec3)
         Vector<Vec3> x(exec, mesh.nCells(), zero<Vec3>());
         auto solverStats = solver.solve(ls, x);
 
-        REQUIRE(solverStats.entries.size() > 0);
+        REQUIRE(solverStats.entries.size() == 3); // one entry per Vec3 component
         const auto& stats = solverStats.entries[0];
 
         // The solver must have iterated at least once.

--- a/test/finiteVolume/cellCentred/operator/gaussGreenDivLaplacian.cpp
+++ b/test/finiteVolume/cellCentred/operator/gaussGreenDivLaplacian.cpp
@@ -83,7 +83,7 @@ TEMPLATE_TEST_CASE("Div + Laplacian Operator ", "[template]", NeoN::Vec3)
         REQUIRE(matAbsSum > 0.0);
     }
 
-    SECTION("Can assemble to Vec3 matrix with rhs<vec3>")
+    SECTION("Can assemble to Vec3 matrix with rhs<Vec3>")
     {
         auto ls = expr.template assemble<NeoN::Vec3>(mesh, t, dt);
 
@@ -104,6 +104,7 @@ TEMPLATE_TEST_CASE("Div + Laplacian Operator ", "[template]", NeoN::Vec3)
         REQUIRE(matMagSum > 0.0);
     }
 
+#if NF_WITH_GINKGO
     SECTION("Can solve with multiple RHS")
     {
         auto ls = expr.template assemble<NeoN::scalar>(mesh, t, dt);
@@ -137,6 +138,7 @@ TEMPLATE_TEST_CASE("Div + Laplacian Operator ", "[template]", NeoN::Vec3)
         }
         REQUIRE(xMagSum > 0.0);
     }
+#endif // NF_WITH_GINKGO
 }
 
 } // namespace NeoN

--- a/test/finiteVolume/cellCentred/operator/gaussGreenDivLaplacian.cpp
+++ b/test/finiteVolume/cellCentred/operator/gaussGreenDivLaplacian.cpp
@@ -108,15 +108,16 @@ TEMPLATE_TEST_CASE("Div + Laplacian Operator ", "[template]", NeoN::Vec3)
     SECTION("Can solve with multiple RHS")
     {
         auto ls = expr.template assemble<NeoN::scalar>(mesh, t, dt);
+        fill(ls.rhs(), 2.0 * one<Vec3>());
 
         Dictionary solverDict {
             {{"solver", std::string {"Ginkgo"}},
-             {"type", "solver::Cg"},
-             {"criteria", Dictionary {{{"iteration", 3}, {"relative_residual_norm", 1e-7}}}}}
+             {"type", "solver::Gmres"},
+             {"criteria", Dictionary {{{"iteration", 200}, {"relative_residual_norm", 1e-7}}}}}
         };
 
         auto solver = NeoN::la::Solver(exec, solverDict);
-        Vector<Vec3> x(exec, {{0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}});
+        Vector<Vec3> x(exec, mesh.nCells(), zero<Vec3>());
         auto solverStats = solver.solve(ls, x);
 
         REQUIRE(solverStats.entries.size() > 0);

--- a/test/finiteVolume/cellCentred/operator/gaussGreenDivLaplacian.cpp
+++ b/test/finiteVolume/cellCentred/operator/gaussGreenDivLaplacian.cpp
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
+                            // a custom main
+#include "catch2_common.hpp"
+
+#include "NeoN/NeoN.hpp"
+
+
+namespace fvcc = NeoN::finiteVolume::cellCentred;
+
+using Operator = NeoN::dsl::Operator;
+
+namespace NeoN
+{
+
+auto makeFvSchemes = []()
+{
+    NeoN::Dictionary fvSchemes;
+    NeoN::Dictionary divSchemes;
+    divSchemes.insert(
+        "div(faceFlux,phi)", NeoN::TokenList({std::string("Gauss"), std::string("linear")})
+    );
+    fvSchemes.insert("divSchemes", divSchemes);
+
+    NeoN::Dictionary lapSchemes;
+    lapSchemes.insert(
+        "laplacian(gamma,phi)",
+        NeoN::TokenList({std::string("Gauss"), std::string("linear"), std::string("uncorrected")})
+    );
+    fvSchemes.insert("laplacianSchemes", lapSchemes);
+    return fvSchemes;
+};
+
+TEMPLATE_TEST_CASE("Div + Laplacian Operator ", "[template]", NeoN::Vec3)
+{
+    auto [execName, exec] = GENERATE(allAvailableExecutor());
+
+    auto mesh = create1DUniformMesh(exec, 10);
+    auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<scalar>>(mesh);
+    auto volBCs = fvcc::createCalculatedBCs<fvcc::VolumeBoundary<TestType>>(mesh);
+
+    fvcc::VolumeField<TestType> phi(exec, "phi", mesh, volBCs);
+    NeoN::fill(phi.internalVector(), NeoN::one<TestType>());
+    NeoN::fill(phi.boundaryData().value(), NeoN::zero<TestType>());
+    phi.correctBoundaryConditions();
+
+    auto fvSchemes = makeFvSchemes();
+
+    fvcc::SurfaceField<NeoN::scalar> faceFlux(exec, "faceFlux", mesh, surfaceBCs);
+    NeoN::fill(faceFlux.internalVector(), 1.0);
+
+    fvcc::SurfaceField<NeoN::scalar> gamma(exec, "gamma", mesh, surfaceBCs);
+    NeoN::fill(gamma.internalVector(), 1.0);
+
+    auto expr = NeoN::dsl::imp::div(faceFlux, phi) + NeoN::dsl::imp::laplacian(gamma, phi);
+
+    expr.read(fvSchemes);
+
+    auto t = NeoN::scalar(1.0);
+    auto dt = NeoN::scalar(1.0);
+
+    SECTION("Can assemble to scalar matrix with rhs<Vec3>")
+    {
+        auto ls = expr.template assemble<NeoN::scalar>(mesh, t, dt);
+
+        // Matrix coefficients are scalar; rhs values are Vec3.
+        static_assert(std::is_same_v<
+                      std::decay_t<decltype(ls.matrix().values())>,
+                      NeoN::Vector<NeoN::scalar>>);
+        static_assert(std::is_same_v<std::decay_t<decltype(ls.rhs())>, NeoN::Vector<NeoN::Vec3>>);
+
+        // Assembly must have produced non-zero matrix entries.
+        auto matHost = ls.matrix().values().copyToHost();
+        auto matView = matHost.view();
+        NeoN::scalar matAbsSum = 0.0;
+        for (localIdx i = 0; i < matView.size(); ++i)
+        {
+            matAbsSum += std::abs(matView[i]);
+        }
+        REQUIRE(matAbsSum > 0.0);
+    }
+
+    SECTION("Can assemble to Vec3 matrix with rhs<vec3>")
+    {
+        auto ls = expr.template assemble<NeoN::Vec3>(mesh, t, dt);
+
+        // Matrix coefficients and rhs values are both Vec3.
+        static_assert(std::is_same_v<
+                      std::decay_t<decltype(ls.matrix().values())>,
+                      NeoN::Vector<NeoN::Vec3>>);
+        static_assert(std::is_same_v<std::decay_t<decltype(ls.rhs())>, NeoN::Vector<NeoN::Vec3>>);
+
+        // Assembly must have produced non-zero matrix entries.
+        auto matHost = ls.matrix().values().copyToHost();
+        auto matView = matHost.view();
+        NeoN::scalar matMagSum = 0.0;
+        for (localIdx i = 0; i < matView.size(); ++i)
+        {
+            matMagSum += mag(matView[i]);
+        }
+        REQUIRE(matMagSum > 0.0);
+    }
+
+    SECTION("Can solve with multiple RHS")
+    {
+        auto ls = expr.template assemble<NeoN::scalar>(mesh, t, dt);
+
+        Dictionary solverDict {
+            {{"solver", std::string {"Ginkgo"}},
+             {"type", "solver::Cg"},
+             {"criteria", Dictionary {{{"iteration", 3}, {"relative_residual_norm", 1e-7}}}}}
+        };
+
+        auto solver = NeoN::la::Solver(exec, solverDict);
+        Vector<Vec3> x(exec, {{0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}});
+        auto solverStats = solver.solve(ls, x);
+
+        REQUIRE(solverStats.entries.size() > 0);
+        const auto& stats = solverStats.entries[0];
+
+        // The solver must have iterated at least once.
+        REQUIRE(stats.numIter > 0);
+
+        // Residual should not have grown.
+        REQUIRE(stats.finalResNorm <= stats.initResNorm);
+
+        // x should be non-zero after solving.
+        auto xHost = x.copyToHost();
+        auto xView = xHost.view();
+        NeoN::scalar xMagSum = 0.0;
+        for (localIdx i = 0; i < xView.size(); ++i)
+        {
+            xMagSum += mag(xView[i]);
+        }
+        REQUIRE(xMagSum > 0.0);
+    }
+}
+
+} // namespace NeoN

--- a/test/linearAlgebra/ginkgo.cpp
+++ b/test/linearAlgebra/ginkgo.cpp
@@ -195,9 +195,7 @@ TEST_CASE("MatrixAssembly - Ginkgo")
         COOMatrix<scalar, localIdx> bCooMatrix(bValues, bSparsity);
         Vector<scalar> bRhs(exec, {});
 
-        auto linearSystem = LinearSystem<scalar, NeoN::la::CSRMatrix<scalar, NeoN::localIdx>>(
-            csrMatrix, rhs, bCooMatrix, bCooMatrix, bRhs
-        );
+        auto linearSystem = LinearSystem<scalar>(csrMatrix, rhs, bCooMatrix, bCooMatrix, bRhs);
 
         Vector<scalar> x(exec, {0.0, 0.0, 0.0});
 
@@ -245,9 +243,7 @@ TEST_CASE("MatrixAssembly - Ginkgo")
         Vector<Vec3> rhs(exec, {{1.0, 1.0, 1.0}, {2.0, 2.0, 2.0}, {3.0, 3.0, 3.0}});
         Vector<Vec3> x(exec, {{0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}});
 
-        auto linearSystem = LinearSystem<Vec3, NeoN::la::CSRMatrix<Vec3, NeoN::localIdx>>(
-            csrMatrix, rhs, bCooMatrix, bCooMatrix, bRhs
-        );
+        auto linearSystem = LinearSystem<Vec3>(csrMatrix, rhs, bCooMatrix, bCooMatrix, bRhs);
 
         SECTION("Segregated" + execName)
         {
@@ -336,9 +332,9 @@ TEST_CASE("MatrixAssembly - Ginkgo")
 
             auto linearSystem = LinearSystem<
                 scalar,
+                NeoN::Vec3,
                 NeoN::la::CSRMatrix<scalar, NeoN::localIdx>,
-                NeoN::la::COOMatrix<scalar, NeoN::localIdx>,
-                NeoN::Vec3>(csrMatrix, rhs, bCsrMatrix, bRhs);
+                NeoN::la::COOMatrix<scalar, NeoN::localIdx>>(csrMatrix, rhs, bCsrMatrix, bRhs);
 
             Vector<Vec3> x(exec, {{0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}});
 

--- a/test/linearAlgebra/linearSystem.cpp
+++ b/test/linearAlgebra/linearSystem.cpp
@@ -35,9 +35,7 @@ TEMPLATE_TEST_CASE("LinearSystem", "[template]", NeoN::scalar)
     {
         Vector<scalar> rhs(exec, 3, 0.0);
         Vector<scalar> bRhs(exec, 3, 0.0);
-        LinearSystem<scalar, NeoN::la::CSRMatrix<scalar, NeoN::localIdx>> linearSystem(
-            csrMatrix, rhs, bCooMatrix, bCooMatrix, bRhs
-        );
+        LinearSystem<scalar> linearSystem(csrMatrix, rhs, bCooMatrix, bCooMatrix, bRhs);
 
         REQUIRE(linearSystem.matrix().values().size() == 9);
         REQUIRE(linearSystem.matrix().colIdxs().size() == 9);
@@ -71,7 +69,8 @@ TEMPLATE_TEST_CASE("LinearSystem", "[template]", NeoN::scalar)
 
         using CSRMatrix = NeoN::la::CSRMatrix<scalar, localIdx>;
 
-        auto linearSystem = NeoN::la::createEmptyLinearSystem<scalar, CSRMatrix, CSRMatrix>(mesh);
+        auto linearSystem =
+            NeoN::la::createEmptyLinearSystem<scalar, scalar, CSRMatrix, CSRMatrix>(mesh);
 
         REQUIRE(linearSystem.matrix().values().size() == nnz);
         REQUIRE(linearSystem.matrix().colIdxs().size() == nnz);
@@ -89,7 +88,8 @@ TEMPLATE_TEST_CASE("LinearSystem", "[template]", NeoN::scalar)
 
         using COOMatrix = NeoN::la::COOMatrix<scalar, localIdx>;
 
-        auto linearSystem = NeoN::la::createEmptyLinearSystem<scalar, COOMatrix, COOMatrix>(mesh);
+        auto linearSystem =
+            NeoN::la::createEmptyLinearSystem<scalar, scalar, COOMatrix, COOMatrix>(mesh);
 
         REQUIRE(linearSystem.matrix().values().size() == nnz);
         REQUIRE(linearSystem.matrix().colIdxs().size() == nnz);
@@ -101,9 +101,7 @@ TEMPLATE_TEST_CASE("LinearSystem", "[template]", NeoN::scalar)
     {
         Vector<scalar> rhs(exec, {10.0, 20.0, 30.0});
         Vector<scalar> bRhs(exec, {0.0, 0.0, 0.0});
-        LinearSystem<scalar, NeoN::la::CSRMatrix<scalar, NeoN::localIdx>> linearSystem(
-            csrMatrix, rhs, bCooMatrix, bCooMatrix, bRhs
-        );
+        LinearSystem<scalar> linearSystem(csrMatrix, rhs, bCooMatrix, bCooMatrix, bRhs);
 
         auto lsView = linearSystem.view();
         auto hostLS = linearSystem.copyToHost();

--- a/test/linearAlgebra/utilities.cpp
+++ b/test/linearAlgebra/utilities.cpp
@@ -142,9 +142,7 @@ TEST_CASE("Utilities")
         Vector<localIdx> bRowOffs(exec, {0, 1, 2});
         COOMatrix<scalar, localIdx> bCooMatrix(bValues, bColIdx, bRowOffs, {3, 1});
         Vector<scalar> bRhs(exec, 3, 0.0);
-        LinearSystem<scalar, CSRMatrix<scalar, localIdx>> linearSystem(
-            csrMatrix, rhs, bCooMatrix, bCooMatrix, bRhs
-        );
+        LinearSystem<scalar> linearSystem(csrMatrix, rhs, bCooMatrix, bCooMatrix, bRhs);
 
         NeoN::la::computeResidual(csrMatrix, rhs, x, res);
 


### PR DESCRIPTION
This PR extends NeoN’s linear-system/DSL assembly pipeline to support **mixed matrix/RHS value types** (notably **scalar matrix + Vec3 RHS** for segregated vector solves), and updates finite-volume Gauss-Green operators plus solver backends/tests accordingly.

**Changes:**
- Generalize `la::LinearSystem` to carry an explicit `RHSValueType` (matrix value type and RHS value type can differ).
- Add scalar-matrix assembly paths for Gauss-Green `div`/`laplacian` operators and thread the new `LinearSystem` type through the DSL (`Expression`, spatial/temporal operators).
- Update Ginkgo solver interfaces/implementations and adjust/add tests (including a new div+laplacian assembly test).
