### PR TITLE
fix(bindings): register Gauss div/laplacian operators inside _neon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,10 @@ option(NeoN_BUILD_PYTHON_BINDINGS "Build python bindings" OFF)
 # shared runtime has to be installed alongside _neon, and wheel repair tools (auditwheel, delocate,
 # delvewheel) vendor it under a mangled SONAME, which defeats the sharing it exists for.
 option(NeoN_NANOBIND_SHARED "Link the python bindings against a shared libnanobind" OFF)
+# Take nanobind from the active Python environment instead of fetching NeoN_NANOBIND_VERSION via
+# CPM. Useful together with NeoN_NANOBIND_SHARED: pybFoam builds against that same copy, so both
+# modules share one libnanobind ABI by construction rather than by a version pin.
+option(NeoN_EXTERNAL_NANOBIND "Use the nanobind from the active Python environment" OFF)
 option(NeoN_INSTALL_CMAKE_PACKAGE "Install CMake package config files and exported targets" ON)
 
 # Third party dependencies

--- a/cmake/CxxThirdParty.cmake
+++ b/cmake/CxxThirdParty.cmake
@@ -282,15 +282,26 @@ if(${NeoN_BUILD_PYTHON_BINDINGS})
     Python
     COMPONENTS Interpreter ${DEV_MODULE}
     REQUIRED)
-  cpmaddpackage(
-    NAME
-    nanobind
-    GITHUB_REPOSITORY
-    wjakob/nanobind
-    VERSION
-    ${NeoN_NANOBIND_VERSION}
-    SYSTEM
-    YES)
+  if(NeoN_EXTERNAL_NANOBIND)
+    # Use the nanobind shipped in the active Python environment (a build requirement, see
+    # pyproject). pybFoam is built against that same copy, so _neon and pybFoam share one
+    # libnanobind ABI by construction and NeoN_NANOBIND_VERSION does not have to be kept in sync.
+    execute_process(
+      COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      OUTPUT_VARIABLE nanobind_ROOT)
+    find_package(nanobind CONFIG REQUIRED)
+  else()
+    cpmaddpackage(
+      NAME
+      nanobind
+      GITHUB_REPOSITORY
+      wjakob/nanobind
+      VERSION
+      ${NeoN_NANOBIND_VERSION}
+      SYSTEM
+      YES)
+  endif()
 endif()
 
 if(NeoN_BUILD_TESTS OR NeoN_BUILD_BENCHMARKS)

--- a/src/bindings/dsl.cpp
+++ b/src/bindings/dsl.cpp
@@ -227,6 +227,26 @@ void registerDSL(nb::module_& m)
            const Dictionary& schemes,
            const Dictionary& solution) { return dsl::solve(exp, sol, t, dt, schemes, solution); }
     );
+
+    // Registered runtime-selection scheme names per operator factory, keyed by
+    // "<operator><value-type>". Regression hook for the force-instantiated operator
+    // registration above: an empty list means self-registration did not fire in _neon.
+    namespace fvcc = NeoN::finiteVolume::cellCentred;
+    m.def(
+        "registered_operator_schemes",
+        []()
+        {
+            nb::dict schemes;
+            schemes["div<scalar>"] = fvcc::DivOperatorFactory<scalar>::entries();
+            schemes["div<Vector>"] = fvcc::DivOperatorFactory<Vec3>::entries();
+            schemes["div<Vector,scalar>"] = fvcc::DivOperatorFactory<Vec3, scalar>::entries();
+            schemes["laplacian<scalar>"] = fvcc::LaplacianOperatorFactory<scalar>::entries();
+            schemes["laplacian<Vector>"] = fvcc::LaplacianOperatorFactory<Vec3>::entries();
+            schemes["laplacian<Vector,scalar>"] =
+                fvcc::LaplacianOperatorFactory<Vec3, scalar>::entries();
+            return schemes;
+        }
+    );
 }
 
 } // namespace NeoN::bindings

--- a/test/bindings/test_operator_registration.py
+++ b/test/bindings/test_operator_registration.py
@@ -17,10 +17,32 @@ These tests drive ``Expression.read`` — the call that performs the factory loo
 A scalar equation exercises the ``<scalar>`` instantiation; a vector equation
 additionally exercises the ``<Vec3>`` and ``<Vec3, scalar>`` instantiations (the
 vector ``div``/``laplacian`` build both same-type and scalar-matrix strategies).
+
+``test_registered_operator_schemes_match_expected`` additionally asserts the exact
+contents of each factory table, so a newly force-instantiated scheme (or one that
+silently disappears) has to be reflected here.
 """
 
 import neon
 from neon import imp
+
+# The schemes each operator factory is expected to have registered in ``_neon``.
+# Equality (below) makes this the source of truth: force-instantiate another scheme in
+# ``dsl.cpp`` and this must be updated in lockstep, so registration drift is caught.
+EXPECTED_SCHEMES = {
+    "div<scalar>": {"Gauss"},
+    "div<Vector>": {"Gauss"},
+    "div<Vector,scalar>": {"Gauss"},
+    "laplacian<scalar>": {"Gauss"},
+    "laplacian<Vector>": {"Gauss"},
+    "laplacian<Vector,scalar>": {"Gauss"},
+}
+
+
+def test_registered_operator_schemes_match_expected():
+    """Every operator factory has exactly its expected schemes registered in _neon."""
+    registered = {k: set(v) for k, v in neon.registered_operator_schemes().items()}
+    assert registered == EXPECTED_SCHEMES
 
 
 def _make_schemes() -> neon.Dictionary:


### PR DESCRIPTION
## Problem

The Gauss `div`/`laplacian` operators self-register into a `RuntimeSelectionFactory`
lookup table via CRTP (`Register<>::REGISTERED`). Their headers are declared
`extern template`, so **including** the headers does not instantiate them — the
self-registration only fires where the templates are explicitly instantiated, i.e.
in `libNeoN`.

The `_neon` Python module is compiled `-fvisibility=hidden`, so it receives its own
private, empty copy of the factory's function-local-static table. Scheme resolution
at assembly time (e.g. `"Gauss"` for `div`/`laplacian`) then aborts with:

```
Error: Could not find constructor for Gauss
valid constructors are:
```

This breaks every downstream binding path that constructs an implicit `div`/`laplacian`
through `_neon` (e.g. the `incompressibleFluidNeoN` solver).

## Fix

Force explicit instantiation of `GaussGreenDiv` / `GaussGreenLaplacian`
(`<scalar>`, `<Vec3>`, `<Vec3, scalar>`) inside `src/bindings/dsl.cpp` so their
self-registration fires *inside* `_neon` and populates its table.

Supporting build changes so the shared-runtime path is ABI-correct:
- build `_neon` with nanobind `NB_SHARED` (shares pybFoam's `libnanobind.so`);
- pin nanobind to `2.13.0` to match pybFoam's ABI (overridable downstream).

## Test

`test/bindings/test_operator_registration.py` drives `Expression.read(...)` — the call
that performs the `create("Gauss")` factory lookup — for both scalar and vector
equations, so it fails loudly if this registration ever regresses. Requires the
`Dictionary.insert_dict` / `insert_token_list` bindings added in `src/bindings/inputs.cpp`.

## Notes

This supersedes #560: it is the same set of fixes rebased cleanly onto the **current**
`develop` head (that PR's branch, `port/solvers`, is otherwise behind `develop`).

A `TODO` in `dsl.cpp` tracks the proper long-term fix — exporting the factory table
with default visibility so registration is shared across shared objects, making the
explicit-instantiation workaround unnecessary.
