### PR TITLE
Add nominsize for nanobind for nvcc

### DIFF
--- a/src/bindings/CMakeLists.txt
+++ b/src/bindings/CMakeLists.txt
@@ -28,6 +28,7 @@ endif()
 
 nanobind_add_module(
   _neon
+  NOMINSIZE
   neon.cpp
   executors.cpp
   scalar.cpp


### PR DESCRIPTION
This pull request makes a small change to the build configuration for the `_neon` Python module. The `NOMINSIZE` option was added to the `nanobind_add_module` call in `src/bindings/CMakeLists.txt`, which may affect how the module is built or optimized.