### PR TITLE
Cell limited grad Operator

### DIFF
--- a/include/NeoN/finiteVolume/cellCentred/operators/cellLimitedGrad.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/cellLimitedGrad.hpp
@@ -10,6 +10,8 @@
 #include "NeoN/core/error.hpp"
 #include "NeoN/core/executor/executor.hpp"
 #include "NeoN/core/input.hpp"
+#include "NeoN/core/primitives/tensor.hpp"
+#include "NeoN/core/segmentedVector.hpp"
 #include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
 #include "NeoN/finiteVolume/cellCentred/fields/volumeField.hpp"
 #include "NeoN/finiteVolume/cellCentred/operators/gradOperator.hpp"
@@ -34,10 +36,17 @@ namespace NeoN::finiteVolume::cellCentred
  * the unlimited base gradient), k = 1 is the strongest, most stable limiting,
  * and intermediate values widen the admissible bounds accordingly.
  *
+ * Both the scalar gradient (grad of a scalar field -> Vec3) and the tensor
+ * gradient (grad of a vector field -> Tensor, e.g. grad(U)) are limited. For the
+ * tensor case the limiter is per-component (three independent minmod limiters,
+ * one per field component), matching the standard cell-limited vector gradient.
+ *
+ * GPU-first: the tensor limiter uses a cell-based gather over each cell's
+ * internal-face stencil (atomic-free, coalesced writes) for the bulk of the work;
+ * only the small physical/processor boundary-face set uses an atomic scatter.
+ *
  * v1 assembles the explicit gradient on cell-centred fields; the implicit
- * (LinearSystem) path is not provided. The kernels use face-scatter atomics so
- * the design extends to device and distributed (processor-boundary) execution;
- * only CPU-serial is validated in v1.
+ * (LinearSystem) path is not provided. CPU-serial is validated in v1.
  */
 class CellLimitedGrad : public GradOperatorFactory<Vec3>::template Register<CellLimitedGrad>
 {
@@ -73,6 +82,11 @@ public:
         const VolumeField<scalar>& phi, const dsl::Coeff operatorScaling = dsl::Coeff {}
     ) const override;
 
+    /* @brief slope-limited tensor gradient of a vector field (e.g. grad(U)) */
+    void gradTensor(
+        const VolumeField<Vec3>& u, VolumeField<Tensor>& gradU, const dsl::Coeff operatorScaling
+    ) const override;
+
     virtual std::unique_ptr<GradOperatorFactory<Vec3>> clone() const override
     {
         NF_ERROR_EXIT("Not implemented");
@@ -91,6 +105,8 @@ private:
     // Supplies the cached internal-face cell-to-face displacement vectors; the raw
     // mesh centres are freed once the geometry scheme is built.
     std::shared_ptr<GeometryScheme> geometryScheme_;
+    // Per-cell internal-face stencil for the atomic-free cell-based tensor gather.
+    SegmentedVector<localIdx, localIdx> cellInternalFaces_;
 };
 
 } // namespace NeoN::finiteVolume::cellCentred

--- a/include/NeoN/finiteVolume/cellCentred/operators/cellLimitedGrad.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/cellLimitedGrad.hpp
@@ -36,6 +36,12 @@ namespace NeoN::finiteVolume::cellCentred
  * the unlimited base gradient), k = 1 is the strongest, most stable limiting,
  * and intermediate values widen the admissible bounds accordingly.
  *
+ * Scheme specification (Dictionary): the base scheme cannot be looked up under
+ * the same "GradOperator" key used to select "cellLimited" (that would recurse),
+ * so it is nested under a separate "baseGradOperator" sub-dictionary:
+ *   { GradOperator: cellLimited, baseGradOperator: { GradOperator: Gauss }, cellLimitedCoeff: 1 }
+ * "cellLimitedCoeff" defaults to DEFAULT_COEFF (1) when omitted.
+ *
  * Both the scalar gradient (grad of a scalar field -> Vec3) and the tensor
  * gradient (grad of a vector field -> Tensor, e.g. grad(U)) are limited. For the
  * tensor case the limiter is per-component (three independent minmod limiters,
@@ -97,6 +103,16 @@ private:
 
     /* @brief read the limiter coefficient k from the scheme Input */
     static scalar readCoeff(const Input& inputs);
+
+    /* @brief construct the wrapped base gradient scheme from the scheme Input
+     *
+     * For TokenList input the base scheme reads its own tokens directly off the
+     * shared cursor. For Dictionary input the same key ("GradOperator") that
+     * selected "cellLimited" cannot be reused, so the base scheme is looked up
+     * under a separate "baseGradOperator" sub-dictionary instead.
+     */
+    static std::unique_ptr<GradOperatorFactory<Vec3>>
+    readBaseGradScheme(const Executor& exec, const UnstructuredMesh& mesh, const Input& inputs);
 
     // Declared before coeff_ so the base scheme consumes its tokens from the
     // shared Input cursor before readCoeff reads the trailing coefficient.

--- a/include/NeoN/finiteVolume/cellCentred/operators/cellLimitedGrad.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/cellLimitedGrad.hpp
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "NeoN/core/error.hpp"
+#include "NeoN/core/executor/executor.hpp"
+#include "NeoN/core/input.hpp"
+#include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
+#include "NeoN/finiteVolume/cellCentred/fields/volumeField.hpp"
+#include "NeoN/finiteVolume/cellCentred/operators/gradOperator.hpp"
+#include "NeoN/finiteVolume/cellCentred/stencil/geometryScheme.hpp"
+
+namespace NeoN::finiteVolume::cellCentred
+{
+
+/* @class CellLimitedGrad
+ * @brief Slope-limited cell gradient.
+ *
+ * Wraps a runtime-selected base gradient scheme and clips its reconstructed
+ * gradient so that values extrapolated from the cell centre to the surrounding
+ * faces stay bounded by the minimum and maximum of the cell's own value and its
+ * face-neighbour cell values. Uses the minmod limiter, limiter(r) = min(r, 1),
+ * applied identically to every gradient component.
+ *
+ * Scheme specification (gradSchemes / TokenList):
+ *   cellLimited <baseScheme ...> <k>
+ * e.g.  cellLimited Gauss linear 1
+ * where 0 <= k <= 1 sets the limiting strength: k = 0 disables limiting (returns
+ * the unlimited base gradient), k = 1 is the strongest, most stable limiting,
+ * and intermediate values widen the admissible bounds accordingly.
+ *
+ * v1 assembles the explicit gradient on cell-centred fields; the implicit
+ * (LinearSystem) path is not provided. The kernels use face-scatter atomics so
+ * the design extends to device and distributed (processor-boundary) execution;
+ * only CPU-serial is validated in v1.
+ */
+class CellLimitedGrad : public GradOperatorFactory<Vec3>::template Register<CellLimitedGrad>
+{
+    using Base = GradOperatorFactory<Vec3>::template Register<CellLimitedGrad>;
+
+    // Limiter strength used when no coefficient is supplied (strongest limiting).
+    static constexpr scalar DEFAULT_COEFF = scalar(1);
+
+public:
+
+    static std::string name() { return "cellLimited"; }
+
+    static std::string doc() { return "Cell limited gradient (minmod slope limiter)"; }
+
+    static std::string schema() { return "none"; }
+
+    CellLimitedGrad(const Executor& exec, const UnstructuredMesh& mesh, const Input& inputs);
+
+    /* @brief implicit gradient assembly — not supported for the cell-limited scheme */
+    virtual void
+    grad(const VolumeField<scalar>&, const dsl::Coeff, la::LinearSystem<Vec3>&) const override
+    {
+        NF_ERROR_EXIT("Not implemented");
+    };
+
+    /* @brief explicit limited gradient assembled into the supplied vector */
+    virtual void grad(
+        const VolumeField<scalar>& phi, const dsl::Coeff operatorScaling, Vector<Vec3>& gradPhi
+    ) const override;
+
+    /* @brief explicit limited gradient returned as a new VolumeField */
+    VolumeField<Vec3> grad(
+        const VolumeField<scalar>& phi, const dsl::Coeff operatorScaling = dsl::Coeff {}
+    ) const override;
+
+    virtual std::unique_ptr<GradOperatorFactory<Vec3>> clone() const override
+    {
+        NF_ERROR_EXIT("Not implemented");
+        return nullptr;
+    };
+
+private:
+
+    /* @brief read the limiter coefficient k from the scheme Input */
+    static scalar readCoeff(const Input& inputs);
+
+    // Declared before coeff_ so the base scheme consumes its tokens from the
+    // shared Input cursor before readCoeff reads the trailing coefficient.
+    std::unique_ptr<GradOperatorFactory<Vec3>> baseGradScheme_;
+    scalar coeff_;
+    // Supplies the cached internal-face cell-to-face displacement vectors; the raw
+    // mesh centres are freed once the geometry scheme is built.
+    std::shared_ptr<GeometryScheme> geometryScheme_;
+};
+
+} // namespace NeoN::finiteVolume::cellCentred

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp
@@ -29,6 +29,14 @@ public:
 
     GaussGreenGrad(const Executor& exec, const UnstructuredMesh& mesh);
 
+    /* @brief Factory-registered constructor.
+     *
+     * The factory threads the scheme Input through to every registered grad
+     * operator. Gauss-Green uses linear face interpolation unconditionally, so
+     * any trailing interpolation tokens (e.g. "linear") are accepted and ignored.
+     */
+    GaussGreenGrad(const Executor& exec, const UnstructuredMesh& mesh, const Input& inputs);
+
     // fvcc::VolumeField<Vec3> grad(const fvcc::VolumeField<scalar>& phi);
 
     /* @brief compute implicit gradient operator contribution

--- a/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp
@@ -81,7 +81,7 @@ public:
         const VolumeField<Vec3>& u,
         VolumeField<Tensor>& gradU,
         const dsl::Coeff operatorScaling = dsl::Coeff {}
-    ) const;
+    ) const override;
 
     VolumeField<Tensor>
     gradTensor(const VolumeField<Vec3>& u, const dsl::Coeff operatorScaling = dsl::Coeff {}) const;

--- a/include/NeoN/finiteVolume/cellCentred/operators/gradOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gradOperator.hpp
@@ -22,7 +22,7 @@ template<typename ValueType>
 class GradOperatorFactory :
     public RuntimeSelectionFactory<
         GradOperatorFactory<ValueType>,
-        Parameters<const Executor&, const UnstructuredMesh&>>
+        Parameters<const Executor&, const UnstructuredMesh&, const Input&>>
 {
 
 public:
@@ -34,7 +34,7 @@ public:
                             ? std::get<Dictionary>(inputs).get<std::string>("GradOperator")
                             : std::get<TokenList>(inputs).next<std::string>();
         GradOperatorFactory<ValueType>::keyExistsOrError(key);
-        return GradOperatorFactory<ValueType>::table().at(key)(exec, uMesh);
+        return GradOperatorFactory<ValueType>::table().at(key)(exec, uMesh, inputs);
     }
 
     static std::string name() { return "GradOperatorFactory"; }

--- a/include/NeoN/finiteVolume/cellCentred/operators/gradOperator.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/gradOperator.hpp
@@ -7,6 +7,8 @@
 #include "NeoN/fields/field.hpp"
 #include "NeoN/linearAlgebra/linearSystem.hpp"
 #include "NeoN/core/executor/executor.hpp"
+#include "NeoN/core/error.hpp"
+#include "NeoN/core/primitives/tensor.hpp"
 #include "NeoN/core/input.hpp"
 #include "NeoN/dsl/spatialOperator.hpp"
 #include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
@@ -74,6 +76,23 @@ public:
      */
     virtual VolumeField<ValueType>
     grad(const VolumeField<scalar>& phi, const dsl::Coeff operatorScaling) const = 0;
+
+    /* @brief compute the tensor gradient of a vector field into @p gradU
+     *
+     * Result convention: gradU(i, j) = d U_i / d x_j (row i is the gradient of
+     * the i-th velocity component). Schemes that do not support a tensor gradient
+     * leave this as the aborting default.
+     *
+     * @param u [in] - vector field to differentiate
+     * @param gradU [in,out] - resulting tensor field
+     * @param operatorScaling [in] - scales the operator by a coefficient
+     */
+    virtual void gradTensor(
+        const VolumeField<Vec3>& u, VolumeField<Tensor>& gradU, const dsl::Coeff operatorScaling
+    ) const
+    {
+        NF_ERROR_EXIT("gradTensor is not implemented for this gradient scheme");
+    }
 
     // Pure virtual function for cloning
     virtual std::unique_ptr<GradOperatorFactory<ValueType>> clone() const = 0;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,6 +58,7 @@ target_sources(
           "finiteVolume/cellCentred/operators/ddtOperator.cpp"
           "finiteVolume/cellCentred/fields/volumeField.cpp"
           "finiteVolume/cellCentred/operators/gaussGreenGrad.cpp"
+          "finiteVolume/cellCentred/operators/cellLimitedGrad.cpp"
           "finiteVolume/cellCentred/operators/gaussGreenDiv.cpp"
           "finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp"
           "finiteVolume/cellCentred/operators/gaussGreenDivLaplacian.cpp"

--- a/src/finiteVolume/cellCentred/operators/cellLimitedGrad.cpp
+++ b/src/finiteVolume/cellCentred/operators/cellLimitedGrad.cpp
@@ -228,7 +228,7 @@ void computeCellLimitedGrad(
 CellLimitedGrad::CellLimitedGrad(
     const Executor& exec, const UnstructuredMesh& mesh, const Input& inputs
 )
-    : Base(exec, mesh), baseGradScheme_(GradOperatorFactory<Vec3>::create(exec, mesh, inputs)),
+    : Base(exec, mesh), baseGradScheme_(readBaseGradScheme(exec, mesh, inputs)),
       coeff_(readCoeff(inputs)), geometryScheme_(GeometryScheme::readOrCreate(mesh)),
       cellInternalFaces_(CellToFaceStencil(mesh).computeInternalStencil())
 {
@@ -239,6 +239,31 @@ CellLimitedGrad::CellLimitedGrad(
             + std::to_string(coeff_)
         );
     }
+}
+
+std::unique_ptr<GradOperatorFactory<Vec3>> CellLimitedGrad::readBaseGradScheme(
+    const Executor& exec, const UnstructuredMesh& mesh, const Input& inputs
+)
+{
+    if (std::holds_alternative<Dictionary>(inputs))
+    {
+        const auto& dict = std::get<Dictionary>(inputs);
+        if (!dict.isDict("baseGradOperator"))
+        {
+            NF_THROW(std::string(
+                "cellLimited gradient (Dictionary input) requires a 'baseGradOperator' "
+                "sub-dictionary specifying the wrapped base scheme, e.g. "
+                "{ GradOperator: cellLimited, baseGradOperator: { GradOperator: Gauss }, "
+                "cellLimitedCoeff: 1 }"
+            ));
+        }
+        Input baseInputs = dict.subDict("baseGradOperator");
+        return GradOperatorFactory<Vec3>::create(exec, mesh, baseInputs);
+    }
+
+    // TokenList form: the factory has already consumed "cellLimited" off the shared
+    // cursor, so the base scheme reads its own tokens (e.g. "Gauss") directly.
+    return GradOperatorFactory<Vec3>::create(exec, mesh, inputs);
 }
 
 scalar CellLimitedGrad::readCoeff(const Input& inputs)

--- a/src/finiteVolume/cellCentred/operators/cellLimitedGrad.cpp
+++ b/src/finiteVolume/cellCentred/operators/cellLimitedGrad.cpp
@@ -4,6 +4,7 @@
 
 #include "NeoN/finiteVolume/cellCentred/operators/cellLimitedGrad.hpp"
 #include "NeoN/finiteVolume/cellCentred/boundary.hpp"
+#include "NeoN/finiteVolume/cellCentred/stencil/cellToFaceStencil.hpp"
 #include "NeoN/core/containerFreeFunctions.hpp"
 #include "NeoN/core/parallelAlgorithms.hpp"
 #include "NeoN/core/view.hpp"
@@ -228,7 +229,8 @@ CellLimitedGrad::CellLimitedGrad(
     const Executor& exec, const UnstructuredMesh& mesh, const Input& inputs
 )
     : Base(exec, mesh), baseGradScheme_(GradOperatorFactory<Vec3>::create(exec, mesh, inputs)),
-      coeff_(readCoeff(inputs)), geometryScheme_(GeometryScheme::readOrCreate(mesh))
+      coeff_(readCoeff(inputs)), geometryScheme_(GeometryScheme::readOrCreate(mesh)),
+      cellInternalFaces_(CellToFaceStencil(mesh).computeInternalStencil())
 {
     if (!(coeff_ >= scalar(0) && coeff_ <= scalar(1)))
     {
@@ -294,6 +296,246 @@ CellLimitedGrad::grad(const VolumeField<scalar>& phi, const dsl::Coeff operatorS
     );
     gradPhi.correctBoundaryConditions();
     return gradPhi;
+}
+
+/* @brief GPU-first cell-limited tensor gradient of a vector field.
+ *
+ * Limits grad(U) per component: three independent minmod limiters (one per U
+ * component), clipping the gradient so the value extrapolated from the cell centre
+ * to each surrounding face stays within the neighbour cell-value range. Row i of
+ * gradU (= grad of U_i) is scaled by limiter component i.
+ *
+ * Iteration is cell-based: each cell gathers its own internal-face stencil in
+ * registers (no atomics, coalesced writes); only the comparatively small set of
+ * physical/processor boundary faces uses an atomic scatter into the owner cell.
+ */
+void computeCellLimitedGradTensor(
+    const VolumeField<Vec3>& u,
+    const GradOperatorFactory<Vec3>& baseScheme,
+    const GeometryScheme& geometryScheme,
+    const SegmentedVector<localIdx, localIdx>& cellInternalFaces,
+    const scalar coeff,
+    const dsl::Coeff operatorScaling,
+    VolumeField<Tensor>& gradU
+)
+{
+    const UnstructuredMesh& mesh = u.mesh();
+    const auto exec = gradU.exec();
+    const auto nCells = mesh.nCells();
+    const auto nBoundaryFaces = mesh.nBoundaryFaces();
+    const auto nProcBoundaryFaces = mesh.nProcBoundaryFaces();
+
+    // 1. Unlimited base tensor gradient (internal + boundary), without operator scaling.
+    baseScheme.gradTensor(u, gradU, dsl::Coeff(scalar(1)));
+
+    auto g = gradU.internalVector().view();
+    const auto uV = u.internalVector().view();
+
+    // coeff == 0: limiting disabled — apply operator scaling and return.
+    if (coeff < ROOTVSMALL)
+    {
+        parallelFor(
+            exec,
+            {0, nCells},
+            NEON_LAMBDA(const localIdx celli) { g[celli] *= operatorScaling[celli]; },
+            "cellLimitedGradTensorNoLimit"
+        );
+        return;
+    }
+
+    // Per cell, per component (Vec3 = one scalar per U component).
+    Vector<Vec3> maxDelta(exec, nCells, zero<Vec3>());
+    Vector<Vec3> minDelta(exec, nCells, zero<Vec3>());
+    Vector<Vec3> limiter(exec, nCells, one<Vec3>());
+    auto maxD = maxDelta.view();
+    auto minD = minDelta.view();
+    auto lim = limiter.view();
+
+    const auto [owner, neighbour, bOwner] =
+        views(mesh.faceOwners(), mesh.faceNeighbors(), mesh.boundaryMesh().faceOwners());
+    const auto cellFaces = cellInternalFaces.values().view();
+    const auto cellFaceOffs = cellInternalFaces.segments().view();
+
+    // 2a. Cell-based gather (atomic-free): component-wise neighbour deltas over internal faces.
+    parallelFor(
+        exec,
+        {0, nCells},
+        NEON_LAMBDA(const localIdx celli) {
+            const Vec3 uOwn = uV[celli];
+            Vec3 mx = zero<Vec3>();
+            Vec3 mn = zero<Vec3>();
+            for (auto sIdx = cellFaceOffs[celli]; sIdx < cellFaceOffs[celli + 1]; ++sIdx)
+            {
+                const auto facei = cellFaces[sIdx];
+                const auto other = (owner[facei] == celli) ? neighbour[facei] : owner[facei];
+                const Vec3 dU = uV[other] - uOwn;
+                for (size_t c = 0; c < 3; ++c)
+                {
+                    mx[c] = Kokkos::max(mx[c], dU[c]);
+                    mn[c] = Kokkos::min(mn[c], dU[c]);
+                }
+            }
+            maxD[celli] = mx;
+            minD[celli] = mn;
+        },
+        "cellLimitedTensorRangeInternal"
+    );
+
+    // 2b. Boundary scatter (atomics, small): fold boundary-face values into the owner range.
+    const auto uBoundary = u.boundaryData().value().view();
+    parallelFor(
+        exec,
+        {0, nBoundaryFaces},
+        NEON_LAMBDA(const localIdx bfi) {
+            const auto own = bOwner[bfi];
+            const Vec3 dU = uBoundary[bfi] - uV[own];
+            for (size_t c = 0; c < 3; ++c)
+            {
+                Kokkos::atomic_max(&maxD[own][c], dU[c]);
+                Kokkos::atomic_min(&minD[own][c], dU[c]);
+            }
+        },
+        "cellLimitedTensorRangeBoundary"
+    );
+
+    if (nProcBoundaryFaces > 0)
+    {
+        parallelFor(
+            exec,
+            {0, nProcBoundaryFaces},
+            NEON_LAMBDA(const localIdx procFacei) {
+                const auto bfi = nBoundaryFaces + procFacei;
+                const auto own = bOwner[bfi];
+                const Vec3 dU = uBoundary[bfi] - uV[own];
+                for (size_t c = 0; c < 3; ++c)
+                {
+                    Kokkos::atomic_max(&maxD[own][c], dU[c]);
+                    Kokkos::atomic_min(&minD[own][c], dU[c]);
+                }
+            },
+            "cellLimitedTensorRangeProcBoundary"
+        );
+    }
+
+    // 3. Widen the per-component bounds by the coefficient (k < 1 relaxes the limiter).
+    const scalar k = coeff;
+    parallelFor(
+        exec,
+        {0, nCells},
+        NEON_LAMBDA(const localIdx celli) {
+            Vec3 mx = maxD[celli];
+            Vec3 mn = minD[celli];
+            if (k < scalar(1))
+            {
+                for (size_t c = 0; c < 3; ++c)
+                {
+                    const scalar d = (scalar(1) / k - scalar(1)) * (mx[c] - mn[c]);
+                    mx[c] += d;
+                    mn[c] -= d;
+                }
+            }
+            maxD[celli] = mx;
+            minD[celli] = mn;
+        },
+        "cellLimitedTensorDeltas"
+    );
+
+    // 4a. Cell-based gather (atomic-free): per-component limiter over internal faces. The
+    //     base (unlimited) gradient extrapolated to each face must stay within the deltas.
+    const auto ownerToFace = geometryScheme.faceDeltaOwner().internalVector().view();
+    const auto neighbourToFace = geometryScheme.faceDeltaNeighbour().internalVector().view();
+    parallelFor(
+        exec,
+        {0, nCells},
+        NEON_LAMBDA(const localIdx celli) {
+            const Tensor gc = g[celli];
+            const Vec3 mx = maxD[celli];
+            const Vec3 mn = minD[celli];
+            Vec3 l = one<Vec3>();
+            for (auto sIdx = cellFaceOffs[celli]; sIdx < cellFaceOffs[celli + 1]; ++sIdx)
+            {
+                const auto facei = cellFaces[sIdx];
+                const Vec3 d =
+                    (owner[facei] == celli) ? ownerToFace[facei] : neighbourToFace[facei];
+                const Vec3 extrap = gc & d; // predicted delta of each U component at the face
+                for (size_t c = 0; c < 3; ++c)
+                {
+                    l[c] = Kokkos::min(l[c], cellLimiterRatio(extrap[c], mx[c], mn[c]));
+                }
+            }
+            lim[celli] = l;
+        },
+        "cellLimitedTensorLimiterInternal"
+    );
+
+    // 4b. Boundary scatter (atomics, small): per-component limiter over boundary faces.
+    const auto [bFaceC, bOwnerC] =
+        views(mesh.boundaryMesh().faceCenters(), mesh.boundaryMesh().ownerCellCenters());
+    parallelFor(
+        exec,
+        {0, nBoundaryFaces},
+        NEON_LAMBDA(const localIdx bfi) {
+            const auto own = bOwner[bfi];
+            const Vec3 extrap = g[own] & (bFaceC[bfi] - bOwnerC[bfi]);
+            for (size_t c = 0; c < 3; ++c)
+            {
+                Kokkos::atomic_min(
+                    &lim[own][c], cellLimiterRatio(extrap[c], maxD[own][c], minD[own][c])
+                );
+            }
+        },
+        "cellLimitedTensorLimiterBoundary"
+    );
+
+    if (nProcBoundaryFaces > 0)
+    {
+        parallelFor(
+            exec,
+            {0, nProcBoundaryFaces},
+            NEON_LAMBDA(const localIdx procFacei) {
+                const auto bfi = nBoundaryFaces + procFacei;
+                const auto own = bOwner[bfi];
+                const Vec3 extrap = g[own] & (bFaceC[bfi] - bOwnerC[bfi]);
+                for (size_t c = 0; c < 3; ++c)
+                {
+                    Kokkos::atomic_min(
+                        &lim[own][c], cellLimiterRatio(extrap[c], maxD[own][c], minD[own][c])
+                    );
+                }
+            },
+            "cellLimitedTensorLimiterProcBoundary"
+        );
+    }
+
+    // 5. Apply: scale row i of gradU (grad of U_i) by limiter[i], then the operator scaling.
+    parallelFor(
+        exec,
+        {0, nCells},
+        NEON_LAMBDA(const localIdx celli) {
+            const Vec3 l = lim[celli];
+            const scalar s = operatorScaling[celli];
+            Tensor gc = g[celli];
+            for (size_t i = 0; i < 3; ++i)
+            {
+                const scalar si = l[i] * s;
+                for (size_t j = 0; j < 3; ++j)
+                {
+                    gc(i, j) *= si;
+                }
+            }
+            g[celli] = gc;
+        },
+        "cellLimitedTensorApply"
+    );
+}
+
+void CellLimitedGrad::gradTensor(
+    const VolumeField<Vec3>& u, VolumeField<Tensor>& gradU, const dsl::Coeff operatorScaling
+) const
+{
+    computeCellLimitedGradTensor(
+        u, *baseGradScheme_, *geometryScheme_, cellInternalFaces_, coeff_, operatorScaling, gradU
+    );
 }
 
 } // namespace NeoN::finiteVolume::cellCentred

--- a/src/finiteVolume/cellCentred/operators/cellLimitedGrad.cpp
+++ b/src/finiteVolume/cellCentred/operators/cellLimitedGrad.cpp
@@ -1,0 +1,299 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#include "NeoN/finiteVolume/cellCentred/operators/cellLimitedGrad.hpp"
+#include "NeoN/finiteVolume/cellCentred/boundary.hpp"
+#include "NeoN/core/containerFreeFunctions.hpp"
+#include "NeoN/core/parallelAlgorithms.hpp"
+#include "NeoN/core/view.hpp"
+
+namespace NeoN::finiteVolume::cellCentred
+{
+
+/* @brief minmod limiter ratio for one cell-face pair.
+ *
+ * Returns min(r, 1), where r bounds the face-extrapolated value within the
+ * cell's admissible delta range [minDelta, maxDelta]. A negligible extrapolation
+ * imposes no constraint and returns 1. With maxDelta >= 0 and minDelta <= 0 the
+ * result is always within [0, 1].
+ */
+NEON_INLINE_FUNCTION
+scalar cellLimiterRatio(const scalar extrapolate, const scalar maxDelta, const scalar minDelta)
+{
+    if (extrapolate > ROOTVSMALL)
+    {
+        return Kokkos::min(maxDelta / extrapolate, scalar(1));
+    }
+    if (extrapolate < -ROOTVSMALL)
+    {
+        return Kokkos::min(minDelta / extrapolate, scalar(1));
+    }
+    return scalar(1);
+}
+
+/* @brief free-standing implementation of the cell-limited explicit gradient.
+ *
+ * Computes the unlimited base gradient, derives a per-cell scalar limiter that
+ * clips the gradient so cell-to-face extrapolated values stay bounded by the
+ * neighbour cell values, then applies the limiter and the operator scaling.
+ */
+void computeCellLimitedGrad(
+    const VolumeField<scalar>& phi,
+    const GradOperatorFactory<Vec3>& baseScheme,
+    const GeometryScheme& geometryScheme,
+    const scalar coeff,
+    const dsl::Coeff operatorScaling,
+    Vector<Vec3>& gradPhi
+)
+{
+    const UnstructuredMesh& mesh = phi.mesh();
+    const auto exec = gradPhi.exec();
+    const auto nCells = mesh.nCells();
+    const auto nInternalFaces = mesh.nInternalFaces();
+    const auto nBoundaryFaces = mesh.nBoundaryFaces();
+    const auto nProcBoundaryFaces = mesh.nProcBoundaryFaces();
+
+    // 1. Unlimited base gradient. The limiter is a geometric property of the
+    //    field, so the base gradient is computed without operator scaling and the
+    //    scaling is folded in only at the final step.
+    baseScheme.grad(phi, dsl::Coeff(scalar(1)), gradPhi);
+
+    auto g = gradPhi.view();
+    const auto phiV = phi.internalVector().view();
+
+    // coeff == 0: limiting disabled — apply operator scaling and return.
+    if (coeff < ROOTVSMALL)
+    {
+        parallelFor(
+            exec,
+            {0, nCells},
+            NEON_LAMBDA(const localIdx celli) { g[celli] *= operatorScaling[celli]; },
+            "cellLimitedGradNoLimit"
+        );
+        return;
+    }
+
+    // 2. Per-cell admissible value range: max/min over the cell value and all
+    //    face-neighbour cell values.
+    Vector<scalar> maxVsf(exec, nCells, scalar(0));
+    Vector<scalar> minVsf(exec, nCells, scalar(0));
+    auto maxV = maxVsf.view();
+    auto minV = minVsf.view();
+    parallelFor(
+        exec,
+        {0, nCells},
+        NEON_LAMBDA(const localIdx celli) {
+            maxV[celli] = phiV[celli];
+            minV[celli] = phiV[celli];
+        },
+        "cellLimitedInitRange"
+    );
+
+    const auto [owner, neighbour, bOwner] =
+        views(mesh.faceOwners(), mesh.faceNeighbors(), mesh.boundaryMesh().faceOwners());
+
+    parallelFor(
+        exec,
+        {0, nInternalFaces},
+        NEON_LAMBDA(const localIdx facei) {
+            const auto own = owner[facei];
+            const auto nei = neighbour[facei];
+            const scalar vOwn = phiV[own];
+            const scalar vNei = phiV[nei];
+            Kokkos::atomic_max(&maxV[own], vNei);
+            Kokkos::atomic_min(&minV[own], vNei);
+            Kokkos::atomic_max(&maxV[nei], vOwn);
+            Kokkos::atomic_min(&minV[nei], vOwn);
+        },
+        "cellLimitedRangeInternal"
+    );
+
+    const auto phiBValue = phi.boundaryData().value().view();
+    parallelFor(
+        exec,
+        {0, nBoundaryFaces},
+        NEON_LAMBDA(const localIdx bfi) {
+            const auto own = bOwner[bfi];
+            const scalar vb = phiBValue[bfi];
+            Kokkos::atomic_max(&maxV[own], vb);
+            Kokkos::atomic_min(&minV[own], vb);
+        },
+        "cellLimitedRangeBoundary"
+    );
+
+    // Processor-boundary faces: fold the communicated neighbour value into the
+    // owner range. Mirrors the physical-boundary loop so the limiter extends to
+    // distributed runs; the slot nBoundaryFaces+procFacei carries the halo value.
+    if (nProcBoundaryFaces > 0)
+    {
+        parallelFor(
+            exec,
+            {0, nProcBoundaryFaces},
+            NEON_LAMBDA(const localIdx procFacei) {
+                const auto bfi = nBoundaryFaces + procFacei;
+                const auto own = bOwner[bfi];
+                const scalar vb = phiBValue[bfi];
+                Kokkos::atomic_max(&maxV[own], vb);
+                Kokkos::atomic_min(&minV[own], vb);
+            },
+            "cellLimitedRangeProcBoundary"
+        );
+    }
+
+    // 3. Convert the absolute range to deltas about the cell value and widen the
+    //    bounds by the coefficient (k < 1 relaxes the limiter).
+    const scalar k = coeff;
+    parallelFor(
+        exec,
+        {0, nCells},
+        NEON_LAMBDA(const localIdx celli) {
+            scalar mx = maxV[celli] - phiV[celli];
+            scalar mn = minV[celli] - phiV[celli];
+            if (k < scalar(1))
+            {
+                const scalar d = (scalar(1) / k - scalar(1)) * (mx - mn);
+                mx += d;
+                mn -= d;
+            }
+            maxV[celli] = mx;
+            minV[celli] = mn;
+        },
+        "cellLimitedDeltas"
+    );
+
+    // 4. Limiter: clip each cell's gradient so the value extrapolated to every
+    //    surrounding face stays within the admissible delta range.
+    Vector<scalar> limiter(exec, nCells, scalar(1));
+    auto lim = limiter.view();
+
+    // Internal-face cell-to-face displacement vectors come from the geometry scheme:
+    // the raw mesh cell/face centres are freed once the geometry scheme is built, so
+    // they cannot be read here directly.
+    const auto ownerToFace = geometryScheme.faceDeltaOwner().internalVector().view();
+    const auto neighbourToFace = geometryScheme.faceDeltaNeighbour().internalVector().view();
+
+    parallelFor(
+        exec,
+        {0, nInternalFaces},
+        NEON_LAMBDA(const localIdx facei) {
+            const auto own = owner[facei];
+            const auto nei = neighbour[facei];
+            const scalar extrapOwn = ownerToFace[facei] & g[own];
+            const scalar extrapNei = neighbourToFace[facei] & g[nei];
+            Kokkos::atomic_min(&lim[own], cellLimiterRatio(extrapOwn, maxV[own], minV[own]));
+            Kokkos::atomic_min(&lim[nei], cellLimiterRatio(extrapNei, maxV[nei], minV[nei]));
+        },
+        "cellLimitedLimiterInternal"
+    );
+
+    const auto [bFaceC, bOwnerC] =
+        views(mesh.boundaryMesh().faceCenters(), mesh.boundaryMesh().ownerCellCenters());
+    parallelFor(
+        exec,
+        {0, nBoundaryFaces},
+        NEON_LAMBDA(const localIdx bfi) {
+            const auto own = bOwner[bfi];
+            const scalar extrap = (bFaceC[bfi] - bOwnerC[bfi]) & g[own];
+            Kokkos::atomic_min(&lim[own], cellLimiterRatio(extrap, maxV[own], minV[own]));
+        },
+        "cellLimitedLimiterBoundary"
+    );
+
+    if (nProcBoundaryFaces > 0)
+    {
+        parallelFor(
+            exec,
+            {0, nProcBoundaryFaces},
+            NEON_LAMBDA(const localIdx procFacei) {
+                const auto bfi = nBoundaryFaces + procFacei;
+                const auto own = bOwner[bfi];
+                const scalar extrap = (bFaceC[bfi] - bOwnerC[bfi]) & g[own];
+                Kokkos::atomic_min(&lim[own], cellLimiterRatio(extrap, maxV[own], minV[own]));
+            },
+            "cellLimitedLimiterProcBoundary"
+        );
+    }
+
+    // 5. Apply the per-cell limiter and the operator scaling to the gradient.
+    parallelFor(
+        exec,
+        {0, nCells},
+        NEON_LAMBDA(const localIdx celli) { g[celli] *= (operatorScaling[celli] * lim[celli]); },
+        "cellLimitedApply"
+    );
+}
+
+CellLimitedGrad::CellLimitedGrad(
+    const Executor& exec, const UnstructuredMesh& mesh, const Input& inputs
+)
+    : Base(exec, mesh), baseGradScheme_(GradOperatorFactory<Vec3>::create(exec, mesh, inputs)),
+      coeff_(readCoeff(inputs)), geometryScheme_(GeometryScheme::readOrCreate(mesh))
+{
+    if (!(coeff_ >= scalar(0) && coeff_ <= scalar(1)))
+    {
+        NF_THROW(
+            std::string("cellLimited gradient coefficient must be in [0, 1], got ")
+            + std::to_string(coeff_)
+        );
+    }
+}
+
+scalar CellLimitedGrad::readCoeff(const Input& inputs)
+{
+    if (std::holds_alternative<Dictionary>(inputs))
+    {
+        const auto& dict = std::get<Dictionary>(inputs);
+        if (dict.contains("cellLimitedCoeff"))
+        {
+            return dict.get<scalar>("cellLimitedCoeff");
+        }
+        return DEFAULT_COEFF;
+    }
+
+    // TokenList form "cellLimited <baseScheme ...> <coeff>": the factory consumed
+    // "cellLimited" and the base scheme consumed its own tokens (e.g. "Gauss
+    // linear"); only the trailing coefficient remains. Skip any unconsumed
+    // sub-scheme words, then read the coefficient — written as an integer (e.g. 1)
+    // or a fractional value (e.g. 0.5).
+    const auto& tl = std::get<TokenList>(inputs);
+    while (tl.peekIs<std::string>())
+    {
+        tl.next<std::string>();
+    }
+    if (tl.peekIs<scalar>())
+    {
+        return tl.next<scalar>();
+    }
+    if (tl.peekIs<label>())
+    {
+        return static_cast<scalar>(tl.next<label>());
+    }
+    return DEFAULT_COEFF;
+}
+
+void CellLimitedGrad::grad(
+    const VolumeField<scalar>& phi, const dsl::Coeff operatorScaling, Vector<Vec3>& gradPhi
+) const
+{
+    computeCellLimitedGrad(
+        phi, *baseGradScheme_, *geometryScheme_, coeff_, operatorScaling, gradPhi
+    );
+}
+
+VolumeField<Vec3>
+CellLimitedGrad::grad(const VolumeField<scalar>& phi, const dsl::Coeff operatorScaling) const
+{
+    // Proc-aware calculated BCs mirror GaussGreenGrad::grad so processor patches
+    // carry the halo-exchange BC for the boundary gradient refresh below.
+    auto gradBCs = createCalculatedProcBCs<VolumeBoundary<Vec3>>(phi.mesh());
+    VolumeField<Vec3> gradPhi(phi.exec(), "gradPhi", phi.mesh(), gradBCs);
+    fill(gradPhi.internalVector(), zero<Vec3>());
+    computeCellLimitedGrad(
+        phi, *baseGradScheme_, *geometryScheme_, coeff_, operatorScaling, gradPhi.internalVector()
+    );
+    gradPhi.correctBoundaryConditions();
+    return gradPhi;
+}
+
+} // namespace NeoN::finiteVolume::cellCentred

--- a/src/finiteVolume/cellCentred/operators/gaussGreenGrad.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenGrad.cpp
@@ -198,6 +198,11 @@ GaussGreenGrad::GaussGreenGrad(const Executor& exec, const UnstructuredMesh& mes
           exec, mesh, std::make_unique<Linear<Vec3>>(exec, mesh, Dictionary())
       ) {};
 
+GaussGreenGrad::GaussGreenGrad(
+    const Executor& exec, const UnstructuredMesh& mesh, const Input& /* inputs */
+)
+    : GaussGreenGrad(exec, mesh) {};
+
 
 void GaussGreenGrad::grad(
     const VolumeField<scalar>& phi, const dsl::Coeff operatorScaling, Vector<Vec3>& gradPhi

--- a/test/finiteVolume/cellCentred/operator/CMakeLists.txt
+++ b/test/finiteVolume/cellCentred/operator/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 neon_unit_test(ddtOperator)
 neon_unit_test(laplacianOperator)
+neon_unit_test(cellLimitedGrad)
 neon_unit_test(gaussGreenDiv)
 neon_unit_test(gaussGreenDivLaplacian)
 neon_unit_test(sourceTerm)

--- a/test/finiteVolume/cellCentred/operator/cellLimitedGrad.cpp
+++ b/test/finiteVolume/cellCentred/operator/cellLimitedGrad.cpp
@@ -164,6 +164,44 @@ TEST_CASE("cellLimited gradient")
             REQUIRE(hLimV[i][0] == Catch::Approx(hBaseV[i][0]).margin(1e-12));
         }
     }
+
+    SECTION(
+        "Dictionary input with baseGradOperator builds and matches TokenList result on " + execName
+    )
+    {
+        // Dictionary form cannot reuse the "GradOperator" key to select the base
+        // scheme (that key already selects "cellLimited" and would recurse), so
+        // the base scheme is nested under "baseGradOperator".
+        auto phi = linearField();
+
+        Dictionary baseDict {{std::string("GradOperator"), std::string("Gauss")}};
+        Dictionary dict {
+            {std::string("GradOperator"), std::string("cellLimited")},
+            {std::string("baseGradOperator"), baseDict},
+            {std::string("cellLimitedCoeff"), scalar(1)}
+        };
+        Input input = dict;
+        auto op = fvcc::GradOperatorFactory<Vec3>::create(exec, mesh, input);
+        auto gLim = op->grad(phi, dsl::Coeff {});
+        auto gTokens = makeLimited(phi, scalar(1));
+
+        auto hLim = gLim.internalVector().copyToHost();
+        auto hTokens = gTokens.internalVector().copyToHost();
+        auto hLimV = hLim.view();
+        auto hTokensV = hTokens.view();
+
+        for (localIdx i = 1; i < nCells - 1; ++i)
+        {
+            REQUIRE(hLimV[i][0] == Catch::Approx(hTokensV[i][0]).margin(1e-12));
+        }
+    }
+
+    SECTION("Dictionary input without baseGradOperator throws instead of recursing on " + execName)
+    {
+        Dictionary dict {{std::string("GradOperator"), std::string("cellLimited")}};
+        Input input = dict;
+        REQUIRE_THROWS(fvcc::GradOperatorFactory<Vec3>::create(exec, mesh, input));
+    }
 }
 
 // Tensor path: grad(U) where U is a vector field. On the 1D mesh the only non-zero

--- a/test/finiteVolume/cellCentred/operator/cellLimitedGrad.cpp
+++ b/test/finiteVolume/cellCentred/operator/cellLimitedGrad.cpp
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
+                            // a custom main
+#include "catch2_common.hpp"
+
+#include "NeoN/NeoN.hpp"
+
+#include <algorithm>
+#include <any>
+#include <cmath>
+
+
+namespace fvcc = NeoN::finiteVolume::cellCentred;
+
+namespace NeoN
+{
+
+// The cellLimited scheme wraps a base gradient (Gauss linear) and clips the
+// reconstructed gradient with the minmod slope limiter. These tests run on a 1D
+// uniform mesh where the gradient has a single non-zero (x) component, so all
+// assertions compare component [0]. Only interior cells [1, nCells-1) are
+// checked — they are unaffected by the boundary-face contributions.
+TEST_CASE("cellLimited gradient")
+{
+    auto [execName, exec] = GENERATE(allAvailableExecutor());
+
+    const localIdx nCells = 10;
+    auto mesh = create1DUniformMesh(exec, nCells);
+    auto bcs = fvcc::createCalculatedBCs<fvcc::VolumeBoundary<scalar>>(mesh);
+
+    // Build a cellLimited grad operator from the scheme tokens
+    //   cellLimited Gauss linear <coeff>
+    // via the runtime factory, exactly as a gradSchemes entry would.
+    auto makeLimited = [&](const fvcc::VolumeField<scalar>& phi, std::any coeff)
+    {
+        Input input = TokenList(
+            {std::string("cellLimited"), std::string("Gauss"), std::string("linear"), coeff}
+        );
+        auto op = fvcc::GradOperatorFactory<Vec3>::create(exec, mesh, input);
+        return op->grad(phi, dsl::Coeff {});
+    };
+
+    auto linearField = [&]()
+    {
+        fvcc::VolumeField<scalar> phi(exec, "phi", mesh, bcs);
+        parallelFor(
+            phi.internalVector(), NEON_LAMBDA(const localIdx i) { return scalar(2) * scalar(i); }
+        );
+        fill(phi.boundaryData().value(), scalar(0));
+        phi.correctBoundaryConditions();
+        return phi;
+    };
+
+    auto stepField = [&]()
+    {
+        fvcc::VolumeField<scalar> phi(exec, "phi", mesh, bcs);
+        const localIdx half = nCells / 2;
+        parallelFor(
+            phi.internalVector(),
+            NEON_LAMBDA(const localIdx i) { return i < half ? scalar(0) : scalar(1); }
+        );
+        fill(phi.boundaryData().value(), scalar(0));
+        phi.correctBoundaryConditions();
+        return phi;
+    };
+
+    SECTION("is registered in the grad operator factory on " + execName)
+    {
+        auto entries = fvcc::GradOperatorFactory<Vec3>::entries();
+        REQUIRE(
+            std::find(entries.begin(), entries.end(), std::string("cellLimited")) != entries.end()
+        );
+    }
+
+    SECTION("linear field is not clipped — equals base Gauss gradient on " + execName)
+    {
+        auto phi = linearField();
+
+        fvcc::GaussGreenGrad gauss(exec, mesh);
+        auto gBase = gauss.grad(phi);
+        auto gLim = makeLimited(phi, scalar(1.0));
+
+        auto hBase = gBase.internalVector().copyToHost();
+        auto hLim = gLim.internalVector().copyToHost();
+        auto hBaseV = hBase.view();
+        auto hLimV = hLim.view();
+
+        for (localIdx i = 1; i < nCells - 1; ++i)
+        {
+            REQUIRE(std::abs(hBaseV[i][0]) > 1e-6); // gradient is genuinely non-trivial
+            REQUIRE(hLimV[i][0] == Catch::Approx(hBaseV[i][0]).margin(1e-12));
+        }
+    }
+
+    SECTION("step field is clipped — limited magnitude below base on " + execName)
+    {
+        auto phi = stepField();
+
+        fvcc::GaussGreenGrad gauss(exec, mesh);
+        auto gBase = gauss.grad(phi);
+        auto gLim = makeLimited(phi, scalar(1.0));
+
+        auto hBase = gBase.internalVector().copyToHost();
+        auto hLim = gLim.internalVector().copyToHost();
+        auto hBaseV = hBase.view();
+        auto hLimV = hLim.view();
+
+        bool anyClipped = false;
+        for (localIdx i = 1; i < nCells - 1; ++i)
+        {
+            const scalar magBase = std::abs(hBaseV[i][0]);
+            const scalar magLim = std::abs(hLimV[i][0]);
+            // the limiter lies in [0,1], so the limited gradient never grows
+            REQUIRE(magLim <= magBase + 1e-12);
+            if (magLim < magBase - 1e-9)
+            {
+                anyClipped = true;
+            }
+        }
+        REQUIRE(anyClipped); // the jump must be limited somewhere
+    }
+
+    SECTION("k=0 disables limiting — equals base gradient even at a jump on " + execName)
+    {
+        auto phi = stepField();
+
+        fvcc::GaussGreenGrad gauss(exec, mesh);
+        auto gBase = gauss.grad(phi);
+        auto gLim = makeLimited(phi, scalar(0.0));
+
+        auto hBase = gBase.internalVector().copyToHost();
+        auto hLim = gLim.internalVector().copyToHost();
+        auto hBaseV = hBase.view();
+        auto hLimV = hLim.view();
+
+        for (localIdx i = 1; i < nCells - 1; ++i)
+        {
+            REQUIRE(hLimV[i][0] == Catch::Approx(hBaseV[i][0]).margin(1e-12));
+        }
+    }
+
+    SECTION("integer coefficient token (label) parses on " + execName)
+    {
+        // gradSchemes writes the coefficient as an integer, e.g.
+        //   grad(p)  cellLimited Gauss linear 1;
+        // which is tokenized as a label rather than a scalar — the scheme must
+        // accept it. k=1 (full limiting) leaves a linear field unclipped.
+        auto phi = linearField();
+
+        fvcc::GaussGreenGrad gauss(exec, mesh);
+        auto gBase = gauss.grad(phi);
+        auto gLim = makeLimited(phi, label(1));
+
+        auto hBase = gBase.internalVector().copyToHost();
+        auto hLim = gLim.internalVector().copyToHost();
+        auto hBaseV = hBase.view();
+        auto hLimV = hLim.view();
+
+        for (localIdx i = 1; i < nCells - 1; ++i)
+        {
+            REQUIRE(hLimV[i][0] == Catch::Approx(hBaseV[i][0]).margin(1e-12));
+        }
+    }
+}
+
+} // namespace NeoN

--- a/test/finiteVolume/cellCentred/operator/cellLimitedGrad.cpp
+++ b/test/finiteVolume/cellCentred/operator/cellLimitedGrad.cpp
@@ -166,4 +166,137 @@ TEST_CASE("cellLimited gradient")
     }
 }
 
+// Tensor path: grad(U) where U is a vector field. On the 1D mesh the only non-zero
+// spatial derivative is d/dx, so component (i,0) of the tensor = dU_i/dx; the limiter
+// is per U-component (three independent minmod limiters). Interior cells only.
+TEST_CASE("cellLimited tensor gradient")
+{
+    auto [execName, exec] = GENERATE(allAvailableExecutor());
+
+    const localIdx nCells = 10;
+    auto mesh = create1DUniformMesh(exec, nCells);
+    auto bcs = fvcc::createCalculatedProcBCs<fvcc::VolumeBoundary<Vec3>>(mesh);
+
+    auto makeLimitedTensor = [&](const fvcc::VolumeField<Vec3>& u, std::any coeff)
+    {
+        Input input = TokenList(
+            {std::string("cellLimited"), std::string("Gauss"), std::string("linear"), coeff}
+        );
+        auto op = fvcc::GradOperatorFactory<Vec3>::create(exec, mesh, input);
+        auto gradU = fvcc::VolumeField<Tensor>(
+            exec, "gradU", mesh, fvcc::createCalculatedProcBCs<fvcc::VolumeBoundary<Tensor>>(mesh)
+        );
+        fill(gradU.internalVector(), zero<Tensor>());
+        op->gradTensor(u, gradU, dsl::Coeff {});
+        return gradU;
+    };
+
+    // U with each component a distinct linear ramp: U = (2 i, -3 i, i).
+    auto linearU = [&]()
+    {
+        fvcc::VolumeField<Vec3> u(exec, "U", mesh, bcs);
+        parallelFor(
+            u.internalVector(),
+            NEON_LAMBDA(const localIdx i) {
+                return Vec3(scalar(2) * scalar(i), scalar(-3) * scalar(i), scalar(i));
+            }
+        );
+        fill(u.boundaryData().value(), zero<Vec3>());
+        u.correctBoundaryConditions();
+        return u;
+    };
+
+    // U with a per-component step at the mid-plane.
+    auto stepU = [&]()
+    {
+        fvcc::VolumeField<Vec3> u(exec, "U", mesh, bcs);
+        const localIdx half = nCells / 2;
+        parallelFor(
+            u.internalVector(),
+            NEON_LAMBDA(const localIdx i) {
+                return i < half ? zero<Vec3>() : Vec3(scalar(1), scalar(1), scalar(1));
+            }
+        );
+        fill(u.boundaryData().value(), zero<Vec3>());
+        u.correctBoundaryConditions();
+        return u;
+    };
+
+    SECTION("linear U is not clipped — equals base Gauss tensor gradient on " + execName)
+    {
+        auto u = linearU();
+
+        fvcc::GaussGreenGrad gauss(exec, mesh);
+        auto gBase = gauss.gradTensor(u);
+        auto gLim = makeLimitedTensor(u, scalar(1.0));
+
+        auto hBase = gBase.internalVector().copyToHost();
+        auto hLim = gLim.internalVector().copyToHost();
+        auto hBaseV = hBase.view();
+        auto hLimV = hLim.view();
+
+        for (localIdx i = 1; i < nCells - 1; ++i)
+        {
+            for (size_t cmpt = 0; cmpt < 3; ++cmpt)
+            {
+                // gradient of U_cmpt in x is genuinely non-trivial and unclipped
+                REQUIRE(std::abs(hBaseV[i](cmpt, 0)) > 1e-6);
+                REQUIRE(hLimV[i](cmpt, 0) == Catch::Approx(hBaseV[i](cmpt, 0)).margin(1e-12));
+            }
+        }
+    }
+
+    SECTION("step U is clipped per component — limited magnitude below base on " + execName)
+    {
+        auto u = stepU();
+
+        fvcc::GaussGreenGrad gauss(exec, mesh);
+        auto gBase = gauss.gradTensor(u);
+        auto gLim = makeLimitedTensor(u, scalar(1.0));
+
+        auto hBase = gBase.internalVector().copyToHost();
+        auto hLim = gLim.internalVector().copyToHost();
+        auto hBaseV = hBase.view();
+        auto hLimV = hLim.view();
+
+        bool anyClipped = false;
+        for (localIdx i = 1; i < nCells - 1; ++i)
+        {
+            for (size_t cmpt = 0; cmpt < 3; ++cmpt)
+            {
+                const scalar magBase = std::abs(hBaseV[i](cmpt, 0));
+                const scalar magLim = std::abs(hLimV[i](cmpt, 0));
+                REQUIRE(magLim <= magBase + 1e-12);
+                if (magLim < magBase - 1e-9)
+                {
+                    anyClipped = true;
+                }
+            }
+        }
+        REQUIRE(anyClipped);
+    }
+
+    SECTION("k=0 disables tensor limiting — equals base gradient at a jump on " + execName)
+    {
+        auto u = stepU();
+
+        fvcc::GaussGreenGrad gauss(exec, mesh);
+        auto gBase = gauss.gradTensor(u);
+        auto gLim = makeLimitedTensor(u, scalar(0.0));
+
+        auto hBase = gBase.internalVector().copyToHost();
+        auto hLim = gLim.internalVector().copyToHost();
+        auto hBaseV = hBase.view();
+        auto hLimV = hLim.view();
+
+        for (localIdx i = 1; i < nCells - 1; ++i)
+        {
+            for (size_t cmpt = 0; cmpt < 3; ++cmpt)
+            {
+                REQUIRE(hLimV[i](cmpt, 0) == Catch::Approx(hBaseV[i](cmpt, 0)).margin(1e-12));
+            }
+        }
+    }
+}
+
 } // namespace NeoN


### PR DESCRIPTION
This PR introduces a new slope-limited gradient scheme (cellLimited) for the cell-centred finite-volume operators, including the supporting geometry data needed for face extrapolation and a unit test validating factory registration and limiter behavior.


