### PR TITLE
add calls to nonOrthogonal correction

### DIFF
--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp
@@ -15,6 +15,17 @@
 namespace NeoN::finiteVolume::cellCentred
 {
 
+// Deferred non-orthogonal correction kernel for the Laplacian (defined in gaussGreenLaplacian.cpp).
+// Declared here so other operators (e.g. GaussGreenDivLaplacian) can reuse it. Adds the explicit
+// snGrad correction to the linear system's rhs; a no-op unless the snGrad scheme is corrected.
+template<typename FieldValueType, typename AssemblyType = FieldValueType>
+void computeLaplacianNonOrthCorrImpl(
+    la::LinearSystem<AssemblyType, FieldValueType>& ls,
+    const SurfaceField<scalar>& gamma,
+    const VolumeField<FieldValueType>& phi,
+    const dsl::Coeff coeff,
+    const FaceNormalGradient<FieldValueType>& faceNormalGradient
+);
 
 template<typename FieldValueType, typename AssemblyType = FieldValueType>
 class GaussGreenLaplacian :

--- a/src/finiteVolume/cellCentred/operators/gaussGreenDdtDivLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenDdtDivLaplacian.cpp
@@ -7,6 +7,7 @@
 #include "NeoN/core/database/oldTimeCollection.hpp"
 #include "NeoN/finiteVolume/cellCentred/faceNormalGradient/faceNormalGradient.hpp"
 #include "NeoN/finiteVolume/cellCentred/operators/gaussGreenDdtDivLaplacian.hpp"
+#include "NeoN/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp"
 
 namespace NeoN::finiteVolume::cellCentred
 {
@@ -128,6 +129,9 @@ void GaussGreenDdtDivLaplacian<ValueType>::implicitOperation(
             coeffA_,
             coeffB_,
             std::dynamic_pointer_cast<la::CellBasedIterator>(ls.getMeshIterator()->get())
+        );
+        computeLaplacianNonOrthCorrImpl(
+            ls, gamma_, this->getVector(), coeffB_, *faceNormalGradient_
         );
         return;
     }

--- a/src/finiteVolume/cellCentred/operators/gaussGreenDivLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenDivLaplacian.cpp
@@ -4,9 +4,11 @@
 
 #include "NeoN/core/containerFreeFunctions.hpp"
 #include "NeoN/core/parallelAlgorithms.hpp"
+
 #include "NeoN/finiteVolume/cellCentred/faceNormalGradient/faceNormalGradient.hpp"
 #include "NeoN/finiteVolume/cellCentred/operators/gaussGreenDivLaplacian.hpp"
 #include "NeoN/finiteVolume/cellCentred/operators/gaussGreenDiv.hpp"
+#include "NeoN/finiteVolume/cellCentred/operators/gaussGreenLaplacian.hpp"
 #include "NeoN/linearAlgebra/meshIterationStrategies.hpp"
 
 namespace NeoN::finiteVolume::cellCentred
@@ -353,6 +355,7 @@ void GaussGreenDivLaplacian<ValueType>::implicitOperation(la::LinearSystem<Value
             coeffB_
         );
     }
+    computeLaplacianNonOrthCorrImpl(ls, gamma_, this->getVector(), coeffB_, *faceNormalGradient_);
     computeDivLaplacianBoundImpl(
         ls,
         this->getVector(),
@@ -427,6 +430,9 @@ void GaussGreenDivLaplacian<ValueType>::implicitOperation(la::LinearSystem<scala
             coeffB_
         );
     }
+    computeLaplacianNonOrthCorrImpl<ValueType, scalar>(
+        ls, gamma_, this->getVector(), coeffB_, *faceNormalGradient_
+    );
     computeDivLaplacianBoundImpl<ValueType, scalar>(
         ls,
         this->getVector(),
@@ -498,11 +504,6 @@ void GaussGreenDivLaplacian<ValueType>::read(const Input& input)
     laplTokens.remove(0);
     faceNormalGradient_ =
         std::make_shared<FaceNormalGradient<ValueType>>(this->field_.exec(), mesh, laplTokens);
-    if (faceNormalGradient_->hasImplicitCorrection())
-    {
-        NF_ERROR_EXIT("GaussGreenDivLaplacian does not support non-orthogonal correction. "
-                      "Use 'Gauss linear uncorrected' for laplacianSchemes.");
-    }
 }
 
 template<typename ValueType>

--- a/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
@@ -196,7 +196,7 @@ void computeLaplacianBoundImpl(
     );
 }
 
-template<typename FieldValueType, typename AssemblyType = FieldValueType>
+template<typename FieldValueType, typename AssemblyType>
 void computeLaplacianNonOrthCorrImpl(
     la::LinearSystem<AssemblyType, FieldValueType>& ls,
     const SurfaceField<scalar>& gamma,
@@ -462,5 +462,15 @@ void GaussGreenLaplacian<FieldValueType, AssemblyType>::laplacian(
 template class GaussGreenLaplacian<scalar>;
 template class GaussGreenLaplacian<Vec3>;
 template class GaussGreenLaplacian<Vec3, scalar>;
+
+template void computeLaplacianNonOrthCorrImpl<
+    scalar,
+    scalar>(la::LinearSystem<scalar, scalar>&, const SurfaceField<scalar>&, const VolumeField<scalar>&, dsl::Coeff, const FaceNormalGradient<scalar>&);
+template void computeLaplacianNonOrthCorrImpl<
+    Vec3,
+    Vec3>(la::LinearSystem<Vec3, Vec3>&, const SurfaceField<scalar>&, const VolumeField<Vec3>&, dsl::Coeff, const FaceNormalGradient<Vec3>&);
+template void computeLaplacianNonOrthCorrImpl<
+    Vec3,
+    scalar>(la::LinearSystem<scalar, Vec3>&, const SurfaceField<scalar>&, const VolumeField<Vec3>&, dsl::Coeff, const FaceNormalGradient<Vec3>&);
 
 };


### PR DESCRIPTION
# Motivation
This PR aims to enable (and reuse) the Laplacian deferred non-orthogonal correction path from the Gauss-Green Laplacian inside the fused GaussGreenDivLaplacian and. GaussDdtGreenDivLaplacianoperator, instead of rejecting corrected snGrad schemes.

