### PR TITLE
build: fix umpire/camp install RPATH so libcamp loads from the wheel layout

### DIFF
--- a/.github/workflows/python_wheels.yaml
+++ b/.github/workflows/python_wheels.yaml
@@ -150,12 +150,18 @@ jobs:
           CIBW_ARCHS: ${{ matrix.archs }}
           # Build only this job's Python version (overrides the pyproject build list).
           CIBW_BUILD: ${{ matrix.python }}-*
+          # auditwheel and delocate rewrite RPATHs and install names, so the wheel they
+          # produce looks relocatable even when the build did not make it so. The check
+          # runs first, on the unrepaired {wheel}, and is the only thing guarding against
+          # a dependency being recorded by its wheel-staging path.
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
+            python /project/ci/check_wheel_rpath.py {wheel} &&
             LD_LIBRARY_PATH="/project/_skbuild/lib:/project/_skbuild/_deps/ginkgo-build/lib:${LD_LIBRARY_PATH:-}"
             auditwheel repair -w {dest_dir} {wheel}
           # delocate must find the build-tree dylibs (libNeoN, libkokkos*, libginkgo*)
           # that _neon.so references via @rpath. The build persists in _skbuild.
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
+            python "$GITHUB_WORKSPACE/ci/check_wheel_rpath.py" {wheel} &&
             DYLD_LIBRARY_PATH="$GITHUB_WORKSPACE/_skbuild/lib:$GITHUB_WORKSPACE/_skbuild/_deps/ginkgo-build/lib:${DYLD_LIBRARY_PATH:-}"
             delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
           # _neon.pyd depends on NeoN/Kokkos/umpire DLLs in _skbuild/bin; delvewheel
@@ -257,7 +263,10 @@ jobs:
           CIBW_BUILD: "cp312-manylinux_x86_64"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_34
           CIBW_BEFORE_ALL_LINUX: ${{ matrix.before_all }}
+          # The GPU wheels skip the import smoke test below, so the pre-repair check is
+          # the only relocatability coverage they get.
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
+            python /project/ci/check_wheel_rpath.py {wheel} &&
             LD_LIBRARY_PATH="/project/_skbuild/lib:/project/_skbuild/_deps/ginkgo-build/lib:/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-}"
             auditwheel -v repair --plat manylinux_2_34_x86_64 --exclude libcuda.so.1 -w {dest_dir} {wheel}
           CIBW_CONFIG_SETTINGS: ${{ matrix.config_settings }}

--- a/.github/workflows/static_checks.yaml
+++ b/.github/workflows/static_checks.yaml
@@ -147,6 +147,23 @@ jobs:
     #      git add .
     #      git commit -m 'fix format'
     #      git push origin "${{ github.BRANCH_NAME }}"
+  ci-script-tests:
+    name: CI script tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{env.BRANCH_NAME}}
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Install dependencies
+      run: pip install pytest
+    # These exercise ci/check_wheel_rpath.py, the wheel relocatability gate. They
+    # need no build: the fixtures are shared libraries compiled on the fly, which
+    # also covers the ELF side that the macOS developer machines cannot reach.
+    - name: Run CI script tests
+      run: python -m pytest test/ci -vv
   changelog:
     if: ${{!contains(github.event.pull_request.labels.*.name, 'skip-changelog')}}
     name: Changelog check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Bump Ginkgo to 1.11  [#409](https://github.com/exasim-project/NeoN/pull/409)
 
 ## Fixes
+- Fix umpire/camp RPATH and macOS install names so wheels stay relocatable, and check relocatability on the unrepaired wheel in CI [#559](https://github.com/exasim-project/NeoN/pull/559)
 - Fix distributed processor-face correctness: multi-patch (scotch) halo exchange, ddtFluxCorr proc-face correction, processor BC on coupled patches, and row-sorted non-local COO for correct CUDA distributed apply [#528](https://github.com/exasim-project/NeoN/pull/528)
 
 # Version 0.2.0 (2025/12/03)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,22 +151,31 @@ endif()
 
 include(cmake/CxxThirdParty.cmake)
 
-# Umpire (and its bundled camp) are built and installed by their own BLT-based
-# CMake, which sets each target's INSTALL_RPATH to ${CMAKE_INSTALL_PREFIX}/lib.
-# Under scikit-build that prefix is the wheel-staging temp directory, which no
-# longer exists after install, so at import time libumpire.so cannot find its
-# direct dependency libcamp.so ("libcamp.so: cannot open shared object file").
-# A per-target override is the only thing that beats BLT's own RPATH — the global
-# CMAKE_INSTALL_RPATH set above does not reach these CPM targets (it does reach
-# NeoN's own libraries). $ORIGIN-relative entries keep the install relocatable and
-# reach camp whether it sits beside umpire ($ORIGIN) or is installed to the
-# package-root lib/ ($ORIGIN/../../lib).
+# Umpire (and its bundled camp) are built and installed by their own BLT-based CMake, which sets
+# each target's INSTALL_RPATH to ${CMAKE_INSTALL_PREFIX}/lib. Under scikit-build that prefix is the
+# wheel-staging temp directory, which no longer exists after install, so at import time libumpire.so
+# cannot find its direct dependency libcamp.so ("libcamp.so: cannot open shared object file"). A
+# per-target override is the only thing that beats BLT's own RPATH — the global CMAKE_INSTALL_RPATH
+# set above does not reach these CPM targets (it does reach NeoN's own libraries). The
+# loader-relative entries keep the install relocatable and reach camp whether it sits beside umpire
+# or is installed to the package-root lib/. On macOS BLT also points CMAKE_INSTALL_NAME_DIR at that
+# same stale prefix, so overriding the RPATH alone would change nothing: the install name has to
+# become @rpath-relative before any RPATH entry is consulted.
 if(DEFINED SKBUILD)
-  foreach(_neon_cpm_dep umpire camp)
+  if(APPLE)
+    set(_neon_cpm_dep_rpath "@loader_path;@loader_path/../lib;@loader_path/../../lib")
+  else()
+    set(_neon_cpm_dep_rpath "$ORIGIN;$ORIGIN/../lib;$ORIGIN/../../lib")
+  endif()
+  # umpire_device only exists for CUDA/HIP builds with UMPIRE_ENABLE_DEVICE_ALLOCATOR, and
+  # INSTALL_NAME_DIR is ignored on non-Apple platforms, so both are safe to set unconditionally.
+  foreach(_neon_cpm_dep umpire umpire_device camp)
     if(TARGET ${_neon_cpm_dep})
       set_target_properties(
-        ${_neon_cpm_dep} PROPERTIES INSTALL_RPATH
-        "$ORIGIN;$ORIGIN/../lib;$ORIGIN/../../lib" INSTALL_RPATH_USE_LINK_PATH FALSE)
+        ${_neon_cpm_dep}
+        PROPERTIES INSTALL_RPATH "${_neon_cpm_dep_rpath}"
+                   INSTALL_RPATH_USE_LINK_PATH FALSE
+                   INSTALL_NAME_DIR "@rpath")
     endif()
   endforeach()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,27 @@ if(DEFINED SKBUILD)
 endif()
 
 include(cmake/CxxThirdParty.cmake)
+
+# Umpire (and its bundled camp) are built and installed by their own BLT-based
+# CMake, which sets each target's INSTALL_RPATH to ${CMAKE_INSTALL_PREFIX}/lib.
+# Under scikit-build that prefix is the wheel-staging temp directory, which no
+# longer exists after install, so at import time libumpire.so cannot find its
+# direct dependency libcamp.so ("libcamp.so: cannot open shared object file").
+# A per-target override is the only thing that beats BLT's own RPATH — the global
+# CMAKE_INSTALL_RPATH set above does not reach these CPM targets (it does reach
+# NeoN's own libraries). $ORIGIN-relative entries keep the install relocatable and
+# reach camp whether it sits beside umpire ($ORIGIN) or is installed to the
+# package-root lib/ ($ORIGIN/../../lib).
+if(DEFINED SKBUILD)
+  foreach(_neon_cpm_dep umpire camp)
+    if(TARGET ${_neon_cpm_dep})
+      set_target_properties(
+        ${_neon_cpm_dep} PROPERTIES INSTALL_RPATH
+        "$ORIGIN;$ORIGIN/../lib;$ORIGIN/../../lib" INSTALL_RPATH_USE_LINK_PATH FALSE)
+    endif()
+  endforeach()
+endif()
+
 include(cmake/PreventInSourceBuilds.cmake)
 include(cmake/StandardProjectSettings.cmake)
 include(cmake/CompilerWarnings.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,8 +145,14 @@ if(DEFINED SKBUILD)
   set(CMAKE_SKIP_BUILD_RPATH FALSE)
   set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
   set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-  # Set RPATH so _neon.so can find libNeoN.so at ../lib/
-  set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib")
+  # Set RPATH so _neon.so can find libNeoN.so at ../lib/. dyld does not expand $ORIGIN, so macOS
+  # needs @loader_path to express the same layout; without it the installed extension resolves
+  # libNeoN only because delocate rewrites the wheel.
+  if(APPLE)
+    set(CMAKE_INSTALL_RPATH "@loader_path/../lib")
+  else()
+    set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib")
+  endif()
 endif()
 
 include(cmake/CxxThirdParty.cmake)

--- a/ci/check_wheel_rpath.py
+++ b/ci/check_wheel_rpath.py
@@ -45,18 +45,48 @@ STAGING_MARKERS = (
     "/private/var/folders/",
 )
 
-LOADER_TOKENS = ("$ORIGIN", "${ORIGIN}", "@loader_path", "@executable_path", "@rpath")
+# Loader-relative tokens, per binary format. These are not interchangeable: ld.so
+# expands neither @loader_path nor @rpath, and dyld does not expand $ORIGIN, so a
+# token borrowed from the other format is a dead RPATH entry rather than a
+# relocatable one -- which is exactly the defect this check exists to catch.
+ELF_RPATH_TOKENS = ("$ORIGIN", "${ORIGIN}")
+MACHO_RPATH_TOKENS = ("@loader_path", "@executable_path")
+# @rpath is resolved against the LC_RPATH list, so it is meaningful in an install
+# name or a load command but never as an LC_RPATH entry itself.
+MACHO_NAME_TOKENS = MACHO_RPATH_TOKENS + ("@rpath",)
+ALL_LOADER_TOKENS = ELF_RPATH_TOKENS + MACHO_NAME_TOKENS
+
+ELF, MACHO = "ELF", "Mach-O"
 
 BINARY_SUFFIXES = (".so", ".dylib", ".pyd")
 
 
-def is_loader_relative(path: str) -> bool:
-    return path.startswith(LOADER_TOKENS)
+def rpath_tokens(fmt: str) -> tuple[str, ...]:
+    """The loader-relative RPATH tokens the given format's loader can expand."""
+    return ELF_RPATH_TOKENS if fmt == ELF else MACHO_RPATH_TOKENS
+
+
+def is_loader_relative(path: str, fmt: str) -> bool:
+    """True if this format's loader expands path relative to the loading binary."""
+    return path.startswith(rpath_tokens(fmt))
+
+
+def has_loader_token(path: str) -> bool:
+    """True for any loader-relative token, whichever format it belongs to."""
+    return path.startswith(ALL_LOADER_TOKENS)
+
+
+def wrong_format_token(path: str, fmt: str) -> str | None:
+    """Return the token in path that this format's loader cannot expand, if any."""
+    if is_loader_relative(path, fmt):
+        return None
+    foreign = MACHO_NAME_TOKENS if fmt == ELF else ELF_RPATH_TOKENS
+    return next((token for token in foreign if path.startswith(token)), None)
 
 
 def is_staging(path: str) -> bool:
     """True for an absolute path that points into the build or staging tree."""
-    if is_loader_relative(path) or not path.startswith("/"):
+    if has_loader_token(path) or not path.startswith("/"):
         return False
     return any(marker in path for marker in STAGING_MARKERS)
 
@@ -178,16 +208,16 @@ def parse_macho(data: bytes) -> tuple[list[str], list[str]]:
     return rpaths, names
 
 
-def inspect(path: Path) -> tuple[list[str], list[str]] | None:
-    """Return (rpaths, dependency names) or None if the file is not ELF/Mach-O."""
+def inspect(path: Path) -> tuple[str, list[str], list[str]] | None:
+    """Return (format, rpaths, dependency names), or None if not ELF/Mach-O."""
     data = path.read_bytes()
     if len(data) < 8:
         return None
     if data[:4] == b"\x7fELF":
-        return parse_elf(data)
+        return (ELF, *parse_elf(data))
     (magic,) = struct.unpack_from(">I", data, 0)
     if magic in (MH_MAGIC, MH_MAGIC_64, FAT_MAGIC, FAT_MAGIC_64, 0xCEFAEDFE, 0xCFFAEDFE):
-        return parse_macho(data)
+        return (MACHO, *parse_macho(data))
     return None
 
 
@@ -198,7 +228,7 @@ def check_tree(root: Path) -> list[str]:
     """Check every ELF/Mach-O library under root; return a list of problems."""
     problems: list[str] = []
     inspected: list[Path] = []
-    umpire_rpaths: list[str] = []
+    umpire: tuple[str, list[str]] | None = None
 
     for path in sorted(root.rglob("*")):
         if not path.is_file() or not looks_binary(path):
@@ -206,16 +236,23 @@ def check_tree(root: Path) -> list[str]:
         parsed = inspect(path)
         if parsed is None:
             continue
-        rpaths, names = parsed
+        fmt, rpaths, names = parsed
         inspected.append(path)
         rel = path.relative_to(root)
 
         if path.name.startswith("libumpire"):
-            umpire_rpaths = rpaths
+            umpire = (fmt, rpaths)
 
         for entry in rpaths:
             if is_staging(entry):
                 problems.append(f"{rel}: RPATH entry points into the staging tree: {entry}")
+                continue
+            foreign = wrong_format_token(entry, fmt)
+            if foreign is not None:
+                problems.append(
+                    f"{rel}: RPATH entry uses {foreign}, which the {fmt} loader "
+                    f"does not expand: {entry}"
+                )
         for name in names:
             if is_staging(name):
                 problems.append(f"{rel}: dependency recorded by absolute staging path: {name}")
@@ -227,9 +264,15 @@ def check_tree(root: Path) -> list[str]:
         problems.append("the _neon extension module was not found in the wheel")
 
     # Regression guard: umpire's dependency on camp is the case that motivated
-    # this check, and BLT's own RPATH is absolute.
-    if umpire_rpaths and not any(is_loader_relative(e) for e in umpire_rpaths):
-        problems.append(f"libumpire has no loader-relative RPATH entry: {umpire_rpaths}")
+    # this check, and BLT's own RPATH is absolute. The token must be one this
+    # binary's own loader expands -- $ORIGIN on a dylib is as useless as no RPATH.
+    if umpire is not None:
+        fmt, umpire_rpaths = umpire
+        if umpire_rpaths and not any(is_loader_relative(e, fmt) for e in umpire_rpaths):
+            problems.append(
+                f"libumpire has no {fmt} loader-relative RPATH entry "
+                f"(expected one of {rpath_tokens(fmt)}): {umpire_rpaths}"
+            )
 
     print(f"checked {len(inspected)} shared libraries in {root.name}")
     return problems

--- a/ci/check_wheel_rpath.py
+++ b/ci/check_wheel_rpath.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 NeoN authors
+#
+# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Unlicense
+
+"""Assert that an *unrepaired* wheel's shared libraries are relocatable.
+
+``auditwheel repair`` and ``delocate-wheel`` rewrite RPATHs and install names
+while repairing a wheel, so any check running after repair -- including the
+``import neon`` smoke test in ``check_installed_wheel.py`` -- cannot tell
+whether the build itself produced relocatable binaries. It only sees what the
+repair tool patched up.
+
+This script therefore runs from the cibuildwheel repair command, on the wheel
+*before* it is repaired. It fails the build when a library would search for its
+dependencies in the wheel-staging directory, which does not survive the
+install. That is the failure mode bundled BLT-based dependencies (umpire, camp)
+produce: BLT sets INSTALL_RPATH and, on macOS, CMAKE_INSTALL_NAME_DIR to
+``${CMAKE_INSTALL_PREFIX}/lib``, and under scikit-build that prefix is a
+temporary directory.
+
+ELF and Mach-O are parsed directly rather than shelling out to readelf/otool so
+that a missing binutils in a manylinux image cannot turn this check into a
+silent pass.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import struct
+import sys
+import tempfile
+import zipfile
+
+# Absolute paths containing one of these are build- or staging-tree paths that
+# do not exist on the machine that installs the wheel.
+STAGING_MARKERS = (
+    "_skbuild",
+    "cibuildwheel",
+    "/tmp/",
+    "/var/folders/",
+    "/project/",
+    "/private/var/folders/",
+)
+
+LOADER_TOKENS = ("$ORIGIN", "${ORIGIN}", "@loader_path", "@executable_path", "@rpath")
+
+BINARY_SUFFIXES = (".so", ".dylib", ".pyd")
+
+
+def is_loader_relative(path: str) -> bool:
+    return path.startswith(LOADER_TOKENS)
+
+
+def is_staging(path: str) -> bool:
+    """True for an absolute path that points into the build or staging tree."""
+    if is_loader_relative(path) or not path.startswith("/"):
+        return False
+    return any(marker in path for marker in STAGING_MARKERS)
+
+
+def looks_binary(path: Path) -> bool:
+    name = path.name
+    return name.endswith(BINARY_SUFFIXES) or ".so." in name
+
+
+# --------------------------------------------------------------------------
+# ELF
+# --------------------------------------------------------------------------
+
+SHT_DYNAMIC = 6
+DT_NULL, DT_NEEDED, DT_RPATH, DT_RUNPATH = 0, 1, 15, 29
+
+
+def parse_elf(data: bytes) -> tuple[list[str], list[str]]:
+    """Return (rpath entries, NEEDED names) from an ELF file's dynamic section."""
+    is64 = data[4] == 2
+    endian = "<" if data[5] == 1 else ">"
+
+    if is64:
+        (e_shoff,) = struct.unpack_from(endian + "Q", data, 0x28)
+        e_shentsize, e_shnum = struct.unpack_from(endian + "HH", data, 0x3A)
+        sh_fmt, sh_word = endian + "IIQQQQIIQQ", "Q"
+    else:
+        (e_shoff,) = struct.unpack_from(endian + "I", data, 0x20)
+        e_shentsize, e_shnum = struct.unpack_from(endian + "HH", data, 0x2E)
+        sh_fmt, sh_word = endian + "IIIIIIIIII", "I"
+
+    dynamic = None
+    sections = []
+    for i in range(e_shnum):
+        fields = struct.unpack_from(sh_fmt, data, e_shoff + i * e_shentsize)
+        # sh_type, sh_offset, sh_size, sh_link
+        sections.append((fields[1], fields[4], fields[5], fields[6]))
+        if fields[1] == SHT_DYNAMIC:
+            dynamic = sections[-1]
+
+    if dynamic is None:
+        return [], []
+
+    _, dyn_off, dyn_size, dyn_link = dynamic
+    _, str_off, str_size, _ = sections[dyn_link]
+    strtab = data[str_off : str_off + str_size]
+
+    def string_at(offset: int) -> str:
+        end = strtab.find(b"\0", offset)
+        return strtab[offset:end].decode("utf-8", "replace")
+
+    rpaths: list[str] = []
+    needed: list[str] = []
+    entry_fmt = endian + sh_word * 2
+    entry_size = struct.calcsize(entry_fmt)
+    for pos in range(dyn_off, dyn_off + dyn_size, entry_size):
+        d_tag, d_val = struct.unpack_from(entry_fmt, data, pos)
+        if d_tag == DT_NULL:
+            break
+        if d_tag in (DT_RPATH, DT_RUNPATH):
+            rpaths.extend(e for e in string_at(d_val).split(":") if e)
+        elif d_tag == DT_NEEDED:
+            needed.append(string_at(d_val))
+    return rpaths, needed
+
+
+# --------------------------------------------------------------------------
+# Mach-O
+# --------------------------------------------------------------------------
+
+MH_MAGIC, MH_MAGIC_64 = 0xFEEDFACE, 0xFEEDFACF
+FAT_MAGIC, FAT_MAGIC_64 = 0xCAFEBABE, 0xCAFEBABF
+LC_LOAD_DYLIB, LC_ID_DYLIB = 0x0C, 0x0D
+LC_LOAD_WEAK_DYLIB, LC_REEXPORT_DYLIB, LC_RPATH = 0x80000018, 0x8000001F, 0x8000001C
+DYLIB_COMMANDS = (LC_LOAD_DYLIB, LC_ID_DYLIB, LC_LOAD_WEAK_DYLIB, LC_REEXPORT_DYLIB)
+
+
+def _macho_slice(data: bytes, base: int) -> tuple[list[str], list[str]]:
+    (magic,) = struct.unpack_from(">I", data, base)
+    is64 = magic in (MH_MAGIC_64, 0xCFFAEDFE)
+    endian = "<" if magic in (0xCFFAEDFE, 0xCEFAEDFE) else ">"
+    (ncmds,) = struct.unpack_from(endian + "I", data, base + 16)
+    pos = base + (32 if is64 else 28)
+
+    rpaths: list[str] = []
+    names: list[str] = []
+    for _ in range(ncmds):
+        cmd, cmdsize = struct.unpack_from(endian + "II", data, pos)
+        if cmdsize == 0:
+            break
+        if cmd == LC_RPATH or cmd in DYLIB_COMMANDS:
+            (str_off,) = struct.unpack_from(endian + "I", data, pos + 8)
+            raw = data[pos + str_off : pos + cmdsize]
+            value = raw.split(b"\0", 1)[0].decode("utf-8", "replace")
+            (rpaths if cmd == LC_RPATH else names).append(value)
+        pos += cmdsize
+    return rpaths, names
+
+
+def parse_macho(data: bytes) -> tuple[list[str], list[str]]:
+    """Return (LC_RPATH paths, dylib install/load names), merged over fat slices."""
+    (magic,) = struct.unpack_from(">I", data, 0)
+    if magic not in (FAT_MAGIC, FAT_MAGIC_64):
+        return _macho_slice(data, 0)
+
+    (nfat,) = struct.unpack_from(">I", data, 4)
+    entry_size = 32 if magic == FAT_MAGIC_64 else 20
+    rpaths: list[str] = []
+    names: list[str] = []
+    for i in range(nfat):
+        base = 8 + i * entry_size
+        if magic == FAT_MAGIC_64:
+            (offset,) = struct.unpack_from(">Q", data, base + 8)
+        else:
+            (offset,) = struct.unpack_from(">I", data, base + 8)
+        slice_rpaths, slice_names = _macho_slice(data, offset)
+        rpaths.extend(slice_rpaths)
+        names.extend(slice_names)
+    return rpaths, names
+
+
+def inspect(path: Path) -> tuple[list[str], list[str]] | None:
+    """Return (rpaths, dependency names) or None if the file is not ELF/Mach-O."""
+    data = path.read_bytes()
+    if len(data) < 8:
+        return None
+    if data[:4] == b"\x7fELF":
+        return parse_elf(data)
+    (magic,) = struct.unpack_from(">I", data, 0)
+    if magic in (MH_MAGIC, MH_MAGIC_64, FAT_MAGIC, FAT_MAGIC_64, 0xCEFAEDFE, 0xCFFAEDFE):
+        return parse_macho(data)
+    return None
+
+
+# --------------------------------------------------------------------------
+
+
+def check_tree(root: Path) -> list[str]:
+    """Check every ELF/Mach-O library under root; return a list of problems."""
+    problems: list[str] = []
+    inspected: list[Path] = []
+    umpire_rpaths: list[str] = []
+
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or not looks_binary(path):
+            continue
+        parsed = inspect(path)
+        if parsed is None:
+            continue
+        rpaths, names = parsed
+        inspected.append(path)
+        rel = path.relative_to(root)
+
+        if path.name.startswith("libumpire"):
+            umpire_rpaths = rpaths
+
+        for entry in rpaths:
+            if is_staging(entry):
+                problems.append(f"{rel}: RPATH entry points into the staging tree: {entry}")
+        for name in names:
+            if is_staging(name):
+                problems.append(f"{rel}: dependency recorded by absolute staging path: {name}")
+
+    # A glob that matches nothing must not read as a clean bill of health.
+    if not inspected:
+        problems.append(f"no ELF or Mach-O libraries found under {root} -- nothing was checked")
+    elif not any(p.name.startswith("_neon") for p in inspected):
+        problems.append("the _neon extension module was not found in the wheel")
+
+    # Regression guard: umpire's dependency on camp is the case that motivated
+    # this check, and BLT's own RPATH is absolute.
+    if umpire_rpaths and not any(is_loader_relative(e) for e in umpire_rpaths):
+        problems.append(f"libumpire has no loader-relative RPATH entry: {umpire_rpaths}")
+
+    print(f"checked {len(inspected)} shared libraries in {root.name}")
+    return problems
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(f"usage: {Path(argv[0]).name} <wheel>", file=sys.stderr)
+        return 2
+
+    wheel = Path(argv[1])
+    if not wheel.is_file():
+        print(f"error: no such wheel: {wheel}", file=sys.stderr)
+        return 2
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        with zipfile.ZipFile(wheel) as archive:
+            archive.extractall(root)
+        problems = check_tree(root)
+
+    if problems:
+        print(f"\n{wheel.name} is not relocatable:", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        return 1
+
+    print(f"{wheel.name}: all libraries are relocatable")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/test/ci/test_check_wheel_rpath.py
+++ b/test/ci/test_check_wheel_rpath.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 NeoN authors
+#
+# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Unlicense
+
+"""Tests for ci/check_wheel_rpath.py.
+
+The wheel check is a CI gate, so it must fail on a broken wheel rather than
+pass vacuously. The end-to-end cases compile real shared libraries with the
+platform compiler and give them the exact RPATH/install-name shape that BLT
+produces, so the parsers are exercised against genuine ELF/Mach-O rather than
+hand-written fixtures.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import sysconfig
+import zipfile
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "ci"))
+
+import check_wheel_rpath as cwr  # noqa: E402
+
+
+IS_MACOS = sys.platform == "darwin"
+EXT = ".dylib" if IS_MACOS else ".so"
+CC = shutil.which("cc") or shutil.which("gcc") or shutil.which("clang")
+needs_cc = pytest.mark.skipif(CC is None, reason="no C compiler to build fixture libraries")
+
+
+def build_library(
+    directory: Path,
+    name: str,
+    rpaths: list[str],
+    install_name: str | None = None,
+    new_dtags: bool = True,
+) -> Path:
+    """Compile an empty shared library carrying the given RPATH entries."""
+    directory.mkdir(parents=True, exist_ok=True)
+    source = directory / f"{name}.c"
+    source.write_text("int neon_probe(void) { return 0; }\n")
+    library = directory / f"lib{name}{EXT}"
+
+    cmd = [CC, "-shared", "-fPIC", str(source), "-o", str(library)]
+    for rpath in rpaths:
+        cmd += ["-Wl,-rpath," + rpath]
+    if install_name and IS_MACOS:
+        cmd += ["-Wl,-install_name," + install_name]
+    if not IS_MACOS and not new_dtags:
+        # ld emits DT_RUNPATH by default; this produces the older DT_RPATH instead.
+        cmd += ["-Wl,--disable-new-dtags"]
+    subprocess.run(cmd, check=True, capture_output=True)
+    source.unlink()
+    return library
+
+
+def make_wheel(tmp_path: Path, libraries: list[Path], with_extension: bool = True) -> Path:
+    """Pack libraries into a wheel-shaped zip, mirroring the real layout."""
+    wheel = tmp_path / "neon-0.0.0-cp312-cp312-test.whl"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        for library in libraries:
+            archive.write(library, f"lib/{library.name}")
+        if with_extension:
+            suffix = sysconfig.get_config_var("EXT_SUFFIX") or EXT
+            archive.write(libraries[0], f"neon/_neon{suffix}")
+        archive.writestr("neon/__init__.py", "")
+    return wheel
+
+
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        ("$ORIGIN", False),
+        ("$ORIGIN/../lib", False),
+        ("@loader_path/../lib", False),
+        ("@rpath/libcamp.dylib", False),
+        ("/usr/local/cuda/lib64", False),
+        ("/usr/lib", False),
+        ("libcamp.so", False),
+        ("/tmp/tmp1a2b3c/wheel/platlib/lib", True),
+        ("/private/var/folders/x9/T/tmpabcd/lib", True),
+        ("/project/_skbuild/lib", True),
+        ("/home/runner/work/NeoN/NeoN/_skbuild/lib", True),
+    ],
+)
+def test_is_staging(path: str, expected: bool) -> None:
+    assert cwr.is_staging(path) is expected
+
+
+def test_empty_tree_is_not_a_pass(tmp_path: Path) -> None:
+    """A glob matching nothing must be reported, not silently accepted."""
+    problems = cwr.check_tree(tmp_path)
+    assert any("nothing was checked" in problem for problem in problems)
+
+
+def test_missing_extension_module_is_reported(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(cwr, "inspect", lambda path: ([], []))
+    (tmp_path / "lib").mkdir()
+    (tmp_path / "lib" / f"libNeoN{EXT}").write_bytes(b"\x7fELF" + b"\0" * 64)
+    problems = cwr.check_tree(tmp_path)
+    assert any("_neon extension module was not found" in problem for problem in problems)
+
+
+@needs_cc
+def test_relocatable_wheel_passes(tmp_path: Path) -> None:
+    loader = "@loader_path" if IS_MACOS else "$ORIGIN"
+    libraries = [
+        build_library(tmp_path / "build", "umpire", [loader, f"{loader}/../lib"], "@rpath/libumpire.dylib"),
+        build_library(tmp_path / "build", "camp", [loader], "@rpath/libcamp.dylib"),
+    ]
+    assert cwr.main(["check", str(make_wheel(tmp_path, libraries))]) == 0
+
+
+@needs_cc
+def test_staging_rpath_is_rejected(tmp_path: Path) -> None:
+    """The BLT failure mode: INSTALL_RPATH left at the staging prefix."""
+    staging = "/tmp/tmp0k2j/wheel/platlib/lib"
+    libraries = [build_library(tmp_path / "build", "umpire", [staging], "@rpath/libumpire.dylib")]
+    assert cwr.main(["check", str(make_wheel(tmp_path, libraries))]) == 1
+
+
+@needs_cc
+@pytest.mark.skipif(not IS_MACOS, reason="install names are a Mach-O concept")
+def test_staging_install_name_is_rejected(tmp_path: Path) -> None:
+    """The macOS half: CMAKE_INSTALL_NAME_DIR left at the staging prefix."""
+    staging = "/tmp/tmp0k2j/wheel/platlib/lib"
+    libraries = [
+        build_library(tmp_path / "build", "umpire", ["@loader_path"], f"{staging}/libumpire.dylib")
+    ]
+    assert cwr.main(["check", str(make_wheel(tmp_path, libraries))]) == 1
+
+
+@needs_cc
+def test_umpire_without_loader_relative_rpath_is_rejected(tmp_path: Path) -> None:
+    libraries = [build_library(tmp_path / "build", "umpire", ["/usr/local/lib"], "@rpath/libumpire.dylib")]
+    assert cwr.main(["check", str(make_wheel(tmp_path, libraries))]) == 1
+
+
+@needs_cc
+@pytest.mark.skipif(IS_MACOS, reason="DT_RPATH is an ELF concept")
+def test_legacy_dt_rpath_is_read(tmp_path: Path) -> None:
+    """Libraries built with the older DT_RPATH tag must be inspected too."""
+    library = build_library(
+        tmp_path / "build", "umpire", ["/tmp/tmp0k2j/wheel/platlib/lib"], new_dtags=False
+    )
+    rpaths, _ = cwr.inspect(library)
+    assert rpaths == ["/tmp/tmp0k2j/wheel/platlib/lib"]
+    assert cwr.main(["check", str(make_wheel(tmp_path, [library]))]) == 1

--- a/test/ci/test_check_wheel_rpath.py
+++ b/test/ci/test_check_wheel_rpath.py
@@ -95,6 +95,45 @@ def test_is_staging(path: str, expected: bool) -> None:
     assert cwr.is_staging(path) is expected
 
 
+@pytest.mark.parametrize(
+    "path, fmt, expected",
+    [
+        ("$ORIGIN/../lib", cwr.ELF, True),
+        ("${ORIGIN}/../lib", cwr.ELF, True),
+        ("@loader_path/../lib", cwr.ELF, False),
+        ("@rpath", cwr.ELF, False),
+        ("@loader_path/../lib", cwr.MACHO, True),
+        ("@executable_path", cwr.MACHO, True),
+        ("$ORIGIN/../lib", cwr.MACHO, False),
+        # @rpath is resolved via LC_RPATH, so it is not itself a usable RPATH entry.
+        ("@rpath", cwr.MACHO, False),
+        ("/usr/local/lib", cwr.ELF, False),
+    ],
+)
+def test_is_loader_relative_is_format_specific(path: str, fmt: str, expected: bool) -> None:
+    assert cwr.is_loader_relative(path, fmt) is expected
+
+
+@pytest.mark.parametrize(
+    "path, fmt, expected",
+    [
+        ("@loader_path/../lib", cwr.ELF, "@loader_path"),
+        ("$ORIGIN/../lib", cwr.MACHO, "$ORIGIN"),
+        ("$ORIGIN/../lib", cwr.ELF, None),
+        ("@loader_path", cwr.MACHO, None),
+        ("/usr/local/cuda/lib64", cwr.ELF, None),
+    ],
+)
+def test_wrong_format_token(path: str, fmt: str, expected: str | None) -> None:
+    assert cwr.wrong_format_token(path, fmt) == expected
+
+
+def test_staging_detection_ignores_token_format(tmp_path: Path) -> None:
+    """A foreign token is still not an absolute staging path."""
+    assert cwr.is_staging("@loader_path/../lib") is False
+    assert cwr.is_staging("$ORIGIN/../lib") is False
+
+
 def test_empty_tree_is_not_a_pass(tmp_path: Path) -> None:
     """A glob matching nothing must be reported, not silently accepted."""
     problems = cwr.check_tree(tmp_path)
@@ -102,7 +141,7 @@ def test_empty_tree_is_not_a_pass(tmp_path: Path) -> None:
 
 
 def test_missing_extension_module_is_reported(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.setattr(cwr, "inspect", lambda path: ([], []))
+    monkeypatch.setattr(cwr, "inspect", lambda path: (cwr.ELF, [], []))
     (tmp_path / "lib").mkdir()
     (tmp_path / "lib" / f"libNeoN{EXT}").write_bytes(b"\x7fELF" + b"\0" * 64)
     problems = cwr.check_tree(tmp_path)
@@ -151,6 +190,25 @@ def test_legacy_dt_rpath_is_read(tmp_path: Path) -> None:
     library = build_library(
         tmp_path / "build", "umpire", ["/tmp/tmp0k2j/wheel/platlib/lib"], new_dtags=False
     )
-    rpaths, _ = cwr.inspect(library)
+    fmt, rpaths, _ = cwr.inspect(library)
+    assert fmt == cwr.ELF
     assert rpaths == ["/tmp/tmp0k2j/wheel/platlib/lib"]
     assert cwr.main(["check", str(make_wheel(tmp_path, [library]))]) == 1
+
+
+@needs_cc
+@pytest.mark.skipif(not IS_MACOS, reason="dyld is what cannot expand $ORIGIN")
+def test_elf_token_on_macho_is_rejected(tmp_path: Path) -> None:
+    """The regression this PR fixes: $ORIGIN baked into a dylib is a dead RPATH."""
+    libraries = [
+        build_library(tmp_path / "build", "umpire", ["$ORIGIN", "$ORIGIN/../lib"], "@rpath/libumpire.dylib")
+    ]
+    assert cwr.main(["check", str(make_wheel(tmp_path, libraries))]) == 1
+
+
+@needs_cc
+@pytest.mark.skipif(IS_MACOS, reason="ld.so is what cannot expand @loader_path")
+def test_macho_token_on_elf_is_rejected(tmp_path: Path) -> None:
+    """The mirror image: @loader_path baked into an ELF library."""
+    libraries = [build_library(tmp_path / "build", "umpire", ["@loader_path", "@loader_path/../lib"])]
+    assert cwr.main(["check", str(make_wheel(tmp_path, libraries))]) == 1


### PR DESCRIPTION
## Problem

Importing the `_neon` extension (or any wheel that bundles NeoN) fails unless
`LD_LIBRARY_PATH` is set by hand:

```
ImportError: libcamp.so: cannot open shared object file: No such file or directory
```

## Root cause

`umpire` and its bundled `camp` are built **and installed by their own BLT-based
CMake**, which sets each target's `INSTALL_RPATH` to `${CMAKE_INSTALL_PREFIX}/lib`.
Under scikit-build that prefix is the wheel-staging **temp directory**, which is
gone after install:

```
$ readelf -d .../lib/libumpire.so | grep RUNPATH
RUNPATH  [/tmp/tmpXXXX/wheel/platlib/lib]
```

RUNPATH is not used for *transitive* deps, so `libumpire.so` can't find its
direct dependency `libcamp.so`. NeoN's own libraries are unaffected — they get
the intended `$ORIGIN/../lib` from `CMAKE_INSTALL_RPATH`. Only these BLT-managed
CPM targets escape that policy, because **a per-target `INSTALL_RPATH` wins over
the global variable**.

## Fix

Override the `umpire`/`camp` targets' `INSTALL_RPATH` with `$ORIGIN`-relative
entries right after `include(cmake/CxxThirdParty.cmake)` (the only scope where
the targets exist). It's the one mechanism that beats BLT's own per-target RPATH.
Guarded by `if(DEFINED SKBUILD)`.

## Verification

- `import neon._neon` works in a **fully clean env** (`LD_LIBRARY_PATH` unset) —
  `libcamp` resolves purely via RPATH.
- `libumpire.so` RUNPATH is now `$ORIGIN:$ORIGIN/../lib:$ORIGIN/../../lib`.
- **C++ build unaffected:** `cmake --preset develop` (no scikit-build) configures
  cleanly — `SKBUILD` is undefined so the block is skipped. The change is
  install-RPATH only and never touches compilation/linking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
