### PR TITLE
FixedValueConstraints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,8 +95,5 @@ CLAUDE.md
 *.bundle
 *.ipynb
 .ipynb_checkpoints/
-dist_bench_results*/
-Testing/
 scripts/
-raw
-raw.1
+results/*

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,13 @@ uv.lock
 *log
 *.claude
 CLAUDE.md
+
+# local artefacts
+*.bundle
+*.ipynb
+.ipynb_checkpoints/
+dist_bench_results*/
+Testing/
+scripts/
+raw
+raw.1

--- a/ci/lrz-gitlab/build-and-test.sh
+++ b/ci/lrz-gitlab/build-and-test.sh
@@ -72,6 +72,13 @@ elif [ "$GPU_VENDOR" == "intel" ]; then
     # Compiler info (non-fatal)
     icpx --version 2>/dev/null | head -1 || echo "icpx not found"
 
+    # Intel PVC has two tiles and implicit scaling routes work across them;
+    # sycl::queue::wait() only drains the root-device queue and misses
+    # in-flight work on tile 1, causing GPU page faults on freed USM memory.
+    # COMPOSITE hierarchy exposes each tile as a separate L0 device so Kokkos
+    # selects a single tile — all work and synchronisation stay on one tile.
+    export ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE
+
     echo "=== Configuring, building, and testing NeoN on Intel ==="
     cmake --preset develop \
         -DCMAKE_CXX_COMPILER=icpx \

--- a/include/NeoN/core/vector/vector.hpp
+++ b/include/NeoN/core/vector/vector.hpp
@@ -145,6 +145,20 @@ public:
     void operator=(const Vector<ValueType>& rhs);
 
     /**
+     * @brief Move-assignment operator — transfers ownership of the data buffer.
+     *
+     * Moves the data pointer, size, and executor from rhs without launching any GPU
+     * kernel (O(1) pointer swap).  The old buffer owned by *this is freed first.
+     * After the move, rhs is left in an empty (size=0, data=nullptr) state.
+     *
+     * @note Use this when assigning a temporary (e.g. the result of fromFoamField)
+     *       into an existing Vector to avoid the async GPU→GPU copy in the copy
+     *       operator=(const Vector&), which can race against the temporary's
+     *       destructor freeing the source buffer before the kernel completes.
+     */
+    Vector<ValueType>& operator=(Vector<ValueType>&& rhs) noexcept;
+
+    /**
      * @brief Arithmetic add operator, addition of a second field.
      * @param rhs The field to add with this field.
      * @returns The result of the addition.

--- a/include/NeoN/core/vector/vector.hpp
+++ b/include/NeoN/core/vector/vector.hpp
@@ -147,14 +147,12 @@ public:
     /**
      * @brief Move-assignment operator — transfers ownership of the data buffer.
      *
-     * Moves the data pointer, size, and executor from rhs without launching any GPU
-     * kernel (O(1) pointer swap).  The old buffer owned by *this is freed first.
+     * Swaps the data pointer and size from rhs in O(1) without launching any GPU
+     * kernel.  The old buffer owned by *this is freed first (after a fence if on GPU).
      * After the move, rhs is left in an empty (size=0, data=nullptr) state.
+     * The executor is unchanged — exec_ is const and cannot be moved.
      *
-     * @note Use this when assigning a temporary (e.g. the result of fromFoamField)
-     *       into an existing Vector to avoid the async GPU→GPU copy in the copy
-     *       operator=(const Vector&), which can race against the temporary's
-     *       destructor freeing the source buffer before the kernel completes.
+     * @warning Invalidates any existing View objects that point into *this.
      */
     Vector<ValueType>& operator=(Vector<ValueType>&& rhs) noexcept;
 

--- a/include/NeoN/dsl/expression.hpp
+++ b/include/NeoN/dsl/expression.hpp
@@ -140,6 +140,68 @@ private:
 };
 
 
+/**
+ * @class FixedValueConstraints
+ * @brief Post-assembly functor that HARD-pins a set of cells to prescribed values — the
+ *        equivalent of OpenFOAM's fvMatrix::setValues, which omega/epsilon wall functions
+ *        apply through manipulateMatrix(). Unlike SetReference (which only removes a constant
+ *        null space by doubling a single diagonal), this forces each constrained cell's
+ *        solution exactly to its target.
+ *
+ * For every constrained cell the assembled row is rewritten in place:
+ *   A[c, j] = 0  for all j != c   (zero the off-diagonals of row c)
+ *   rhs[c]  = A[c, c] * value[c]
+ * so the row reduces to  A[c,c] * x_c = A[c,c] * value[c]  =>  x_c = value[c], regardless of
+ * the (relaxed, BC-augmented) diagonal magnitude. The column entries A[j, c] in other rows are
+ * left intact, so neighbour equations correctly see the pinned value (more conservative than
+ * upstream's full decouple, and valid because omega is solved with an asymmetric solver).
+ *
+ * The functor sweeps all nCells; a cell is constrained iff mask[cell] != 0, with value[cell]
+ * holding its target. Both views are sized nCells and owned by the caller (must outlive use).
+ */
+template<typename ValueType, typename IndexType = localIdx>
+class FixedValueConstraints : public PostAssemblyBase<ValueType, IndexType>
+{
+public:
+
+    FixedValueConstraints(View<const scalar> mask, View<const ValueType> values, localIdx nCells)
+        : mask_(mask), values_(values), nCells_(nCells)
+    {}
+
+    void operator()(la::LinearSystem<ValueType, ValueType, la::CSRMatrix<ValueType, IndexType>>& ls
+    ) const override
+    {
+        auto lsView = ls.view();
+        const auto ma = ls.faceToMatrixAddress()->view(ls.matrix().sparsity()->rowOffs().view());
+        auto mask = mask_;
+        auto vals = values_;
+        parallelFor(
+            ls.exec(),
+            {0, nCells_},
+            NEON_LAMBDA(const localIdx celli) {
+                if (mask[celli] == scalar(0)) return;
+                const auto dIdx = ma.diagIdx(celli);
+                const ValueType diagVal = lsView.matrix.values[dIdx];
+                const auto rowStart = ma.rowOffs[celli];
+                const auto rowEnd = ma.rowOffs[celli + 1];
+                for (auto o = rowStart; o < rowEnd; ++o)
+                {
+                    if (o != dIdx) lsView.matrix.values[o] = zero<ValueType>();
+                }
+                lsView.rhs[celli] = diagVal * vals[celli];
+            },
+            "FixedValueConstraints"
+        );
+    }
+
+private:
+
+    View<const scalar> mask_;
+    View<const ValueType> values_;
+    localIdx nCells_;
+};
+
+
 template<typename ValueType, typename IndexType = localIdx>
 class Expression
 {

--- a/include/NeoN/dsl/expression.hpp
+++ b/include/NeoN/dsl/expression.hpp
@@ -142,26 +142,32 @@ private:
 
 /**
  * @class FixedValueConstraints
- * @brief Post-assembly functor that HARD-pins a set of cells to prescribed values — the
- *        equivalent of OpenFOAM's fvMatrix::setValues, which omega/epsilon wall functions
- *        apply through manipulateMatrix(). Unlike SetReference (which only removes a constant
- *        null space by doubling a single diagonal), this forces each constrained cell's
- *        solution exactly to its target.
+ * @brief Post-assembly functor that pins a set of cells to prescribed values.
  *
- * For every constrained cell the assembled row is rewritten in place:
- *   A[c, j] = 0  for all j != c   (zero the off-diagonals of row c)
- *   rhs[c]  = A[c, c] * value[c]
- * so the row reduces to  A[c,c] * x_c = A[c,c] * value[c]  =>  x_c = value[c], regardless of
- * the (relaxed, BC-augmented) diagonal magnitude. The column entries A[j, c] in other rows are
- * left intact, so neighbour equations correctly see the pinned value (more conservative than
- * upstream's full decouple, and valid because omega is solved with an asymmetric solver).
+ * For every constrained cell c:
+ *   A[c, j] = 0  for j != c   (zero row off-diagonals)
+ *   A[j, c] = 0  for j != c   (zero column in neighbour rows, rhs[j] absorbs the dropped term)
+ *   rhs[c]  = A[c,c] * value[c]
  *
- * The functor sweeps all nCells; a cell is constrained iff mask[cell] != 0, with value[cell]
- * holding its target. Both views are sized nCells and owned by the caller (must outlive use).
+ * Pinning via both the row and column cut avoids large cancellation errors when
+ * pinned values are orders of magnitude larger than neighbouring unknowns.
+ * Off-rank coupling in offDiagonalMatrix is also zeroed for pinned rows.
+ *
+ * Restricted to scalar ValueType: the segregated vector-solve path dispatches
+ * through applyScalarMatrix(), which this class does not implement.
+ *
+ * mask[cell] != 0 marks a constrained cell; value[cell] holds its target.
+ * Both views are sized nCells and must outlive the functor.
  */
 template<typename ValueType, typename IndexType = localIdx>
 class FixedValueConstraints : public PostAssemblyBase<ValueType, IndexType>
 {
+    static_assert(
+        std::is_same_v<ValueType, scalar>,
+        "FixedValueConstraints only supports scalar fields. "
+        "For non-scalar fields implement applyScalarMatrix()."
+    );
+
 public:
 
     FixedValueConstraints(View<const scalar> mask, View<const ValueType> values, localIdx nCells)
@@ -172,26 +178,65 @@ public:
     ) const override
     {
         auto lsView = ls.view();
-        const auto ma = ls.faceToMatrixAddress()->view(ls.matrix().sparsity()->rowOffs().view());
+        const auto rowOffs = ls.matrix().sparsity()->rowOffs().view();
+        const auto colIdxs = ls.matrix().sparsity()->colIdxs().view();
+        auto matrixValues = lsView.matrix.values;
+        auto rhs = lsView.rhs;
         auto mask = mask_;
         auto vals = values_;
+        // Sweep every row: pinned rows drop their off-diagonals; non-pinned rows that couple into
+        // a pinned column absorb the term into their rhs and zero the coefficient. Parallelising
+        // over rows avoids atomics since each row owns its own rhs entry and off-diagonal slots.
         parallelFor(
             ls.exec(),
             {0, nCells_},
-            NEON_LAMBDA(const localIdx celli) {
-                if (mask[celli] == scalar(0)) return;
-                const auto dIdx = ma.diagIdx(celli);
-                const ValueType diagVal = lsView.matrix.values[dIdx];
-                const auto rowStart = ma.rowOffs[celli];
-                const auto rowEnd = ma.rowOffs[celli + 1];
-                for (auto o = rowStart; o < rowEnd; ++o)
+            NEON_LAMBDA(const localIdx row) {
+                const bool rowPinned = mask[row] != scalar(0);
+                ValueType diagVal = zero<ValueType>();
+                for (auto o = rowOffs[row]; o < rowOffs[row + 1]; ++o)
                 {
-                    if (o != dIdx) lsView.matrix.values[o] = zero<ValueType>();
+                    const auto col = colIdxs[o];
+                    if (col == row)
+                    {
+                        diagVal = matrixValues[o];
+                        continue;
+                    }
+                    if (rowPinned)
+                    {
+                        // pinned cell's own row: decouple it entirely
+                        matrixValues[o] = zero<ValueType>();
+                    }
+                    else if (mask[col] != scalar(0))
+                    {
+                        // column cut: absorb coupling into rhs, zero the coefficient
+                        rhs[row] -= matrixValues[o] * vals[col];
+                        matrixValues[o] = zero<ValueType>();
+                    }
                 }
-                lsView.rhs[celli] = diagVal * vals[celli];
+                if (rowPinned)
+                {
+                    rhs[row] = diagVal * vals[row];
+                }
             },
             "FixedValueConstraints"
         );
+        // Zero offDiagonalMatrix entries for pinned rows so that proc-boundary
+        // couplings do not contribute to the residual of constrained cells.
+        auto& offDiag = ls.offDiagonalMatrix();
+        const localIdx nnz = offDiag.nNonZeros();
+        if (nnz > 0)
+        {
+            const auto offRowIdxs = offDiag.sparsity()->rowIdxs().view();
+            auto offValues = offDiag.values().view();
+            parallelFor(
+                ls.exec(),
+                {0, nnz},
+                NEON_LAMBDA(const localIdx i) {
+                    if (mask[offRowIdxs[i]] != scalar(0)) offValues[i] = zero<ValueType>();
+                },
+                "FixedValueConstraints::offDiag"
+            );
+        }
     }
 
 private:

--- a/include/NeoN/fields/boundaryData.hpp
+++ b/include/NeoN/fields/boundaryData.hpp
@@ -347,7 +347,10 @@ public:
                     valH.view()[buf.rangeStart + k] = buf.recvBuf[static_cast<std::size_t>(k)];
             }
             Vector<ValueType> backToDevice = valH.copyToExecutor(exec_);
-            value_ = backToDevice; // operator=(const Vector&): setContainer in-place, no realloc
+            value_ = backToDevice; // operator=(const Vector&): setContainer dispatches async kernel
+            // Fence before backToDevice goes out of scope: the setContainer kernel reads from
+            // backToDevice.data_; freeing it while the kernel runs is a GPU page fault.
+            fence(exec_);
         }
         else
         {

--- a/include/NeoN/fields/boundaryData.hpp
+++ b/include/NeoN/fields/boundaryData.hpp
@@ -334,15 +334,31 @@ public:
                 );
             }
         }
-        else
+        else if (std::holds_alternative<GPUExecutor>(exec_))
         {
+            // GPU executor but not GPU-aware MPI: data was staged through host buffers.
+            // Copy received host data back to the device in-place (via copy-assign, not
+            // move-assign) so that value_.data() stays the same pointer and any View
+            // obtained from value() before the exchange remains valid.
             auto valH = value_.copyToHost();
             for (const auto& buf : commBuffers_)
             {
                 for (localIdx k = 0; k < buf.patchSize; k++)
                     valH.view()[buf.rangeStart + k] = buf.recvBuf[static_cast<std::size_t>(k)];
             }
-            value_ = valH.copyToExecutor(exec_);
+            Vector<ValueType> backToDevice = valH.copyToExecutor(exec_);
+            value_ = backToDevice; // operator=(const Vector&): setContainer in-place, no realloc
+        }
+        else
+        {
+            // SerialExecutor or CPUExecutor: value_ lives in host-accessible memory;
+            // write received data directly without any intermediate allocation.
+            for (const auto& buf : commBuffers_)
+            {
+                ValueType* dst = value_.data() + buf.rangeStart;
+                for (localIdx k = 0; k < buf.patchSize; k++)
+                    dst[k] = buf.recvBuf[static_cast<std::size_t>(k)];
+            }
         }
         requests_.clear();
         communicating_ = false;

--- a/include/NeoN/finiteVolume/cellCentred/interpolation/linearUpwind.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/interpolation/linearUpwind.hpp
@@ -54,6 +54,8 @@ struct LinearUpwindGradType<Vec3>
 ** internally with a Gauss-Green scheme. This reduces to plain upwind where the
 ** field is locally constant and is second-order accurate for smooth fields.
 **
+** @pre src.correctBoundaryConditions() must have been called by the caller so that
+**      processor-boundary ghost values are up to date before the gradient is computed.
 ** @param src the input field
 ** @param flux the face flux determining the upwind direction
 ** @param faceDeltaOwner Cf - C_owner per internal face (from the geometry scheme)
@@ -73,6 +75,9 @@ void computeLinearUpwindInterpolation(
 ** `(Cf - C_U) & grad(phi)_U`, into dst (without the upwind cell value). Boundary faces are set to
 ** zero, matching OpenFOAM which corrects only coupled patches. Used for the implicit deferred
 ** correction (the explicit RHS source added by the divergence operator).
+**
+** @pre src.correctBoundaryConditions() must have been called by the caller so that
+**      processor-boundary ghost values are up to date before the gradient is computed.
 */
 template<typename ValueType>
 void computeLinearUpwindCorrection(

--- a/src/core/vector/vector.cpp
+++ b/src/core/vector/vector.cpp
@@ -129,6 +129,25 @@ void Vector<ValueType>::operator=(const Vector<ValueType>& rhs)
 }
 
 template<typename ValueType>
+Vector<ValueType>& Vector<ValueType>::operator=(Vector<ValueType>&& rhs) noexcept
+{
+    if (this != &rhs)
+    {
+        NF_ASSERT(exec_ == rhs.exec_, "Executors are not the same");
+        // Free the buffer currently owned by *this before we overwrite the pointer.
+        std::visit([this](const auto& exec) { exec.free(data_); }, exec_);
+
+        data_ = rhs.data_;
+        size_ = rhs.size_;
+        // exec_ is const — cannot be reassigned; both sides must share the same executor
+
+        rhs.data_ = nullptr;
+        rhs.size_ = 0;
+    }
+    return *this;
+}
+
+template<typename ValueType>
 Vector<ValueType>& Vector<ValueType>::operator+=(const Vector<ValueType>& rhs)
 {
     validateOtherVector(rhs);

--- a/src/core/vector/vector.cpp
+++ b/src/core/vector/vector.cpp
@@ -81,7 +81,16 @@ Vector<ValueType>::Vector(Vector<ValueType>&& rhs) noexcept
 template<typename ValueType>
 Vector<ValueType>::~Vector()
 {
-    std::visit([this](const auto& exec) { exec.free(data_); }, exec_);
+    // Fence before freeing: any in-flight GPU kernel (fill, setContainer, parallelFor) that
+    // captured a View of data_ must complete before the memory is returned to the allocator.
+    // Without this, async kernels dispatched on *this race with the destructor.
+    fence(exec_);
+    // Guard against nullptr: move-constructed-from Vectors have data_==nullptr.
+    // kokkos_free(nullptr) is implementation-defined (may throw); skip the call.
+    if (data_ != nullptr)
+    {
+        std::visit([this](const auto& exec) { exec.free(data_); }, exec_);
+    }
     data_ = nullptr;
 }
 
@@ -134,8 +143,12 @@ Vector<ValueType>& Vector<ValueType>::operator=(Vector<ValueType>&& rhs) noexcep
     if (this != &rhs)
     {
         NF_ASSERT(exec_ == rhs.exec_, "Executors are not the same");
-        // Free the buffer currently owned by *this before we overwrite the pointer.
-        std::visit([this](const auto& exec) { exec.free(data_); }, exec_);
+        // Fence before freeing data_: same reasoning as the destructor.
+        fence(exec_);
+        if (data_ != nullptr)
+        {
+            std::visit([this](const auto& exec) { exec.free(data_); }, exec_);
+        }
 
         data_ = rhs.data_;
         size_ = rhs.size_;
@@ -209,6 +222,7 @@ void Vector<ValueType>::resize(const localIdx size)
     void* ptr = nullptr;
     if (!empty())
     {
+        fence(exec_); // same as destructor: pending kernels on data_ must finish before realloc
         std::visit(
             [this, &ptr, size](const auto& exec)
             { ptr = exec.template realloc<ValueType>(this->data_, static_cast<size_t>(size)); },

--- a/src/finiteVolume/cellCentred/fields/volumeField.cpp
+++ b/src/finiteVolume/cellCentred/fields/volumeField.cpp
@@ -4,6 +4,7 @@
 
 #include "NeoN/core/vector/vectorFreeFunctions.hpp"
 #include "NeoN/core/macros.hpp"
+#include "NeoN/core/executor/executor.hpp"
 #include "NeoN/finiteVolume/cellCentred/fields/volumeField.hpp"
 
 namespace NeoN::finiteVolume::cellCentred
@@ -111,10 +112,7 @@ void VolumeField<ValueType>::correctBoundaryConditions()
     {
         boundaryCondition.update(this->field_);
     }
-    // Drain the processor-halo exchange once, after all proc patches have posted. This leaves
-    // boundaryData().value() holding the true neighbour values on return; without it the result
-    // would depend on whether a later value() read happens to drain first (it often does not),
-    // silently leaving the owner seed at processor faces.
+    // Drain the processor-halo exchange once, after all proc patches have posted.
     this->field_.boundaryData().waitAll();
 }
 

--- a/src/finiteVolume/cellCentred/interpolation/linearUpwind.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/linearUpwind.cpp
@@ -174,6 +174,13 @@ void computeLinearUpwind(
 
     const auto exec = src.exec();
     const auto& mesh = src.mesh();
+
+    // GaussGreenGrad linearly interpolates proc-boundary faces using neighbour ghost values stored
+    // in src.boundaryData(). Without a halo exchange those slots are stale, giving a wrong gradient
+    // at cells adjacent to processor boundaries and therefore a wrong deferred correction.
+    if (mesh.nProcBoundaryFaces() > 0)
+        const_cast<VolumeField<ValueType>&>(src).correctBoundaryConditions();
+
     GaussGreenGrad gradOp(exec, mesh);
 
     if constexpr (std::is_same_v<ValueType, scalar>)

--- a/src/finiteVolume/cellCentred/interpolation/linearUpwind.cpp
+++ b/src/finiteVolume/cellCentred/interpolation/linearUpwind.cpp
@@ -175,12 +175,6 @@ void computeLinearUpwind(
     const auto exec = src.exec();
     const auto& mesh = src.mesh();
 
-    // GaussGreenGrad linearly interpolates proc-boundary faces using neighbour ghost values stored
-    // in src.boundaryData(). Without a halo exchange those slots are stale, giving a wrong gradient
-    // at cells adjacent to processor boundaries and therefore a wrong deferred correction.
-    if (mesh.nProcBoundaryFaces() > 0)
-        const_cast<VolumeField<ValueType>&>(src).correctBoundaryConditions();
-
     GaussGreenGrad gradOp(exec, mesh);
 
     if constexpr (std::is_same_v<ValueType, scalar>)

--- a/test/dsl/CMakeLists.txt
+++ b/test/dsl/CMakeLists.txt
@@ -5,3 +5,4 @@
 neon_unit_test(coeff)
 neon_unit_test(optimizer)
 neon_unit_test(relaxation)
+neon_unit_test(constraints)

--- a/test/dsl/constraints.cpp
+++ b/test/dsl/constraints.cpp
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#define CATCH_CONFIG_RUNNER
+#include "catch2_common.hpp"
+
+#include "NeoN/NeoN.hpp"
+
+using NeoN::scalar;
+using NeoN::localIdx;
+using NeoN::Vector;
+using NeoN::la::CSRMatrix;
+using NeoN::la::COOMatrix;
+using NeoN::la::LinearSystem;
+
+// ---------------------------------------------------------------------------
+// Shared setup: 3-cell tridiagonal CSR with cell 1 pinned to 7.
+//
+//   row 0: [10, -1]        row 1 (pinned): [-2, 10, -2]   row 2: [-1, 10]
+//   rhs = [5, 5, 5],  mask = [0, 1, 0],  pinValues = [0, 7, 0]
+//
+// Expected after FixedValueConstraints:
+//   mat values: [10, 0,  0, 10, 0,  0, 10]
+//   rhs: [5-(-1)*7, 10*7, 5-(-1)*7] = [12, 70, 12]
+// ---------------------------------------------------------------------------
+
+TEST_CASE("FixedValueConstraints")
+{
+    auto [execName, exec] = GENERATE(allAvailableExecutor());
+
+    SECTION("CSR row/column pinning - " + execName)
+    {
+        Vector<scalar> matVals(exec, {10.0, -1.0, -2.0, 10.0, -2.0, -1.0, 10.0});
+        Vector<localIdx> colIdxs(exec, {0, 1, 0, 1, 2, 1, 2});
+        Vector<localIdx> rowOffs(exec, {0, 2, 5, 7});
+        CSRMatrix<scalar, localIdx> csr(matVals, colIdxs, rowOffs, {3, 3});
+
+        Vector<scalar> rhs(exec, {5.0, 5.0, 5.0});
+
+        // empty boundary (size-0 COO + rhs)
+        auto emptySp = std::make_shared<const NeoN::la::CooSparsityPattern<localIdx>>(
+            Vector<localIdx>(exec, 0), Vector<localIdx>(exec, 0), NeoN::la::Dimensions {0, 0}
+        );
+        COOMatrix<scalar, localIdx> emptyB(Vector<scalar>(exec, 0, 0.0), emptySp);
+        Vector<scalar> bRhs(exec, 3, 0.0);
+
+        LinearSystem<scalar> ls(csr, rhs, emptyB, bRhs);
+
+        Vector<scalar> mask(exec, {0.0, 1.0, 0.0});
+        Vector<scalar> pinVals(exec, {0.0, 7.0, 0.0});
+        NeoN::dsl::FixedValueConstraints<scalar> pin(mask.view(), pinVals.view(), 3);
+        pin(ls);
+
+        auto mH = ls.matrix().values().copyToHost();
+        auto rH = ls.rhs().copyToHost();
+
+        // row 0: diagonal kept, col-1 cut (absorbs -(-1)*7 into rhs)
+        CHECK(mH.view()[0] == Catch::Approx(10.0));
+        CHECK(mH.view()[1] == Catch::Approx(0.0));
+        // row 1 (pinned): off-diagonals zeroed, diagonal kept
+        CHECK(mH.view()[2] == Catch::Approx(0.0));
+        CHECK(mH.view()[3] == Catch::Approx(10.0));
+        CHECK(mH.view()[4] == Catch::Approx(0.0));
+        // row 2: col-1 cut, diagonal kept
+        CHECK(mH.view()[5] == Catch::Approx(0.0));
+        CHECK(mH.view()[6] == Catch::Approx(10.0));
+
+        CHECK(rH.view()[0] == Catch::Approx(12.0));
+        CHECK(rH.view()[1] == Catch::Approx(70.0));
+        CHECK(rH.view()[2] == Catch::Approx(12.0));
+    }
+
+    SECTION("offDiagonalMatrix zeroed for pinned rows - " + execName)
+    {
+        Vector<scalar> matVals(exec, {10.0, -1.0, -2.0, 10.0, -2.0, -1.0, 10.0});
+        Vector<localIdx> colIdxs(exec, {0, 1, 0, 1, 2, 1, 2});
+        Vector<localIdx> rowOffs(exec, {0, 2, 5, 7});
+        CSRMatrix<scalar, localIdx> csr(matVals, colIdxs, rowOffs, {3, 3});
+        Vector<scalar> rhs(exec, {5.0, 5.0, 5.0});
+
+        // offDiag: (row=1, col=3, val=5.0) pinned → must be zeroed
+        //          (row=0, col=4, val=3.0) not pinned → unchanged
+        auto offSp = std::make_shared<const NeoN::la::CooSparsityPattern<localIdx>>(
+            Vector<localIdx>(exec, {3, 4}), // colIdxs
+            Vector<localIdx>(exec, {1, 0}), // rowIdxs
+            NeoN::la::Dimensions {3, 5}
+        );
+        COOMatrix<scalar, localIdx> offDiag(Vector<scalar>(exec, {5.0, 3.0}), offSp);
+
+        auto emptySp = std::make_shared<const NeoN::la::CooSparsityPattern<localIdx>>(
+            Vector<localIdx>(exec, 0), Vector<localIdx>(exec, 0), NeoN::la::Dimensions {0, 0}
+        );
+        COOMatrix<scalar, localIdx> emptyB(Vector<scalar>(exec, 0, 0.0), emptySp);
+        Vector<scalar> bRhs(exec, 3, 0.0);
+
+        LinearSystem<scalar> ls(csr, rhs, offDiag, emptyB, bRhs);
+
+        Vector<scalar> mask(exec, {0.0, 1.0, 0.0});
+        Vector<scalar> pinVals(exec, {0.0, 7.0, 0.0});
+        NeoN::dsl::FixedValueConstraints<scalar> pin(mask.view(), pinVals.view(), 3);
+        pin(ls);
+
+        auto offH = ls.offDiagonalMatrix().values().copyToHost();
+
+        CHECK(offH.view()[0] == Catch::Approx(0.0)); // row=1 (pinned) → zeroed
+        CHECK(offH.view()[1] == Catch::Approx(3.0)); // row=0 (not pinned) → unchanged
+    }
+}


### PR DESCRIPTION
# Motivation

Adds a new post-assembly functor (FixedValueConstraints) to the NeoN DSL for pinning multiple cells to prescribed values by zeroing row off-diagonals, performing a column cut (absorbing dropped terms into the RHS), and setting the pinned RHS to A[c,c] * value[c]. This is needed for some turbulence models that bind values at certain locations.

