### PR TITLE
move rhs explicit sources to neon assemble

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add uniform mesh generator [#475](https://github.com/exasim-project/NeoN/pull/475)
 
 ### Misc
+- Include RHS / explicit source assembly [#539](https://github.com/exasim-project/NeoN/pull/539)
 - Bump Ginkgo to 1.11 and Kokkos 4.7.01 [#409](https://github.com/exasim-project/NeoN/pull/409)
 - Remove stencilDataBase [#416](https://github.com/exasim-project/NeoN/pull/416)
 - Added backward ddtScheme and scheme selection mechanism [#419](https://github.com/exasim-project/NeoN/pull/419)

--- a/include/NeoN/dsl/expression.hpp
+++ b/include/NeoN/dsl/expression.hpp
@@ -189,7 +189,19 @@ public:
         }
     }
 
-    /** @brief construct a linear system and force assembly
+    /*@brief subtract explicit source terms from the linear system rhs, scaled by cell volumes */
+    void assembleExplicitSource(la::LinearSystem<ValueType>& ls, const UnstructuredMesh& mesh) const
+    {
+        auto expTmp = explicitOperation(static_cast<localIdx>(mesh.nCells()));
+        auto [vol, expSource, rhs] = views(mesh.cellVolumes(), expTmp, ls.rhs());
+        parallelFor(
+            ls.exec(),
+            {0, static_cast<localIdx>(rhs.size())},
+            NEON_LAMBDA(const localIdx i) { rhs[i] -= expSource[i] * vol[i]; }
+        );
+    }
+
+    /** @brief construct a linear system and force assembly including explicit source terms
      *
      * @param ps post-assembly functors applied to the system after assembly
      * @return the assembled linear system
@@ -202,11 +214,27 @@ public:
     ) const
     {
         auto ls = la::createEmptyLinearSystem<ValueType>(mesh);
-        assemble(t, dt, ls, ps);
+        assemble(t, dt, ls, mesh, ps);
         return ls;
     }
 
-    /* @brief assemble into a given linear system
+    /** @brief assemble into a given linear system including explicit source terms
+     *
+     * @param ps post-assembly functors applied to the system after assembly
+     */
+    void assemble(
+        scalar t,
+        scalar dt,
+        la::LinearSystem<ValueType>& ls,
+        const UnstructuredMesh& mesh,
+        std::vector<const PostAssemblyBase<ValueType, IndexType>*> ps = {}
+    ) const
+    {
+        assemble(t, dt, ls, ps);
+        assembleExplicitSource(ls, mesh);
+    }
+
+    /* @brief assemble into a given linear system (implicit operators only, no explicit sources)
      *
      * @param ps post-assembly functors applied to the system after assembly
      */

--- a/include/NeoN/dsl/solver.hpp
+++ b/include/NeoN/dsl/solver.hpp
@@ -39,18 +39,7 @@ la::SolverStats iterativeSolveImpl(
 )
 {
     exp.read(fvSchemes);
-    exp.assemble(t, dt, ls, ps);
-
-    // TODO move that to expression explicit operation or
-    // into functor ?
-    // subtract the explicit source term from the rhs
-    auto expTmp = exp.explicitOperation(solution.mesh().nCells());
-    auto [vol, expSource, rhs] = views(solution.mesh().cellVolumes(), expTmp, ls.rhs());
-    parallelFor(
-        solution.exec(),
-        {0, rhs.size()},
-        NEON_LAMBDA(const localIdx i) { rhs[i] -= expSource[i] * vol[i]; }
-    );
+    exp.assemble(t, dt, ls, solution.mesh(), ps);
 
     auto solver = la::Solver(solution.exec(), fvSolution);
     fence(solution.exec());
@@ -71,17 +60,6 @@ la::SolverStats iterativeSolveImpl(
 )
 {
     auto ls = exp.assemble(solution.mesh(), t, dt, ps);
-
-    // TODO move that to expression explicit operation or
-    // into functor ?
-    // subtract the explicit source term from the rhs
-    auto expTmp = exp.explicitOperation(solution.mesh().nCells());
-    auto [vol, expSource, rhs] = views(solution.mesh().cellVolumes(), expTmp, ls.rhs());
-    parallelFor(
-        solution.exec(),
-        {0, rhs.size()},
-        NEON_LAMBDA(const localIdx i) { rhs[i] -= expSource[i] * vol[i]; }
-    );
 
     auto solver = la::Solver(solution.exec(), fvSolution);
     fence(solution.exec());


### PR DESCRIPTION
# Motivation
This PR moves explicit source-term handling (subtracting explicit sources scaled by cell volumes from the linear-system RHS) out of the solver implementation and into dsl::Expression assembly, centralizing the behavior where the system is constructed.