### PR TITLE
perf(geometryScheme): make faceDelta* lazy/opt-in 

### DIFF
--- a/include/NeoN/finiteVolume/cellCentred/interpolation/linearUpwind.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/interpolation/linearUpwind.hpp
@@ -93,7 +93,14 @@ public:
 
     LinearUpwind(const Executor& exec, const UnstructuredMesh& mesh, Input input)
         : Base(exec, mesh), geometryScheme_(GeometryScheme::readOrCreate(mesh)),
-          gradSchemeName_(readGradSchemeName(input)) {};
+          gradSchemeName_(readGradSchemeName(input))
+    {
+        // Opt in to the geometry scheme's per-internal-face cell-to-face offset vectors. These are
+        // computed lazily and only for schemes that need them, so non-linearUpwind runs never
+        // allocate them. Done in the constructor — while the mesh centres are still alive — because
+        // the geometry scheme frees those centres on the first read of any cached geometry field.
+        geometryScheme_->ensureFaceDeltas();
+    };
 
     static std::string name() { return "linearUpwind"; }
 

--- a/include/NeoN/finiteVolume/cellCentred/interpolation/linearUpwind.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/interpolation/linearUpwind.hpp
@@ -97,8 +97,9 @@ public:
     {
         // Opt in to the geometry scheme's per-internal-face cell-to-face offset vectors. These are
         // computed lazily and only for schemes that need them, so non-linearUpwind runs never
-        // allocate them. Done in the constructor — while the mesh centres are still alive — because
-        // the geometry scheme frees those centres on the first read of any cached geometry field.
+        // allocate them. The geometry scheme keeps the mesh centres resident (it no longer frees
+        // them as a side effect of reading a cached field), so this opt-in is valid regardless of
+        // construction order relative to other schemes on the same cached GeometryScheme.
         geometryScheme_->ensureFaceDeltas();
     };
 

--- a/include/NeoN/finiteVolume/cellCentred/stencil/geometryScheme.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/stencil/geometryScheme.hpp
@@ -87,20 +87,23 @@ public:
     // Vector from the neighbour cell centre to the face centre (Cf - C_nei), one per internal face.
     const SurfaceField<Vec3>& faceDeltaNeighbour() const;
 
-    // Opt-in trigger for the faceDelta* fields. Computes them (from the still-live mesh centres)
-    // and then releases the source geometry. Consumers that need faceDelta* (linearUpwind) call
-    // this in their constructor — while the mesh centres are guaranteed alive — because reset()
-    // frees those centres on the first read of any cached geometry field. Idempotent; const so it
-    // is reachable through the shared (read-only) GeometryScheme handle. No-op cost after the first
-    // call is a single bool check.
+    // Opt-in trigger for the faceDelta* fields. Computes them from the mesh centres, which the
+    // geometry scheme keeps resident. Consumers that need faceDelta* (linearUpwind) call this in
+    // their constructor; because the centres are no longer freed as a side effect of reading a
+    // cached field, the call is valid at any point in the scheme's lifetime, independent of
+    // construction order relative to other schemes. Idempotent; const so it is reachable through
+    // the shared (read-only) GeometryScheme handle. No-op cost after the first call is a single
+    // bool check.
     void ensureFaceDeltas() const;
 
     void update();
 
-    // Frees the mesh's per-cell/face centre arrays once the geometry-scheme fields are cached, to
-    // save device memory. Deferred (lazy + idempotent): triggered on the first read of any cached
-    // geometry field, or by ensureFaceDeltas() right after the faceDelta* fields are built — not in
-    // update(), so that a late faceDelta* opt-in can still read the centres.
+    // Frees the mesh's per-cell/face centre arrays to save device memory. EXPLICIT and NOT
+    // auto-invoked: callers run it only once they are certain no further faceDelta* opt-in will
+    // occur. It is deliberately not triggered by the field accessors or ensureFaceDeltas() — doing
+    // so used to free the centres before a late linearUpwind opt-in (constructed after another
+    // scheme on the same cached GeometryScheme had read a field) could compute the faceDelta*.
+    // Idempotent via sourceGeometryReleased_.
     // TODO: check if we can remove the temporary fields from the unstructured mesh
     // altogether: compute the geometry-scheme data explicitly first and pass it as an
     // argument, instead of freeing mesh members after the fact.

--- a/include/NeoN/finiteVolume/cellCentred/stencil/geometryScheme.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/stencil/geometryScheme.hpp
@@ -87,27 +87,30 @@ public:
     // Vector from the neighbour cell centre to the face centre (Cf - C_nei), one per internal face.
     const SurfaceField<Vec3>& faceDeltaNeighbour() const;
 
-    // Opt-in trigger for the faceDelta* fields. Computes them from the mesh centres, which the
-    // geometry scheme keeps resident. Consumers that need faceDelta* (linearUpwind) call this in
-    // their constructor; because the centres are no longer freed as a side effect of reading a
-    // cached field, the call is valid at any point in the scheme's lifetime, independent of
-    // construction order relative to other schemes. Idempotent; const so it is reachable through
-    // the shared (read-only) GeometryScheme handle. No-op cost after the first call is a single
-    // bool check.
+    // Opt-in trigger for the faceDelta* fields. Computes them from the mesh centres (which the
+    // scheme keeps resident until this runs), then releases those centres via
+    // releaseSourceGeometry(). Consumers that need faceDelta* (linearUpwind) call this in their
+    // constructor; because the centres are not freed as a side effect of reading a cached field,
+    // the call is valid at any point in the scheme's lifetime, independent of construction order
+    // relative to other schemes. Idempotent; const so it is reachable through the shared
+    // (read-only) GeometryScheme handle. No-op cost after the first call is a single bool check.
     void ensureFaceDeltas() const;
 
     void update();
 
-    // Frees the mesh's per-cell/face centre arrays to save device memory. EXPLICIT and NOT
-    // auto-invoked: callers run it only once they are certain no further faceDelta* opt-in will
-    // occur. It is deliberately not triggered by the field accessors or ensureFaceDeltas() — doing
-    // so used to free the centres before a late linearUpwind opt-in (constructed after another
-    // scheme on the same cached GeometryScheme had read a field) could compute the faceDelta*.
-    // Idempotent via sourceGeometryReleased_.
+    // Frees the mesh's per-point/cell/face centre arrays to save device memory (~3 GB at 18M
+    // cells). Auto-invoked exactly once at the tail of ensureFaceDeltas() — right after the
+    // faceDelta* opt-in has consumed the centres, the single point where freeing is provably safe.
+    // It is deliberately NOT triggered by the field accessors: doing so used to free the centres
+    // before a late linearUpwind opt-in (constructed after another scheme on the same cached
+    // GeometryScheme had read a field) could compute the faceDelta*. Runs that never opt in (no
+    // linearUpwind) never call ensureFaceDeltas(), so they keep the centres resident. May also be
+    // called explicitly by a caller certain no further opt-in will occur. Idempotent via
+    // sourceGeometryReleased_.
     // TODO: check if we can remove the temporary fields from the unstructured mesh
     // altogether: compute the geometry-scheme data explicitly first and pass it as an
     // argument, instead of freeing mesh members after the fact.
-    void reset() const;
+    void releaseSourceGeometry() const;
 
     std::string name() const;
 
@@ -131,7 +134,7 @@ private:
     mutable std::optional<SurfaceField<Vec3>> faceDeltaOwner_;
     mutable std::optional<SurfaceField<Vec3>> faceDeltaNeighbour_;
     mutable bool faceDeltasComputed_ = false;
-    // Guards the one-shot, deferred release of the mesh centre arrays (see reset()).
+    // Guards the one-shot release of the mesh centre arrays (see releaseSourceGeometry()).
     mutable bool sourceGeometryReleased_ = false;
 };
 

--- a/include/NeoN/finiteVolume/cellCentred/stencil/geometryScheme.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/stencil/geometryScheme.hpp
@@ -5,6 +5,8 @@
 #pragma once
 
 
+#include <optional>
+
 #include "NeoN/core/primitives/vec3.hpp"
 #include "NeoN/core/primitives/scalar.hpp"
 #include "NeoN/core/executor/executor.hpp"
@@ -77,17 +79,28 @@ public:
     const SurfaceField<Vec3>& nonOrthCorrectionVec3s() const;
 
     // Vector from the owner cell centre to the face centre (Cf - C_own), one per internal face.
-    // Cached here because the underlying cell/face centres are freed by reset(); schemes that need
-    // a cell-to-face offset (e.g. linearUpwind's gradient correction) read it from this object.
+    // Computed lazily on first access (or via ensureFaceDeltas()); only schemes that need a
+    // cell-to-face offset (e.g. linearUpwind's gradient correction) ever trigger the allocation,
+    // so a run that never selects such a scheme pays nothing.
     const SurfaceField<Vec3>& faceDeltaOwner() const;
 
     // Vector from the neighbour cell centre to the face centre (Cf - C_nei), one per internal face.
     const SurfaceField<Vec3>& faceDeltaNeighbour() const;
 
+    // Opt-in trigger for the faceDelta* fields. Computes them (from the still-live mesh centres)
+    // and then releases the source geometry. Consumers that need faceDelta* (linearUpwind) call
+    // this in their constructor — while the mesh centres are guaranteed alive — because reset()
+    // frees those centres on the first read of any cached geometry field. Idempotent; const so it
+    // is reachable through the shared (read-only) GeometryScheme handle. No-op cost after the first
+    // call is a single bool check.
+    void ensureFaceDeltas() const;
+
     void update();
 
-    // Frees the mesh's per-cell/face centre arrays after update() to save device memory;
-    // they are not needed once the geometry-scheme fields are cached.
+    // Frees the mesh's per-cell/face centre arrays once the geometry-scheme fields are cached, to
+    // save device memory. Deferred (lazy + idempotent): triggered on the first read of any cached
+    // geometry field, or by ensureFaceDeltas() right after the faceDelta* fields are built — not in
+    // update(), so that a late faceDelta* opt-in can still read the centres.
     // TODO: check if we can remove the temporary fields from the unstructured mesh
     // altogether: compute the geometry-scheme data explicitly first and pass it as an
     // argument, instead of freeing mesh members after the fact.
@@ -107,8 +120,16 @@ private:
     SurfaceField<scalar> weights_;
     SurfaceField<scalar> nonOrthDeltaCoeffs_;
     SurfaceField<Vec3> nonOrthCorrectionVec3s_;
-    SurfaceField<Vec3> faceDeltaOwner_;
-    SurfaceField<Vec3> faceDeltaNeighbour_;
+
+    // Lazily allocated and filled: empty until a consumer opts in via ensureFaceDeltas() (or first
+    // reads them). A run that never selects linearUpwind leaves these nullopt, saving
+    // 2 * nInternalFaces * sizeof(Vec3) of device memory (~2.6 GB on an 18M-cell mesh). mutable so
+    // the const accessors / ensureFaceDeltas() can populate them through the shared handle.
+    mutable std::optional<SurfaceField<Vec3>> faceDeltaOwner_;
+    mutable std::optional<SurfaceField<Vec3>> faceDeltaNeighbour_;
+    mutable bool faceDeltasComputed_ = false;
+    // Guards the one-shot, deferred release of the mesh centre arrays (see reset()).
+    mutable bool sourceGeometryReleased_ = false;
 };
 
 } // namespace NeoN

--- a/include/NeoN/linearAlgebra/faceToMatrixAddress.hpp
+++ b/include/NeoN/linearAlgebra/faceToMatrixAddress.hpp
@@ -169,4 +169,52 @@ std::shared_ptr<const SparsityType> createOffDiagonalSparsityPattern(
     const UnstructuredMesh& mesh, const FaceToMatrixAddress& faceToMatrixAddress
 );
 
+/* @brief Immutable, topology-only bundle shared across every LinearSystem built on a mesh.
+ *
+ * The CSR system sparsity (colIdxs/rowOffs), its FaceToMatrixAddress (diag/owner/neighbour
+ * offsets), and the boundary COO sparsity depend ONLY on mesh topology — they are byte-identical
+ * for every equation (U, p, nuTilda, ...) on the same mesh. Only the per-system value/RHS vectors
+ * legitimately differ. Caching this bundle once per mesh removes the per-equation duplication of
+ * these identical arrays.
+ *
+ * All three members are stored as shared_ptr<const ...> so the cached objects stay immutable and
+ * are safe to share between systems; consumers write only their own per-system value/RHS vectors.
+ *
+ * @tparam SystemSparsityType   - the system sparsity type, e.g. CsrSparsityPattern<localIdx>
+ * @tparam BoundarySparsityType - the boundary sparsity type, e.g. CooSparsityPattern<localIdx>
+ */
+template<typename SystemSparsityType, typename BoundarySparsityType>
+struct SharedSparsityBundle
+{
+    std::shared_ptr<const SystemSparsityType> systemSparsity;
+    std::shared_ptr<const FaceToMatrixAddress> faceToMatrixAddress;
+    std::shared_ptr<const BoundarySparsityType> boundarySparsity;
+
+    // Explicit constructor: CUDA-12.4 nvcc rejects parenthesized aggregate init, so give the
+    // bundle a real constructor for portability (brace-init would otherwise suffice).
+    SharedSparsityBundle(
+        std::shared_ptr<const SystemSparsityType> systemSparsity_,
+        std::shared_ptr<const FaceToMatrixAddress> faceToMatrixAddress_,
+        std::shared_ptr<const BoundarySparsityType> boundarySparsity_
+    )
+        : systemSparsity(std::move(systemSparsity_)),
+          faceToMatrixAddress(std::move(faceToMatrixAddress_)),
+          boundarySparsity(std::move(boundarySparsity_))
+    {}
+};
+
+/* @brief Returns the SHARED, immutable topology bundle for a mesh, caching it in
+ * mesh.stencilDB(). Mirrors the GeometryScheme::readOrCreate precedent exactly
+ * (contains/insert/get of a std::shared_ptr keyed by a type-specific string).
+ *
+ * The cache key encodes both sparsity types so the CSR system pattern and the COO boundary pattern
+ * (and the index type) never collide. Returns a cheap copy of the bundle (three shared_ptrs).
+ *
+ * @note mesh.stencilDB() is mutable and not thread-safe; this matches the GeometryScheme cache and
+ *       is acceptable for CPU-serial v1. No locking is added here.
+ */
+template<typename SystemSparsityType, typename BoundarySparsityType>
+[[nodiscard]] SharedSparsityBundle<SystemSparsityType, BoundarySparsityType>
+readOrCreateSparsityBundle(const UnstructuredMesh& mesh);
+
 }

--- a/include/NeoN/linearAlgebra/linearSystem.hpp
+++ b/include/NeoN/linearAlgebra/linearSystem.hpp
@@ -321,16 +321,22 @@ LinearSystem<ValueType, RHSValueType, SystemMatrixType, BoundaryMatrixType> crea
     std::shared_ptr<MeshIterationStrategy> strategy = std::make_shared<FaceBasedIterator>()
 )
 {
-    auto [sp, mi] =
-        createSparsityPatternFaceToMatrixAddress<typename SystemMatrixType::MatrixSparsityType>(mesh
-        );
-    auto bSp =
-        createBoundarySparsityPattern<typename BoundaryMatrixType::MatrixSparsityType>(mesh, *mi);
+    // Consume the per-mesh cached, immutable topology bundle (CSR system sparsity +
+    // FaceToMatrixAddress + boundary sparsity). These arrays depend only on mesh topology, so they
+    // are shared by every LinearSystem built on this mesh; only the per-system value/RHS vectors
+    // below are allocated fresh.
+    auto bundle = readOrCreateSparsityBundle<
+        typename SystemMatrixType::MatrixSparsityType,
+        typename BoundaryMatrixType::MatrixSparsityType>(mesh);
+    const auto& sp = bundle.systemSparsity;
+    const auto& mi = bundle.faceToMatrixAddress;
+    const auto& bSp = bundle.boundarySparsity;
     const auto exec = sp->exec();
     const auto nCells = static_cast<localIdx>(mesh.nCells());
     const auto nProcFaces = static_cast<localIdx>(mesh.nProcBoundaryFaces());
     using IndexType = typename BoundaryMatrixType::MatrixSparsityType::SparsityIndexType;
 
+    // Off-diagonal / proc-face sparsity stays per-system (comm-pattern-derived); not shared in v1.
     Vector<IndexType> offDiagColIdxs(exec, nProcFaces, 0);
     Vector<IndexType> offDiagRowIdxs(exec, nProcFaces, 0);
 

--- a/src/finiteVolume/cellCentred/stencil/geometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/geometryScheme.cpp
@@ -15,9 +15,8 @@ namespace NeoN::finiteVolume::cellCentred
 GeometrySchemeFactory::GeometrySchemeFactory() {}
 
 // Cache the per-internal-face vector from each adjacent cell centre to the face centre
-// (Cf - C_own and Cf - C_nei). These are derived from the mesh cell/face centres;
-// ensureFaceDeltas() calls this while those centres are still alive, then releases them via
-// reset().
+// (Cf - C_own and Cf - C_nei). These are derived from the mesh cell/face centres, which the
+// geometry scheme keeps resident; ensureFaceDeltas() calls this on the first opt-in.
 namespace
 {
 void computeFaceDeltaVectors(
@@ -144,8 +143,8 @@ void GeometryScheme::update()
         );
         // faceDeltaOwner_/faceDeltaNeighbour_ are NOT computed here: they are only needed by
         // schemes that opt in (linearUpwind), so they are built lazily in ensureFaceDeltas(). The
-        // mesh centres are likewise NOT freed here (reset() is deferred) so a later opt-in can
-        // still read them.
+        // mesh centres are likewise NOT freed here (reset() is explicit and not auto-invoked) so a
+        // later opt-in can still read them.
     }
 }
 
@@ -170,22 +169,24 @@ void GeometryScheme::ensureFaceDeltas() const
         computeFaceDeltaVectors(exec_, mesh_, *faceDeltaOwner_, *faceDeltaNeighbour_);
         faceDeltasComputed_ = true;
     }
-    // The faceDelta* fields now hold everything derived from the mesh centres, so release them.
-    reset();
 }
 
 void GeometryScheme::reset() const
 {
-    // Free the per-point/cell/face geometry on the device once the geometry scheme has consumed
-    // it. weights / nonOrthDeltaCoeffs / corrVec (and, if opted in, faceDelta*) are now cached in
-    // this object, so the points/cellCentres/faceCentres arrays are no longer needed for
-    // subsequent computations and freeing them saves device memory on large meshes (revisit for
-    // moving/rotating meshes, which would repopulate all three). Deferred and one-shot: it runs on
-    // the first read of any cached geometry field (the accessors below) or from ensureFaceDeltas(),
-    // whichever comes first, so a late faceDelta* opt-in can still read the centres. points() is
-    // read only during construction/partitioning, never after this point. The const_cast is safe
-    // while the underlying mesh object is non-const, which holds for all current construction
-    // paths.
+    // Free the per-point/cell/face geometry on the device once the caller knows it is no longer
+    // needed. weights / nonOrthDeltaCoeffs / corrVec (and, if opted in, faceDelta*) are cached in
+    // this object, so the points/cellCentres/faceCentres arrays are not needed for subsequent
+    // computations and freeing them saves device memory on large meshes (revisit for
+    // moving/rotating meshes, which would repopulate all three). One-shot (idempotent via
+    // sourceGeometryReleased_) and EXPLICIT: it is NOT auto-invoked by the field accessors or by
+    // ensureFaceDeltas(). It used to fire on the first read of any cached geometry field, but that
+    // freed the centres before a later, separately-constructed scheme (e.g. an upwind div built
+    // before a linearUpwind div on the same cached GeometryScheme) could opt into the lazy
+    // faceDelta* — which need the centres — leaving ensureFaceDeltas() to abort. A caller that is
+    // certain no further faceDelta* opt-in will occur may invoke this to reclaim the centres.
+    // points() is read only during construction/partitioning, never after this point. The
+    // const_cast is safe while the underlying mesh object is non-const, which holds for all current
+    // construction paths.
     if (sourceGeometryReleased_)
     {
         return;
@@ -197,21 +198,15 @@ void GeometryScheme::reset() const
 }
 
 
-const SurfaceField<scalar>& GeometryScheme::weights() const
-{
-    reset();
-    return weights_;
-}
+const SurfaceField<scalar>& GeometryScheme::weights() const { return weights_; }
 
 const SurfaceField<scalar>& GeometryScheme::nonOrthDeltaCoeffs() const
 {
-    reset();
     return nonOrthDeltaCoeffs_;
 }
 
 const SurfaceField<Vec3>& GeometryScheme::nonOrthCorrectionVec3s() const
 {
-    reset();
     return nonOrthCorrectionVec3s_;
 }
 

--- a/src/finiteVolume/cellCentred/stencil/geometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/geometryScheme.cpp
@@ -15,8 +15,9 @@ namespace NeoN::finiteVolume::cellCentred
 GeometrySchemeFactory::GeometrySchemeFactory() {}
 
 // Cache the per-internal-face vector from each adjacent cell centre to the face centre
-// (Cf - C_own and Cf - C_nei). These are derived from the mesh cell/face centres, which
-// reset() frees right after the geometry scheme is built, so they must be computed here.
+// (Cf - C_own and Cf - C_nei). These are derived from the mesh cell/face centres;
+// ensureFaceDeltas() calls this while those centres are still alive, then releases them via
+// reset().
 namespace
 {
 void computeFaceDeltaVectors(
@@ -65,19 +66,7 @@ GeometryScheme::GeometryScheme(
     const SurfaceField<Vec3>& nonOrthCorrectionVec3s
 )
     : exec_(exec), mesh_(weights.mesh()), kernel_(std::move(kernel)), weights_(weights),
-      nonOrthDeltaCoeffs_(nonOrthDeltaCoeffs), nonOrthCorrectionVec3s_(nonOrthCorrectionVec3s),
-      faceDeltaOwner_(
-          weights.exec(),
-          "faceDeltaOwner",
-          weights.mesh(),
-          createCalculatedBCs<SurfaceBoundary<Vec3>>(weights.mesh())
-      ),
-      faceDeltaNeighbour_(
-          weights.exec(),
-          "faceDeltaNeighbour",
-          weights.mesh(),
-          createCalculatedBCs<SurfaceBoundary<Vec3>>(weights.mesh())
-      )
+      nonOrthDeltaCoeffs_(nonOrthDeltaCoeffs), nonOrthCorrectionVec3s_(nonOrthCorrectionVec3s)
 {
     if (kernel_ == nullptr)
     {
@@ -103,12 +92,6 @@ GeometryScheme::GeometryScheme(
           "nonOrthCorrectionVec3s",
           mesh,
           createCalculatedBCs<SurfaceBoundary<Vec3>>(mesh)
-      ),
-      faceDeltaOwner_(
-          mesh.exec(), "faceDeltaOwner", mesh, createCalculatedBCs<SurfaceBoundary<Vec3>>(mesh)
-      ),
-      faceDeltaNeighbour_(
-          mesh.exec(), "faceDeltaNeighbour", mesh, createCalculatedBCs<SurfaceBoundary<Vec3>>(mesh)
       )
 {
     if (kernel_ == nullptr)
@@ -133,12 +116,6 @@ GeometryScheme::GeometryScheme(const UnstructuredMesh& mesh)
           "nonOrthCorrectionVec3s",
           mesh,
           createCalculatedBCs<SurfaceBoundary<Vec3>>(mesh)
-      ),
-      faceDeltaOwner_(
-          mesh.exec(), "faceDeltaOwner", mesh, createCalculatedBCs<SurfaceBoundary<Vec3>>(mesh)
-      ),
-      faceDeltaNeighbour_(
-          mesh.exec(), "faceDeltaNeighbour", mesh, createCalculatedBCs<SurfaceBoundary<Vec3>>(mesh)
       )
 {
     if (kernel_ == nullptr)
@@ -165,40 +142,89 @@ void GeometryScheme::update()
             },
             exec_
         );
-        computeFaceDeltaVectors(exec_, mesh_, faceDeltaOwner_, faceDeltaNeighbour_);
-        reset();
+        // faceDeltaOwner_/faceDeltaNeighbour_ are NOT computed here: they are only needed by
+        // schemes that opt in (linearUpwind), so they are built lazily in ensureFaceDeltas(). The
+        // mesh centres are likewise NOT freed here (reset() is deferred) so a later opt-in can
+        // still read them.
     }
+}
+
+void GeometryScheme::ensureFaceDeltas() const
+{
+    if (!faceDeltasComputed_)
+    {
+        if (mesh_.faceCenters().size() == 0)
+        {
+            NF_ERROR_EXIT(
+                "GeometryScheme: face-to-cell delta vectors requested after the source mesh "
+                "geometry was released. A scheme that needs them (e.g. linearUpwind) must be "
+                "constructed before the first read of a cached geometry field."
+            );
+        }
+        faceDeltaOwner_.emplace(
+            exec_, "faceDeltaOwner", mesh_, createCalculatedBCs<SurfaceBoundary<Vec3>>(mesh_)
+        );
+        faceDeltaNeighbour_.emplace(
+            exec_, "faceDeltaNeighbour", mesh_, createCalculatedBCs<SurfaceBoundary<Vec3>>(mesh_)
+        );
+        computeFaceDeltaVectors(exec_, mesh_, *faceDeltaOwner_, *faceDeltaNeighbour_);
+        faceDeltasComputed_ = true;
+    }
+    // The faceDelta* fields now hold everything derived from the mesh centres, so release them.
+    reset();
 }
 
 void GeometryScheme::reset() const
 {
     // Free the per-point/cell/face geometry on the device once the geometry scheme has consumed
-    // it. weights / nonOrthDeltaCoeffs / corrVec are now cached in this object, so the
-    // points/cellCentres/faceCentres arrays are no longer needed for subsequent computations and
-    // freeing them saves device memory on large meshes (revisit for moving/rotating meshes, which
-    // would repopulate all three). points() is read only during construction/partitioning, never
-    // after this point. The const_cast is safe while the underlying mesh object is non-const,
-    // which holds for all current construction paths.
+    // it. weights / nonOrthDeltaCoeffs / corrVec (and, if opted in, faceDelta*) are now cached in
+    // this object, so the points/cellCentres/faceCentres arrays are no longer needed for
+    // subsequent computations and freeing them saves device memory on large meshes (revisit for
+    // moving/rotating meshes, which would repopulate all three). Deferred and one-shot: it runs on
+    // the first read of any cached geometry field (the accessors below) or from ensureFaceDeltas(),
+    // whichever comes first, so a late faceDelta* opt-in can still read the centres. points() is
+    // read only during construction/partitioning, never after this point. The const_cast is safe
+    // while the underlying mesh object is non-const, which holds for all current construction
+    // paths.
+    if (sourceGeometryReleased_)
+    {
+        return;
+    }
     const_cast<UnstructuredMesh&>(mesh_).points().resize(0);
     const_cast<UnstructuredMesh&>(mesh_).faceCenters().resize(0);
     const_cast<UnstructuredMesh&>(mesh_).cellCenters().resize(0);
+    sourceGeometryReleased_ = true;
 }
 
 
-const SurfaceField<scalar>& GeometryScheme::weights() const { return weights_; }
+const SurfaceField<scalar>& GeometryScheme::weights() const
+{
+    reset();
+    return weights_;
+}
 
 const SurfaceField<scalar>& GeometryScheme::nonOrthDeltaCoeffs() const
 {
+    reset();
     return nonOrthDeltaCoeffs_;
 }
 
 const SurfaceField<Vec3>& GeometryScheme::nonOrthCorrectionVec3s() const
 {
+    reset();
     return nonOrthCorrectionVec3s_;
 }
 
-const SurfaceField<Vec3>& GeometryScheme::faceDeltaOwner() const { return faceDeltaOwner_; }
+const SurfaceField<Vec3>& GeometryScheme::faceDeltaOwner() const
+{
+    ensureFaceDeltas();
+    return *faceDeltaOwner_;
+}
 
-const SurfaceField<Vec3>& GeometryScheme::faceDeltaNeighbour() const { return faceDeltaNeighbour_; }
+const SurfaceField<Vec3>& GeometryScheme::faceDeltaNeighbour() const
+{
+    ensureFaceDeltas();
+    return *faceDeltaNeighbour_;
+}
 
 } // namespace NeoN

--- a/src/finiteVolume/cellCentred/stencil/geometryScheme.cpp
+++ b/src/finiteVolume/cellCentred/stencil/geometryScheme.cpp
@@ -15,8 +15,9 @@ namespace NeoN::finiteVolume::cellCentred
 GeometrySchemeFactory::GeometrySchemeFactory() {}
 
 // Cache the per-internal-face vector from each adjacent cell centre to the face centre
-// (Cf - C_own and Cf - C_nei). These are derived from the mesh cell/face centres, which the
-// geometry scheme keeps resident; ensureFaceDeltas() calls this on the first opt-in.
+// (Cf - C_own and Cf - C_nei). These are derived from the mesh cell/face centres;
+// ensureFaceDeltas() calls this on the first opt-in and then releases those centres
+// (releaseSourceGeometry()).
 namespace
 {
 void computeFaceDeltaVectors(
@@ -143,8 +144,9 @@ void GeometryScheme::update()
         );
         // faceDeltaOwner_/faceDeltaNeighbour_ are NOT computed here: they are only needed by
         // schemes that opt in (linearUpwind), so they are built lazily in ensureFaceDeltas(). The
-        // mesh centres are likewise NOT freed here (reset() is explicit and not auto-invoked) so a
-        // later opt-in can still read them.
+        // mesh centres are likewise NOT freed here so a later opt-in can still read them;
+        // ensureFaceDeltas() releases them (releaseSourceGeometry()) once it has built the
+        // faceDelta* from them.
     }
 }
 
@@ -168,23 +170,33 @@ void GeometryScheme::ensureFaceDeltas() const
         );
         computeFaceDeltaVectors(exec_, mesh_, *faceDeltaOwner_, *faceDeltaNeighbour_);
         faceDeltasComputed_ = true;
+
+        // The faceDelta* fields now hold everything this scheme derives from the mesh centres, and
+        // ensureFaceDeltas() is the last NeoN consumer of those centres, so reclaim them here. This
+        // is the only point where freeing is provably safe: it runs strictly AFTER the (possibly
+        // late) faceDelta* opt-in has consumed the centres, never before — which is exactly the
+        // ordering that broke when the field accessors used to free them (see
+        // releaseSourceGeometry).
+        releaseSourceGeometry();
     }
 }
 
-void GeometryScheme::reset() const
+void GeometryScheme::releaseSourceGeometry() const
 {
-    // Free the per-point/cell/face geometry on the device once the caller knows it is no longer
-    // needed. weights / nonOrthDeltaCoeffs / corrVec (and, if opted in, faceDelta*) are cached in
-    // this object, so the points/cellCentres/faceCentres arrays are not needed for subsequent
-    // computations and freeing them saves device memory on large meshes (revisit for
-    // moving/rotating meshes, which would repopulate all three). One-shot (idempotent via
-    // sourceGeometryReleased_) and EXPLICIT: it is NOT auto-invoked by the field accessors or by
-    // ensureFaceDeltas(). It used to fire on the first read of any cached geometry field, but that
-    // freed the centres before a later, separately-constructed scheme (e.g. an upwind div built
-    // before a linearUpwind div on the same cached GeometryScheme) could opt into the lazy
-    // faceDelta* — which need the centres — leaving ensureFaceDeltas() to abort. A caller that is
-    // certain no further faceDelta* opt-in will occur may invoke this to reclaim the centres.
-    // points() is read only during construction/partitioning, never after this point. The
+    // Free the per-point/cell/face geometry on the device once it is no longer needed. weights /
+    // nonOrthDeltaCoeffs / corrVec (and, if opted in, faceDelta*) are cached in this object, so the
+    // points/cellCentres/faceCentres arrays are not needed for subsequent computations and freeing
+    // them saves device memory on large meshes (~3 GB at 18M cells; revisit for moving/rotating
+    // meshes, which would repopulate all three). One-shot (idempotent via sourceGeometryReleased_).
+    // Auto-invoked exactly once at the tail of ensureFaceDeltas(), i.e. right after the faceDelta*
+    // opt-in has consumed the centres — the single point where freeing is provably safe. It is NOT
+    // invoked by the field accessors: doing so used to free the centres before a late linearUpwind
+    // opt-in (constructed after another scheme on the same cached GeometryScheme had read a field)
+    // could compute the faceDelta*, leaving ensureFaceDeltas() to abort. Runs that never opt into
+    // faceDelta* (no linearUpwind) never call ensureFaceDeltas(), so they keep the centres
+    // resident; they already avoid the larger faceDelta* allocation, and no other safe auto-trigger
+    // exists for them. May also be called explicitly by a caller certain no further opt-in will
+    // occur. points() is read only during construction/partitioning, never after this point. The
     // const_cast is safe while the underlying mesh object is non-const, which holds for all current
     // construction paths.
     if (sourceGeometryReleased_)

--- a/src/linearAlgebra/faceToMatrixAddress.cpp
+++ b/src/linearAlgebra/faceToMatrixAddress.cpp
@@ -9,6 +9,10 @@
 #include "NeoN/linearAlgebra/csrSparsityPattern.hpp"
 #include "NeoN/linearAlgebra/faceToMatrixAddress.hpp"
 
+#include <memory>
+#include <string>
+#include <typeinfo>
+
 #ifdef NF_WITH_MPI_SUPPORT
 #include "NeoN/distributed/communicationPattern.hpp"
 #endif
@@ -444,10 +448,61 @@ createOffDiagonalSparsityPattern<CsrSparsityPattern<localIdx>>(
     );
 }
 
+template<typename SystemSparsityType, typename BoundarySparsityType>
+SharedSparsityBundle<SystemSparsityType, BoundarySparsityType>
+readOrCreateSparsityBundle(const UnstructuredMesh& mesh)
+{
+    using Bundle = SharedSparsityBundle<SystemSparsityType, BoundarySparsityType>;
+
+    // Type-specific cache key so different sparsity-type combinations (CSR system vs COO boundary,
+    // and the index type) cache separately and never collide. typeid().name() disambiguates them.
+    const std::string key = std::string("SharedSparsityBundle<") + typeid(SystemSparsityType).name()
+                          + "," + typeid(BoundarySparsityType).name() + ">";
+
+    // NOTE mesh.stencilDB() is mutable and not thread-safe; this matches the GeometryScheme cache
+    // and is acceptable for CPU-serial v1. No locking is added here.
+    auto& db = mesh.stencilDB();
+    if (!db.contains(key))
+    {
+        auto [systemSparsity, faceToMatrixAddress] =
+            createSparsityPatternFaceToMatrixAddress<SystemSparsityType>(mesh);
+        auto boundarySparsity =
+            createBoundarySparsityPattern<BoundarySparsityType>(mesh, *faceToMatrixAddress);
+        db.insert(
+            key,
+            std::make_shared<const Bundle>(
+                std::move(systemSparsity),
+                std::move(faceToMatrixAddress),
+                std::move(boundarySparsity)
+            )
+        );
+    }
+    // Return a (cheap) copy of the cached bundle: three shared_ptrs to immutable topology.
+    return *db.get<std::shared_ptr<const Bundle>>(key);
+}
+
 // TODO currently CSR is hardcoded here
 template std::pair<
     std::shared_ptr<const CsrSparsityPattern<localIdx>>,
     std::shared_ptr<const FaceToMatrixAddress>>
 createSparsityPatternFaceToMatrixAddress<CsrSparsityPattern<localIdx>>(const UnstructuredMesh&);
+
+// Production combination: CSR system sparsity + COO boundary sparsity (used by every solver via
+// the default createEmptyLinearSystem<ValueType>). The remaining two combinations are exercised by
+// the createEmptyLinearSystem<...,CSRMatrix,CSRMatrix> / <...,COOMatrix,COOMatrix> test overloads.
+template SharedSparsityBundle<CsrSparsityPattern<localIdx>, CooSparsityPattern<localIdx>>
+readOrCreateSparsityBundle<
+    CsrSparsityPattern<localIdx>,
+    CooSparsityPattern<localIdx>>(const UnstructuredMesh&);
+
+template SharedSparsityBundle<CsrSparsityPattern<localIdx>, CsrSparsityPattern<localIdx>>
+readOrCreateSparsityBundle<
+    CsrSparsityPattern<localIdx>,
+    CsrSparsityPattern<localIdx>>(const UnstructuredMesh&);
+
+template SharedSparsityBundle<CooSparsityPattern<localIdx>, CooSparsityPattern<localIdx>>
+readOrCreateSparsityBundle<
+    CooSparsityPattern<localIdx>,
+    CooSparsityPattern<localIdx>>(const UnstructuredMesh&);
 
 }

--- a/src/linearAlgebra/ginkgo/ginkgo.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgo.cpp
@@ -10,14 +10,33 @@
 
 #include "NeoN/linearAlgebra/ginkgo.hpp"
 #include "NeoN/core/vector/vectorFreeFunctions.hpp"
+#include "NeoN/core/memory/umpire.hpp"
+
+#include <ginkgo/core/base/memory.hpp>
 
 gko::config::pnode NeoN::la::ginkgo::parse(const Dictionary& dictIn)
 {
     Dictionary dict = dictIn;
-    // remove 'solver Ginkgo;' entry
-    if (dict.contains("solver") && std::any_cast<std::string>(dict["solver"]) == "Ginkgo")
+    // remove 'solver Ginkgo;' entry (type-checked: a "solver" key may legitimately hold a
+    // sub-dictionary, e.g. solver::Ir's inner factory, which must not be any_cast to string)
+    if (dict.contains("solver") && dict["solver"].type() == typeid(std::string)
+        && std::any_cast<std::string>(dict["solver"]) == "Ginkgo")
     {
         dict.remove("solver");
+    }
+
+    // solver::Ir names its inner preconditioner factory "solver" in Ginkgo's config, which
+    // collides with NeoFOAM's top-level "solver: Ginkgo" backend-dispatch key (stripped just
+    // above). NeoFOAM emits that inner factory under "preconditioner" (the smoothSolver -> Ir +
+    // Jacobi mapping); remap it to the "solver" key Ir::parse() reads. Only fires for an Ir config
+    // carrying a "preconditioner" — the nested Ir smoothers NeoFOAM builds for multigrid already
+    // use "solver" directly and are left untouched.
+    if (dict.contains("type") && dict["type"].type() == typeid(std::string)
+        && std::any_cast<std::string>(dict["type"]) == "solver::Ir"
+        && dict.contains("preconditioner") && !dict.contains("solver"))
+    {
+        dict.insert("solver", dict.subDict("preconditioner"));
+        dict.remove("preconditioner");
     }
 
     if (dict.contains("coupled"))
@@ -154,6 +173,41 @@ std::array<std::shared_ptr<gko::Executor>, 3>& gkoExecutorCache()
     return cache;
 }
 
+#if NF_WITH_UMPIRE && defined(KOKKOS_ENABLE_CUDA)
+// Ginkgo CUDA allocator backed by NeoN's Umpire device QuickPool (DEVICE_POOL). Requests are served
+// from the pool's cached free blocks, so Ginkgo's per-solve build/teardown of the multigrid
+// hierarchy reuses device memory instead of churning cudaMalloc/cudaFree -- which fragmented the
+// device heap and made the SECOND pressure solve OOM on large cases. The default Ginkgo executor
+// otherwise uses a raw-cudaMalloc CudaAllocator, fragmenting against NeoN's separate Kokkos memory.
+class UmpireCudaAllocator : public gko::CudaAllocatorBase
+{
+public:
+
+    void* allocate(gko::size_type numBytes) override
+    {
+        ensurePool();
+        return NeoN::UmpireMempoolHandler::getUmpirePool(NeoN::MemorySpace::GPU).allocate(numBytes);
+    }
+
+    void deallocate(void* ptr) override
+    {
+        NeoN::UmpireMempoolHandler::getUmpirePool(NeoN::MemorySpace::GPU).deallocate(ptr);
+    }
+
+private:
+
+    static void ensurePool()
+    {
+        // Idempotent: setupUmpirePool no-ops if DEVICE_POOL already exists. The size argument is
+        // the QuickPool's initial block reservation; the pool grows on demand, so this is just a
+        // tunable starting point (revisit / make env-driven if it over- or under-reserves).
+        NeoN::UmpireMempoolHandler::setupUmpirePool(
+            NeoN::MemorySpace::GPU, std::size_t {512} << 20
+        );
+    }
+};
+#endif
+
 std::shared_ptr<gko::Executor> createGkoExecutor(NeoN::Executor exec)
 {
     // Defer to Ginkgo's Kokkos extension instead of a hand-rolled #ifdef mapping. Each NeoN
@@ -166,6 +220,23 @@ std::shared_ptr<gko::Executor> createGkoExecutor(NeoN::Executor exec)
         [](auto concreteExec) -> std::shared_ptr<gko::Executor>
         {
             using ExecType = std::decay_t<decltype(concreteExec)>;
+#if NF_WITH_UMPIRE && defined(KOKKOS_ENABLE_CUDA)
+            // For the CUDA device executor, mirror gko::ext::kokkos's construction (device id, host
+            // executor, Kokkos stream) but substitute the Umpire-pool allocator. Krylov/multigrid
+            // device allocations then come from the reused QuickPool. Serial/CPU keep the default
+            // path; HIP is left on the default path for now (TODO: add an Umpire HIP allocator).
+            if constexpr (std::is_same_v<ExecType, NeoN::GPUExecutor>)
+            {
+                typename ExecType::exec ex {
+                }; // Kokkos::DefaultExecutionSpace (== Kokkos::Cuda here)
+                return gko::CudaExecutor::create(
+                    Kokkos::device_id(),
+                    gko::ext::kokkos::create_default_host_executor(),
+                    std::make_shared<UmpireCudaAllocator>(),
+                    ex.cuda_stream()
+                );
+            }
+#endif
             return gko::ext::kokkos::create_executor(typename ExecType::exec {});
         },
         exec

--- a/src/linearAlgebra/ginkgo/ginkgo.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgo.cpp
@@ -366,6 +366,10 @@ createGkoMtxImpl(std::shared_ptr<const gko::Executor> exec, const CSRMatrix<Vec3
     const auto colsCopy = unpackColIdx(mtx.colIdxs(), rowsCopy, mtx.rowOffs());
     const auto valuesCopy = unpackMtxValues(mtx.values(), mtx.rowOffs(), rowsCopy);
 
+    // Ensure the Kokkos unpack kernels have completed before Ginkgo reads the data via
+    // gkoCopyArray, which may use a different SYCL queue on Intel GPU.
+    Kokkos::fence();
+
     auto nrows = static_cast<gko::size_type>(3 * mtx.nRows());
     return gko::share(gko::matrix::Csr<scalar, IndexType>::create(
         exec,
@@ -535,6 +539,10 @@ std::shared_ptr<const gko::matrix::Csr<scalar, IndexType>> createGkoMtxImpl(
     const auto colsCopy = unpackColIdx(mtx.colIdxs(), rowsCopy, mtx.rowOffs());
     const auto valuesCopy = unpackMtxValues(mtx.values(), mtx.rowOffs(), rowsCopy);
 
+    // Ensure the Kokkos unpack kernels have completed before Ginkgo reads the data via
+    // gkoCopyArray, which may use a different SYCL queue on Intel GPU.
+    Kokkos::fence();
+
     auto nrows = static_cast<gko::size_type>(computeNRows(sys));
     return gko::share(gko::matrix::Csr<scalar, IndexType>::create(
         exec,
@@ -573,6 +581,10 @@ SolverStats GinkgoSolver::solve(
         const auto gkoMtx = createGkoMtx(sys.matrix());
         auto rhsCopy = unpackVecValues(sys.rhs());
         auto xCopy = unpackVecValues(x);
+
+        // Ensure the Kokkos unpack kernels have completed before Ginkgo reads rhsCopy/xCopy,
+        // which may use a different SYCL queue on Intel GPU.
+        Kokkos::fence();
 
         auto stats =
             solve_impl(gkoExec_, rhsCopy, xCopy, gkoMtx, factory_->generate(gkoMtx), l1Control);

--- a/test/linearAlgebra/CMakeLists.txt
+++ b/test/linearAlgebra/CMakeLists.txt
@@ -8,6 +8,7 @@ neon_unit_test(linearSystem)
 neon_unit_test(cooSparsityPattern)
 neon_unit_test(csrSparsityPattern)
 neon_unit_test(faceToMatrixAddress)
+neon_unit_test(sharedSparsity)
 neon_unit_test(utilities)
 
 # the following tests currently require Ginkgo

--- a/test/linearAlgebra/sharedSparsity.cpp
+++ b/test/linearAlgebra/sharedSparsity.cpp
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#define CATCH_CONFIG_RUNNER // Define this before including catch.hpp to create
+                            // a custom main
+#include <string>
+
+#include "catch2_common.hpp"
+
+#include "NeoN/NeoN.hpp"
+
+using NeoN::scalar;
+using NeoN::localIdx;
+using NeoN::Vector;
+
+// These tests prove that createEmptyLinearSystem caches and SHARES a single immutable,
+// topology-only sparsity bundle (CSR system sparsity + FaceToMatrixAddress + COO boundary
+// sparsity) per mesh, while keeping the per-system value vectors independent. This is a pure
+// memory/aliasing refactor — there must be zero numerical change.
+TEST_CASE("SharedSparsity")
+{
+    auto [execName, exec] = GENERATE(allAvailableExecutor());
+
+    const auto nCells = 10;
+
+    SECTION(
+        "shares system/address/boundary sparsity pointers across two systems on same mesh "
+        + execName
+    )
+    {
+        auto mesh = create1DUniformMesh(exec, nCells);
+
+        auto lsA = NeoN::la::createEmptyLinearSystem<scalar>(mesh);
+        auto lsB = NeoN::la::createEmptyLinearSystem<scalar>(mesh);
+
+        // identical system sparsity pointer
+        REQUIRE(lsA.matrix().sparsity().get() == lsB.matrix().sparsity().get());
+        // identical FaceToMatrixAddress pointer
+        REQUIRE(
+            lsA.matrix().faceToMatrixAddress().get() == lsB.matrix().faceToMatrixAddress().get()
+        );
+        // identical boundary sparsity pointer
+        REQUIRE(lsA.boundaryMatrix().sparsity().get() == lsB.boundaryMatrix().sparsity().get());
+    }
+
+    SECTION("keeps values independent across two systems on same mesh " + execName)
+    {
+        auto mesh = create1DUniformMesh(exec, nCells);
+
+        auto lsA = NeoN::la::createEmptyLinearSystem<scalar>(mesh);
+        auto lsB = NeoN::la::createEmptyLinearSystem<scalar>(mesh);
+
+        // The value vectors must be distinct allocations.
+        REQUIRE(lsA.matrix().values().data() != lsB.matrix().values().data());
+
+        // Mutate every value of lsA and confirm lsB is unchanged (no aliasing of values_).
+        auto aView = lsA.matrix().values().view();
+        parallelFor(
+            exec, {0, aView.size()}, NEON_LAMBDA(const localIdx i) { aView[i] = scalar {42.0}; }
+        );
+
+        auto bHost = lsB.matrix().values().copyToHost();
+        auto bHostV = bHost.view();
+        for (localIdx i = 0; i < bHostV.size(); ++i)
+        {
+            REQUIRE(bHostV[i] == scalar {0.0});
+        }
+    }
+
+    SECTION("distinct meshes get distinct sparsity pointers " + execName)
+    {
+        auto meshA = create1DUniformMesh(exec, nCells);
+        auto meshB = create1DUniformMesh(exec, nCells);
+
+        auto lsA = NeoN::la::createEmptyLinearSystem<scalar>(meshA);
+        auto lsB = NeoN::la::createEmptyLinearSystem<scalar>(meshB);
+
+        // The two meshes own independent stencilDB caches → distinct cached pointers.
+        REQUIRE(lsA.matrix().sparsity().get() != lsB.matrix().sparsity().get());
+        REQUIRE(
+            lsA.matrix().faceToMatrixAddress().get() != lsB.matrix().faceToMatrixAddress().get()
+        );
+        REQUIRE(lsA.boundaryMatrix().sparsity().get() != lsB.boundaryMatrix().sparsity().get());
+    }
+
+    SECTION("scalar and Vec3 systems share the topology bundle on the same mesh " + execName)
+    {
+        auto mesh = create1DUniformMesh(exec, nCells);
+
+        auto lsScalar = NeoN::la::createEmptyLinearSystem<scalar>(mesh);
+        auto lsVec3 = NeoN::la::createEmptyLinearSystem<NeoN::Vec3>(mesh);
+
+        // Topology is value-type-independent: the bundle is keyed on the sparsity type, which is
+        // CsrSparsityPattern<localIdx> for both scalar and Vec3 systems → same cached pointers.
+        REQUIRE(lsScalar.matrix().sparsity().get() == lsVec3.matrix().sparsity().get());
+        REQUIRE(
+            lsScalar.matrix().faceToMatrixAddress().get()
+            == lsVec3.matrix().faceToMatrixAddress().get()
+        );
+        REQUIRE(
+            lsScalar.boundaryMatrix().sparsity().get() == lsVec3.boundaryMatrix().sparsity().get()
+        );
+    }
+}


### PR DESCRIPTION
GeometryScheme eagerly computed and stored two SurfaceField<Vec3> (faceDeltaOwner_, faceDeltaNeighbour_) for every mesh in update(), even when the only consumer (linearUpwind) is not selected. On an ~18M-cell mesh that is ~2*nInternalFaces*Vec3 (~2.6 GB) of always-on device memory, preventing the case from fitting on one GPU.

Make them lazy/opt-in, mirroring edf9888c28 (faceFluxCorrection opt-in):
- faceDelta* are now mutable std::optional, allocated+filled only via ensureFaceDeltas().
- LinearUpwind's constructor opts in (while the mesh centres are still alive), so cases using Gauss upwind/linear allocate nothing.
- update() no longer computes faceDelta* nor frees the mesh centres; reset() (the centre release) is deferred + made idempotent, triggered on first read of any cached geometry field or right after faceDelta* are built, so a late opt-in can still read the centres.
- The fast streaming linearUpwind kernel is unchanged.

Runs that select linearUpwind keep identical behaviour and field values.
