### PR TITLE
Fix iteration count type consistency for the Ginkgo backend

### DIFF
--- a/include/NeoN/core/primitives/label.hpp
+++ b/include/NeoN/core/primitives/label.hpp
@@ -8,6 +8,24 @@
 
 #include "NeoN/core/primitives/traits.hpp"
 
+/**
+ * @brief Integer types used throughout NeoN.
+ *
+ * The following type aliases distinguish between different kinds of integer
+ * values:
+ *
+ * - `label` identifies mesh entities (e.g. cell number and face number)
+ * - `localIdx` indexes data that is local to a process or execution space,
+ *   such as arrays, views, and local graph structures.
+ * - `globalIdx` identifies globally unique entities in distributed-memory
+ *   computations.
+ * - `size_t` represents sizes and counts (e.g. container sizes, iteration
+ *   counts, and memory sizes) and should not be used to identify mesh
+ *   entities.
+ *
+ * The widths of `label`, `localIdx`, and `globalIdx` depend on the compile-time
+ * configuration (`NeoN_DP_LABEL` and `NeoN_US_IDX`).
+ */
 
 namespace NeoN
 {

--- a/include/NeoN/dsl/solver.hpp
+++ b/include/NeoN/dsl/solver.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <utility>
 #include <concepts>
+#include <optional>
 
 #include "NeoN/fields/field.hpp"
 #include "NeoN/core/primitives/scalar.hpp"

--- a/include/NeoN/dsl/solver.hpp
+++ b/include/NeoN/dsl/solver.hpp
@@ -114,7 +114,6 @@ std::optional<la::SolverStats> solve(
     {
         // integrate equations in time
         integrator.solve(exp, solution, t, dt);
-        // return {{.numIter = -1, .initResNorm = 0, .finalResNorm = 0, .solveTime = 0}};
         return std::nullopt; // no linear solve was performed, so no stats to return
     }
     else

--- a/include/NeoN/dsl/solver.hpp
+++ b/include/NeoN/dsl/solver.hpp
@@ -91,7 +91,7 @@ la::SolverStats iterativeSolveImpl(
  * @param p - A chainable functor that performs manipulations on the assembled system
  */
 template<typename VectorType, typename IndexType>
-la::SolverStats solve(
+std::optional<la::SolverStats> solve(
     Expression<typename VectorType::ElementType, IndexType>& exp,
     VectorType& solution,
     scalar t,
@@ -114,7 +114,8 @@ la::SolverStats solve(
     {
         // integrate equations in time
         integrator.solve(exp, solution, t, dt);
-        return {{.numIter = -1, .initResNorm = 0, .finalResNorm = 0, .solveTime = 0}};
+        // return {{.numIter = -1, .initResNorm = 0, .finalResNorm = 0, .solveTime = 0}};
+        return std::nullopt; // no linear solve was performed, so no stats to return
     }
     else
     {

--- a/include/NeoN/finiteVolume/cellCentred/operators/surfaceIntegrate.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/surfaceIntegrate.hpp
@@ -18,9 +18,9 @@ template<typename ValueType>
 void surfaceIntegrate(
     const Executor& exec,
     localIdx nInternalFaces,
-    View<const int> neighbors,
-    View<const int> owners,
-    View<const int> faceOwners,
+    View<const int> internalFaceNeighbors,
+    View<const int> internalFaceOwners,
+    View<const int> boundaryFaceOwners,
     View<const ValueType> flux,
     View<const ValueType> bFlux,
     View<const scalar> v,

--- a/include/NeoN/finiteVolume/cellCentred/operators/surfaceIntegrate.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/operators/surfaceIntegrate.hpp
@@ -18,9 +18,9 @@ template<typename ValueType>
 void surfaceIntegrate(
     const Executor& exec,
     localIdx nInternalFaces,
-    View<const int> internalFaceNeighbors,
-    View<const int> internalFaceOwners,
-    View<const int> boundaryFaceOwners,
+    View<const label> internalFaceNeighbors,
+    View<const label> internalFaceOwners,
+    View<const label> boundaryFaceOwners,
     View<const ValueType> flux,
     View<const ValueType> bFlux,
     View<const scalar> v,

--- a/include/NeoN/linearAlgebra/ginkgo.hpp
+++ b/include/NeoN/linearAlgebra/ginkgo.hpp
@@ -102,8 +102,8 @@ struct L1ResidualControl
 {
     scalar tolerance;        //!< absolute tolerance on the scaled L1 residual
     scalar relTol;           //!< relative tolerance (vs. initial residual); 0 disables
-    localIdx maxIter;        //!< maximum iteration count
-    localIdx minIter;        //!< minimum iteration count before tolerances are tested
+    gko::size_type maxIter;  //!< maximum iteration count
+    gko::size_type minIter;  //!< minimum iteration count before tolerances are tested
     localIdx checkFrequency; //!< evaluate the (expensive) true residual every N iterations; <=1 =
                              //!< every iteration
 };
@@ -111,9 +111,9 @@ struct L1ResidualControl
 /** @brief Result of a solve governed by the L1-scaled residual stopping criterion. */
 struct L1ResidualResult
 {
-    localIdx numIter;    //!< iterations performed
-    scalar initResNorm;  //!< combined scaled L1 initial residual (sum of columns)
-    scalar finalResNorm; //!< combined scaled L1 final residual (sum of columns)
+    gko::size_type numIter; //!< iterations performed
+    scalar initResNorm;     //!< combined scaled L1 initial residual (sum of columns)
+    scalar finalResNorm;    //!< combined scaled L1 final residual (sum of columns)
     // Per-column scaled residuals; populated only for multi-RHS (Vec3) solves (size == ncols).
     std::vector<scalar> perColInitNorms;
     std::vector<scalar> perColFinalNorms;

--- a/include/NeoN/linearAlgebra/solver.hpp
+++ b/include/NeoN/linearAlgebra/solver.hpp
@@ -13,7 +13,7 @@ namespace NeoN::la
 
 struct SolverStatsEntry
 {
-    int numIter;
+    size_t numIter;
     scalar initResNorm;
     scalar finalResNorm;
     scalar solveTime;
@@ -26,7 +26,7 @@ struct SolverStats
 
     SolverStats() : entries() {}
 
-    SolverStats(int numIter, scalar initResNorm, scalar finalResNorm, scalar solveTime)
+    SolverStats(size_t numIter, scalar initResNorm, scalar finalResNorm, scalar solveTime)
         : entries({SolverStatsEntry {numIter, initResNorm, finalResNorm, solveTime}})
     {}
 

--- a/src/finiteVolume/cellCentred/operators/surfaceIntegrate.cpp
+++ b/src/finiteVolume/cellCentred/operators/surfaceIntegrate.cpp
@@ -12,9 +12,9 @@ template<typename ValueType>
 void surfaceIntegrate(
     const Executor& exec,
     localIdx nInternalFaces,
-    View<const int> neighbors,
-    View<const int> owners,
-    View<const int> faceOwners,
+    View<const label> internalFaceNeighbors,
+    View<const label> internalFaceOwners,
+    View<const label> boundaryFaceOwners,
     View<const ValueType> flux,
     View<const ValueType> bFlux,
     View<const scalar> v,
@@ -23,13 +23,13 @@ void surfaceIntegrate(
 )
 {
     auto nCells = v.size();
-    const auto nBoundaryFaces = faceOwners.size();
+    const auto nBoundaryFaces = boundaryFaceOwners.size();
     parallelFor(
         exec,
         {0, nInternalFaces},
         NEON_LAMBDA(const localIdx i) {
-            Kokkos::atomic_add(&res[owners[i]], flux[i]);
-            Kokkos::atomic_sub(&res[neighbors[i]], flux[i]);
+            Kokkos::atomic_add(&res[internalFaceOwners[i]], flux[i]);
+            Kokkos::atomic_sub(&res[internalFaceNeighbors[i]], flux[i]);
         },
         "surfaceIntegrateInternalFaces"
     );
@@ -38,7 +38,7 @@ void surfaceIntegrate(
         exec,
         {0, nBoundaryFaces},
         NEON_LAMBDA(const localIdx bfi) {
-            auto own = faceOwners[bfi];
+            auto own = boundaryFaceOwners[bfi];
             Kokkos::atomic_add(&res[own], bFlux[bfi]);
         },
         "surfaceIntegrateBoundaryFaces"
@@ -56,9 +56,9 @@ void surfaceIntegrate(
     template void surfaceIntegrate<TYPENAME>(                                                      \
         const Executor&,                                                                           \
         localIdx,                                                                                  \
-        View<const int>,                                                                           \
-        View<const int>,                                                                           \
-        View<const int>,                                                                           \
+        View<const label>,                                                                         \
+        View<const label>,                                                                         \
+        View<const label>,                                                                         \
         View<const TYPENAME>,                                                                      \
         View<const TYPENAME>,                                                                      \
         View<const scalar>,                                                                        \

--- a/src/linearAlgebra/ginkgo/ginkgo.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgo.cpp
@@ -70,7 +70,7 @@ gko::config::pnode NeoN::la::ginkgo::parse(const Dictionary& dictIn)
         {
             auto token = std::any_cast<TokenList>(fn);
             std::stringstream s;
-            for (NeoN::size_t i = 0; i < token.size() - 1; i++)
+            for (size_t i = 0; i < token.size() - 1; i++)
             {
                 s << token.next<std::string>() << "/";
             }
@@ -604,8 +604,7 @@ SolverStats GinkgoSolver::solve(
                         )
                                                 .count())
                       / 1000.0;
-        stats.entries.push_back(
-            {static_cast<NeoN::size_t>(numIter), initResNorm, finalResNorm, duration}
+        stats.entries.push_back({static_cast<size_t>(numIter), initResNorm, finalResNorm, duration}
         );
     }
     return stats;

--- a/src/linearAlgebra/ginkgo/ginkgo.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgo.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <mutex>
 #include <sstream>
+#include <stdexcept>
 
 #include "NeoN/linearAlgebra/ginkgo.hpp"
 #include "NeoN/core/vector/vectorFreeFunctions.hpp"
@@ -70,10 +71,16 @@ gko::config::pnode NeoN::la::ginkgo::parse(const Dictionary& dictIn)
         {
             auto token = std::any_cast<TokenList>(fn);
             std::stringstream s;
-            for (size_t i = 0; i < token.size() - 1; i++)
+            if (token.empty())
             {
-                s << token.next<std::string>() << "/";
+                throw std::runtime_error("configFile token list is empty");
             }
+
+            for (size_t i = 0; i + 1 < token.size(); ++i)
+            {
+                s << token.next<std::string>() << '/';
+            }
+
             s << token.next<std::string>();
             fn_str = s.str();
         }

--- a/src/linearAlgebra/ginkgo/ginkgo.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgo.cpp
@@ -349,7 +349,9 @@ SolverStatsEntry solve_impl(
                 std::chrono::duration_cast<std::chrono::microseconds>(endEval - startEval).count()
             )
             / 1000.0;
-        return {static_cast<label>(l1Res.numIter), l1Res.initResNorm, l1Res.finalResNorm, duration};
+        return {
+            static_cast<size_t>(l1Res.numIter), l1Res.initResNorm, l1Res.finalResNorm, duration
+        };
     }
 
     // copy of rhs to compute the initial residual inline
@@ -370,7 +372,7 @@ SolverStatsEntry solve_impl(
     solver->apply(b, x);
 
     scalar finalResNorm = retrieve(gko::as<vec>(logger->get_residual_norm()));
-    auto numIter = label(logger->get_num_iterations());
+    auto numIter = static_cast<size_t>(logger->get_num_iterations());
     exec->synchronize();
 
     auto endEval = std::chrono::steady_clock::now();
@@ -426,7 +428,7 @@ SolverStats solve_impl(
     mtx->apply(one, x, neg_one, resFinal);
     auto finalNorms = colNorms(resFinal);
 
-    auto numIter = label(logger->get_num_iterations());
+    auto numIter = static_cast<size_t>(logger->get_num_iterations());
     exec->synchronize();
     auto endEval = std::chrono::steady_clock::now();
     auto duration =
@@ -549,7 +551,10 @@ SolverStats GinkgoSolver::solve(
         SolverStats stats;
         for (int i = 0; i < 3; ++i)
             stats.entries.push_back(
-                {l1Res.numIter, l1Res.perColInitNorms[i], l1Res.perColFinalNorms[i], duration}
+                {static_cast<size_t>(l1Res.numIter),
+                 l1Res.perColInitNorms[i],
+                 l1Res.perColFinalNorms[i],
+                 duration}
             );
         return stats;
     }
@@ -592,14 +597,16 @@ SolverStats GinkgoSolver::solve(
         solver->apply(b_col, x_col);
 
         scalar finalResNorm = retrieve(gko::as<vec>(logger->get_residual_norm()));
-        auto numIter = label(logger->get_num_iterations());
+        gko::size_type numIter = logger->get_num_iterations();
         gkoExec_->synchronize();
         auto duration = static_cast<scalar>(std::chrono::duration_cast<std::chrono::microseconds>(
                                                 std::chrono::steady_clock::now() - t0
                         )
                                                 .count())
                       / 1000.0;
-        stats.entries.push_back({numIter, initResNorm, finalResNorm, duration});
+        stats.entries.push_back(
+            {static_cast<NeoN::size_t>(numIter), initResNorm, finalResNorm, duration}
+        );
     }
     return stats;
 }

--- a/src/linearAlgebra/ginkgo/ginkgoDistributed.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgoDistributed.cpp
@@ -291,10 +291,7 @@ SolverStatsEntry solve_impl_dist(
             )
             / 1000.0;
         return {
-            static_cast<NeoN::size_t>(l1Res.numIter),
-            l1Res.initResNorm,
-            l1Res.finalResNorm,
-            duration
+            static_cast<size_t>(l1Res.numIter), l1Res.initResNorm, l1Res.finalResNorm, duration
         };
     }
 
@@ -333,7 +330,7 @@ SolverStatsEntry solve_impl_dist(
         )
         / 1000.0;
 
-    return {static_cast<NeoN::size_t>(numIter), initResNorm, finalResNorm, duration};
+    return {static_cast<size_t>(numIter), initResNorm, finalResNorm, duration};
 }
 
 SolverStats solve_impl_dist(
@@ -380,7 +377,7 @@ SolverStats solve_impl_dist(
             for (std::size_t i = 0; i < l1Res.perColInitNorms.size(); ++i)
             {
                 stats.entries.push_back(
-                    {static_cast<NeoN::size_t>(l1Res.numIter),
+                    {static_cast<size_t>(l1Res.numIter),
                      l1Res.perColInitNorms[i],
                      l1Res.perColFinalNorms[i],
                      duration}
@@ -389,10 +386,7 @@ SolverStats solve_impl_dist(
             return stats;
         }
         return {
-            static_cast<NeoN::size_t>(l1Res.numIter),
-            l1Res.initResNorm,
-            l1Res.finalResNorm,
-            duration
+            static_cast<size_t>(l1Res.numIter), l1Res.initResNorm, l1Res.finalResNorm, duration
         };
     }
 
@@ -437,7 +431,7 @@ SolverStats solve_impl_dist(
     SolverStats stats;
     for (int i = 0; i < 3; ++i)
         stats.entries.push_back(
-            {static_cast<NeoN::size_t>(numIter), initNorms[i], finalNorms[i], duration}
+            {static_cast<size_t>(numIter), initNorms[i], finalNorms[i], duration}
         );
     return stats;
 }

--- a/src/linearAlgebra/ginkgo/ginkgoDistributed.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgoDistributed.cpp
@@ -290,7 +290,12 @@ SolverStatsEntry solve_impl_dist(
                 std::chrono::duration_cast<std::chrono::microseconds>(endEval - startEval).count()
             )
             / 1000.0;
-        return {static_cast<label>(l1Res.numIter), l1Res.initResNorm, l1Res.finalResNorm, duration};
+        return {
+            static_cast<NeoN::size_t>(l1Res.numIter),
+            l1Res.initResNorm,
+            l1Res.finalResNorm,
+            duration
+        };
     }
 
     // copy of rhs to compute the initial residual (res is modified in-place by apply)
@@ -319,7 +324,7 @@ SolverStatsEntry solve_impl_dist(
     gko::as<dist_vec>(resFinal)->compute_norm2(finalNormVec);
     scalar finalResNorm = retrieve(finalNormVec);
 
-    auto numIter = label(logger->get_num_iterations());
+    gko::size_type numIter = logger->get_num_iterations();
     exec->synchronize();
     auto endEval = std::chrono::steady_clock::now();
     auto duration =
@@ -328,7 +333,7 @@ SolverStatsEntry solve_impl_dist(
         )
         / 1000.0;
 
-    return {numIter, initResNorm, finalResNorm, duration};
+    return {static_cast<NeoN::size_t>(numIter), initResNorm, finalResNorm, duration};
 }
 
 SolverStats solve_impl_dist(
@@ -375,7 +380,7 @@ SolverStats solve_impl_dist(
             for (std::size_t i = 0; i < l1Res.perColInitNorms.size(); ++i)
             {
                 stats.entries.push_back(
-                    {static_cast<label>(l1Res.numIter),
+                    {static_cast<NeoN::size_t>(l1Res.numIter),
                      l1Res.perColInitNorms[i],
                      l1Res.perColFinalNorms[i],
                      duration}
@@ -383,7 +388,12 @@ SolverStats solve_impl_dist(
             }
             return stats;
         }
-        return {static_cast<label>(l1Res.numIter), l1Res.initResNorm, l1Res.finalResNorm, duration};
+        return {
+            static_cast<NeoN::size_t>(l1Res.numIter),
+            l1Res.initResNorm,
+            l1Res.finalResNorm,
+            duration
+        };
     }
 
     auto rhsCopy = Vector<Vec3>(rhs);
@@ -415,7 +425,7 @@ SolverStats solve_impl_dist(
     mtx->apply(one, x, neg_one, res);
     auto finalNorms = colNorms(res);
 
-    auto numIter = label(logger->get_num_iterations());
+    gko::size_type numIter = logger->get_num_iterations();
     exec->synchronize();
     auto endEval = std::chrono::steady_clock::now();
     auto duration =
@@ -426,7 +436,9 @@ SolverStats solve_impl_dist(
 
     SolverStats stats;
     for (int i = 0; i < 3; ++i)
-        stats.entries.push_back({numIter, initNorms[i], finalNorms[i], duration});
+        stats.entries.push_back(
+            {static_cast<NeoN::size_t>(numIter), initNorms[i], finalNorms[i], duration}
+        );
     return stats;
 }
 

--- a/src/linearAlgebra/ginkgo/ginkgoL1Stop.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgoL1Stop.cpp
@@ -164,9 +164,9 @@ public:
 
         scalar GKO_FACTORY_PARAMETER_SCALAR(relative_tolerance, 0.0);
 
-        localIdx GKO_FACTORY_PARAMETER_SCALAR(min_iter, 0);
+        gko::size_type GKO_FACTORY_PARAMETER_SCALAR(min_iter, 0);
 
-        localIdx GKO_FACTORY_PARAMETER_SCALAR(max_iter, 1000);
+        gko::size_type GKO_FACTORY_PARAMETER_SCALAR(max_iter, 1000);
 
         localIdx GKO_FACTORY_PARAMETER_SCALAR(check_frequency, 1);
 
@@ -178,7 +178,7 @@ public:
 
         std::add_pointer<scalar>::type GKO_FACTORY_PARAMETER_SCALAR(final_residual, NULL);
 
-        std::add_pointer<localIdx>::type GKO_FACTORY_PARAMETER_SCALAR(num_iters, NULL);
+        std::add_pointer<gko::size_type>::type GKO_FACTORY_PARAMETER_SCALAR(num_iters, NULL);
 
         // Per-column scaled residual output for multi-RHS (Vec3) solves.
         // When non-null, filled with one entry per column (size == ncols).
@@ -226,7 +226,7 @@ protected:
             return false;
         }
         const auto* solution = gko::as<VecType>(updater.solution_);
-        const auto numIter = static_cast<localIdx>(updater.num_iterations_);
+        const auto numIter = updater.num_iterations_;
 
         // Skip the residual-norm evaluation on iterations where the criterion cannot stop
         // anyway: before min_iter the tolerances are not tested, and between check_frequency-
@@ -373,7 +373,7 @@ L1ResidualResult attachL1StopAndSolve(
 {
     scalar initResNorm = 0.0;
     scalar finalResNorm = 0.0;
-    localIdx numIter = 0;
+    gko::size_type numIter = 0;
     std::vector<scalar> perColInit, perColFinal;
 
     const bool multiRhs = b->get_size()[1] > 1;


### PR DESCRIPTION
This pull request fixes the iteration-count type handling in the Ginkgo backend and aligns it with NeoN’s type conventions.

### Motivation

The Ginkgo backend was using a type inconsistency for the iteration count, which could lead to mismatches between Ginkgo-native types and NeoN types. This PR makes the handling of iteration counts consistent and robust across the backend implementation.

### What changed

- Used a more proper type alias to represent the number of solver iterations, providing clearer semantics 

- Used std::optional to explicitly represent when an iteration count is unavailable, replacing implicit or sentinel-value based handling.

* Added changes related to using Ginkgo-native types in solver code where appropriate, while keeping NeoN types for generic interfaces.

* Improved clarity around `surfaceIntegrate` argument names of face owners and neighbors, and used the native type for them

- Add a documentation of the usage of different type alias

### Why this matters

This improves type safety and reduces the risk of subtle backend mismatches when NeoN interacts with Ginkgo. It also makes the backend interface clearer and easier to maintain.

## Related issues

Closes #571 
Closes #572 
Closes #573 
