### PR TITLE
Add slip and inletOutlet boundary conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Version 0.3.0 (unreleased)
 ## Features
+- Add `slip` and `inletOutlet` volume boundary conditions [#565](https://github.com/exasim-project/NeoN/pull/565)
 - Add corrected and limited-corrected face-normal gradient schemes [#514](https://github.com/exasim-project/NeoN/pull/514)
 - Add experimental support for cell based assembly strategies [#471](https://github.com/exasim-project/NeoN/pull/471),[#517](https://github.com/exasim-project/NeoN/pull/517), [#473](https://github.com/exasim-project/NeoN/pull/473)
 - Add experimental support for COO and CSR Matrices [#486](https://github.com/exasim-project/NeoN/pull/486)

--- a/include/NeoN/finiteVolume/cellCentred/boundary.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary.hpp
@@ -16,6 +16,7 @@
 #include "boundary/volume/fixedGradient.hpp"
 #include "boundary/volume/symmetry.hpp"
 #include "boundary/volume/slip.hpp"
+#include "boundary/volume/inletOutlet.hpp"
 
 #include "boundary/surface/empty.hpp"
 #include "boundary/surface/calculated.hpp"
@@ -127,6 +128,9 @@ template class fvcc::volumeBoundary::Symmetry<Vec3>;
 
 template class fvcc::volumeBoundary::Slip<scalar>;
 template class fvcc::volumeBoundary::Slip<Vec3>;
+
+template class fvcc::volumeBoundary::InletOutlet<scalar>;
+template class fvcc::volumeBoundary::InletOutlet<Vec3>;
 
 template class fvcc::SurfaceBoundaryFactory<scalar>;
 template class fvcc::SurfaceBoundaryFactory<Vec3>;

--- a/include/NeoN/finiteVolume/cellCentred/boundary/boundaryContext.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/boundaryContext.hpp
@@ -18,12 +18,17 @@ namespace NeoN::finiteVolume::cellCentred
 template<typename ValueType>
 class VolumeField;
 
+template<typename ValueType>
+class SurfaceField;
+
 /**
  * @class BoundaryContext
- * @brief Carries named field references for wall-function boundary conditions.
+ * @brief Carries named field references for context-aware boundary conditions.
  *
- * Wall functions that need auxiliary fields (U, nu, nearWallDist, omega, k …)
+ * Boundary conditions that need auxiliary fields (U, nu, nearWallDist, omega, k …)
  * look up what they need by name instead of accepting a fixed argument list.
+ * Volume fields cover wall functions; the surface-scalar slot carries the face
+ * flux phi consumed by flux-dependent BCs such as inletOutlet.
  * All fields are stored as non-owning const pointers; the caller is responsible
  * for ensuring the lifetime of the referenced fields exceeds the context.
  */
@@ -34,20 +39,24 @@ public:
     void insert(std::string name, const VolumeField<scalar>& f);
     void insert(std::string name, const VolumeField<Vec3>& f);
     void insert(std::string name, const VolumeField<Tensor>& f);
+    void insert(std::string name, const SurfaceField<scalar>& f);
 
     const VolumeField<scalar>& scalarFieldPtr(const std::string& name) const;
     const VolumeField<Vec3>& vectorFieldPtr(const std::string& name) const;
     const VolumeField<Tensor>& tensorFieldPtr(const std::string& name) const;
+    const SurfaceField<scalar>& surfaceScalarField(const std::string& name) const;
 
     bool hasScalar(const std::string& name) const noexcept;
     bool hasVector(const std::string& name) const noexcept;
     bool hasTensor(const std::string& name) const noexcept;
+    bool hasSurfaceScalar(const std::string& name) const noexcept;
 
 private:
 
     std::unordered_map<std::string, const VolumeField<NeoN::scalar>*> scalarFields_;
     std::unordered_map<std::string, const VolumeField<Vec3>*> vectorFields_;
     std::unordered_map<std::string, const VolumeField<Tensor>*> tensorFields_;
+    std::unordered_map<std::string, const SurfaceField<NeoN::scalar>*> surfaceScalarFields_;
 };
 
 } // namespace NeoN::finiteVolume::cellCentred

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/detail/slipSymmetry.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/detail/slipSymmetry.hpp
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <Kokkos_Core.hpp>
+
+#include "NeoN/fields/field.hpp"
+#include "NeoN/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp"
+#include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
+#include "NeoN/core/dictionary.hpp"
+#include "NeoN/core/parallelAlgorithms.hpp"
+
+// Shared implementation behind the `slip` and `symmetry` boundary conditions: they apply the same
+// operator and differ only in their registered name and in where they may be applied (slip on a
+// wall/regular patch, symmetry on a symmetry-plane patch). The operator is, per face:
+//   scalar => zero-gradient
+//   vector => tangential projection of the boundary value (the normal component is removed), plus a
+//             normal-damping surface-normal gradient that drives the normal component of the cell
+//             value towards zero.
+//
+// The normal damping can be realised two ways, selected by NormalDamping:
+//   - Deferred: written into refGrad as -deltaCoeffs*(v·n)*n, so it enters the per-component RHS
+//     through the existing fixed-gradient assembly. Keeps the shared scalar matrix + multi-RHS
+//     solve, at the cost of lagging the normal coupling by one outer iteration.
+//   - Implicit: refGrad is left zero here; the BoundaryAttributes::transformImplicit flag signals
+//     the Laplacian assembly to add a per-component diagonal correction (γ|S|·deltaCoeffs·|n_c|)
+//     instead, which the solver applies column-by-column. Fully implicit, single matrix, but the
+//     solve runs segregated rather than multi-RHS.
+//
+// NOTE: a future Tensor specialization (e.g. for a transported Reynolds-stress field) must use the
+// full reflective transform (T + H·T·H)/2 with H = I - 2 n⊗n, NOT a per-component projection.
+namespace NeoN::finiteVolume::cellCentred::volumeBoundary::detail
+{
+
+enum class NormalDamping
+{
+    Deferred, ///< normal damping via refGrad -> per-component RHS (multi-RHS friendly)
+    Implicit  ///< normal damping via per-component diagonal correction (segregated solve)
+};
+
+/** @brief Read the "implicit" flag from a slip/symmetry patch dictionary.
+ *
+ * Defaults to FALSE (Deferred), the multi-RHS-friendly mode. Set "implicit true" to opt into the
+ * fully-implicit per-component diagonal correction path (required when the shared scalar matrix +
+ * multi-RHS solve cannot carry the direction-dependent normal damping, e.g. occDrivAre ground/
+ * freestream patches where U_normal diverges with Deferred). A boolean read from a dictionary
+ * arrives as a word/string, so accept bool, int, and the common truthy spellings.
+ */
+inline bool readTransformImplicit(const Dictionary& dict)
+{
+    const std::string key = "implicit";
+    if (!dict.contains(key)) return false;
+    if (dict.isType<bool>(key)) return dict.get<bool>(key);
+    if (dict.isType<int>(key)) return dict.get<int>(key) != 0;
+    if (dict.isType<std::string>(key))
+    {
+        const std::string v = dict.get<std::string>(key);
+        return (v == "true" || v == "yes" || v == "on" || v == "1");
+    }
+    return false;
+}
+
+/** @brief Map the implicit flag onto the NormalDamping mode. */
+inline NormalDamping normalDampingMode(bool implicit)
+{
+    return implicit ? NormalDamping::Implicit : NormalDamping::Deferred;
+}
+
+// Primary declaration
+template<typename ValueType>
+void setSlipSymmetryValue(
+    Field<ValueType>& domainVector,
+    const UnstructuredMesh& mesh,
+    std::pair<localIdx, localIdx> range,
+    NormalDamping mode
+);
+
+// --- Scalar specialization: zero-gradient (mode is irrelevant; no normal component) ---
+template<>
+inline void setSlipSymmetryValue<NeoN::scalar>(
+    Field<NeoN::scalar>& domainVector,
+    const UnstructuredMesh& mesh,
+    std::pair<localIdx, localIdx> range,
+    [[maybe_unused]] NormalDamping mode
+)
+{
+    const auto internalV = domainVector.internalVector().view();
+
+    auto [refGradV, valueV, valueFractionV, refValueV, boundaryFaceOwnersV] = views(
+        domainVector.boundaryData().refGrad(),
+        domainVector.boundaryData().value(),
+        domainVector.boundaryData().valueFraction(),
+        domainVector.boundaryData().refValue(),
+        mesh.boundaryMesh().faceOwners()
+    );
+
+    NeoN::parallelFor(
+        domainVector.exec(),
+        range,
+        NEON_LAMBDA(const localIdx i) {
+            const localIdx owner = boundaryFaceOwnersV[i];
+            const auto v = internalV[owner];
+
+            refValueV[i] = v;
+            valueV[i] = v;
+            valueFractionV[i] = 0.0;
+            refGradV[i] = 0.0;
+        },
+        "setSlipSymmetryValue(scalar)"
+    );
+}
+
+// --- Vec3 specialization: tangential projection + normal damping ---
+template<>
+inline void setSlipSymmetryValue<NeoN::Vec3>(
+    Field<NeoN::Vec3>& domainVector,
+    const UnstructuredMesh& mesh,
+    std::pair<localIdx, localIdx> range,
+    NormalDamping mode
+)
+{
+    const auto internalV = domainVector.internalVector().view();
+    const bool deferred = (mode == NormalDamping::Deferred);
+
+    auto
+        [refGradV,
+         valueV,
+         valueFractionV,
+         refValueV,
+         boundaryFaceOwnersV,
+         faceUnitNormalsV,
+         deltaCoeffsV] =
+            views(
+                domainVector.boundaryData().refGrad(),
+                domainVector.boundaryData().value(),
+                domainVector.boundaryData().valueFraction(),
+                domainVector.boundaryData().refValue(),
+                mesh.boundaryMesh().faceOwners(),
+                mesh.boundaryMesh().faceUnitNormals(),
+                mesh.boundaryMesh().deltaCoeffs()
+            );
+
+    NeoN::parallelFor(
+        domainVector.exec(),
+        range,
+        NEON_LAMBDA(const localIdx i) {
+            const localIdx owner = boundaryFaceOwnersV[i];
+            const auto v = internalV[owner];
+            const auto n = faceUnitNormalsV[i];
+
+            const auto un = (v & n);      // normal component (scalar)
+            const auto vtan = v - n * un; // tangential projection (remove normal component)
+
+            // Explicit boundary value: used by convection / face interpolation (no penetration).
+            refValueV[i] = vtan;
+            valueV[i] = vtan;
+
+            // Keep the diagonal contribution component-isotropic (zero here) so the shared scalar
+            // matrix and its multi-RHS solve are preserved.
+            valueFractionV[i] = 0.0;
+
+            // Deferred mode: normal damping as the surface-normal gradient -deltaCoeffs*(v·n)*n
+            // (purely normal, so the tangential components stay zero-gradient). Implicit mode:
+            // leave refGrad zero — the damping is applied as a per-component diagonal correction
+            // during assembly/solve.
+            refGradV[i] = deferred ? n * (-deltaCoeffsV[i] * un) : NeoN::zero<NeoN::Vec3>();
+        },
+        "setSlipSymmetryValue(Vec3)"
+    );
+}
+
+} // namespace NeoN::finiteVolume::cellCentred::volumeBoundary::detail

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/detail/slipSymmetry.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/detail/slipSymmetry.hpp
@@ -16,74 +16,26 @@
 // operator and differ only in their registered name and in where they may be applied (slip on a
 // wall/regular patch, symmetry on a symmetry-plane patch). The operator is, per face:
 //   scalar => zero-gradient
-//   vector => tangential projection of the boundary value (the normal component is removed), plus a
-//             normal-damping surface-normal gradient that drives the normal component of the cell
-//             value towards zero.
-//
-// The normal damping can be realised two ways, selected by NormalDamping:
-//   - Deferred: written into refGrad as -deltaCoeffs*(v·n)*n, so it enters the per-component RHS
-//     through the existing fixed-gradient assembly. Keeps the shared scalar matrix + multi-RHS
-//     solve, at the cost of lagging the normal coupling by one outer iteration.
-//   - Implicit: refGrad is left zero here; the BoundaryAttributes::transformImplicit flag signals
-//     the Laplacian assembly to add a per-component diagonal correction (γ|S|·deltaCoeffs·|n_c|)
-//     instead, which the solver applies column-by-column. Fully implicit, single matrix, but the
-//     solve runs segregated rather than multi-RHS.
-//
-// NOTE: a future Tensor specialization (e.g. for a transported Reynolds-stress field) must use the
-// full reflective transform (T + H·T·H)/2 with H = I - 2 n⊗n, NOT a per-component projection.
+//   vector => tangential projection of the boundary value (the normal component is removed), plus
+//             a deferred normal-damping surface-normal gradient -deltaCoeffs*(v·n)*n that drives
+//             the normal component of the cell value towards zero via the per-component RHS.
 namespace NeoN::finiteVolume::cellCentred::volumeBoundary::detail
 {
-
-enum class NormalDamping
-{
-    Deferred, ///< normal damping via refGrad -> per-component RHS (multi-RHS friendly)
-    Implicit  ///< normal damping via per-component diagonal correction (segregated solve)
-};
-
-/** @brief Read the "implicit" flag from a slip/symmetry patch dictionary.
- *
- * Defaults to FALSE (Deferred), the multi-RHS-friendly mode. Set "implicit true" to opt into the
- * fully-implicit per-component diagonal correction path (required when the shared scalar matrix +
- * multi-RHS solve cannot carry the direction-dependent normal damping, e.g. occDrivAre ground/
- * freestream patches where U_normal diverges with Deferred). A boolean read from a dictionary
- * arrives as a word/string, so accept bool, int, and the common truthy spellings.
- */
-inline bool readTransformImplicit(const Dictionary& dict)
-{
-    const std::string key = "implicit";
-    if (!dict.contains(key)) return false;
-    if (dict.isType<bool>(key)) return dict.get<bool>(key);
-    if (dict.isType<int>(key)) return dict.get<int>(key) != 0;
-    if (dict.isType<std::string>(key))
-    {
-        const std::string v = dict.get<std::string>(key);
-        return (v == "true" || v == "yes" || v == "on" || v == "1");
-    }
-    return false;
-}
-
-/** @brief Map the implicit flag onto the NormalDamping mode. */
-inline NormalDamping normalDampingMode(bool implicit)
-{
-    return implicit ? NormalDamping::Implicit : NormalDamping::Deferred;
-}
 
 // Primary declaration
 template<typename ValueType>
 void setSlipSymmetryValue(
     Field<ValueType>& domainVector,
     const UnstructuredMesh& mesh,
-    std::pair<localIdx, localIdx> range,
-    NormalDamping mode
+    std::pair<localIdx, localIdx> range
 );
 
-// --- Scalar specialization: zero-gradient (mode is irrelevant; no normal component) ---
+// --- Scalar specialization: zero-gradient ---
 template<>
 inline void setSlipSymmetryValue<NeoN::scalar>(
     Field<NeoN::scalar>& domainVector,
     const UnstructuredMesh& mesh,
-    std::pair<localIdx, localIdx> range,
-    [[maybe_unused]] NormalDamping mode
+    std::pair<localIdx, localIdx> range
 )
 {
     const auto internalV = domainVector.internalVector().view();
@@ -112,17 +64,15 @@ inline void setSlipSymmetryValue<NeoN::scalar>(
     );
 }
 
-// --- Vec3 specialization: tangential projection + normal damping ---
+// --- Vec3 specialization: tangential projection + deferred normal damping ---
 template<>
 inline void setSlipSymmetryValue<NeoN::Vec3>(
     Field<NeoN::Vec3>& domainVector,
     const UnstructuredMesh& mesh,
-    std::pair<localIdx, localIdx> range,
-    NormalDamping mode
+    std::pair<localIdx, localIdx> range
 )
 {
     const auto internalV = domainVector.internalVector().view();
-    const bool deferred = (mode == NormalDamping::Deferred);
 
     auto
         [refGradV,
@@ -157,15 +107,13 @@ inline void setSlipSymmetryValue<NeoN::Vec3>(
             refValueV[i] = vtan;
             valueV[i] = vtan;
 
-            // Keep the diagonal contribution component-isotropic (zero here) so the shared scalar
-            // matrix and its multi-RHS solve are preserved.
+            // valueFraction = 0: keep the diagonal contribution component-isotropic so the shared
+            // scalar matrix and multi-RHS solve are preserved.
             valueFractionV[i] = 0.0;
 
-            // Deferred mode: normal damping as the surface-normal gradient -deltaCoeffs*(v·n)*n
-            // (purely normal, so the tangential components stay zero-gradient). Implicit mode:
-            // leave refGrad zero — the damping is applied as a per-component diagonal correction
-            // during assembly/solve.
-            refGradV[i] = deferred ? n * (-deltaCoeffsV[i] * un) : NeoN::zero<NeoN::Vec3>();
+            // Normal damping via the surface-normal gradient -deltaCoeffs*(v·n)*n enters the
+            // per-component RHS through the existing fixed-gradient assembly.
+            refGradV[i] = n * (-deltaCoeffsV[i] * un);
         },
         "setSlipSymmetryValue(Vec3)"
     );

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/inletOutlet.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/inletOutlet.hpp
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: 2023 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <Kokkos_Core.hpp>
+
+#include "NeoN/fields/field.hpp"
+#include "NeoN/core/primitives/traits.hpp"
+#include "NeoN/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp"
+#include "NeoN/finiteVolume/cellCentred/boundary/boundaryContext.hpp"
+#include "NeoN/finiteVolume/cellCentred/fields/surfaceField.hpp"
+#include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
+#include "NeoN/core/parallelAlgorithms.hpp"
+
+namespace NeoN::finiteVolume::cellCentred::volumeBoundary
+{
+
+namespace detail
+{
+// Shared kernel behind inletOutlet. Per boundary face it switches between two mixed-BC states
+// according to the sign of the face flux phi:
+//   inflow  (phi <  0): Dirichlet  -> valueFraction = 1, refValue = inletValue, refGrad = 0
+//   outflow (phi >= 0): zeroGradient -> valueFraction = 0, refGrad = 0
+// The explicit face value is the evaluated mixed value used by convection/interpolation:
+//   value = valueFraction*inletValue + (1 - valueFraction)*(phi_C + refGrad/delta)
+// with refGrad = 0 this is inletValue on inflow and the owner-cell value on outflow.
+//
+// When no flux is available (hasFlux == false, e.g. the plain correctBoundaryCondition path with
+// no BoundaryContext) every face is treated as outflow, degenerating to a pure zeroGradient BC.
+template<typename ValueType>
+void setInletOutletValue(
+    Field<ValueType>& domainVector,
+    const UnstructuredMesh& mesh,
+    std::pair<localIdx, localIdx> range,
+    ValueType inletValue,
+    View<const NeoN::scalar> boundaryFlux,
+    bool hasFlux
+)
+{
+    const auto internalV = domainVector.internalVector().view();
+
+    auto [refGradV, valueV, valueFractionV, refValueV, boundaryFaceOwnersV] = views(
+        domainVector.boundaryData().refGrad(),
+        domainVector.boundaryData().value(),
+        domainVector.boundaryData().valueFraction(),
+        domainVector.boundaryData().refValue(),
+        mesh.boundaryMesh().faceOwners()
+    );
+
+    NeoN::parallelFor(
+        domainVector.exec(),
+        range,
+        NEON_LAMBDA(const localIdx i) {
+            const localIdx owner = boundaryFaceOwnersV[i];
+            const auto internal = internalV[owner];
+
+            // Inflow where the face flux is negative; otherwise outflow (zero-gradient).
+            const NeoN::scalar valueFraction = (hasFlux && boundaryFlux[i] < 0.0) ? 1.0 : 0.0;
+
+            valueFractionV[i] = valueFraction;
+            refValueV[i] = inletValue;
+            refGradV[i] = NeoN::zero<ValueType>();
+            valueV[i] = inletValue * valueFraction + internal * (1.0 - valueFraction);
+        },
+        "setInletOutletValue"
+    );
+}
+
+}
+
+// inletOutlet switches between a fixed inlet value (on inflow faces) and zero-gradient
+// extrapolation (on outflow faces), decided per face by the sign of the face flux phi. It is the
+// generic-transport outlet counterpart to fixedValue and mirrors OpenFOAM's inletOutlet
+// (a mixedFvPatchField with valueFraction = neg(phi), refGrad = 0).
+//
+// The flux is looked up by name (key "phi", default "phi") from the BoundaryContext passed to the
+// context-aware correctBoundaryCondition overload. The plain overload has no flux and degenerates
+// to zeroGradient, so a solver that wants the dynamic switch must call the field's
+// correctBoundaryConditions(ctx) with phi inserted into the context.
+template<typename ValueType>
+class InletOutlet :
+    public VolumeBoundaryFactory<ValueType>::template Register<InletOutlet<ValueType>>
+{
+    using Base =
+        typename VolumeBoundaryFactory<ValueType>::template Register<InletOutlet<ValueType>>;
+
+public:
+
+    using Base::correctBoundaryCondition;
+
+    using InletOutletType = InletOutlet<ValueType>;
+
+    // assignable = true because the boundary value is recomputed from
+    // internal[owner] (outflow / no-flux path) or from inletValue (inflow
+    // path) every correctBoundaryCondition call — any downstream overwrite
+    // is reversible. assignable = false would trip NeoFOAM's constrainHbyA
+    // (src/algorithms/pressureVelocityCoupling.cpp) into pinning HbyA's
+    // boundary to U's at every outflow inletOutlet patch, which over-
+    // constrains SIMPLE and diverges (saw this on motorBike, t≈230).
+    // True Dirichlet inflow handling on mixed-flow patches needs per-face
+    // attributes — not modelled today; the per-face refValue/valueFraction
+    // already drive the operators correctly via the mixed-BC kernels.
+    InletOutlet(const UnstructuredMesh& mesh, const Dictionary& dict, localIdx patchID)
+        : Base(mesh, dict, patchID, {.assignable = true, .fixesValue = false}), mesh_(mesh),
+          inletValue_(dict.get<ValueType>("inletValue")),
+          phiName_(dict.contains("phi") ? dict.get<std::string>("phi") : std::string("phi"))
+    {}
+
+    // No context => no flux available: behave as zero-gradient (all faces treated as outflow).
+    virtual void correctBoundaryCondition(Field<ValueType>& domainVector) final
+    {
+        detail::setInletOutletValue(
+            domainVector, mesh_, this->range(), inletValue_, View<const NeoN::scalar> {}, false
+        );
+    }
+
+    // Context-aware: read the face flux phi and switch inflow/outflow per face.
+    virtual void
+    correctBoundaryCondition(Field<ValueType>& domainVector, const BoundaryContext& ctx) final
+    {
+        if (ctx.hasSurfaceScalar(phiName_))
+        {
+            const auto& phi = ctx.surfaceScalarField(phiName_);
+            detail::setInletOutletValue(
+                domainVector,
+                mesh_,
+                this->range(),
+                inletValue_,
+                phi.boundaryData().value().view(),
+                true
+            );
+        }
+        else
+        {
+            correctBoundaryCondition(domainVector);
+        }
+    }
+
+    static std::string name() { return "inletOutlet"; }
+
+    std::string getName() const override { return name(); }
+
+    static std::string doc()
+    {
+        return "Inlet/outlet: fixed inletValue on inflow faces, zero-gradient on outflow faces "
+               "(switched per face by the sign of the face flux phi).";
+    }
+
+    static std::string schema() { return "none"; }
+
+    virtual std::unique_ptr<VolumeBoundaryFactory<ValueType>> clone() const final
+    {
+        return std::make_unique<InletOutlet>(*this);
+    }
+
+private:
+
+    const UnstructuredMesh& mesh_;
+    ValueType inletValue_;
+    std::string phiName_;
+};
+
+} // namespace NeoN::finiteVolume::cellCentred::volumeBoundary

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/inletOutlet.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/inletOutlet.hpp
@@ -92,18 +92,17 @@ public:
 
     using InletOutletType = InletOutlet<ValueType>;
 
-    // assignable = true because the boundary value is recomputed from
-    // internal[owner] (outflow / no-flux path) or from inletValue (inflow
-    // path) every correctBoundaryCondition call — any downstream overwrite
-    // is reversible. assignable = false would trip NeoFOAM's constrainHbyA
-    // (src/algorithms/pressureVelocityCoupling.cpp) into pinning HbyA's
-    // boundary to U's at every outflow inletOutlet patch, which over-
-    // constrains SIMPLE and diverges (saw this on motorBike, t≈230).
-    // True Dirichlet inflow handling on mixed-flow patches needs per-face
-    // attributes — not modelled today; the per-face refValue/valueFraction
-    // already drive the operators correctly via the mixed-BC kernels.
+    // assignable = true: the boundary value is recomputed every correctBoundaryCondition call, so
+    // any downstream overwrite is reversible. assignable = false would trip NeoFOAM's constrainHbyA
+    // into pinning HbyA's boundary to U's at every outflow patch, over-constraining SIMPLE.
+    //
+    // fixesValue = true: GaussGreenGrad reads snGrad from value() rather than refGrad.
+    // value() is already set to the correct per-face evaluated value (inletValue on inflow,
+    // internal[owner] on outflow), so the computed snGrad is correct for both cases:
+    //   inflow:  snGrad = (inletValue - internal) * deltaCoeffs  (Dirichlet gradient)
+    //   outflow: snGrad = (internal   - internal) * deltaCoeffs = 0  (zero-gradient)
     InletOutlet(const UnstructuredMesh& mesh, const Dictionary& dict, localIdx patchID)
-        : Base(mesh, dict, patchID, {.assignable = true, .fixesValue = false}), mesh_(mesh),
+        : Base(mesh, dict, patchID, {.assignable = true, .fixesValue = true}), mesh_(mesh),
           inletValue_(dict.get<ValueType>("inletValue")),
           phiName_(dict.contains("phi") ? dict.get<std::string>("phi") : std::string("phi"))
     {}

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/slip.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/slip.hpp
@@ -16,10 +16,9 @@ namespace NeoN::finiteVolume::cellCentred::volumeBoundary
 {
 
 // Slip is a frictionless-wall boundary condition: scalar => zero-gradient, vector => tangential
-// projection + normal damping. It shares its implementation with Symmetry via
+// projection + deferred normal damping. It shares its implementation with Symmetry via
 // detail::setSlipSymmetryValue; the two differ only in the registered name and in where they may be
-// applied (slip on wall/patch types, symmetry on a symmetry-plane patch). The optional "implicit"
-// key selects the normal-damping treatment.
+// applied (slip on wall/patch types, symmetry on a symmetry-plane patch).
 template<typename ValueType>
 class Slip : public VolumeBoundaryFactory<ValueType>::template Register<Slip<ValueType>>
 {
@@ -32,22 +31,12 @@ public:
     using SlipType = Slip<ValueType>;
 
     Slip(const UnstructuredMesh& mesh, const Dictionary& dict, localIdx patchID)
-        : Base(
-            mesh,
-            dict,
-            patchID,
-            {.assignable = false,
-             .fixesValue = false,
-             .transformImplicit = detail::readTransformImplicit(dict)}
-        ),
-          mesh_(mesh), implicit_(detail::readTransformImplicit(dict))
+        : Base(mesh, dict, patchID, {.assignable = false, .fixesValue = false}), mesh_(mesh)
     {}
 
     virtual void correctBoundaryCondition(Field<ValueType>& domainVector) final
     {
-        detail::setSlipSymmetryValue(
-            domainVector, mesh_, this->range(), detail::normalDampingMode(implicit_)
-        );
+        detail::setSlipSymmetryValue(domainVector, mesh_, this->range());
     }
 
     static std::string name() { return "slip"; }
@@ -69,7 +58,6 @@ public:
 private:
 
     const UnstructuredMesh& mesh_;
-    bool implicit_;
 };
 
 } // namespace NeoN::finiteVolume::cellCentred::volumeBoundary

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/slip.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/slip.hpp
@@ -8,99 +8,18 @@
 
 #include "NeoN/fields/field.hpp"
 #include "NeoN/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp"
+#include "NeoN/finiteVolume/cellCentred/boundary/volume/detail/slipSymmetry.hpp"
 #include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
 #include "NeoN/core/parallelAlgorithms.hpp"
 
 namespace NeoN::finiteVolume::cellCentred::volumeBoundary
 {
 
-namespace detail
-{
-
-// Primary declaration
-template<typename ValueType>
-void setSlipValue(
-    Field<ValueType>& domainVector,
-    const UnstructuredMesh& mesh,
-    std::pair<localIdx, localIdx> range
-);
-
-// --- Scalar specialization: zero-gradient ---
-template<>
-inline void setSlipValue<NeoN::scalar>(
-    Field<NeoN::scalar>& domainVector,
-    const UnstructuredMesh& mesh,
-    std::pair<localIdx, localIdx> range
-)
-{
-    const auto internalV = domainVector.internalVector().view();
-
-    auto [refGradV, valueV, valueFractionV, refValueV, boundaryFaceOwnersV] = views(
-        domainVector.boundaryData().refGrad(),
-        domainVector.boundaryData().value(),
-        domainVector.boundaryData().valueFraction(),
-        domainVector.boundaryData().refValue(),
-        mesh.boundaryMesh().faceOwners()
-    );
-
-    NeoN::parallelFor(
-        domainVector.exec(),
-        range,
-        NEON_LAMBDA(const localIdx i) {
-            const localIdx owner = boundaryFaceOwnersV[i];
-            const auto v = internalV[owner];
-
-            refValueV[i] = v;
-            valueV[i] = v;
-            valueFractionV[i] = 0.0;
-            refGradV[i] = 0.0;
-        },
-        "setSlipValue(scalar)"
-    );
-}
-
-// --- Vec3 specialization: tangential projection (remove normal component) ---
-template<>
-inline void setSlipValue<NeoN::Vec3>(
-    Field<NeoN::Vec3>& domainVector,
-    const UnstructuredMesh& mesh,
-    std::pair<localIdx, localIdx> range
-)
-{
-    const auto internalV = domainVector.internalVector().view();
-
-    auto [refGradV, valueV, valueFractionV, refValueV, boundaryFaceOwnersV, faceUnitNormalsV] =
-        views(
-            domainVector.boundaryData().refGrad(),
-            domainVector.boundaryData().value(),
-            domainVector.boundaryData().valueFraction(),
-            domainVector.boundaryData().refValue(),
-            mesh.boundaryMesh().faceOwners(),
-            mesh.boundaryMesh().faceUnitNormals()
-        );
-
-    NeoN::parallelFor(
-        domainVector.exec(),
-        range,
-        NEON_LAMBDA(const localIdx i) {
-            const localIdx owner = boundaryFaceOwnersV[i];
-            const auto v = internalV[owner];
-            const auto n = faceUnitNormalsV[i];
-
-            const auto vtan = v - n * (v & n);
-
-            refValueV[i] = vtan;
-            valueV[i] = vtan;
-            valueFractionV[i] = 0.0;
-            refGradV[i] = NeoN::zero<NeoN::Vec3>();
-        },
-        "setSlipValue(Vec3)"
-    );
-}
-
-} // namespace detail
-
-
+// Slip is a frictionless-wall boundary condition: scalar => zero-gradient, vector => tangential
+// projection + normal damping. It shares its implementation with Symmetry via
+// detail::setSlipSymmetryValue; the two differ only in the registered name and in where they may be
+// applied (slip on wall/patch types, symmetry on a symmetry-plane patch). The optional "implicit"
+// key selects the normal-damping treatment.
 template<typename ValueType>
 class Slip : public VolumeBoundaryFactory<ValueType>::template Register<Slip<ValueType>>
 {
@@ -113,12 +32,22 @@ public:
     using SlipType = Slip<ValueType>;
 
     Slip(const UnstructuredMesh& mesh, const Dictionary& dict, localIdx patchID)
-        : Base(mesh, dict, patchID, {.assignable = false, .fixesValue = false}), mesh_(mesh)
+        : Base(
+            mesh,
+            dict,
+            patchID,
+            {.assignable = false,
+             .fixesValue = false,
+             .transformImplicit = detail::readTransformImplicit(dict)}
+        ),
+          mesh_(mesh), implicit_(detail::readTransformImplicit(dict))
     {}
 
     virtual void correctBoundaryCondition(Field<ValueType>& domainVector) final
     {
-        detail::setSlipValue(domainVector, mesh_, this->range());
+        detail::setSlipSymmetryValue(
+            domainVector, mesh_, this->range(), detail::normalDampingMode(implicit_)
+        );
     }
 
     static std::string name() { return "slip"; }
@@ -127,7 +56,7 @@ public:
 
     static std::string doc()
     {
-        return "Slip wall (scalar: zero-gradient; vector: tangential projection).";
+        return "Slip wall (scalar: zero-gradient; vector: tangential projection + normal damping).";
     }
 
     static std::string schema() { return "none"; }
@@ -140,6 +69,7 @@ public:
 private:
 
     const UnstructuredMesh& mesh_;
+    bool implicit_;
 };
 
 } // namespace NeoN::finiteVolume::cellCentred::volumeBoundary

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/symmetry.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/symmetry.hpp
@@ -8,102 +8,17 @@
 
 #include "NeoN/fields/field.hpp"
 #include "NeoN/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp"
+#include "NeoN/finiteVolume/cellCentred/boundary/volume/detail/slipSymmetry.hpp"
 #include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
 #include "NeoN/core/parallelAlgorithms.hpp"
 
 namespace NeoN::finiteVolume::cellCentred::volumeBoundary
 {
 
-namespace detail
-{
-
-// Primary declaration
-template<typename ValueType>
-void setSymmetryValue(
-    Field<ValueType>& domainVector,
-    const UnstructuredMesh& mesh,
-    std::pair<localIdx, localIdx> range
-);
-
-// --- Scalar specialization ---
-template<>
-inline void setSymmetryValue<NeoN::scalar>(
-    Field<NeoN::scalar>& domainVector,
-    const UnstructuredMesh& mesh,
-    std::pair<localIdx, localIdx> range
-)
-{
-    const auto internalV = domainVector.internalVector().view();
-
-    auto [refGradV, valueV, valueFractionV, refValueV, boundaryFaceOwnersV] = views(
-        domainVector.boundaryData().refGrad(),
-        domainVector.boundaryData().value(),
-        domainVector.boundaryData().valueFraction(),
-        domainVector.boundaryData().refValue(),
-        mesh.boundaryMesh().faceOwners()
-    );
-
-    NeoN::parallelFor(
-        domainVector.exec(),
-        range,
-        NEON_LAMBDA(const localIdx i) {
-            const localIdx owner = boundaryFaceOwnersV[i];
-            const auto v = internalV[owner];
-
-            // Scalar symmetry → zero-gradient
-            refValueV[i] = v;
-            valueV[i] = v;
-            valueFractionV[i] = 0.0;
-            refGradV[i] = 0.0;
-        },
-        "setSymmetryValue(scalar)"
-    );
-}
-
-// --- Vec3 specialization ---
-template<>
-inline void setSymmetryValue<NeoN::Vec3>(
-    Field<NeoN::Vec3>& domainVector,
-    const UnstructuredMesh& mesh,
-    std::pair<localIdx, localIdx> range
-)
-{
-    const auto internalV = domainVector.internalVector().view();
-
-    auto [refGradV, valueV, valueFractionV, refValueV, boundaryFaceOwnersV, faceUnitNormalsV] =
-        views(
-            domainVector.boundaryData().refGrad(),
-            domainVector.boundaryData().value(),
-            domainVector.boundaryData().valueFraction(),
-            domainVector.boundaryData().refValue(),
-            mesh.boundaryMesh().faceOwners(),
-            mesh.boundaryMesh().faceUnitNormals()
-        );
-
-    NeoN::parallelFor(
-        domainVector.exec(),
-        range,
-        NEON_LAMBDA(const localIdx i) {
-            const localIdx owner = boundaryFaceOwnersV[i];
-            const auto v = internalV[owner];
-            const auto n = faceUnitNormalsV[i];
-
-            // Tangential projection (remove normal component)
-            const auto vn = v & n;
-            const auto vtan = v - n * vn;
-
-            refValueV[i] = vtan;
-            valueV[i] = vtan;
-            valueFractionV[i] = 0.0;
-            refGradV[i] = NeoN::zero<NeoN::Vec3>();
-        },
-        "setSymmetryValue(Vec3)"
-    );
-}
-
-} // namespace detail
-
-
+// Symmetry is a symmetry-plane boundary condition: scalar => zero-gradient, vector => tangential
+// projection + normal damping. It shares its implementation with Slip via
+// detail::setSlipSymmetryValue; they differ only in the registered name and in where they may be
+// applied. The optional "implicit" key selects the normal-damping treatment.
 template<typename ValueType>
 class Symmetry : public VolumeBoundaryFactory<ValueType>::template Register<Symmetry<ValueType>>
 {
@@ -116,12 +31,22 @@ public:
     using SymmetryType = Symmetry<ValueType>;
 
     Symmetry(const UnstructuredMesh& mesh, const Dictionary& dict, localIdx patchID)
-        : Base(mesh, dict, patchID, {.assignable = false, .fixesValue = false}), mesh_(mesh)
+        : Base(
+            mesh,
+            dict,
+            patchID,
+            {.assignable = false,
+             .fixesValue = false,
+             .transformImplicit = detail::readTransformImplicit(dict)}
+        ),
+          mesh_(mesh), implicit_(detail::readTransformImplicit(dict))
     {}
 
     virtual void correctBoundaryCondition(Field<ValueType>& domainVector) final
     {
-        detail::setSymmetryValue(domainVector, mesh_, this->range());
+        detail::setSlipSymmetryValue(
+            domainVector, mesh_, this->range(), detail::normalDampingMode(implicit_)
+        );
     }
 
     static std::string name() { return "symmetry"; }
@@ -130,7 +55,8 @@ public:
 
     static std::string doc()
     {
-        return "Symmetry plane (scalar: zero-gradient; vector: tangential projection).";
+        return "Symmetry plane (scalar: zero-gradient; vector: tangential projection + normal "
+               "damping).";
     }
 
     static std::string schema() { return "none"; }
@@ -143,6 +69,7 @@ public:
 private:
 
     const UnstructuredMesh& mesh_;
+    bool implicit_;
 };
 
 } // namespace NeoN::finiteVolume::cellCentred::volumeBoundary

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/symmetry.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/symmetry.hpp
@@ -16,9 +16,9 @@ namespace NeoN::finiteVolume::cellCentred::volumeBoundary
 {
 
 // Symmetry is a symmetry-plane boundary condition: scalar => zero-gradient, vector => tangential
-// projection + normal damping. It shares its implementation with Slip via
+// projection + deferred normal damping. It shares its implementation with Slip via
 // detail::setSlipSymmetryValue; they differ only in the registered name and in where they may be
-// applied. The optional "implicit" key selects the normal-damping treatment.
+// applied (symmetry on a symmetry-plane patch, slip on wall/patch types).
 template<typename ValueType>
 class Symmetry : public VolumeBoundaryFactory<ValueType>::template Register<Symmetry<ValueType>>
 {
@@ -31,22 +31,12 @@ public:
     using SymmetryType = Symmetry<ValueType>;
 
     Symmetry(const UnstructuredMesh& mesh, const Dictionary& dict, localIdx patchID)
-        : Base(
-            mesh,
-            dict,
-            patchID,
-            {.assignable = false,
-             .fixesValue = false,
-             .transformImplicit = detail::readTransformImplicit(dict)}
-        ),
-          mesh_(mesh), implicit_(detail::readTransformImplicit(dict))
+        : Base(mesh, dict, patchID, {.assignable = false, .fixesValue = false}), mesh_(mesh)
     {}
 
     virtual void correctBoundaryCondition(Field<ValueType>& domainVector) final
     {
-        detail::setSlipSymmetryValue(
-            domainVector, mesh_, this->range(), detail::normalDampingMode(implicit_)
-        );
+        detail::setSlipSymmetryValue(domainVector, mesh_, this->range());
     }
 
     static std::string name() { return "symmetry"; }
@@ -69,7 +59,6 @@ public:
 private:
 
     const UnstructuredMesh& mesh_;
-    bool implicit_;
 };
 
 } // namespace NeoN::finiteVolume::cellCentred::volumeBoundary

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp
@@ -28,6 +28,11 @@ struct BoundaryAttributes
     bool fixesValue; ///< whether the bc enforces a fixed field value (Dirichlet), not a
                      ///< gradient/Neumann condition NOTE this is somewhat redundant to
                      ///< valueFraction of boundaryData
+    bool transformImplicit = false; ///< whether this is a direction-dependent (transform) BC
+                                    ///< — e.g. slip/symmetry in implicit mode — whose normal
+                                    ///< damping must be applied as a per-component diagonal
+                                    ///< correction at solve time rather than via the RHS.
+                                    ///< Defaults to false so all existing BCs are unaffected.
 };
 
 template<typename ValueType>

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp
@@ -28,11 +28,6 @@ struct BoundaryAttributes
     bool fixesValue; ///< whether the bc enforces a fixed field value (Dirichlet), not a
                      ///< gradient/Neumann condition NOTE this is somewhat redundant to
                      ///< valueFraction of boundaryData
-    bool transformImplicit = false; ///< whether this is a direction-dependent (transform) BC
-                                    ///< — e.g. slip/symmetry in implicit mode — whose normal
-                                    ///< damping must be applied as a per-component diagonal
-                                    ///< correction at solve time rather than via the RHS.
-                                    ///< Defaults to false so all existing BCs are unaffected.
 };
 
 template<typename ValueType>

--- a/src/finiteVolume/cellCentred/boundary/boundaryContext.cpp
+++ b/src/finiteVolume/cellCentred/boundary/boundaryContext.cpp
@@ -4,6 +4,7 @@
 
 #include "NeoN/finiteVolume/cellCentred/boundary/boundaryContext.hpp"
 #include "NeoN/finiteVolume/cellCentred/fields/volumeField.hpp"
+#include "NeoN/finiteVolume/cellCentred/fields/surfaceField.hpp"
 
 namespace NeoN::finiteVolume::cellCentred
 {
@@ -21,6 +22,11 @@ void BoundaryContext::insert(std::string name, const VolumeField<Vec3>& f)
 void BoundaryContext::insert(std::string name, const VolumeField<Tensor>& f)
 {
     tensorFields_.emplace(std::move(name), &f);
+}
+
+void BoundaryContext::insert(std::string name, const SurfaceField<NeoN::scalar>& f)
+{
+    surfaceScalarFields_.emplace(std::move(name), &f);
 }
 
 const VolumeField<NeoN::scalar>& BoundaryContext::scalarFieldPtr(const std::string& name) const
@@ -51,6 +57,16 @@ bool BoundaryContext::hasVector(const std::string& name) const noexcept
 bool BoundaryContext::hasTensor(const std::string& name) const noexcept
 {
     return tensorFields_.count(name) > 0;
+}
+
+const SurfaceField<NeoN::scalar>& BoundaryContext::surfaceScalarField(const std::string& name) const
+{
+    return *surfaceScalarFields_.at(name);
+}
+
+bool BoundaryContext::hasSurfaceScalar(const std::string& name) const noexcept
+{
+    return surfaceScalarFields_.count(name) > 0;
 }
 
 } // namespace NeoN::finiteVolume::cellCentred

--- a/src/linearAlgebra/utilities.cpp
+++ b/src/linearAlgebra/utilities.cpp
@@ -101,42 +101,28 @@ Vector<localIdx> unpackRowOffs(const Vector<localIdx>& in)
 {
     const auto exec = in.exec();
     const auto inV = in.view();
-    // for a 3x3 matrix with 7 nnz 4
-    // 0, 2, 5, 7  -> size = 4
-    auto length = Vector<localIdx> {exec, 3 * (in.size() - 1)};
-    fill(length, 0);
-    auto lengthV = length.view();
-
-    // compute the length of each row and stretch it out
-    // [0, 2, 5, 7] -> [2, 2, 2, ..., 2,2,2 ]
-    NeoN::parallelFor(
-        exec,
-        {0, in.size() - 1},
-        NEON_LAMBDA(const localIdx i) {
-            localIdx j = 3 * i;
-            const auto val = inV[i + 1] - inV[i];
-            lengthV[j + 0] = val;
-            lengthV[j + 1] = val;
-            lengthV[j + 2] = val;
-        },
-        "computeUnpackedRowOffs"
-    );
-
-    auto ret = Vector<localIdx> {exec, 3 * (in.size() - 1) + 1};
-    fill(ret, 0);
+    // for a 3x3 matrix with 7 nnz, input is [0, 2, 5, 7] (4 entries = nRows+1)
+    const localIdx nOldRows = static_cast<localIdx>(in.size() - 1);
+    auto ret = Vector<localIdx>(exec, 3 * nOldRows + 1);
     auto retV = ret.view();
 
-    // [2, 2, 2] -> [0, 2, 4, 6, 8]
-    NeoN::parallelScan(
+    // Closed-form expansion: for original row i with offset off and length len,
+    // the 3 expanded rows start at: 3*off, 3*off+len, 3*off+2*len.
+    // The sentinel (last element) is 3*inV[nOldRows].
+    // Example: [0,2,5,7] -> [0,2,4, 6,9,12, 15,17,19, 21]
+    NeoN::parallelFor(
         exec,
-        {1, length.size() + 1},
-        NEON_LAMBDA(const NeoN::localIdx i, NeoN::localIdx& update, const bool final) {
-            update += lengthV[i - 1];
-            if (final)
+        {0, nOldRows + 1},
+        NEON_LAMBDA(const localIdx i) {
+            retV[3 * i] = 3 * inV[i];
+            if (i < nOldRows)
             {
-                retV[i] = update;
+                const localIdx len = inV[i + 1] - inV[i];
+                retV[3 * i + 1] = 3 * inV[i] + len;
+                retV[3 * i + 2] = 3 * inV[i] + 2 * len;
             }
-        }
+        },
+        "computeUnpackedRowOffs"
     );
     return ret;
 }

--- a/test/finiteVolume/cellCentred/boundary/volume/CMakeLists.txt
+++ b/test/finiteVolume/cellCentred/boundary/volume/CMakeLists.txt
@@ -5,3 +5,4 @@
 neon_unit_test(volFixedValue)
 neon_unit_test(volFixedGradient)
 neon_unit_test(volSymmetry)
+neon_unit_test(volInletOutlet)

--- a/test/finiteVolume/cellCentred/boundary/volume/volInletOutlet.cpp
+++ b/test/finiteVolume/cellCentred/boundary/volume/volInletOutlet.cpp
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: 2024 - 2026 NeoN authors
+//
+// SPDX-License-Identifier: MIT
+
+#define CATCH_CONFIG_RUNNER
+#include "catch2_common.hpp"
+
+#include "NeoN/NeoN.hpp"
+
+namespace fvcc = NeoN::finiteVolume::cellCentred;
+
+// Build a face-flux phi (surface scalar field) whose boundary faces all carry `flux`.
+fvcc::SurfaceField<NeoN::scalar>
+makeFlux(const NeoN::Executor& exec, const NeoN::UnstructuredMesh& mesh, NeoN::scalar flux)
+{
+    auto bcs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<NeoN::scalar>>(mesh);
+    fvcc::SurfaceField<NeoN::scalar> phi(exec, "phi", mesh, bcs);
+    NeoN::fill(phi.internalVector(), flux);
+    NeoN::fill(phi.boundaryData().value(), flux);
+    return phi;
+}
+
+TEST_CASE("inletOutlet_volume")
+{
+    auto [execName, exec] = GENERATE(allAvailableExecutor());
+
+    SECTION("scalar: inflow => fixedValue, outflow => zeroGradient " + execName)
+    {
+        auto mesh = NeoN::createSingleCellMesh(exec);
+
+        NeoN::Dictionary dict;
+        dict.insert("type", std::string("inletOutlet"));
+        dict.insert("inletValue", NeoN::scalar(7.0));
+        auto boundary =
+            fvcc::VolumeBoundaryFactory<NeoN::scalar>::create("inletOutlet", mesh, dict, 0);
+
+        // === inflow (phi < 0): Dirichlet inletValue ============================
+        {
+            auto field =
+                NeoN::Field<NeoN::scalar>(exec, mesh.nCells(), mesh.boundaryMesh().offset());
+            NeoN::fill(field.internalVector(), 4.0);
+
+            auto phi = makeFlux(exec, mesh, -2.0);
+            fvcc::BoundaryContext ctx;
+            ctx.insert("phi", phi);
+
+            boundary->correctBoundaryCondition(field, ctx);
+
+            auto [valuesH, refValuesH, refGradH, valueFractionH] = copyToHosts(
+                field.boundaryData().value(),
+                field.boundaryData().refValue(),
+                field.boundaryData().refGrad(),
+                field.boundaryData().valueFraction()
+            );
+
+            for (auto& v : valuesH.view(boundary->range()))
+                REQUIRE(v == Catch::Approx(7.0));
+            for (auto& v : refValuesH.view(boundary->range()))
+                REQUIRE(v == Catch::Approx(7.0));
+            for (auto& f : valueFractionH.view(boundary->range()))
+                REQUIRE(f == Catch::Approx(1.0));
+            for (auto& g : refGradH.view(boundary->range()))
+                REQUIRE(g == Catch::Approx(0.0));
+        }
+
+        // === outflow (phi >= 0): zero-gradient (owner-cell value) ==============
+        {
+            auto field =
+                NeoN::Field<NeoN::scalar>(exec, mesh.nCells(), mesh.boundaryMesh().offset());
+            NeoN::fill(field.internalVector(), 4.0);
+
+            auto phi = makeFlux(exec, mesh, 2.0);
+            fvcc::BoundaryContext ctx;
+            ctx.insert("phi", phi);
+
+            boundary->correctBoundaryCondition(field, ctx);
+
+            auto [valuesH, refGradH, valueFractionH] = copyToHosts(
+                field.boundaryData().value(),
+                field.boundaryData().refGrad(),
+                field.boundaryData().valueFraction()
+            );
+
+            for (auto& v : valuesH.view(boundary->range()))
+                REQUIRE(v == Catch::Approx(4.0));
+            for (auto& f : valueFractionH.view(boundary->range()))
+                REQUIRE(f == Catch::Approx(0.0));
+            for (auto& g : refGradH.view(boundary->range()))
+                REQUIRE(g == Catch::Approx(0.0));
+        }
+
+        // === no context => no flux => zero-gradient ============================
+        {
+            auto field =
+                NeoN::Field<NeoN::scalar>(exec, mesh.nCells(), mesh.boundaryMesh().offset());
+            NeoN::fill(field.internalVector(), 4.0);
+
+            boundary->correctBoundaryCondition(field);
+
+            auto [valuesH, valueFractionH] =
+                copyToHosts(field.boundaryData().value(), field.boundaryData().valueFraction());
+
+            for (auto& v : valuesH.view(boundary->range()))
+                REQUIRE(v == Catch::Approx(4.0));
+            for (auto& f : valueFractionH.view(boundary->range()))
+                REQUIRE(f == Catch::Approx(0.0));
+        }
+    }
+
+    SECTION("vector: inflow => fixedValue, outflow => zeroGradient " + execName)
+    {
+        auto mesh = NeoN::createSingleCellMesh(exec);
+        const NeoN::Vec3 inletValue(1.0, 2.0, 3.0);
+
+        NeoN::Dictionary dict;
+        dict.insert("type", std::string("inletOutlet"));
+        dict.insert("inletValue", inletValue);
+        auto boundary =
+            fvcc::VolumeBoundaryFactory<NeoN::Vec3>::create("inletOutlet", mesh, dict, 0);
+
+        // inflow
+        {
+            auto field = NeoN::Field<NeoN::Vec3>(exec, mesh.nCells(), mesh.boundaryMesh().offset());
+            NeoN::fill(field.internalVector(), NeoN::Vec3(-1.0, -1.0, -1.0));
+
+            auto phi = makeFlux(exec, mesh, -2.0);
+            fvcc::BoundaryContext ctx;
+            ctx.insert("phi", phi);
+
+            boundary->correctBoundaryCondition(field, ctx);
+
+            auto [valuesH, valueFractionH] =
+                copyToHosts(field.boundaryData().value(), field.boundaryData().valueFraction());
+
+            for (auto& v : valuesH.view(boundary->range()))
+            {
+                const auto i = static_cast<NeoN::localIdx>(&v - valuesH.data());
+                REQUIRE(valueFractionH.view()[i] == Catch::Approx(1.0));
+                for (auto d = 0u; d < 3; ++d)
+                    REQUIRE(v[d] == Catch::Approx(inletValue[d]));
+            }
+        }
+
+        // outflow
+        {
+            auto field = NeoN::Field<NeoN::Vec3>(exec, mesh.nCells(), mesh.boundaryMesh().offset());
+            const NeoN::Vec3 internal(-1.0, -1.0, -1.0);
+            NeoN::fill(field.internalVector(), internal);
+
+            auto phi = makeFlux(exec, mesh, 2.0);
+            fvcc::BoundaryContext ctx;
+            ctx.insert("phi", phi);
+
+            boundary->correctBoundaryCondition(field, ctx);
+
+            auto [valuesH, valueFractionH] =
+                copyToHosts(field.boundaryData().value(), field.boundaryData().valueFraction());
+
+            for (auto& v : valuesH.view(boundary->range()))
+            {
+                const auto i = static_cast<NeoN::localIdx>(&v - valuesH.data());
+                REQUIRE(valueFractionH.view()[i] == Catch::Approx(0.0));
+                for (auto d = 0u; d < 3; ++d)
+                    REQUIRE(v[d] == Catch::Approx(internal[d]));
+            }
+        }
+    }
+}

--- a/test/finiteVolume/cellCentred/boundary/volume/volInletOutlet.cpp
+++ b/test/finiteVolume/cellCentred/boundary/volume/volInletOutlet.cpp
@@ -34,6 +34,10 @@ TEST_CASE("inletOutlet_volume")
         auto boundary =
             fvcc::VolumeBoundaryFactory<NeoN::scalar>::create("inletOutlet", mesh, dict, 0);
 
+        // fixesValue=true: GaussGreenGrad uses value() for snGrad, giving the correct
+        // Dirichlet gradient on inflow faces and zero gradient on outflow faces.
+        REQUIRE(boundary->attributes().fixesValue == true);
+
         // === inflow (phi < 0): Dirichlet inletValue ============================
         {
             auto field =

--- a/test/finiteVolume/cellCentred/boundary/volume/volSymmetry.cpp
+++ b/test/finiteVolume/cellCentred/boundary/volume/volSymmetry.cpp
@@ -76,14 +76,19 @@ TEST_CASE("symmetry_slip_volume")
 
             boundary->correctBoundaryCondition(field);
 
-            auto [refValuesH, valuesH, refGradH, nHatH, faceCellsH, internalH] = copyToHosts(
-                field.boundaryData().refValue(),
-                field.boundaryData().value(),
-                field.boundaryData().refGrad(),
-                mesh.boundaryMesh().faceUnitNormals(),
-                mesh.boundaryMesh().faceOwners(),
-                field.internalVector()
-            );
+            // default mode is deferred (multi-RHS friendly)
+            REQUIRE(boundary->attributes().transformImplicit == false);
+
+            auto [refValuesH, valuesH, refGradH, nHatH, deltaCoeffsH, faceCellsH, internalH] =
+                copyToHosts(
+                    field.boundaryData().refValue(),
+                    field.boundaryData().value(),
+                    field.boundaryData().refGrad(),
+                    mesh.boundaryMesh().faceUnitNormals(),
+                    mesh.boundaryMesh().deltaCoeffs(),
+                    mesh.boundaryMesh().faceOwners(),
+                    field.internalVector()
+                );
 
             for (auto& boundaryValueV : refValuesH.view(boundary->range()))
             {
@@ -91,7 +96,6 @@ TEST_CASE("symmetry_slip_volume")
                 const auto ownerV = faceCellsH.view()[i];
                 const auto nV = nHatH.view()[i];
                 const auto intV = internalH.view()[ownerV];
-                // const auto vn = vInt & n;
                 const auto vExpected = intV - nV * (intV & nV); // half-symmetry
 
                 for (auto d = 0u; d < 3; ++d)
@@ -100,6 +104,61 @@ TEST_CASE("symmetry_slip_volume")
                 }
             }
 
+            // deferred mode: refGrad = -deltaCoeffs * (U·n) * n  (purely normal => refGrad ∥ n)
+            for (auto& gradValueV : refGradH.view(boundary->range()))
+            {
+                const auto i = static_cast<NeoN::localIdx>(&gradValueV - refGradH.data());
+                const auto nV = nHatH.view()[i];
+                const auto intV = internalH.view()[faceCellsH.view()[i]];
+                const auto gExpected = nV * (-deltaCoeffsH.view()[i] * (intV & nV));
+
+                for (auto d = 0u; d < 3; ++d)
+                {
+                    REQUIRE(gradValueV[d] == Catch::Approx(gExpected[d]));
+                }
+            }
+        }
+
+        // === vector field: implicit mode ======================================
+        {
+            auto field = NeoN::Field<NeoN::Vec3>(exec, mesh.nCells(), mesh.boundaryMesh().offset());
+            NeoN::fill(field.internalVector(), NeoN::Vec3(1.0, -1.0, 0.5));
+            NeoN::fill(field.boundaryData().refGrad(), NeoN::Vec3(-1.0, -1.0, -1.0));
+            NeoN::fill(field.boundaryData().value(), NeoN::Vec3(-1.0, -1.0, -1.0));
+
+            NeoN::Dictionary dict;
+            dict.insert("implicit", true);
+            auto boundary =
+                NeoN::finiteVolume::cellCentred::VolumeBoundaryFactory<NeoN::Vec3>::create(
+                    "symmetry", mesh, dict, 0
+                );
+
+            boundary->correctBoundaryCondition(field);
+
+            REQUIRE(boundary->attributes().transformImplicit == true);
+
+            auto [valuesH, refGradH, nHatH, faceCellsH, internalH] = copyToHosts(
+                field.boundaryData().value(),
+                field.boundaryData().refGrad(),
+                mesh.boundaryMesh().faceUnitNormals(),
+                mesh.boundaryMesh().faceOwners(),
+                field.internalVector()
+            );
+
+            for (auto& boundaryValueV : valuesH.view(boundary->range()))
+            {
+                const auto i = static_cast<NeoN::localIdx>(&boundaryValueV - valuesH.data());
+                const auto nV = nHatH.view()[i];
+                const auto intV = internalH.view()[faceCellsH.view()[i]];
+                const auto vExpected = intV - nV * (intV & nV);
+
+                for (auto d = 0u; d < 3; ++d)
+                {
+                    REQUIRE(boundaryValueV[d] == Catch::Approx(vExpected[d]));
+                }
+            }
+
+            // implicit mode leaves refGrad zero (normal damping handled at assembly/solve)
             for (auto& gradValueV : refGradH.view(boundary->range()))
             {
                 for (auto d = 0u; d < 3; ++d)

--- a/test/finiteVolume/cellCentred/boundary/volume/volSymmetry.cpp
+++ b/test/finiteVolume/cellCentred/boundary/volume/volSymmetry.cpp
@@ -76,9 +76,6 @@ TEST_CASE("symmetry_slip_volume")
 
             boundary->correctBoundaryCondition(field);
 
-            // default mode is deferred (multi-RHS friendly)
-            REQUIRE(boundary->attributes().transformImplicit == false);
-
             auto [refValuesH, valuesH, refGradH, nHatH, deltaCoeffsH, faceCellsH, internalH] =
                 copyToHosts(
                     field.boundaryData().refValue(),
@@ -115,55 +112,6 @@ TEST_CASE("symmetry_slip_volume")
                 for (auto d = 0u; d < 3; ++d)
                 {
                     REQUIRE(gradValueV[d] == Catch::Approx(gExpected[d]));
-                }
-            }
-        }
-
-        // === vector field: implicit mode ======================================
-        {
-            auto field = NeoN::Field<NeoN::Vec3>(exec, mesh.nCells(), mesh.boundaryMesh().offset());
-            NeoN::fill(field.internalVector(), NeoN::Vec3(1.0, -1.0, 0.5));
-            NeoN::fill(field.boundaryData().refGrad(), NeoN::Vec3(-1.0, -1.0, -1.0));
-            NeoN::fill(field.boundaryData().value(), NeoN::Vec3(-1.0, -1.0, -1.0));
-
-            NeoN::Dictionary dict;
-            dict.insert("implicit", true);
-            auto boundary =
-                NeoN::finiteVolume::cellCentred::VolumeBoundaryFactory<NeoN::Vec3>::create(
-                    "symmetry", mesh, dict, 0
-                );
-
-            boundary->correctBoundaryCondition(field);
-
-            REQUIRE(boundary->attributes().transformImplicit == true);
-
-            auto [valuesH, refGradH, nHatH, faceCellsH, internalH] = copyToHosts(
-                field.boundaryData().value(),
-                field.boundaryData().refGrad(),
-                mesh.boundaryMesh().faceUnitNormals(),
-                mesh.boundaryMesh().faceOwners(),
-                field.internalVector()
-            );
-
-            for (auto& boundaryValueV : valuesH.view(boundary->range()))
-            {
-                const auto i = static_cast<NeoN::localIdx>(&boundaryValueV - valuesH.data());
-                const auto nV = nHatH.view()[i];
-                const auto intV = internalH.view()[faceCellsH.view()[i]];
-                const auto vExpected = intV - nV * (intV & nV);
-
-                for (auto d = 0u; d < 3; ++d)
-                {
-                    REQUIRE(boundaryValueV[d] == Catch::Approx(vExpected[d]));
-                }
-            }
-
-            // implicit mode leaves refGrad zero (normal damping handled at assembly/solve)
-            for (auto& gradValueV : refGradH.view(boundary->range()))
-            {
-                for (auto d = 0u; d < 3; ++d)
-                {
-                    REQUIRE(gradValueV[d] == Catch::Approx(0.0));
                 }
             }
         }


### PR DESCRIPTION
# Motivation

This PR extends the cell-centred finiteVolume boundary-condition set by adding an inletOutlet volume BC (flux-sign dependent mixed BC) and refactoring/augmenting slip and symmetry to support an “implicit/transform” mode signaled via a new BoundaryAttributes::transformImplicit flag. It also expands BoundaryContext to carry a surface-scalar field (intended for face flux phi) so BCs can switch behavior based on auxiliary fields.