### PR TITLE
fix(laplacian): correct non-orth correction sign + store faceFluxCorrection

### DIFF
--- a/include/NeoN/linearAlgebra/linearSystem.hpp
+++ b/include/NeoN/linearAlgebra/linearSystem.hpp
@@ -133,7 +133,9 @@ public:
     LinearSystem(const LinearSystem& ls)
         : matrix_(ls.matrix_), rhs_(ls.rhs_), boundaryMatrix_(ls.boundaryMatrix_),
           offDiagonalMatrix_(ls.offDiagonalMatrix_), boundaryRhs_(ls.boundaryRhs_),
-          faceFluxCorrection_(ls.faceFluxCorrection_), meshIteratorContext_(ls.meshIteratorContext_)
+          faceFluxCorrection_(ls.faceFluxCorrection_),
+          keepFaceFluxCorrection_(ls.keepFaceFluxCorrection_),
+          meshIteratorContext_(ls.meshIteratorContext_)
 #ifdef NF_WITH_MPI_SUPPORT
           ,
           commPattern_(ls.commPattern_)
@@ -180,6 +182,14 @@ public:
     {
         return faceFluxCorrection_;
     }
+
+    // Whether Laplacian assembly should populate faceFluxCorrection() for this system. Off by
+    // default; only the consumer that reconstructs the flux (the scalar pressure equation, via
+    // NeoFOAM updateFaceVelocity) opts in, so momentum / turbulence systems — which never
+    // reconstruct flux — allocate nothing for the correction.
+    [[nodiscard]] bool keepFaceFluxCorrection() const { return keepFaceFluxCorrection_; }
+
+    void keepFaceFluxCorrection(bool keep) { keepFaceFluxCorrection_ = keep; }
 
     [[nodiscard]] LinearSystem<MatrixValueType, RHSValueType, SystemMatrixType, BoundaryMatrixType>
     copyToExecutor(Executor exec) const override
@@ -285,6 +295,9 @@ private:
     // OpenFOAM faceFluxCorrectionPtr_ analogue; see faceFluxCorrection(). shared_ptr so the
     // (existing) member-wise copy ctor and the default-constructed empty state stay cheap.
     std::shared_ptr<Vector<RHSValueType>> faceFluxCorrection_ = nullptr;
+
+    // Opt-in toggle for faceFluxCorrection_ storage; see keepFaceFluxCorrection().
+    bool keepFaceFluxCorrection_ = false;
 
     Dictionary auxiliaryCoefficients_;
 

--- a/include/NeoN/linearAlgebra/linearSystem.hpp
+++ b/include/NeoN/linearAlgebra/linearSystem.hpp
@@ -133,6 +133,7 @@ public:
     LinearSystem(const LinearSystem& ls)
         : matrix_(ls.matrix_), rhs_(ls.rhs_), boundaryMatrix_(ls.boundaryMatrix_),
           offDiagonalMatrix_(ls.offDiagonalMatrix_), boundaryRhs_(ls.boundaryRhs_),
+          // TODO move to a different location since this seems to be unrelated to linearSystem
           faceFluxCorrection_(ls.faceFluxCorrection_),
           keepFaceFluxCorrection_(ls.keepFaceFluxCorrection_),
           meshIteratorContext_(ls.meshIteratorContext_)
@@ -292,7 +293,7 @@ private:
 
     Vector<RHSValueType> boundaryRhs_;
 
-    // OpenFOAM faceFluxCorrectionPtr_ analogue; see faceFluxCorrection(). shared_ptr so the
+    // see faceFluxCorrection(). shared_ptr so the
     // (existing) member-wise copy ctor and the default-constructed empty state stay cheap.
     std::shared_ptr<Vector<RHSValueType>> faceFluxCorrection_ = nullptr;
 

--- a/include/NeoN/linearAlgebra/linearSystem.hpp
+++ b/include/NeoN/linearAlgebra/linearSystem.hpp
@@ -133,7 +133,7 @@ public:
     LinearSystem(const LinearSystem& ls)
         : matrix_(ls.matrix_), rhs_(ls.rhs_), boundaryMatrix_(ls.boundaryMatrix_),
           offDiagonalMatrix_(ls.offDiagonalMatrix_), boundaryRhs_(ls.boundaryRhs_),
-          meshIteratorContext_(ls.meshIteratorContext_)
+          faceFluxCorrection_(ls.faceFluxCorrection_), meshIteratorContext_(ls.meshIteratorContext_)
 #ifdef NF_WITH_MPI_SUPPORT
           ,
           commPattern_(ls.commPattern_)
@@ -163,6 +163,23 @@ public:
     [[nodiscard]] Vector<RHSValueType>& boundaryRhs() { return boundaryRhs_; }
 
     [[nodiscard]] const Vector<RHSValueType>& boundaryRhs() const { return boundaryRhs_; }
+
+    // Optional per-internal-face deferred flux correction — the OpenFOAM
+    // fvMatrix::faceFluxCorrectionPtr_ analogue. Populated by a corrected/limitedCorrected
+    // Laplacian assembly with the SAME per-face correction it deferred to the RHS, so the flux
+    // reconstruction phi = phiHbyA - pEqn.flux() (NeoFOAM updateFaceVelocity) can add it back and
+    // close div(phi) on non-orthogonal meshes. Null when no corrected Laplacian contributed
+    // (orthogonal / uncorrected schemes); never cleared by reset() since each corrected assembly
+    // overwrites every internal-face entry.
+    [[nodiscard]] std::shared_ptr<Vector<RHSValueType>>& faceFluxCorrection()
+    {
+        return faceFluxCorrection_;
+    }
+
+    [[nodiscard]] const std::shared_ptr<Vector<RHSValueType>>& faceFluxCorrection() const
+    {
+        return faceFluxCorrection_;
+    }
 
     [[nodiscard]] LinearSystem<MatrixValueType, RHSValueType, SystemMatrixType, BoundaryMatrixType>
     copyToExecutor(Executor exec) const override
@@ -264,6 +281,10 @@ private:
     BoundaryMatrixType offDiagonalMatrix_;
 
     Vector<RHSValueType> boundaryRhs_;
+
+    // OpenFOAM faceFluxCorrectionPtr_ analogue; see faceFluxCorrection(). shared_ptr so the
+    // (existing) member-wise copy ctor and the default-constructed empty state stay cheap.
+    std::shared_ptr<Vector<RHSValueType>> faceFluxCorrection_ = nullptr;
 
     Dictionary auxiliaryCoefficients_;
 

--- a/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
@@ -261,12 +261,13 @@ void computeLaplacianNonOrthCorrImpl(
             auto nei = neiV[facei];
             Kokkos::atomic_sub(&rhs[own], corrFlux * coeff[own]);
             Kokkos::atomic_add(&rhs[nei], corrFlux * coeff[nei]);
-            if constexpr (std::is_same_v<FieldValueType, scalar>)
+            // Plain runtime branch (not if-constexpr): nvcc forbids an extended device lambda
+            // from first-capturing a variable inside an if-constexpr context. storeFfc already
+            // folds in (FieldValueType == scalar), so it is compile-time false for Vec3 systems
+            // and this write is dead-code-eliminated there.
+            if (storeFfc)
             {
-                if (storeFfc)
-                {
-                    ffc[facei] = corrFlux * coeff[own];
-                }
+                ffc[facei] = corrFlux * coeff[own];
             }
         },
         "computeLaplacianImplicitCorrection"

--- a/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
@@ -228,11 +228,17 @@ void computeLaplacianNonOrthCorrImpl(
     // div(phi) = corrDiv(p_before) - corrDiv(p_after) on non-orthogonal meshes). Stored value is
     // the signed face flux out of the owner, corrFlux * coeff[own], matching the matrix-based
     // orthogonal reconstruction's operator scaling.
+    //
+    // Stored only when the consumer opted in (ls.keepFaceFluxCorrection(), set by the scalar
+    // pressure equation that reconstructs the flux) AND the system is scalar. Momentum and
+    // turbulence systems never reconstruct flux, so they keep a 0-size placeholder and allocate
+    // nothing for the correction.
+    const bool storeFfc = ls.keepFaceFluxCorrection() && std::is_same_v<FieldValueType, scalar>;
     auto& ffcPtr = ls.faceFluxCorrection();
-    if (!ffcPtr || ffcPtr->size() != nInternalFaces)
+    const auto ffcSize = storeFfc ? nInternalFaces : localIdx {0};
+    if (!ffcPtr || ffcPtr->size() != ffcSize)
     {
-        ffcPtr =
-            std::make_shared<Vector<FieldValueType>>(exec, nInternalFaces, zero<FieldValueType>());
+        ffcPtr = std::make_shared<Vector<FieldValueType>>(exec, ffcSize, zero<FieldValueType>());
     }
     auto ffc = ffcPtr->view();
 
@@ -255,7 +261,13 @@ void computeLaplacianNonOrthCorrImpl(
             auto nei = neiV[facei];
             Kokkos::atomic_sub(&rhs[own], corrFlux * coeff[own]);
             Kokkos::atomic_add(&rhs[nei], corrFlux * coeff[nei]);
-            ffc[facei] = corrFlux * coeff[own];
+            if constexpr (std::is_same_v<FieldValueType, scalar>)
+            {
+                if (storeFfc)
+                {
+                    ffc[facei] = corrFlux * coeff[own];
+                }
+            }
         },
         "computeLaplacianImplicitCorrection"
     );

--- a/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
@@ -222,9 +222,30 @@ void computeLaplacianNonOrthCorrImpl(
     const auto corrV = corrField.internalVector().view();
     auto rhs = ls.rhs().view();
 
-    // Non-orthogonal correction (deferred correction) for corrected / limitedCorrected snGrad:
-    //   rhs[own] += corr[f] * γ_f * |S_f| * coeff[own]
-    //   rhs[nei] -= corr[f] * γ_f * |S_f| * coeff[nei]
+    // Persist the per-internal-face correction flux (OpenFOAM faceFluxCorrectionPtr_ analogue)
+    // so the flux reconstruction can add back the SAME deferred correction this assembly used,
+    // rather than recomputing it from the post-solve field (which would leave a residual
+    // div(phi) = corrDiv(p_before) - corrDiv(p_after) on non-orthogonal meshes). Stored value is
+    // the signed face flux out of the owner, corrFlux * coeff[own], matching the matrix-based
+    // orthogonal reconstruction's operator scaling.
+    auto& ffcPtr = ls.faceFluxCorrection();
+    if (!ffcPtr || ffcPtr->size() != nInternalFaces)
+    {
+        ffcPtr =
+            std::make_shared<Vector<FieldValueType>>(exec, nInternalFaces, zero<FieldValueType>());
+    }
+    auto ffc = ffcPtr->view();
+
+    // Non-orthogonal correction (deferred correction) for corrected / limitedCorrected snGrad.
+    // Sign convention: NeoN's Laplacian matrix is the *negative-definite* form (diag<0,
+    // off-diag>0; see the atomic_sub on the diagonal in computeLaplacianIntImpl). The deferred
+    // correction must enter the RHS with the matching (negative-of-OpenFOAM) sign so the whole
+    // assembly stays internally consistent; otherwise the correction is applied with reversed
+    // sign relative to the rest of the system, which on snappy/non-orthogonal meshes (motorBike,
+    // tiltedCube) corrupts the solved pressure — continuity error climbs each step and the run
+    // diverges. With the consistent sign below NeoFOAM converges on par with OpenFOAM.
+    //   rhs[own] -= corr[f] * γ_f * |S_f| * coeff[own]
+    //   rhs[nei] += corr[f] * γ_f * |S_f| * coeff[nei]
     parallelFor(
         exec,
         {0, nInternalFaces},
@@ -232,8 +253,9 @@ void computeLaplacianNonOrthCorrImpl(
             auto corrFlux = corrV[facei] * gammaV[facei] * magFaceArea[facei];
             auto own = ownV[facei];
             auto nei = neiV[facei];
-            Kokkos::atomic_add(&rhs[own], corrFlux * coeff[own]);
-            Kokkos::atomic_sub(&rhs[nei], corrFlux * coeff[nei]);
+            Kokkos::atomic_sub(&rhs[own], corrFlux * coeff[own]);
+            Kokkos::atomic_add(&rhs[nei], corrFlux * coeff[nei]);
+            ffc[facei] = corrFlux * coeff[own];
         },
         "computeLaplacianImplicitCorrection"
     );


### PR DESCRIPTION
The deferred non-orthogonal Laplacian correction entered the RHS with the wrong sign for NeoN's negative-definite matrix, corrupting the solved pressure on non-orthogonal meshes (continuity error climbs each step, runs diverge). Flip to rhs[own] -= corrFlux, rhs[nei] += corrFlux.

Also store the per-internal-face correction flux in LinearSystem (faceFluxCorrection, the OpenFOAM faceFluxCorrectionPtr_ analogue) so the flux reconstruction phi = phiHbyA - pEqn.flux() can add back the SAME correction the assembly deferred. Recomputing it from the post-solve field would leave div(phi) = corrDiv(p_before) - corrDiv(p_after) != 0 on non-orthogonal meshes.

