### PR TITLE
add guard rails against missing Kokkos_ENABLE_CUDA_CONSTEXPR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,15 +137,19 @@ endif()
 # (forced in cmake/AutoEnableDevice.cmake) these never fire. If that flag is ever disabled, nvcc
 # would otherwise SILENTLY miscompile device-side element access through View/std::span operator[]
 # (writes vanish on the GPU, results are garbage). Failing the build is far safer than shipping
-# wrong numerics. Source files are compiled either as CXX (via nvcc_wrapper) or as CUDA, so cover
-# both languages. -Xcudafe needs each number in its own flag; SHELL: keeps the repeated tokens from
+# wrong numerics. -Xcudafe needs each number in its own flag; SHELL: keeps the repeated tokens from
 # being de-duplicated by CMake.
 if(Kokkos_ENABLE_CUDA)
   set(_neon_cuda_diag_errors "SHELL:-Xcudafe --diag_error=20013"
                              "SHELL:-Xcudafe --diag_error=20015")
-  target_compile_options(
-    NeoN_warnings INTERFACE "$<$<COMPILE_LANGUAGE:CXX>:${_neon_cuda_diag_errors}>"
-                            "$<$<COMPILE_LANGUAGE:CUDA>:${_neon_cuda_diag_errors}>")
+  # Always apply to CUDA-language translation units (nvcc compiles .cu files directly).
+  target_compile_options(NeoN_warnings
+                         INTERFACE "$<$<COMPILE_LANGUAGE:CUDA>:${_neon_cuda_diag_errors}>")
+  # Apply to CXX only when nvcc_wrapper is the CXX compiler; plain g++/clang++ reject -Xcudafe.
+  if(CMAKE_CXX_COMPILER MATCHES "nvcc_wrapper")
+    target_compile_options(NeoN_warnings
+                           INTERFACE "$<$<COMPILE_LANGUAGE:CXX>:${_neon_cuda_diag_errors}>")
+  endif()
 endif()
 
 if(NeoN_BUILD_PCH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,22 @@ if(NeoN_ENABLE_WARNINGS)
   neon_set_project_warnings(NeoN_warnings ${NeoN_WARNINGS_AS_ERRORS} "" "" "")
 endif()
 
+# Promote nvcc's "constexpr __host__ function called from a __host__ __device__ function"
+# diagnostics (20013 / 20015) to hard errors on CUDA builds. With Kokkos_ENABLE_CUDA_CONSTEXPR=ON
+# (forced in cmake/AutoEnableDevice.cmake) these never fire. If that flag is ever disabled, nvcc
+# would otherwise SILENTLY miscompile device-side element access through View/std::span operator[]
+# (writes vanish on the GPU, results are garbage). Failing the build is far safer than shipping
+# wrong numerics. Source files are compiled either as CXX (via nvcc_wrapper) or as CUDA, so cover
+# both languages. -Xcudafe needs each number in its own flag; SHELL: keeps the repeated tokens from
+# being de-duplicated by CMake.
+if(Kokkos_ENABLE_CUDA)
+  set(_neon_cuda_diag_errors "SHELL:-Xcudafe --diag_error=20013"
+                             "SHELL:-Xcudafe --diag_error=20015")
+  target_compile_options(
+    NeoN_warnings INTERFACE "$<$<COMPILE_LANGUAGE:CXX>:${_neon_cuda_diag_errors}>"
+                            "$<$<COMPILE_LANGUAGE:CUDA>:${_neon_cuda_diag_errors}>")
+endif()
+
 if(NeoN_BUILD_PCH)
   target_precompile_headers(NeoN_options INTERFACE <vector> <string> <utility>)
 endif()

--- a/cmake/AutoEnableDevice.cmake
+++ b/cmake/AutoEnableDevice.cmake
@@ -50,9 +50,6 @@ if(NOT DEFINED Kokkos_ENABLE_CUDA)
     set(Kokkos_ENABLE_CUDA
         ON
         CACHE INTERNAL "")
-    set(Kokkos_ENABLE_CUDA_CONSTEXPR
-        ON
-        CACHE INTERNAL "")
   else()
     set(NeoN_ENABLE_CUDA
         OFF
@@ -64,6 +61,19 @@ if(NOT DEFINED Kokkos_ENABLE_CUDA)
   endif()
 else()
   message(STATUS "Skip CUDA detection Kokkos_ENABLE_CUDA=${Kokkos_ENABLE_CUDA}")
+endif()
+
+# Kokkos_ENABLE_CUDA_CONSTEXPR must be ON for any CUDA build, NOT only the auto-detected one. It is
+# what makes Kokkos pass --expt-relaxed-constexpr to nvcc. Without it, NeoN device kernels that
+# index a View (a constexpr operator[] forwarding to std::span) hit nvcc warning 20013 ("constexpr
+# __host__ function called from __host__ __device__ function") and are SILENTLY miscompiled -- the
+# device-side element writes simply vanish, so GPU results are garbage while serial/host results are
+# correct. When CUDA is enabled explicitly via -DKokkos_ENABLE_CUDA=ON the detection branch above is
+# skipped, so force it here as well.
+if(Kokkos_ENABLE_CUDA)
+  set(Kokkos_ENABLE_CUDA_CONSTEXPR
+      ON
+      CACHE INTERNAL "")
 endif()
 
 if(NOT DEFINED Kokkos_ENABLE_HIP)

--- a/cmake/AutoEnableDevice.cmake
+++ b/cmake/AutoEnableDevice.cmake
@@ -73,7 +73,7 @@ endif()
 if(Kokkos_ENABLE_CUDA)
   set(Kokkos_ENABLE_CUDA_CONSTEXPR
       ON
-      CACHE INTERNAL "")
+      CACHE INTERNAL "" FORCE)
 endif()
 
 if(NOT DEFINED Kokkos_ENABLE_HIP)

--- a/include/NeoN/core/view.hpp
+++ b/include/NeoN/core/view.hpp
@@ -48,6 +48,13 @@ public:
     KOKKOS_INLINE_FUNCTION
     View(std::span<ValueType> in) : View(in.begin(), in.end()) {}
 
+    // KOKKOS_INLINE_FUNCTION (i.e. __host__ __device__) so element access is valid inside device
+    // kernels, consistent with the other accessors below. NOTE: this forwards to
+    // std::span::operator[], itself a bare constexpr __host__ function, so on CUDA correctness
+    // still relies on --expt-relaxed-constexpr (enabled via Kokkos_ENABLE_CUDA_CONSTEXPR=ON in
+    // cmake/AutoEnableDevice.cmake). Without that flag nvcc miscompiles the device write silently
+    // (warning 20013); the build promotes that warning to an error to prevent shipping it.
+    KOKKOS_INLINE_FUNCTION
     constexpr ValueType& operator[](localIdx index) const
     {
 #ifdef NF_DEBUG


### PR DESCRIPTION
# Motivation
This PR adds build-time guard rails to prevent (or fail fast on) a known CUDA miscompile scenario when View::operator[] (forwarding to std::span::operator[]) is used inside device code without --expt-relaxed-constexpr (normally enabled via Kokkos_ENABLE_CUDA_CONSTEXPR=ON).

