### PR TITLE
perf(grad): volume-integrated explicit gradient + cached phif buffer

### DIFF
--- a/include/NeoN/dsl/expression.hpp
+++ b/include/NeoN/dsl/expression.hpp
@@ -269,6 +269,36 @@ public:
         );
     }
 
+    /** @brief re-assemble only the right-hand side, reusing an already-assembled matrix.
+     *
+     * Refreshes the field-dependent rhs contributions without touching the matrix coefficients:
+     * each implicit spatial operator's rhs-only re-assembly (e.g. a Laplacian's boundary rhs and
+     * its deferred non-orthogonal correction) plus the explicit source terms. Reproduces exactly
+     * the rhs that a full assemble() would produce, given the same field state.
+     *
+     * Preconditions (caller's responsibility): the matrix was assembled by an earlier full
+     * assemble() and its coefficients are unchanged (steady geometry, unchanged implicit
+     * coefficients such as the diffusivity); only the rhs was zeroed (LinearSystem::resetRhs).
+     * Temporal operators are not supported on this path and trigger an error.
+     */
+    template<typename AssemblyType = ValueType>
+    void
+    assembleRhs(la::LinearSystem<AssemblyType, ValueType>& ls, const UnstructuredMesh& mesh) const
+    {
+        NF_ASSERT(
+            temporalOperators_.empty(),
+            "assembleRhs (matrix reuse) does not support temporal operators"
+        );
+        for (auto& op : spatialOperators_)
+        {
+            if (op.getType() == Operator::Type::Implicit)
+            {
+                op.implicitOperationRhs(ls);
+            }
+        }
+        assembleExplicitSource(ls, mesh);
+    }
+
     /** @brief construct a linear system and force assembly including explicit source terms
      *
      * @param ps post-assembly functors applied to the system after assembly

--- a/include/NeoN/dsl/spatialOperator.hpp
+++ b/include/NeoN/dsl/spatialOperator.hpp
@@ -46,6 +46,19 @@ concept HasImplicitOperatorScalarMtx = requires(T const t) {
     } -> std::same_as<void>;
 };
 
+/* @brief Concept satisfied when T can re-assemble only its field-dependent right-hand side
+ *        contribution into a same-type LinearSystem (e.g. a Laplacian's boundary rhs and deferred
+ *        non-orthogonal correction), leaving the matrix coefficients untouched. This is the opt-in
+ *        that enables the matrix-reuse assembly path (assemble the matrix once, refresh only the
+ *        rhs on subsequent solves).
+ */
+template<typename T>
+concept HasImplicitRhsRefresh = requires(T const t) {
+    {
+        t.implicitOperationRhs(std::declval<la::LinearSystem<typename T::VectorValueType>&>())
+    } -> std::same_as<void>;
+};
+
 template<typename T>
 concept IsSpatialOperator =
     HasExplicitOperator<T> || HasImplicitOperator<T> || HasImplicitOperatorScalarMtx<T>;
@@ -86,6 +99,15 @@ public:
     void explicitOperation(Vector<ValueType>& source) const { model_->explicitOperation(source); }
 
     void implicitOperation(la::LinearSystem<ValueType>& ls) const { model_->implicitOperation(ls); }
+
+    /* @brief re-assemble only the operator's field-dependent rhs contribution, leaving the
+     * already-assembled matrix coefficients untouched (matrix-reuse path). Only operators that
+     * opt in (e.g. the Laplacian) implement this; others fail fast.
+     */
+    void implicitOperationRhs(la::LinearSystem<ValueType>& ls) const
+    {
+        model_->implicitOperationRhs(ls);
+    }
 
     /* @brief Implicit assembly into a scalar-matrix / ValueType-rhs linear system
      *        (segregated vector-solve form). Disabled when ValueType == scalar to
@@ -134,6 +156,9 @@ private:
          *        Concrete operators that don't support this form leave it as a no-op.
          */
         virtual void implicitOperationScalarMtx(la::LinearSystem<scalar, ValueType>& ls) const = 0;
+
+        /* @brief Re-assemble only the field-dependent rhs contribution (matrix-reuse path). */
+        virtual void implicitOperationRhs(la::LinearSystem<ValueType>& ls) const = 0;
 
         /* @brief Given an input this function reads required coeffs */
         virtual void read(const Input& input) = 0;
@@ -201,6 +226,24 @@ private:
                 NF_ERROR_EXIT(
                     "Operator '" << getName()
                                  << "' does not support scalar-matrix (segregated) assembly."
+                );
+            }
+        }
+
+        virtual void implicitOperationRhs(la::LinearSystem<ValueType>& ls) const override
+        {
+            if constexpr (HasImplicitRhsRefresh<ConcreteOperatorType>)
+            {
+                concreteOp_.implicitOperationRhs(ls);
+            }
+            else
+            {
+                // Reached only if an operator in a matrix-reuse expression lacks the rhs-only
+                // refresh. Silently skipping it would drop its rhs contribution and yield a wrong
+                // system, so fail fast instead.
+                NF_ERROR_EXIT(
+                    "Operator '" << getName()
+                                 << "' does not support rhs-only re-assembly (matrix reuse)."
                 );
             }
         }

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp
@@ -63,6 +63,16 @@ public:
         const dsl::Coeff coeff
     ) override;
 
+    /* @brief re-assemble only the field-dependent rhs contribution (boundary rhs + deferred
+     * non-orthogonal correction), leaving the matrix coefficients untouched. Mirrors the rhs
+     * writes of the full laplacian(ls, ...) so the refreshed rhs is identical. */
+    virtual void laplacianRhs(
+        la::LinearSystem<AssemblyType, FieldValueType>& ls,
+        const SurfaceField<scalar>& gamma,
+        const VolumeField<FieldValueType>& phi,
+        const dsl::Coeff coeff
+    ) override;
+
     std::unique_ptr<LaplacianOperatorFactory<FieldValueType, AssemblyType>> clone() const override
     {
         return std::make_unique<GaussGreenLaplacian<FieldValueType, AssemblyType>>(*this);

--- a/include/NeoN/finiteVolume/cellCentred/operators/laplacianOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/laplacianOperator.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "NeoN/core/error.hpp"
 #include "NeoN/core/executor/executor.hpp"
 #include "NeoN/core/input.hpp"
 #include "NeoN/core/runtimeSelectionFactory.hpp"
@@ -74,6 +75,20 @@ public:
         const VolumeField<FieldValueType>& phi,
         const dsl::Coeff operatorScaling
     ) = 0;
+
+    /* @brief re-assemble only the field-dependent rhs contribution (boundary rhs + deferred
+     * non-orthogonal correction), leaving the matrix coefficients untouched. Strategies that
+     * support the matrix-reuse path override this; the default fails fast.
+     */
+    virtual void laplacianRhs(
+        la::LinearSystem<AssemblyType, FieldValueType>&,
+        const SurfaceField<scalar>&,
+        const VolumeField<FieldValueType>&,
+        const dsl::Coeff
+    )
+    {
+        NF_ERROR_EXIT("laplacianRhs (matrix-reuse rhs refresh) not implemented for this strategy");
+    }
 
     // Pure virtual function for cloning
     virtual std::unique_ptr<LaplacianOperatorFactory<FieldValueType, AssemblyType>>
@@ -161,6 +176,17 @@ public:
         NF_ASSERT(sameTypeStrategy_, "LaplacianOperatorStrategy not initialized");
         const auto operatorScaling = this->getCoefficient();
         sameTypeStrategy_->laplacian(ls, gamma_, this->field_, operatorScaling);
+    }
+
+    /* @brief re-assemble only the Laplacian's field-dependent rhs contribution (boundary rhs +
+     * deferred non-orthogonal correction), leaving the matrix untouched. Used by the matrix-reuse
+     * assembly path (e.g. the pressure Poisson matrix across non-orthogonal correctors).
+     */
+    void implicitOperationRhs(la::LinearSystem<FieldValueType, FieldValueType>& ls) const
+    {
+        NF_ASSERT(sameTypeStrategy_, "LaplacianOperatorStrategy not initialized");
+        const auto operatorScaling = this->getCoefficient();
+        sameTypeStrategy_->laplacianRhs(ls, gamma_, this->field_, operatorScaling);
     }
 
     /* @brief Implicit assembly into a scalar-matrix / FieldValueType-rhs linear system

--- a/include/NeoN/linearAlgebra/linearSystem.hpp
+++ b/include/NeoN/linearAlgebra/linearSystem.hpp
@@ -189,6 +189,19 @@ public:
         fill(offDiagonalMatrix_.values(), zero<MatrixValueType>());
     }
 
+    /** @brief zero only the right-hand side vectors, leaving the assembled matrix coefficients
+     * (system, boundary and off-diagonal matrices) untouched.
+     *
+     * Used by the matrix-reuse assembly path: when the implicit operator coefficients are known
+     * to be unchanged between solves (e.g. the pressure Poisson matrix across non-orthogonal /
+     * PISO correctors), the matrix is assembled once and only the rhs is refreshed each solve.
+     */
+    void resetRhs()
+    {
+        fill(rhs_, zero<RHSValueType>());
+        fill(boundaryRhs_, zero<RHSValueType>());
+    }
+
     [[nodiscard]] LinearSystemView<
         RHSValueType,
         MatrixView<

--- a/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
@@ -140,7 +140,11 @@ void computeLaplacianBoundImpl(
     const SurfaceField<scalar>& gamma,
     const VolumeField<FieldValueType>& phi,
     const dsl::Coeff operatorScaling,
-    const FaceNormalGradient<FieldValueType>& faceNormalGradient
+    const FaceNormalGradient<FieldValueType>& faceNormalGradient,
+    // When true, only the boundary rhs contribution is written; the boundary matrix
+    // coefficients (boundary matrix + diagonal) are left untouched. Used by the matrix-reuse
+    // rhs-refresh path, where the matrix was assembled on an earlier pass and must be preserved.
+    bool rhsOnly = false
 )
 {
     const auto exec = phi.exec();
@@ -180,11 +184,14 @@ void computeLaplacianBoundImpl(
             auto refValFrac = valueFraction[bfi];
             auto refGradFrac = 1.0 - refValFrac;
             auto flux = bGammaV[bfi] * bFaceAreas[bfi];
-            auto fluxContrib =
-                flux * ownRowCoeff * refValFrac * bDeltaCoeffs[bfi] * one<AssemblyType>();
 
-            bValues[bfi] += fluxContrib;
-            Kokkos::atomic_sub(&values[ma.diagIdx(ownRow)], fluxContrib);
+            if (!rhsOnly)
+            {
+                auto fluxContrib =
+                    flux * ownRowCoeff * refValFrac * bDeltaCoeffs[bfi] * one<AssemblyType>();
+                bValues[bfi] += fluxContrib;
+                Kokkos::atomic_sub(&values[ma.diagIdx(ownRow)], fluxContrib);
+            }
 
             auto valueRhs =
                 flux * ownRowCoeff
@@ -421,6 +428,23 @@ void GaussGreenLaplacian<FieldValueType, AssemblyType>::laplacian(
     computeLaplacianBoundImpl(ls, gamma, phi, coeff, faceNormalGradient_);
     computeLaplacianNonOrthCorrImpl(ls, gamma, phi, coeff, faceNormalGradient_);
     computeLaplacianProcBoundImpl(ls, gamma, phi, coeff, faceNormalGradient_);
+}
+
+
+template<typename FieldValueType, typename AssemblyType>
+void GaussGreenLaplacian<FieldValueType, AssemblyType>::laplacianRhs(
+    la::LinearSystem<AssemblyType, FieldValueType>& ls,
+    const SurfaceField<scalar>& gamma,
+    const VolumeField<FieldValueType>& phi,
+    const dsl::Coeff coeff
+)
+{
+    // Only the field-dependent rhs contributions of the full laplacian(ls, ...): the boundary
+    // rhs (rhsOnly = true skips its matrix writes) and the deferred non-orthogonal correction.
+    // The interior, proc-boundary and boundary-matrix coefficients are left as assembled on the
+    // earlier full pass, so the caller must have zeroed only the rhs (LinearSystem::resetRhs).
+    computeLaplacianBoundImpl(ls, gamma, phi, coeff, faceNormalGradient_, /*rhsOnly=*/true);
+    computeLaplacianNonOrthCorrImpl(ls, gamma, phi, coeff, faceNormalGradient_);
 }
 
 

--- a/test/finiteVolume/cellCentred/operator/laplacianOperator.cpp
+++ b/test/finiteVolume/cellCentred/operator/laplacianOperator.cpp
@@ -134,6 +134,42 @@ TEMPLATE_TEST_CASE("laplacianOperator fixedValue", "[template]", scalar, Vec3)
                 }
             }
         }
+
+        SECTION("matrix-reuse rhs refresh reproduces the full-assemble rhs on " + execName)
+        {
+            // implicitOperationRhs (the matrix-reuse path) must rebuild exactly the rhs that a
+            // full implicitOperation produces, while leaving the assembled matrix untouched.
+            if constexpr (std::is_same_v<TestType, scalar>)
+            {
+                dsl::SpatialOperator lapOp = dsl::imp::laplacian(gamma, phi);
+                lapOp.read(input);
+
+                // full assemble: matrix + rhs
+                ls.reset();
+                lapOp.implicitOperation(ls);
+                auto rhsFull = Vector<scalar>(ls.rhs());
+                auto matFull = Vector<scalar>(ls.matrix().values());
+
+                // rhs-only refresh: zero only the rhs, then re-run just the rhs contribution
+                ls.resetRhs();
+                lapOp.implicitOperationRhs(ls);
+
+                auto rhsRefreshHost = ls.rhs().copyToHost();
+                auto rhsFullHost = rhsFull.copyToHost();
+                for (localIdx i = 0; i < rhsFullHost.size(); ++i)
+                {
+                    REQUIRE(rhsRefreshHost.view()[i] == Catch::Approx(rhsFullHost.view()[i]));
+                }
+
+                // the matrix must be untouched by the rhs refresh
+                auto matAfterHost = ls.matrix().values().copyToHost();
+                auto matFullHost = matFull.copyToHost();
+                for (localIdx i = 0; i < matFullHost.size(); ++i)
+                {
+                    REQUIRE(matAfterHost.view()[i] == Catch::Approx(matFullHost.view()[i]));
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
GaussGreenGrad now caches the scalar face-interpolation SurfaceField (phif) and reuses it across grad evaluations instead of allocating one per call.

Add computeGradVolIntegrated / gradVolIntegrated: accumulate V*grad(phi) (sum_f scaling*S_f*phi_f, without the trailing /V) directly into a target, folding the operator scaling per-face so it stays an allocation-free, accumulate-safe scatter (no temporary, no per-cell rescale). Mirrors the internal/boundary/processor-face handling of computeGrad.

Route it through GradOperator::explicitOperationVolIntegrated and the type-erased SpatialOperator via a new opt-in concept (other operators error). Lets a finite-volume rhs assemble V*grad(phi) with no transient buffer and without the /V (grad) * V (rhs) round-trip.