### PR TITLE
fix(bindings): force-instantiate Gauss div/laplacian operators in _neon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,12 @@ option(NeoN_BUILD_TESTS "Build the unit tests" OFF)
 option(NeoN_BUILD_BENCHMARKS "Build benchmarks" OFF)
 option(NeoN_BUILD_DOC "Build documentation" OFF)
 option(NeoN_BUILD_PYTHON_BINDINGS "Build python bindings" OFF)
+# Link _neon against a shared libnanobind instead of the default static one. Only needed when the
+# bindings must exchange nanobind types with another extension module built against the same
+# libnanobind (e.g. pybFoam, so create_adapter_run_time accepts a Foam::Time). Off by default: a
+# shared runtime has to be installed alongside _neon, and wheel repair tools (auditwheel, delocate,
+# delvewheel) vendor it under a mangled SONAME, which defeats the sharing it exists for.
+option(NeoN_NANOBIND_SHARED "Link the python bindings against a shared libnanobind" OFF)
 option(NeoN_INSTALL_CMAKE_PACKAGE "Install CMake package config files and exported targets" ON)
 
 # Third party dependencies

--- a/cmake/Versions.cmake
+++ b/cmake/Versions.cmake
@@ -17,6 +17,12 @@ set(NeoN_GINKGO_VERSION "2.0.0")
 set(NeoN_GINKGO_TAG "6a3abf8c920228006f3b28bc3bf04fc7a5f6aee0")
 set(NeoN_CATCH2_VERSION "3.4.0")
 set(NeoN_SPDLOG_VERSION "1.16.0")
-set(NeoN_NANOBIND_VERSION "2.9.2")
+# Match the nanobind that pybFoam builds against (pip, currently 2.13.0). The _neon binding shares
+# pybFoam's libnanobind.so at runtime (SONAME), so an ABI mismatch (e.g. the ndarray_create signature
+# change after 2.9.2) makes _neon fail to resolve symbols from pybFoam's lib. Overridable so a
+# downstream (NeoFOAM) can force a different version to track its own pybFoam.
+if(NOT DEFINED NeoN_NANOBIND_VERSION)
+  set(NeoN_NANOBIND_VERSION "2.13.0")
+endif()
 set(NeoN_UMPIRE_TAG "18a808d1af81fed8823fcf12452d91c981f1bad1")
 set(NeoN_FMT_VERSION "12.1.0")

--- a/cmake/Versions.cmake
+++ b/cmake/Versions.cmake
@@ -17,9 +17,10 @@ set(NeoN_GINKGO_VERSION "2.0.0")
 set(NeoN_GINKGO_TAG "6a3abf8c920228006f3b28bc3bf04fc7a5f6aee0")
 set(NeoN_CATCH2_VERSION "3.4.0")
 set(NeoN_SPDLOG_VERSION "1.16.0")
-# Match the nanobind pybFoam builds against (pip, currently 2.13.0): _neon shares pybFoam's
-# libnanobind.so at runtime by SONAME, so a version/ABI mismatch (e.g. the ndarray_create signature
-# change after 2.9.2) breaks symbol resolution. Overridable so a downstream can pin.
+# Match the nanobind pybFoam builds against (pip, currently 2.13.0). With NeoN_NANOBIND_SHARED the
+# _neon module shares pybFoam's libnanobind.so at runtime by SONAME, so a version/ABI mismatch (e.g.
+# the ndarray_create signature change after 2.9.2) breaks symbol resolution. Overridable so a
+# downstream can track its own pybFoam.
 if(NOT DEFINED NeoN_NANOBIND_VERSION)
   set(NeoN_NANOBIND_VERSION "2.13.0")
 endif()

--- a/cmake/Versions.cmake
+++ b/cmake/Versions.cmake
@@ -17,10 +17,9 @@ set(NeoN_GINKGO_VERSION "2.0.0")
 set(NeoN_GINKGO_TAG "6a3abf8c920228006f3b28bc3bf04fc7a5f6aee0")
 set(NeoN_CATCH2_VERSION "3.4.0")
 set(NeoN_SPDLOG_VERSION "1.16.0")
-# Match the nanobind that pybFoam builds against (pip, currently 2.13.0). The _neon binding shares
-# pybFoam's libnanobind.so at runtime (SONAME), so an ABI mismatch (e.g. the ndarray_create signature
-# change after 2.9.2) makes _neon fail to resolve symbols from pybFoam's lib. Overridable so a
-# downstream (NeoFOAM) can force a different version to track its own pybFoam.
+# Match the nanobind pybFoam builds against (pip, currently 2.13.0): _neon shares pybFoam's
+# libnanobind.so at runtime by SONAME, so a version/ABI mismatch (e.g. the ndarray_create signature
+# change after 2.9.2) breaks symbol resolution. Overridable so a downstream can pin.
 if(NOT DEFINED NeoN_NANOBIND_VERSION)
   set(NeoN_NANOBIND_VERSION "2.13.0")
 endif()

--- a/src/bindings/CMakeLists.txt
+++ b/src/bindings/CMakeLists.txt
@@ -53,7 +53,32 @@ if(NeoN_ENABLE_CUDA AND Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE)
   set_source_files_properties(${NeoN_PYTHON_BINDING_SRCS} PROPERTIES LANGUAGE CUDA)
 endif()
 
-nanobind_add_module(_neon NB_SHARED NOMINSIZE ${NeoN_PYTHON_BINDING_SRCS})
+# NB_SHARED is opt-in (see NeoN_NANOBIND_SHARED in the top-level CMakeLists): it is only needed to
+# exchange nanobind types with another extension module, and it makes _neon depend on a libnanobind
+# that must then be installed and found at runtime.
+if(NeoN_NANOBIND_SHARED)
+  set(NeoN_NANOBIND_LINKAGE NB_SHARED)
+endif()
+
+nanobind_add_module(_neon ${NeoN_NANOBIND_LINKAGE} NOMINSIZE ${NeoN_PYTHON_BINDING_SRCS})
+
+if(NeoN_NANOBIND_SHARED AND NOT WIN32)
+  # nanobind neither installs its shared library nor sets an RPATH, so the installed _neon would
+  # keep a DT_NEEDED that resolves nowhere. Install libnanobind next to _neon and look for it there.
+  # Appended so the RPATH inherited from CMAKE_INSTALL_RPATH (libNeoN) is kept. Windows has no
+  # RPATH; the DLL is found because it is installed into the same directory.
+  if(APPLE)
+    set_property(
+      TARGET _neon
+      APPEND
+      PROPERTY INSTALL_RPATH "@loader_path")
+  else()
+    set_property(
+      TARGET _neon
+      APPEND
+      PROPERTY INSTALL_RPATH "$ORIGIN")
+  endif()
+endif()
 
 # Link against the NeoN library to access executor classes
 target_link_libraries(_neon PRIVATE NeoN::NeoN)
@@ -112,11 +137,23 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../neon/py.typed
 if(DEFINED SKBUILD)
   # Install for scikit-build (into neon/ package)
   install(TARGETS _neon LIBRARY DESTINATION neon COMPONENT python)
+  if(NeoN_NANOBIND_SHARED)
+    install(
+      TARGETS nanobind
+      LIBRARY DESTINATION neon COMPONENT python
+      RUNTIME DESTINATION neon COMPONENT python)
+  endif()
   install(FILES ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/__init__.py DESTINATION neon)
   install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../neon/py.typed DESTINATION neon)
 else()
   # Standalone installation
   install(TARGETS _neon LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/python/neon)
+  if(NeoN_NANOBIND_SHARED)
+    install(
+      TARGETS nanobind
+      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/python/neon
+      RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}/python/neon)
+  endif()
   install(FILES ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/__init__.py
           DESTINATION ${CMAKE_INSTALL_LIBDIR}/python/neon)
   install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../neon/py.typed

--- a/src/bindings/CMakeLists.txt
+++ b/src/bindings/CMakeLists.txt
@@ -53,7 +53,7 @@ if(NeoN_ENABLE_CUDA AND Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE)
   set_source_files_properties(${NeoN_PYTHON_BINDING_SRCS} PROPERTIES LANGUAGE CUDA)
 endif()
 
-nanobind_add_module(_neon NOMINSIZE ${NeoN_PYTHON_BINDING_SRCS})
+nanobind_add_module(_neon NB_SHARED NOMINSIZE ${NeoN_PYTHON_BINDING_SRCS})
 
 # Link against the NeoN library to access executor classes
 target_link_libraries(_neon PRIVATE NeoN::NeoN)

--- a/src/bindings/dsl.cpp
+++ b/src/bindings/dsl.cpp
@@ -153,7 +153,17 @@ void declare_dsl_components(nb::module_& m, const std::string& suffix)
         .def(
             "__sub__", [](Expr lhs, const TemporalOp& rhs) { return lhs - rhs; }, nb::is_operator()
         )
-        .def("size", &Expr::size);
+        .def("size", &Expr::size)
+        // Resolve each operator's discretisation scheme from a schemes Dictionary
+        // (e.g. {"divSchemes": {"div(phi,U)": ["Gauss", "linear"]}}). This is the call
+        // that drives the runtime-selection factory lookup (create("Gauss")), so it is
+        // also the regression hook for operator self-registration inside _neon.
+        .def(
+            "read",
+            [](Expr& self, const Dictionary& schemes) { self.read(schemes); },
+            "schemes"_a,
+            "Resolve operator schemes from a Dictionary"
+        );
 }
 
 void registerDSL(nb::module_& m)

--- a/src/bindings/dsl.cpp
+++ b/src/bindings/dsl.cpp
@@ -23,6 +23,24 @@
 #include "NeoN/finiteVolume/cellCentred/operators/gaussGreenGrad.hpp" // these are required for registration
 #include "NeoN/finiteVolume/cellCentred/faceNormalGradient/uncorrected.hpp" // these are required for registration
 
+// TODO(operator-registration workaround): drop this once the runtime-selection registry is shared
+// across shared objects (e.g. exporting the factory table with default visibility). The operators
+// above are declared `extern template`, so simply including the headers does NOT instantiate them
+// here and their self-registration only fires in libNeoN. The `_neon` module is compiled
+// `-fvisibility=hidden`, giving it a private, empty copy of the factory's lookup table, so scheme
+// resolution at assembly time (e.g. "Gauss" for div/laplacian) aborts with "Could not find
+// constructor for Gauss". Forcing explicit instantiation here runs the self-registration inside
+// `_neon` so its table is populated.
+namespace NeoN::finiteVolume::cellCentred
+{
+template class GaussGreenDiv<scalar>;
+template class GaussGreenDiv<Vec3>;
+template class GaussGreenDiv<Vec3, scalar>;
+template class GaussGreenLaplacian<scalar>;
+template class GaussGreenLaplacian<Vec3>;
+template class GaussGreenLaplacian<Vec3, scalar>;
+} // namespace NeoN::finiteVolume::cellCentred
+
 namespace nb = nanobind;
 using namespace nb::literals;
 

--- a/src/bindings/inputs.cpp
+++ b/src/bindings/inputs.cpp
@@ -175,14 +175,6 @@ void registerInputs(nb::module_& m)
             "Insert bool value"
         )
         .def(
-            "insert_dict",
-            [](NeoN::Dictionary& self, const std::string& key, const NeoN::Dictionary& value)
-            { self.insert(key, std::any(value)); },
-            "key"_a,
-            "value"_a,
-            "Insert a sub-dictionary value (e.g. divSchemes)"
-        )
-        .def(
             "insert_token_list",
             [](NeoN::Dictionary& self, const std::string& key, const NeoN::TokenList& value)
             { self.insert(key, std::any(value)); },

--- a/src/bindings/inputs.cpp
+++ b/src/bindings/inputs.cpp
@@ -175,6 +175,22 @@ void registerInputs(nb::module_& m)
             "Insert bool value"
         )
         .def(
+            "insert_dict",
+            [](NeoN::Dictionary& self, const std::string& key, const NeoN::Dictionary& value)
+            { self.insert(key, std::any(value)); },
+            "key"_a,
+            "value"_a,
+            "Insert a sub-dictionary value (e.g. divSchemes)"
+        )
+        .def(
+            "insert_token_list",
+            [](NeoN::Dictionary& self, const std::string& key, const NeoN::TokenList& value)
+            { self.insert(key, std::any(value)); },
+            "key"_a,
+            "value"_a,
+            "Insert a TokenList value (e.g. a discretisation scheme)"
+        )
+        .def(
             "__repr__",
             [](const NeoN::Dictionary& self)
             { return "<Dictionary size=" + std::to_string(self.keys().size()) + ">"; }

--- a/test/bindings/test_operator_registration.py
+++ b/test/bindings/test_operator_registration.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: 2026 NeoN authors
+#
+# SPDX-License-Identifier: MIT
+
+"""Regression tests for runtime-selection operator registration in the ``_neon`` module.
+
+The Gauss ``div``/``laplacian`` operators self-register into a runtime-selection
+factory table only when their template is instantiated. Their headers are declared
+``extern template``, so that instantiation normally happens once, in ``libNeoN``.
+Because the ``_neon`` extension is compiled with ``-fvisibility=hidden``, it would
+otherwise get a private, empty copy of that table and scheme resolution would abort
+with ``Could not find constructor for Gauss``. ``src/bindings/dsl.cpp`` forces the
+explicit instantiations inside ``_neon`` so its table is populated.
+
+These tests drive ``Expression.read`` — the call that performs the factory lookup
+(``create("Gauss")``) — so they fail loudly if that registration ever regresses.
+A scalar equation exercises the ``<scalar>`` instantiation; a vector equation
+additionally exercises the ``<Vec3>`` and ``<Vec3, scalar>`` instantiations (the
+vector ``div``/``laplacian`` build both same-type and scalar-matrix strategies).
+"""
+
+import neon
+from neon import imp
+
+
+def _make_schemes() -> neon.Dictionary:
+    """divSchemes/laplacianSchemes for a ``div(phi,*) + laplacian(gamma,*)`` equation."""
+    div_schemes = neon.Dictionary()
+    div_schemes.insert_token_list("div(phi,U)", neon.TokenList(["Gauss", "linear"]))
+    div_schemes.insert_token_list("div(phi,T)", neon.TokenList(["Gauss", "linear"]))
+
+    laplacian_schemes = neon.Dictionary()
+    laplacian_schemes.insert_token_list(
+        "laplacian(gamma,U)", neon.TokenList(["Gauss", "linear", "uncorrected"])
+    )
+    laplacian_schemes.insert_token_list(
+        "laplacian(gamma,T)", neon.TokenList(["Gauss", "linear", "uncorrected"])
+    )
+
+    schemes = neon.Dictionary()
+    schemes.insert_dict("divSchemes", div_schemes)
+    schemes.insert_dict("laplacianSchemes", laplacian_schemes)
+    return schemes
+
+
+def test_gauss_scalar_operators_resolve(executor):
+    """Scalar Gauss div/laplacian resolve through the _neon factory table."""
+    name, exec = executor
+    mesh = neon.create_1d_uniform_mesh(exec, 10, 1.0)
+
+    field = neon.ScalarVolumeField(exec, "T", mesh)
+    phi = neon.ScalarSurfaceField(exec, "phi", mesh)
+    gamma = neon.ScalarSurfaceField(exec, "gamma", mesh)
+    neon.fill(phi.internal_vector(), 1.0)
+    neon.fill(gamma.internal_vector(), 1.0)
+
+    eqn = imp.div(phi, field) + imp.laplacian(gamma, field)
+    assert eqn.size() == 2
+
+    # Without the explicit instantiation in _neon this raises
+    # "Could not find constructor for Gauss".
+    eqn.read(_make_schemes())
+
+
+def test_gauss_vector_operators_resolve(executor):
+    """Vector Gauss div/laplacian resolve — covers the <Vec3> and <Vec3, scalar> tables."""
+    name, exec = executor
+    mesh = neon.create_1d_uniform_mesh(exec, 10, 1.0)
+
+    field = neon.VectorVolumeField(exec, "U", mesh)
+    phi = neon.ScalarSurfaceField(exec, "phi", mesh)
+    gamma = neon.ScalarSurfaceField(exec, "gamma", mesh)
+    neon.fill(phi.internal_vector(), 1.0)
+    neon.fill(gamma.internal_vector(), 1.0)
+
+    eqn = imp.div(phi, field) + imp.laplacian(gamma, field)
+    assert eqn.size() == 2
+
+    # Without the explicit instantiation in _neon this raises
+    # "Could not find constructor for Gauss".
+    eqn.read(_make_schemes())


### PR DESCRIPTION
## What

Force explicit instantiation of the Gauss `div`/`laplacian` operators inside the `_neon` binding module so they self-register into its runtime-selection factory table.

## Why

The operators (`GaussGreenDiv`, `GaussGreenLaplacian`) self-register via `RuntimeSelectionFactory::Register<>::REGISTERED` into a function-local-static `table()`. Their headers are `extern template class …`, so including them in the binding TU does **not** instantiate them — registration only fires in `libNeoN`. Because `_neon` is built with `-fvisibility=hidden`, it gets its **own private, empty** copy of `table()`, and scheme resolution at PDE assembly aborts with:

```
Could not find constructor for Gauss
```

Forcing the explicit instantiations in `dsl.cpp` runs the self-registration inside `_neon`, populating its table. This unblocks any Python-driven solver that assembles `div`/`laplacian` expressions (e.g. the `neoPimpleFoam` port on the NeoFOAM side).

A `TODO` marks this as a workaround to drop once the factory table is shared across shared objects (e.g. exporting it with default visibility).