### PR TITLE
Enh/tier2 performance features2407

### DIFF
--- a/doc/finiteVolume/cellCentred/boundaryConditions.rst
+++ b/doc/finiteVolume/cellCentred/boundaryConditions.rst
@@ -65,3 +65,51 @@ Currently, the following boundary conditions are implemented for volVector for s
 - fixedValue
 - zeroGradient
 - calculated
+
+
+Slip / Symmetry boundary conditions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``slip`` and ``symmetry`` share a single implementation. They differ only in their
+registered name and in where they may be applied (``slip`` on a wall/regular patch,
+``symmetry`` on a symmetry plane). Per face the operator is:
+
+- **scalar field** => zero-gradient (there is no normal component, so the mode below is
+  irrelevant).
+- **vector field** => the boundary value is the *tangential projection* of the cell value
+  (the wall-normal component is removed), plus a **normal-damping** term
+  :math:`-\Delta\,(\mathbf{v}\cdot\mathbf{n})\,\mathbf{n}` that drives the normal component
+  of the cell value towards zero.
+
+The velocity vector field is assembled as a single shared scalar matrix and solved with a
+Vec3 (multi-RHS) solve, so the same matrix diagonal is used for all three components. The
+normal-damping coefficient :math:`\gamma\,|S|\,\Delta\,|n_c|` is **direction dependent**
+(it carries a per-component :math:`|n_c|` factor) and therefore cannot be held by the shared
+scalar diagonal. NeoN offers two ways to realise it, selected per patch by the ``implicit``
+key:
+
+Deferred (``implicit no``)
+    The damping is written into ``refGrad`` as
+    :math:`-\Delta\,(\mathbf{v}\cdot\mathbf{n})\,\mathbf{n}` and enters the per-component
+    **RHS** through the existing fixed-gradient assembly. This keeps the shared scalar matrix
+    and the fast multi-RHS solve intact. Because the term uses the previous iteration's
+    velocity, the normal coupling **lags by one outer iteration**; on a developed field this
+    can be too weak to hold the normal component and lets it diverge in the momentum solve.
+
+Implicit (``implicit yes``, the default)
+    ``refGrad`` is left zero; instead the ``BoundaryAttributes::transformImplicit`` flag tells
+    the Laplacian assembly to accumulate the per-component diagonal correction
+    :math:`\gamma\,|S|\,\Delta\,|n_c|` into the linear system's ``diagCmpt`` store. Since this
+    correction differs per column, the solver drops the multi-RHS solve and runs the three
+    components **segregated**, temporarily subtracting each column's correction from the shared
+    diagonal in place (no matrix copy). The constraint is applied *inside* the solve, so it does
+    not lag — at the cost of three solves instead of one multi-RHS solve.
+
+The default is **implicit**: the deferred variant was observed to let the wall-normal velocity
+run away at slip/symmetry boundaries on developed external-aerodynamics cases. Set
+``implicit no`` on a patch to opt back into the deferred, multi-RHS-friendly treatment.
+
+.. note::
+    A future ``Tensor`` specialisation (e.g. a transported Reynolds-stress field) must use the
+    full reflective transform :math:`(T + H\,T\,H)/2` with :math:`H = I - 2\,\mathbf{n}\otimes\mathbf{n}`,
+    **not** the per-component projection used for vectors.

--- a/doc/linearAlgebra/operatorAssembly.rst
+++ b/doc/linearAlgebra/operatorAssembly.rst
@@ -403,3 +403,74 @@ The diagonal term uses the **Dirichlet fraction** :math:`f_D`:
    ``valueRhs`` instead, so the total implicit coupling is still
    ``δ · γ · |S_f| · f_D``.  This differs from the internal face
    assembly where ``flux`` already absorbs ``δ``.
+
+
+Vector fields: shared scalar matrix vs. per-component diagonal
+--------------------------------------------------------------
+
+A vector field (``Vec3``) is **not** assembled as three independent scalar
+systems, nor as a block matrix. Instead NeoN builds a **single scalar sparsity
+pattern and matrix** whose entries are shared by all three components, and solves
+
+.. math::
+
+   A\,\mathbf{x} = \mathbf{b}, \qquad
+   \mathbf{x}, \mathbf{b} \in \mathbb{R}^{N \times 3}
+
+as one **multi-RHS** solve: the same scalar operator :math:`A` is applied to the
+:math:`x`, :math:`y`, and :math:`z` columns simultaneously (Ginkgo treats the
+right-hand side as an :math:`N \times 3` dense block). This is the common case —
+the diffusion/convection operators of the momentum equation are identical for each
+component, so one matrix and one Krylov solve serve all three. It halves memory
+versus three matrix copies and amortises the preconditioner setup across components.
+
+The assumption this relies on is that **the operator is the same for every
+component**. That holds as long as every diagonal and off-diagonal entry is a
+scalar that does not depend on the component index. A term whose coefficient is
+**direction dependent** — i.e. differs between the :math:`x`, :math:`y`, and
+:math:`z` rows of the same cell — breaks it, because a single shared scalar
+diagonal cannot store three different values.
+
+The escape hatch: ``diagCmpt``
+    ``LinearSystem`` carries an *optional* secondary store,
+    ``diagCmpt`` (a ``Vector<RHSValueType>``, i.e. one ``Vec3`` per cell,
+    allocated lazily via ``ensureDiagCmpt()``). It holds a **per-component
+    correction to the diagonal only**. An operator that needs a
+    direction-dependent diagonal accumulates the three component weights there
+    instead of into the shared scalar matrix.
+
+    When ``diagCmpt`` is populated the multi-RHS solve is no longer valid, so the
+    solver backend (see ``src/linearAlgebra/ginkgo/ginkgo.cpp``) falls back to
+    **three segregated scalar solves** — one per component. For column
+    :math:`c` it temporarily subtracts ``diagCmpt[·][c]`` from the shared scalar
+    diagonal *in place* (no matrix copy), runs the scalar solve, then restores the
+    diagonal. The off-diagonals — still identical across components — are reused
+    untouched.
+
+This is the mechanism behind the *implicit* slip/symmetry normal damping
+(:ref:`fvcc_BC`): the damping coefficient
+:math:`\gamma\,|S|\,\Delta\,|n_c|` carries a per-component :math:`|n_c|` factor, so
+it is routed through ``diagCmpt`` rather than the shared diagonal. Any future
+operator with a genuinely anisotropic (per-component) diagonal contribution should
+use the same ``diagCmpt`` path; a per-component *off-diagonal* coupling, by
+contrast, would require a true block matrix and is not supported by this scheme.
+
+.. list-table:: Trade-offs
+   :header-rows: 1
+   :widths: 30 35 35
+
+   * -
+     - Shared scalar matrix (default)
+     - ``diagCmpt`` per-component diagonal
+   * - Solve
+     - one multi-RHS (:math:`N \times 3`) solve
+     - three segregated scalar solves
+   * - Matrix storage
+     - one scalar matrix
+     - one scalar matrix + one ``Vec3``/cell
+   * - Requires
+     - component-independent operator
+     - direction-dependent **diagonal** only
+   * - Not supported
+     - direction-dependent entries
+     - per-component **off-diagonal** coupling (needs block matrix)

--- a/include/NeoN/dsl/expression.hpp
+++ b/include/NeoN/dsl/expression.hpp
@@ -144,10 +144,21 @@ private:
  * @class FixedValueConstraints
  * @brief Post-assembly functor that pins a set of cells to prescribed values.
  *
+ * This now performs OpenFOAM's FULL decouple (fvMatrix::setValuesFromList), not just a row wipe.
  * For every constrained cell c:
- *   A[c, j] = 0  for j != c   (zero row off-diagonals)
- *   A[j, c] = 0  for j != c   (zero column in neighbour rows, rhs[j] absorbs the dropped term)
- *   rhs[c]  = A[c,c] * value[c]
+ *   A[c, j] = 0            for all j != c    (zero the off-diagonals of ROW c)
+ *   A[j, c] = 0            for all j != c    (zero the COLUMN c in every neighbour row j)
+ *   rhs[j] -= A[j, c]*value[c]               (relocate that coupling into the neighbour SOURCE)
+ *   rhs[c]  = A[c, c] * value[c]
+ * so the row reduces to A[c,c]*x_c = A[c,c]*value[c] => x_c = value[c] (independent of the
+ * relaxed/BC-augmented diagonal), and — crucially — the SpMV / residual no longer carries the
+ * huge in-matrix A[j,c]*value_c term (value_c is the viscous-sublayer wall omega, up to 1e12).
+ * Leaving that coefficient in the matrix (the previous row-only wipe) made A*x at neighbour cells
+ * a difference of ~1e18 magnitudes, which underflowed/NaN'd the L1 residual norm under FOAM_SIGFPE
+ * — OpenFOAM avoids it precisely by moving the term to the source. Mirrors upstream exactly.
+ *
+ * Proc-boundary caveat: a pinned cell's coupling to an off-rank ghost lives in offDiagonalMatrix,
+ * not the local CSR, so it is not decoupled here (the local CSR column cut is the dominant term).
  *
  * Pinning via both the row and column cut avoids large cancellation errors when
  * pinned values are orders of magnitude larger than neighbouring unknowns.
@@ -184,9 +195,10 @@ public:
         auto rhs = lsView.rhs;
         auto mask = mask_;
         auto vals = values_;
-        // Sweep every row: pinned rows drop their off-diagonals; non-pinned rows that couple into
-        // a pinned column absorb the term into their rhs and zero the coefficient. Parallelising
-        // over rows avoids atomics since each row owns its own rhs entry and off-diagonal slots.
+        // Sweep EVERY row (not only the pinned ones): a pinned row drops its off-diagonals, while
+        // a NON-pinned row that couples into a pinned column relocates that term to its own source
+        // and zeros it (OpenFOAM's column cut). Parallelising over rows means each row owns its own
+        // rhs entry and its own off-diagonal slots, so no atomics are needed.
         parallelFor(
             ls.exec(),
             {0, nCells_},
@@ -208,13 +220,15 @@ public:
                     }
                     else if (mask[col] != scalar(0))
                     {
-                        // column cut: absorb coupling into rhs, zero the coefficient
+                        // neighbour row coupling INTO a pinned cell: move the term to this row's
+                        // source as a constant, then drop the coefficient (OF setValues column cut)
                         rhs[row] -= matrixValues[o] * vals[col];
                         matrixValues[o] = zero<ValueType>();
                     }
                 }
                 if (rowPinned)
                 {
+                    // row now reads A[c,c]*x_c = A[c,c]*value[c] => x_c = value[c]
                     rhs[row] = diagVal * vals[row];
                 }
             },

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/detail/slipSymmetry.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/detail/slipSymmetry.hpp
@@ -40,16 +40,23 @@ enum class NormalDamping
     Implicit  ///< normal damping via per-component diagonal correction (segregated solve)
 };
 
-/** @brief Read the opt-in "implicit" flag from a slip/symmetry patch dictionary.
+/** @brief Read the "implicit" flag from a slip/symmetry patch dictionary.
  *
- * Defaults to false (Deferred). A boolean read from a dictionary file arrives as a word/string
- * rather than a bool, so accept bool, int, and the common truthy spellings — mirroring the
- * tolerant parsing used for the solver's l1ScaledResidual flag.
+ * Defaults to TRUE (Implicit). The velocity is solved as a shared scalar matrix with a Vec3
+ * (multi-RHS) Ginkgo solve, so the direction-dependent slip/symmetry normal damping
+ * (gamma|S|*Delta*|n_c|, different per component) cannot be carried by the shared scalar diagonal.
+ * Implicit mode routes it through the per-component diagCmpt store, which the solver applies
+ * column-by-column, constraining the wall-normal velocity in the solve. The Deferred alternative
+ * only writes the damping into refGrad (RHS) and lags it one outer iteration, which is too weak to
+ * hold the normal component on a developed field and lets it diverge in the momentum solve
+ * (observed on occDrivAer: U_normal runs away at the ground/freestream slip-symmetry boundaries).
+ * Set "implicit no" on a patch to opt back into the Deferred treatment. A boolean read from a
+ * dictionary arrives as a word/string, so accept bool, int, and the common truthy spellings.
  */
 inline bool readTransformImplicit(const Dictionary& dict)
 {
     const std::string key = "implicit";
-    if (!dict.contains(key)) return false;
+    if (!dict.contains(key)) return true;
     if (dict.isType<bool>(key)) return dict.get<bool>(key);
     if (dict.isType<int>(key)) return dict.get<int>(key) != 0;
     if (dict.isType<std::string>(key))

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/detail/slipSymmetry.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/detail/slipSymmetry.hpp
@@ -16,26 +16,72 @@
 // operator and differ only in their registered name and in where they may be applied (slip on a
 // wall/regular patch, symmetry on a symmetry-plane patch). The operator is, per face:
 //   scalar => zero-gradient
-//   vector => tangential projection of the boundary value (the normal component is removed), plus
-//             a deferred normal-damping surface-normal gradient -deltaCoeffs*(v·n)*n that drives
-//             the normal component of the cell value towards zero via the per-component RHS.
+//   vector => tangential projection of the boundary value (the normal component is removed), plus a
+//             normal-damping surface-normal gradient that drives the normal component of the cell
+//             value towards zero.
+//
+// The normal damping can be realised two ways, selected by NormalDamping:
+//   - Deferred: written into refGrad as -deltaCoeffs*(v·n)*n, so it enters the per-component RHS
+//     through the existing fixed-gradient assembly. Keeps the shared scalar matrix + multi-RHS
+//     solve, at the cost of lagging the normal coupling by one outer iteration.
+//   - Implicit: refGrad is left zero here; the BoundaryAttributes::transformImplicit flag signals
+//     the Laplacian assembly to add a per-component diagonal correction (γ|S|·deltaCoeffs·|n_c|)
+//     instead, which the solver applies column-by-column. Fully implicit, single matrix, but the
+//     solve runs segregated rather than multi-RHS.
+//
+// NOTE: a future Tensor specialization (e.g. for a transported Reynolds-stress field) must use the
+// full reflective transform (T + H·T·H)/2 with H = I - 2 n⊗n, NOT a per-component projection.
 namespace NeoN::finiteVolume::cellCentred::volumeBoundary::detail
 {
+
+enum class NormalDamping
+{
+    Deferred, ///< normal damping via refGrad -> per-component RHS (multi-RHS friendly)
+    Implicit  ///< normal damping via per-component diagonal correction (segregated solve)
+};
+
+/** @brief Read the opt-in "implicit" flag from a slip/symmetry patch dictionary.
+ *
+ * Defaults to false (Deferred). A boolean read from a dictionary file arrives as a word/string
+ * rather than a bool, so accept bool, int, and the common truthy spellings — mirroring the
+ * tolerant parsing used for the solver's l1ScaledResidual flag.
+ */
+inline bool readTransformImplicit(const Dictionary& dict)
+{
+    const std::string key = "implicit";
+    if (!dict.contains(key)) return false;
+    if (dict.isType<bool>(key)) return dict.get<bool>(key);
+    if (dict.isType<int>(key)) return dict.get<int>(key) != 0;
+    if (dict.isType<std::string>(key))
+    {
+        const std::string v = dict.get<std::string>(key);
+        return (v == "true" || v == "yes" || v == "on" || v == "1");
+    }
+    return false;
+}
+
+/** @brief Map the implicit flag onto the NormalDamping mode. */
+inline NormalDamping normalDampingMode(bool implicit)
+{
+    return implicit ? NormalDamping::Implicit : NormalDamping::Deferred;
+}
 
 // Primary declaration
 template<typename ValueType>
 void setSlipSymmetryValue(
     Field<ValueType>& domainVector,
     const UnstructuredMesh& mesh,
-    std::pair<localIdx, localIdx> range
+    std::pair<localIdx, localIdx> range,
+    NormalDamping mode
 );
 
-// --- Scalar specialization: zero-gradient ---
+// --- Scalar specialization: zero-gradient (mode is irrelevant; no normal component) ---
 template<>
 inline void setSlipSymmetryValue<NeoN::scalar>(
     Field<NeoN::scalar>& domainVector,
     const UnstructuredMesh& mesh,
-    std::pair<localIdx, localIdx> range
+    std::pair<localIdx, localIdx> range,
+    [[maybe_unused]] NormalDamping mode
 )
 {
     const auto internalV = domainVector.internalVector().view();
@@ -64,15 +110,17 @@ inline void setSlipSymmetryValue<NeoN::scalar>(
     );
 }
 
-// --- Vec3 specialization: tangential projection + deferred normal damping ---
+// --- Vec3 specialization: tangential projection + normal damping ---
 template<>
 inline void setSlipSymmetryValue<NeoN::Vec3>(
     Field<NeoN::Vec3>& domainVector,
     const UnstructuredMesh& mesh,
-    std::pair<localIdx, localIdx> range
+    std::pair<localIdx, localIdx> range,
+    NormalDamping mode
 )
 {
     const auto internalV = domainVector.internalVector().view();
+    const bool deferred = (mode == NormalDamping::Deferred);
 
     auto
         [refGradV,
@@ -107,13 +155,15 @@ inline void setSlipSymmetryValue<NeoN::Vec3>(
             refValueV[i] = vtan;
             valueV[i] = vtan;
 
-            // valueFraction = 0: keep the diagonal contribution component-isotropic so the shared
-            // scalar matrix and multi-RHS solve are preserved.
+            // Keep the diagonal contribution component-isotropic (zero here) so the shared scalar
+            // matrix and its multi-RHS solve are preserved.
             valueFractionV[i] = 0.0;
 
-            // Normal damping via the surface-normal gradient -deltaCoeffs*(v·n)*n enters the
-            // per-component RHS through the existing fixed-gradient assembly.
-            refGradV[i] = n * (-deltaCoeffsV[i] * un);
+            // Deferred mode: normal damping as the surface-normal gradient -deltaCoeffs*(v·n)*n
+            // (purely normal, so the tangential components stay zero-gradient). Implicit mode:
+            // leave refGrad zero — the damping is applied as a per-component diagonal correction
+            // during assembly/solve.
+            refGradV[i] = deferred ? n * (-deltaCoeffsV[i] * un) : NeoN::zero<NeoN::Vec3>();
         },
         "setSlipSymmetryValue(Vec3)"
     );

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/detail/slipSymmetry.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/detail/slipSymmetry.hpp
@@ -48,8 +48,8 @@ enum class NormalDamping
  * Implicit mode routes it through the per-component diagCmpt store, which the solver applies
  * column-by-column, constraining the wall-normal velocity in the solve. The Deferred alternative
  * only writes the damping into refGrad (RHS) and lags it one outer iteration, which is too weak to
- * hold the normal component on a developed field and lets it diverge in the momentum solve
- * (observed on occDrivAer: U_normal runs away at the ground/freestream slip-symmetry boundaries).
+ * hold the normal component on a developed field and lets the wall-normal velocity diverge in the
+ * momentum solve at slip/symmetry boundaries.
  * Set "implicit no" on a patch to opt back into the Deferred treatment. A boolean read from a
  * dictionary arrives as a word/string, so accept bool, int, and the common truthy spellings.
  */

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/slip.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/slip.hpp
@@ -16,9 +16,10 @@ namespace NeoN::finiteVolume::cellCentred::volumeBoundary
 {
 
 // Slip is a frictionless-wall boundary condition: scalar => zero-gradient, vector => tangential
-// projection + deferred normal damping. It shares its implementation with Symmetry via
+// projection + normal damping. It shares its implementation with Symmetry via
 // detail::setSlipSymmetryValue; the two differ only in the registered name and in where they may be
-// applied (slip on wall/patch types, symmetry on a symmetry-plane patch).
+// applied (slip on wall/patch types, symmetry on a symmetry-plane patch). The optional "implicit"
+// key selects the normal-damping treatment.
 template<typename ValueType>
 class Slip : public VolumeBoundaryFactory<ValueType>::template Register<Slip<ValueType>>
 {
@@ -31,12 +32,22 @@ public:
     using SlipType = Slip<ValueType>;
 
     Slip(const UnstructuredMesh& mesh, const Dictionary& dict, localIdx patchID)
-        : Base(mesh, dict, patchID, {.assignable = false, .fixesValue = false}), mesh_(mesh)
+        : Base(
+            mesh,
+            dict,
+            patchID,
+            {.assignable = false,
+             .fixesValue = false,
+             .transformImplicit = detail::readTransformImplicit(dict)}
+        ),
+          mesh_(mesh), implicit_(detail::readTransformImplicit(dict))
     {}
 
     virtual void correctBoundaryCondition(Field<ValueType>& domainVector) final
     {
-        detail::setSlipSymmetryValue(domainVector, mesh_, this->range());
+        detail::setSlipSymmetryValue(
+            domainVector, mesh_, this->range(), detail::normalDampingMode(implicit_)
+        );
     }
 
     static std::string name() { return "slip"; }
@@ -58,6 +69,7 @@ public:
 private:
 
     const UnstructuredMesh& mesh_;
+    bool implicit_;
 };
 
 } // namespace NeoN::finiteVolume::cellCentred::volumeBoundary

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/symmetry.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/symmetry.hpp
@@ -16,9 +16,9 @@ namespace NeoN::finiteVolume::cellCentred::volumeBoundary
 {
 
 // Symmetry is a symmetry-plane boundary condition: scalar => zero-gradient, vector => tangential
-// projection + deferred normal damping. It shares its implementation with Slip via
+// projection + normal damping. It shares its implementation with Slip via
 // detail::setSlipSymmetryValue; they differ only in the registered name and in where they may be
-// applied (symmetry on a symmetry-plane patch, slip on wall/patch types).
+// applied. The optional "implicit" key selects the normal-damping treatment.
 template<typename ValueType>
 class Symmetry : public VolumeBoundaryFactory<ValueType>::template Register<Symmetry<ValueType>>
 {
@@ -31,12 +31,22 @@ public:
     using SymmetryType = Symmetry<ValueType>;
 
     Symmetry(const UnstructuredMesh& mesh, const Dictionary& dict, localIdx patchID)
-        : Base(mesh, dict, patchID, {.assignable = false, .fixesValue = false}), mesh_(mesh)
+        : Base(
+            mesh,
+            dict,
+            patchID,
+            {.assignable = false,
+             .fixesValue = false,
+             .transformImplicit = detail::readTransformImplicit(dict)}
+        ),
+          mesh_(mesh), implicit_(detail::readTransformImplicit(dict))
     {}
 
     virtual void correctBoundaryCondition(Field<ValueType>& domainVector) final
     {
-        detail::setSlipSymmetryValue(domainVector, mesh_, this->range());
+        detail::setSlipSymmetryValue(
+            domainVector, mesh_, this->range(), detail::normalDampingMode(implicit_)
+        );
     }
 
     static std::string name() { return "symmetry"; }
@@ -59,6 +69,7 @@ public:
 private:
 
     const UnstructuredMesh& mesh_;
+    bool implicit_;
 };
 
 } // namespace NeoN::finiteVolume::cellCentred::volumeBoundary

--- a/include/NeoN/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp
@@ -28,6 +28,11 @@ struct BoundaryAttributes
     bool fixesValue; ///< whether the bc enforces a fixed field value (Dirichlet), not a
                      ///< gradient/Neumann condition NOTE this is somewhat redundant to
                      ///< valueFraction of boundaryData
+    bool transformImplicit = false; ///< whether this is a direction-dependent (transform) BC
+                                    ///< — e.g. slip/symmetry in implicit mode — whose normal
+                                    ///< damping must be applied as a per-component diagonal
+                                    ///< correction at solve time rather than via the RHS.
+                                    ///< Defaults to false so all existing BCs are unaffected.
 };
 
 template<typename ValueType>

--- a/include/NeoN/linearAlgebra/ginkgo.hpp
+++ b/include/NeoN/linearAlgebra/ginkgo.hpp
@@ -285,8 +285,7 @@ public:
 
     GinkgoSolver(Executor exec, const Dictionary& solverConfig)
         : Base(exec), gkoExec_(getGkoExecutor(exec)), coupled_(solverConfig.get("coupled", false)),
-          l1Control_(readL1ResidualControl(solverConfig)), config_(parse(solverConfig)),
-          localMatrixFormat_(solverConfig.get("localMatrixFormat", std::string("Csr")))
+          l1Control_(readL1ResidualControl(solverConfig)), config_(parse(solverConfig))
     {
         // Register NeoN's L1-scaled residual criterion in the Ginkgo config registry so a
         // configFile can name it (l1CriterionKey) in its "criteria" array. Only needed when
@@ -355,7 +354,6 @@ private:
     std::optional<L1ResidualControl> l1Control_;
     gko::config::pnode config_;
     std::shared_ptr<const gko::LinOpFactory> factory_;
-    std::string localMatrixFormat_;
     // L1-scaled residual criterion registered into the config registry (l1Control_ set).
     std::shared_ptr<gko::stop::CriterionFactory> l1CritFactory_;
     // True when config_ names the L1 criterion, so it is built into factory_'s solver and

--- a/include/NeoN/linearAlgebra/ginkgo.hpp
+++ b/include/NeoN/linearAlgebra/ginkgo.hpp
@@ -108,16 +108,42 @@ struct L1ResidualControl
                              //!< every iteration
 };
 
-/** @brief Result of a solve governed by the L1-scaled residual stopping criterion. */
+/** @brief Result of a solve governed by the L1-scaled residual stopping criterion.
+ *
+ * Doubles as the report sink for the config-registered criterion (see
+ * makeL1CriterionFactory): @c fired tells the solve path whether the criterion actually ran
+ * (and therefore whether initResNorm/finalResNorm/numIter hold scaled L1 values).
+ */
 struct L1ResidualResult
 {
-    gko::size_type numIter; //!< iterations performed
-    scalar initResNorm;     //!< combined scaled L1 initial residual (sum of columns)
-    scalar finalResNorm;    //!< combined scaled L1 final residual (sum of columns)
+    gko::size_type numIter = 0; //!< iterations performed
+    scalar initResNorm = 0.0;   //!< combined scaled L1 initial residual (sum of columns)
+    scalar finalResNorm = 0.0;  //!< combined scaled L1 final residual (sum of columns)
+    bool fired = false;         //!< set by the criterion on its first check (config path)
     // Per-column scaled residuals; populated only for multi-RHS (Vec3) solves (size == ncols).
     std::vector<scalar> perColInitNorms;
     std::vector<scalar> perColFinalNorms;
 };
+
+/** @brief Registry key under which the L1-scaled residual criterion is stored so a Ginkgo
+ * configFile can reference it by name in its "criteria" array, e.g.
+ *   "criteria": [ {"type": "Iteration", "max_iters": 150}, "neon::l1ScaledResidual" ]
+ * The "neon::" prefix avoids clashing with Ginkgo's own config type names.
+ */
+inline constexpr const char* l1CriterionKey = "neon::l1ScaledResidual";
+
+/** @brief Build the L1-scaled residual criterion as a Ginkgo CriterionFactory for storage in
+ * a gko::config::registry, so it can be named from a configFile (@see l1CriterionKey).
+ *
+ * The matrix / RHS are taken from the CriterionArgs at solve time, so they need not be known
+ * here. When @p report is non-null the criterion writes the scaled initial/final residual and
+ * iteration count there. Defined in ginkgoL1Stop.cpp.
+ */
+std::shared_ptr<gko::stop::CriterionFactory> makeL1CriterionFactory(
+    std::shared_ptr<const gko::Executor> exec,
+    const L1ResidualControl& control,
+    L1ResidualResult* report
+);
 
 /** @brief Solve @p solver with an L1-scaled residual stopping criterion attached.
  *
@@ -205,6 +231,14 @@ inline std::optional<L1ResidualControl> readL1ResidualControl(const Dictionary& 
         return d.get<localIdx>(key);
     };
 
+    // OpenFOAM-style top-level keys (the configFile solver path keeps them: there is no
+    // mapped "criteria" subdict there). Read first so they seed the control...
+    control.tolerance = readScalar(cfg, "tolerance", control.tolerance);
+    control.relTol = readScalar(cfg, "relTol", control.relTol);
+    control.maxIter = readInt(cfg, "maxIter", control.maxIter);
+
+    // ...then let a mapped "criteria" subdict (Ginkgo-style keys) override when present,
+    // preserving the existing behaviour for fvSolution-mapped solvers.
     if (cfg.contains("criteria"))
     {
         const Dictionary& criteria = cfg.subDict("criteria");
@@ -218,6 +252,30 @@ inline std::optional<L1ResidualControl> readL1ResidualControl(const Dictionary& 
     return control;
 }
 
+/** @brief Recursively test whether a Ginkgo config tree references @p name as a (criterion)
+ * string anywhere — used to detect a configFile that names the L1 criterion so the solver
+ * can rely on the in-config criterion instead of attaching one post-hoc.
+ */
+inline bool pnodeReferencesString(const gko::config::pnode& node, const std::string& name)
+{
+    using tag = gko::config::pnode::tag_t;
+    switch (node.get_tag())
+    {
+    case tag::string:
+        return node.get_string() == name;
+    case tag::array:
+        for (const auto& e : node.get_array())
+            if (pnodeReferencesString(e, name)) return true;
+        return false;
+    case tag::map:
+        for (const auto& kv : node.get_map())
+            if (pnodeReferencesString(kv.second, name)) return true;
+        return false;
+    default:
+        return false;
+    }
+}
+
 class GinkgoSolver : public SolverFactory::template Register<GinkgoSolver>
 {
 
@@ -228,12 +286,24 @@ public:
     GinkgoSolver(Executor exec, const Dictionary& solverConfig)
         : Base(exec), gkoExec_(getGkoExecutor(exec)), coupled_(solverConfig.get("coupled", false)),
           l1Control_(readL1ResidualControl(solverConfig)), config_(parse(solverConfig)),
-          factory_(gko::config::parse(
-                       config_, gko::config::registry(), gko::config::make_type_descriptor<scalar>()
-          )
-                       .on(gkoExec_)),
           localMatrixFormat_(solverConfig.get("localMatrixFormat", std::string("Csr")))
-    {}
+    {
+        // Register NeoN's L1-scaled residual criterion in the Ginkgo config registry so a
+        // configFile can name it (l1CriterionKey) in its "criteria" array. Only needed when
+        // the L1 stop is requested (l1ScaledResidual); the factory carries the tolerances and
+        // a report sink. If the parsed config actually references it, the criterion lives
+        // INSIDE the built solver (l1InConfig_) and reports via l1Report_; otherwise the
+        // existing post-hoc attach in solve() handles the flag-only case unchanged.
+        gko::config::registry reg;
+        if (l1Control_)
+        {
+            l1CritFactory_ = makeL1CriterionFactory(gkoExec_, *l1Control_, &l1Report_);
+            reg.emplace(std::string(l1CriterionKey), l1CritFactory_);
+            l1InConfig_ = pnodeReferencesString(config_, l1CriterionKey);
+        }
+        factory_ = gko::config::parse(config_, reg, gko::config::make_type_descriptor<scalar>())
+                       .on(gkoExec_);
+    }
 
     static std::string name() { return "Ginkgo"; }
 
@@ -286,6 +356,13 @@ private:
     gko::config::pnode config_;
     std::shared_ptr<const gko::LinOpFactory> factory_;
     std::string localMatrixFormat_;
+    // L1-scaled residual criterion registered into the config registry (l1Control_ set).
+    std::shared_ptr<gko::stop::CriterionFactory> l1CritFactory_;
+    // True when config_ names the L1 criterion, so it is built into factory_'s solver and
+    // reports through l1Report_ (the in-config path); false keeps the post-hoc attach.
+    bool l1InConfig_ = false;
+    // Report sink the in-config criterion writes its scaled L1 residual / iters into.
+    mutable L1ResidualResult l1Report_;
 #ifdef NF_WITH_MPI_SUPPORT
     // Both caches are null until the first solve; after that topology is fixed.
     mutable std::shared_ptr<gko::experimental::distributed::index_map<label, gko::int64>>

--- a/include/NeoN/linearAlgebra/ginkgo.hpp
+++ b/include/NeoN/linearAlgebra/ginkgo.hpp
@@ -231,7 +231,8 @@ public:
           factory_(gko::config::parse(
                        config_, gko::config::registry(), gko::config::make_type_descriptor<scalar>()
           )
-                       .on(gkoExec_))
+                       .on(gkoExec_)),
+          localMatrixFormat_(solverConfig.get("localMatrixFormat", std::string("Csr")))
     {}
 
     static std::string name() { return "Ginkgo"; }
@@ -280,11 +281,11 @@ public:
 private:
 
     std::shared_ptr<const gko::Executor> gkoExec_;
-    bool coupled_; // whether to solve LinearSystem<Vec3> as one or three systems
-    // L1-scaled residual stopping controls; set only when "l1ScaledResidual" is enabled
+    bool coupled_;
     std::optional<L1ResidualControl> l1Control_;
     gko::config::pnode config_;
     std::shared_ptr<const gko::LinOpFactory> factory_;
+    std::string localMatrixFormat_;
 #ifdef NF_WITH_MPI_SUPPORT
     // Both caches are null until the first solve; after that topology is fixed.
     mutable std::shared_ptr<gko::experimental::distributed::index_map<label, gko::int64>>

--- a/include/NeoN/linearAlgebra/linearSystem.hpp
+++ b/include/NeoN/linearAlgebra/linearSystem.hpp
@@ -136,6 +136,7 @@ public:
           // TODO move to a different location since this seems to be unrelated to linearSystem
           faceFluxCorrection_(ls.faceFluxCorrection_),
           keepFaceFluxCorrection_(ls.keepFaceFluxCorrection_),
+          diagCmpt_(ls.diagCmpt_ ? std::make_shared<Vector<RHSValueType>>(*ls.diagCmpt_) : nullptr),
           meshIteratorContext_(ls.meshIteratorContext_)
 #ifdef NF_WITH_MPI_SUPPORT
           ,
@@ -192,6 +193,27 @@ public:
 
     void keepFaceFluxCorrection(bool keep) { keepFaceFluxCorrection_ = keep; }
 
+    /// @brief Per-component diagonal correction for implicit transform BCs (slip/symmetry).
+    ///        nullptr when no implicit transform patch is present (the fast multi-RHS path).
+    [[nodiscard]] const std::shared_ptr<Vector<RHSValueType>>& diagCmpt() const
+    {
+        return diagCmpt_;
+    }
+
+    /// @brief Lazily allocate (zero-initialised, one RHSValueType per cell) and return the
+    ///        per-component diagonal-correction store, so the Laplacian assembly can accumulate
+    ///        the implicit transform-BC contribution into it.
+    [[nodiscard]] Vector<RHSValueType>& ensureDiagCmpt()
+    {
+        if (!diagCmpt_)
+        {
+            diagCmpt_ =
+                std::make_shared<Vector<RHSValueType>>(exec(), rhs_.size(), zero<RHSValueType>());
+        }
+        return *diagCmpt_;
+    }
+
+
     [[nodiscard]] LinearSystem<MatrixValueType, RHSValueType, SystemMatrixType, BoundaryMatrixType>
     copyToExecutor(Executor exec) const override
     {
@@ -202,6 +224,10 @@ public:
             boundaryMatrix_.copyToExecutor(exec),
             boundaryRhs_.copyToExecutor(exec)
         };
+        if (diagCmpt_)
+        {
+            ls.diagCmpt_ = std::make_shared<Vector<RHSValueType>>(diagCmpt_->copyToExecutor(exec));
+        }
 #ifdef NF_WITH_MPI_SUPPORT
         ls.commPattern_ = commPattern_;
 #endif
@@ -215,6 +241,7 @@ public:
         fill(boundaryMatrix_.values(), zero<MatrixValueType>());
         fill(boundaryRhs_, zero<RHSValueType>());
         fill(offDiagonalMatrix_.values(), zero<MatrixValueType>());
+        if (diagCmpt_) fill(*diagCmpt_, zero<RHSValueType>());
     }
 
     [[nodiscard]] LinearSystemView<
@@ -301,6 +328,13 @@ private:
     bool keepFaceFluxCorrection_ = false;
 
     Dictionary auxiliaryCoefficients_;
+
+    // Optional per-component diagonal correction for direction-dependent (transform) boundary
+    // conditions in implicit mode (slip/symmetry). One RHSValueType (e.g. Vec3) per cell; component
+    // c holds the diagonal contribution γ|S|·Δ·|n_c| applied for solve-component c on cells
+    // adjacent to an implicit transform patch. Lazily allocated by ensureDiagCmpt(); stays nullptr
+    // (and the shared scalar matrix / multi-RHS fast path is used) whenever no such patch exists.
+    std::shared_ptr<Vector<RHSValueType>> diagCmpt_ = nullptr;
 
     std::shared_ptr<MeshIteratorContext> meshIteratorContext_ = nullptr;
 

--- a/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
+++ b/src/finiteVolume/cellCentred/operators/gaussGreenLaplacian.cpp
@@ -194,6 +194,59 @@ void computeLaplacianBoundImpl(
         },
         "computeInterfaceLaplacianCoefficients"
     );
+
+    // Implicit transform boundary conditions (slip/symmetry with "implicit"): the normal-damping
+    // coefficient is direction-dependent (γ|S|·Δ·|n_c|) and therefore differs per momentum
+    // component, which the shared scalar diagonal cannot hold. Instead of three matrix copies we
+    // accumulate the per-component contribution into the linear system's diagCmpt store; the solver
+    // applies it column-by-column (subtracting it from the diagonal, matching the Dirichlet sign
+    // convention above). Only meaningful for a vector field — a scalar transform BC is plain
+    // zero-gradient and contributes nothing here.
+    if constexpr (std::is_same_v<FieldValueType, NeoN::Vec3>)
+    {
+        const auto bcs = phi.boundaryConditions();
+        bool anyImplicit = false;
+        for (const auto& bc : bcs)
+        {
+            if (bc.attributes().transformImplicit)
+            {
+                anyImplicit = true;
+                break;
+            }
+        }
+
+        if (anyImplicit)
+        {
+            auto diagCmptV = ls.ensureDiagCmpt().view();
+            const auto bUnitNormals = mesh.boundaryMesh().faceUnitNormals().view();
+
+            for (localIdx patchID = 0; patchID < mesh.nBoundaries(); ++patchID)
+            {
+                if (!bcs[static_cast<size_t>(patchID)].attributes().transformImplicit)
+                {
+                    continue;
+                }
+                const auto [start, end] = phi.boundaryData().range(patchID);
+                parallelFor(
+                    exec,
+                    {start, end},
+                    NEON_LAMBDA(const localIdx bfi) {
+                        const auto own = boundaryFaceOwners[bfi];
+                        const auto n = bUnitNormals[bfi];
+                        // γ|S|·coeff·Δ — the Dirichlet-strength diagonal weight for this face
+                        const scalar w = bGammaV[bfi] * bFaceAreas[bfi] * operatorScaling[own]
+                                       * bDeltaCoeffs[bfi];
+                        // per-component contribution scaled by |n_c| (a corner cell may own several
+                        // boundary faces, hence the atomics)
+                        Kokkos::atomic_add(&diagCmptV[own][0], w * Kokkos::abs(n[0]));
+                        Kokkos::atomic_add(&diagCmptV[own][1], w * Kokkos::abs(n[1]));
+                        Kokkos::atomic_add(&diagCmptV[own][2], w * Kokkos::abs(n[2]));
+                    },
+                    "computeImplicitTransformDiag"
+                );
+            }
+        }
+    }
 }
 
 template<typename FieldValueType, typename AssemblyType>

--- a/src/linearAlgebra/ginkgo/ginkgo.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgo.cpp
@@ -11,6 +11,7 @@
 
 #include "NeoN/linearAlgebra/ginkgo.hpp"
 #include "NeoN/core/vector/vectorFreeFunctions.hpp"
+#include "NeoN/core/parallelAlgorithms.hpp"
 
 gko::config::pnode NeoN::la::ginkgo::parse(const Dictionary& dictIn)
 {
@@ -24,6 +25,11 @@ gko::config::pnode NeoN::la::ginkgo::parse(const Dictionary& dictIn)
     if (dict.contains("coupled"))
     {
         dict.remove("coupled");
+    }
+
+    if (dict.contains("localMatrixFormat"))
+    {
+        dict.remove("localMatrixFormat");
     }
 
     // 'reportName' is a human-readable solver label (e.g. DICPCG) carried for
@@ -529,13 +535,90 @@ SolverStats GinkgoSolver::solve(
 }
 
 
+// Solve one component of a scalar-matrix / Vec3-rhs system under an implicit transform BC
+// (slip/symmetry). The component's diagonal correction is temporarily subtracted from the shared
+// scalar diagonal (in place, no matrix copy), the column is solved by reusing solve_impl — so the
+// l1ScaledResidual criterion is honoured for free — and the diagonal is restored. The diag edits
+// use atomics because a corner cell may receive contributions from several boundary faces.
+template<unsigned int I>
+void solveImplicitTransformComponent(
+    const auto& sys,
+    Vector<Vec3>& x,
+    const auto& exec,
+    std::shared_ptr<const gko::Executor> gkoExec,
+    std::shared_ptr<const gko::LinOp> gkoMtx,
+    const auto& factory,
+    SolverStats& stats,
+    const L1ResidualControl* l1Control,
+    auto values,
+    const auto& ma,
+    auto diagC,
+    localIdx nrows
+)
+{
+    parallelFor(
+        exec,
+        {0, nrows},
+        NEON_LAMBDA(const localIdx cell) {
+            Kokkos::atomic_sub(&values[ma.diagIdx(cell)], diagC[cell][I]);
+        },
+        "applyImplicitTransformDiag"
+    );
+    gkoExec->synchronize();
+
+    auto rhs = getComponent<I>(sys.rhs());
+    auto xcopy = getComponent<I>(x);
+    stats.entries.push_back(
+        solve_impl(gkoExec, rhs, xcopy, gkoMtx, factory->generate(gkoMtx), l1Control)
+    );
+    setComponent<I>(xcopy, x);
+
+    parallelFor(
+        exec,
+        {0, nrows},
+        NEON_LAMBDA(const localIdx cell) {
+            Kokkos::atomic_add(&values[ma.diagIdx(cell)], diagC[cell][I]);
+        },
+        "restoreImplicitTransformDiag"
+    );
+    gkoExec->synchronize();
+}
+
 SolverStats GinkgoSolver::solve(
     const LinearSystem<scalar, Vec3, CSRMatrix<scalar, localIdx>, COOMatrix<scalar, localIdx>>& sys,
     Vector<Vec3>& x
 ) const
 {
     auto gkoMtx = createGkoMtx(sys.matrix());
+
     const L1ResidualControl* l1Control = l1Control_ ? &l1Control_.value() : nullptr;
+
+    // Implicit transform-BC path (slip/symmetry with "implicit"): the per-component diagonal
+    // correction differs per column, so solve the three components segregated, reusing solve_impl
+    // (which honours the l1ScaledResidual criterion). Each column's correction is temporarily
+    // subtracted from the shared scalar diagonal in place — no matrix copy — and restored after;
+    // createGkoMtx only views the matrix, so the edits are seen at generate()/apply() time, and the
+    // const_cast is safe because the storage is owned mutably by the caller.
+    if (sys.diagCmpt() && sys.diagCmpt()->size() > 0)
+    {
+        auto values = const_cast<Vector<scalar>&>(sys.matrix().values()).view();
+        const auto ma = sys.faceToMatrixAddress()->view(sys.matrix().rowOffs().view());
+        auto diagC = sys.diagCmpt()->view();
+        const localIdx nrows = sys.rhs().size();
+        gkoExec_->synchronize();
+
+        SolverStats stats;
+        solveImplicitTransformComponent<0>(
+            sys, x, exec_, gkoExec_, gkoMtx, factory_, stats, l1Control, values, ma, diagC, nrows
+        );
+        solveImplicitTransformComponent<1>(
+            sys, x, exec_, gkoExec_, gkoMtx, factory_, stats, l1Control, values, ma, diagC, nrows
+        );
+        solveImplicitTransformComponent<2>(
+            sys, x, exec_, gkoExec_, gkoMtx, factory_, stats, l1Control, values, ma, diagC, nrows
+        );
+        return stats;
+    }
     if (l1Control)
     {
         gkoExec_->synchronize();

--- a/src/linearAlgebra/ginkgo/ginkgo.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgo.cpp
@@ -462,7 +462,11 @@ SolverStats GinkgoSolver::solve(
 ) const
 {
     auto gkoMtx = createGkoMtx(sys.matrix());
-    const L1ResidualControl* l1Control = l1Control_ ? &l1Control_.value() : nullptr;
+    // When the configFile names the L1 criterion it is already built into the solver and
+    // governs convergence (l1InConfig_); suppress the post-hoc attach so it is not applied
+    // twice. The flag-only case (criterion not in the config) still attaches it here.
+    const L1ResidualControl* l1Control =
+        (l1Control_ && !l1InConfig_) ? &l1Control_.value() : nullptr;
     return {solve_impl(gkoExec_, sys.rhs(), x, gkoMtx, factory_->generate(gkoMtx), l1Control)};
 }
 
@@ -511,7 +515,11 @@ SolverStats GinkgoSolver::solve(
     const LinearSystem<Vec3, Vec3, CSRMatrix<Vec3, localIdx>>& sys, Vector<Vec3>& x
 ) const
 {
-    const L1ResidualControl* l1Control = l1Control_ ? &l1Control_.value() : nullptr;
+    // When the configFile names the L1 criterion it is already built into the solver and
+    // governs convergence (l1InConfig_); suppress the post-hoc attach so it is not applied
+    // twice. The flag-only case (criterion not in the config) still attaches it here.
+    const L1ResidualControl* l1Control =
+        (l1Control_ && !l1InConfig_) ? &l1Control_.value() : nullptr;
     if (coupled_)
     {
         const auto gkoMtx = createGkoMtx(sys.matrix());
@@ -591,7 +599,11 @@ SolverStats GinkgoSolver::solve(
 {
     auto gkoMtx = createGkoMtx(sys.matrix());
 
-    const L1ResidualControl* l1Control = l1Control_ ? &l1Control_.value() : nullptr;
+    // When the configFile names the L1 criterion it is already built into the solver and
+    // governs convergence (l1InConfig_); suppress the post-hoc attach so it is not applied
+    // twice. The flag-only case (criterion not in the config) still attaches it here.
+    const L1ResidualControl* l1Control =
+        (l1Control_ && !l1InConfig_) ? &l1Control_.value() : nullptr;
 
     // Implicit transform-BC path (slip/symmetry with "implicit"): the per-component diagonal
     // correction differs per column, so solve the three components segregated, reusing solve_impl

--- a/src/linearAlgebra/ginkgo/ginkgo.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgo.cpp
@@ -543,19 +543,28 @@ SolverStats GinkgoSolver::solve(
 // scalar diagonal (in place, no matrix copy), the column is solved by reusing solve_impl — so the
 // l1ScaledResidual criterion is honoured for free — and the diagonal is restored. The loop is over
 // cells and each iteration writes its own (distinct) diagonal entry, so plain writes suffice.
-template<unsigned int I>
+// NOTE: named template parameters (not abbreviated `auto` params): nvcc forbids defining an
+// extended __device__ lambda (NEON_LAMBDA below) inside a function with `auto` parameters.
+template<
+    unsigned int I,
+    typename SystemType,
+    typename ExecType,
+    typename FactoryType,
+    typename ValuesType,
+    typename MatAddrType,
+    typename DiagType>
 void solveImplicitTransformComponent(
-    const auto& sys,
+    const SystemType& sys,
     Vector<Vec3>& x,
-    const auto& exec,
+    const ExecType& exec,
     std::shared_ptr<const gko::Executor> gkoExec,
     std::shared_ptr<const gko::LinOp> gkoMtx,
-    const auto& factory,
+    const FactoryType& factory,
     SolverStats& stats,
     const L1ResidualControl* l1Control,
-    auto values,
-    const auto& ma,
-    auto diagC,
+    ValuesType values,
+    const MatAddrType& ma,
+    DiagType diagC,
     localIdx nrows
 )
 {

--- a/src/linearAlgebra/ginkgo/ginkgo.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgo.cpp
@@ -27,11 +27,6 @@ gko::config::pnode NeoN::la::ginkgo::parse(const Dictionary& dictIn)
         dict.remove("coupled");
     }
 
-    if (dict.contains("localMatrixFormat"))
-    {
-        dict.remove("localMatrixFormat");
-    }
-
     // 'reportName' is a human-readable solver label (e.g. DICPCG) carried for
     // residual reporting; it is not a Ginkgo config key.
     if (dict.contains("reportName"))

--- a/src/linearAlgebra/ginkgo/ginkgo.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgo.cpp
@@ -541,8 +541,8 @@ SolverStats GinkgoSolver::solve(
 // Solve one component of a scalar-matrix / Vec3-rhs system under an implicit transform BC
 // (slip/symmetry). The component's diagonal correction is temporarily subtracted from the shared
 // scalar diagonal (in place, no matrix copy), the column is solved by reusing solve_impl — so the
-// l1ScaledResidual criterion is honoured for free — and the diagonal is restored. The diag edits
-// use atomics because a corner cell may receive contributions from several boundary faces.
+// l1ScaledResidual criterion is honoured for free — and the diagonal is restored. The loop is over
+// cells and each iteration writes its own (distinct) diagonal entry, so plain writes suffice.
 template<unsigned int I>
 void solveImplicitTransformComponent(
     const auto& sys,
@@ -562,9 +562,7 @@ void solveImplicitTransformComponent(
     parallelFor(
         exec,
         {0, nrows},
-        NEON_LAMBDA(const localIdx cell) {
-            Kokkos::atomic_sub(&values[ma.diagIdx(cell)], diagC[cell][I]);
-        },
+        NEON_LAMBDA(const localIdx cell) { values[ma.diagIdx(cell)] -= diagC[cell][I]; },
         "applyImplicitTransformDiag"
     );
     gkoExec->synchronize();
@@ -579,9 +577,7 @@ void solveImplicitTransformComponent(
     parallelFor(
         exec,
         {0, nrows},
-        NEON_LAMBDA(const localIdx cell) {
-            Kokkos::atomic_add(&values[ma.diagIdx(cell)], diagC[cell][I]);
-        },
+        NEON_LAMBDA(const localIdx cell) { values[ma.diagIdx(cell)] += diagC[cell][I]; },
         "restoreImplicitTransformDiag"
     );
     gkoExec->synchronize();

--- a/src/linearAlgebra/ginkgo/ginkgoDistributed.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgoDistributed.cpp
@@ -108,7 +108,8 @@ std::shared_ptr<const gko::LinOp> createGkoMtxDist(
     const COOMatrix<scalar, IndexType>& bmtx,
     const CommunicationPattern& commPattern,
     std::shared_ptr<gko::experimental::distributed::index_map<label, gko::int64>>& imapCache,
-    std::shared_ptr<gko::matrix::Coo<scalar, IndexType>>& nonLocalMtxCache
+    std::shared_ptr<gko::matrix::Coo<scalar, IndexType>>& nonLocalMtxCache,
+    const std::string& localMatrixFormat
 )
 {
     // commPattern is currently unused here: all the connectivity information needed to build
@@ -136,11 +137,24 @@ std::shared_ptr<const gko::LinOp> createGkoMtxDist(
     );
 
     const auto nrows = static_cast<gko::size_type>(mtx.sparsity()->rows());
+    const auto matrixSize = gko::dim<2> {nrows, nrows};
 
-    std::shared_ptr<const gko::LinOp> localMtx =
+    std::shared_ptr<const gko::LinOp> localMtx;
+    if (localMatrixFormat == "Sellp")
+    {
+        auto sellp = gko::share(gko::matrix::Sellp<scalar, IndexType>::create(exec, matrixSize));
         gko::share(gko::matrix::Csr<scalar, IndexType>::create_const(
-            exec, gko::dim<2> {nrows, nrows}, std::move(vals), std::move(col), std::move(row)
+                       exec, matrixSize, std::move(vals), std::move(col), std::move(row)
+                   ))
+            ->convert_to(sellp);
+        localMtx = sellp;
+    }
+    else
+    {
+        localMtx = gko::share(gko::matrix::Csr<scalar, IndexType>::create_const(
+            exec, matrixSize, std::move(vals), std::move(col), std::move(row)
         ));
+    }
 
     const auto nNonLocalNnz = static_cast<gko::size_type>(bmtx.values().size());
 
@@ -445,7 +459,8 @@ void solveComponentDist(
     auto& stats,
     const L1ResidualControl* l1Control,
     std::shared_ptr<gko::experimental::distributed::index_map<label, gko::int64>>& imapCache,
-    std::shared_ptr<gko::matrix::Coo<scalar, localIdx>>& nonLocalMtxCache
+    std::shared_ptr<gko::matrix::Coo<scalar, localIdx>>& nonLocalMtxCache,
+    const std::string& localMatrixFormat
 )
 {
     auto rhs = getComponent<I>(sys.rhs());
@@ -462,11 +477,61 @@ void solveComponentDist(
     auto comm = gko::experimental::mpi::communicator(
         commPattern.env.comm(), !commPattern.env.gpuAwareMpi()
     );
-    auto gkoMtx =
-        createGkoMtxDist(exec, comm, mtx, nonLocalMtx, commPattern, imapCache, nonLocalMtxCache);
+    auto gkoMtx = createGkoMtxDist(
+        exec, comm, mtx, nonLocalMtx, commPattern, imapCache, nonLocalMtxCache, localMatrixFormat
+    );
     auto solver = gko::share(factory->generate(gkoMtx));
     stats.entries.push_back(solve_impl_dist(exec, comm, rhs, xcopy, gkoMtx, solver, l1Control));
     setComponent<I>(xcopy, x);
+}
+
+// Distributed counterpart of solveImplicitTransformComponent: solve component I of a scalar-matrix
+// / Vec3-rhs system under an implicit transform BC (slip/symmetry), temporarily applying the
+// component's diagonal correction to the shared rank-local diagonal in place and reusing
+// solve_impl_dist (which honours the l1ScaledResidual criterion). The correction is rank-local, so
+// only the local diagonal entries are touched.
+template<unsigned int I>
+void solveImplicitTransformComponentDist(
+    const auto& sys,
+    Vector<Vec3>& x,
+    const auto& exec,
+    std::shared_ptr<const gko::Executor> gkoExec,
+    const gko::experimental::mpi::communicator& comm,
+    std::shared_ptr<const gko::LinOp> gkoMtx,
+    const auto& factory,
+    SolverStats& stats,
+    const L1ResidualControl* l1Control,
+    auto values,
+    const auto& ma,
+    auto diagC,
+    localIdx nrows
+)
+{
+    parallelFor(
+        exec,
+        {0, nrows},
+        NEON_LAMBDA(const localIdx cell) {
+            Kokkos::atomic_sub(&values[ma.diagIdx(cell)], diagC[cell][I]);
+        },
+        "applyImplicitTransformDiagDist"
+    );
+    gkoExec->synchronize();
+
+    auto rhs = getComponent<I>(sys.rhs());
+    auto xcopy = getComponent<I>(x);
+    auto solver = gko::share(factory->generate(gkoMtx));
+    stats.entries.push_back(solve_impl_dist(gkoExec, comm, rhs, xcopy, gkoMtx, solver, l1Control));
+    setComponent<I>(xcopy, x);
+
+    parallelFor(
+        exec,
+        {0, nrows},
+        NEON_LAMBDA(const localIdx cell) {
+            Kokkos::atomic_add(&values[ma.diagIdx(cell)], diagC[cell][I]);
+        },
+        "restoreImplicitTransformDiagDist"
+    );
+    gkoExec->synchronize();
 }
 
 SolverStats GinkgoSolver::solveDist(
@@ -484,7 +549,8 @@ SolverStats GinkgoSolver::solveDist(
         sys.offDiagonalMatrix(),
         commPattern,
         cachedImap_,
-        cachedNonLocalMtx_
+        cachedNonLocalMtx_,
+        localMatrixFormat_
     );
     auto solver = gko::share(factory_->generate(gkoMtx));
     const L1ResidualControl* l1Control = l1Control_ ? &l1Control_.value() : nullptr;
@@ -498,13 +564,37 @@ SolverStats GinkgoSolver::solveDist(
     auto stats = SolverStats {};
     const L1ResidualControl* l1Control = l1Control_ ? &l1Control_.value() : nullptr;
     solveComponentDist<0>(
-        sys, x, gkoExec_, factory_, stats, l1Control, cachedImap_, cachedNonLocalMtx_
+        sys,
+        x,
+        gkoExec_,
+        factory_,
+        stats,
+        l1Control,
+        cachedImap_,
+        cachedNonLocalMtx_,
+        localMatrixFormat_
     );
     solveComponentDist<1>(
-        sys, x, gkoExec_, factory_, stats, l1Control, cachedImap_, cachedNonLocalMtx_
+        sys,
+        x,
+        gkoExec_,
+        factory_,
+        stats,
+        l1Control,
+        cachedImap_,
+        cachedNonLocalMtx_,
+        localMatrixFormat_
     );
     solveComponentDist<2>(
-        sys, x, gkoExec_, factory_, stats, l1Control, cachedImap_, cachedNonLocalMtx_
+        sys,
+        x,
+        gkoExec_,
+        factory_,
+        stats,
+        l1Control,
+        cachedImap_,
+        cachedNonLocalMtx_,
+        localMatrixFormat_
     );
     return stats;
 }
@@ -518,6 +608,7 @@ SolverStats GinkgoSolver::solveDist(
     auto comm = gko::experimental::mpi::communicator(
         commPattern.env.comm(), !commPattern.env.gpuAwareMpi()
     );
+    const L1ResidualControl* l1Control = l1Control_ ? &l1Control_.value() : nullptr;
     auto gkoMtx = createGkoMtxDist(
         gkoExec_,
         comm,
@@ -525,17 +616,80 @@ SolverStats GinkgoSolver::solveDist(
         sys.offDiagonalMatrix(),
         commPattern,
         cachedImap_,
-        cachedNonLocalMtx_
+        cachedNonLocalMtx_,
+        localMatrixFormat_
     );
+
+    // Implicit transform-BC path: solve the three components segregated, applying each column's
+    // per-component diagonal correction to the shared rank-local diagonal in place. Mirrors the
+    // serial path; createGkoMtxDist views the local matrix, so the in-place edits are seen at solve
+    // time.
+    if (sys.diagCmpt() && sys.diagCmpt()->size() > 0)
+    {
+        auto values = const_cast<Vector<scalar>&>(sys.matrix().values()).view();
+        const auto ma = sys.faceToMatrixAddress()->view(sys.matrix().rowOffs().view());
+        auto diagC = sys.diagCmpt()->view();
+        const localIdx nrows = sys.rhs().size();
+        gkoExec_->synchronize();
+
+        SolverStats stats;
+        solveImplicitTransformComponentDist<0>(
+            sys,
+            x,
+            exec_,
+            gkoExec_,
+            comm,
+            gkoMtx,
+            factory_,
+            stats,
+            l1Control,
+            values,
+            ma,
+            diagC,
+            nrows
+        );
+        solveImplicitTransformComponentDist<1>(
+            sys,
+            x,
+            exec_,
+            gkoExec_,
+            comm,
+            gkoMtx,
+            factory_,
+            stats,
+            l1Control,
+            values,
+            ma,
+            diagC,
+            nrows
+        );
+        solveImplicitTransformComponentDist<2>(
+            sys,
+            x,
+            exec_,
+            gkoExec_,
+            comm,
+            gkoMtx,
+            factory_,
+            stats,
+            l1Control,
+            values,
+            ma,
+            diagC,
+            nrows
+        );
+        return stats;
+    }
+
+
     auto solver = gko::share(factory_->generate(gkoMtx));
-    const L1ResidualControl* l1Control = l1Control_ ? &l1Control_.value() : nullptr;
     return solve_impl_dist(gkoExec_, comm, sys.rhs(), x, gkoMtx, solver, l1Control);
 }
 
 template std::
     shared_ptr<const gko::LinOp>
     createGkoMtxDist<
-        localIdx>(std::shared_ptr<const gko::Executor>, const gko::experimental::mpi::communicator&, const CSRMatrix<scalar, localIdx>&, const COOMatrix<scalar, localIdx>&, const CommunicationPattern&, std::shared_ptr<gko::experimental::distributed::index_map<label, gko::int64>>&, std::shared_ptr<gko::matrix::Coo<scalar, localIdx>>&);
+        localIdx>(std::shared_ptr<const gko::Executor>, const gko::experimental::mpi::communicator&, const CSRMatrix<scalar, localIdx>&, const COOMatrix<scalar, localIdx>&, const CommunicationPattern&, std::shared_ptr<gko::experimental::distributed::index_map<label, gko::int64>>&, std::shared_ptr<gko::matrix::Coo<scalar, localIdx>>&, const std::string&);
 
 }
 

--- a/src/linearAlgebra/ginkgo/ginkgoDistributed.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgoDistributed.cpp
@@ -475,20 +475,29 @@ void solveComponentDist(
 // component's diagonal correction to the shared rank-local diagonal in place and reusing
 // solve_impl_dist (which honours the l1ScaledResidual criterion). The correction is rank-local, so
 // only the local diagonal entries are touched.
-template<unsigned int I>
+// NOTE: named template parameters (not abbreviated `auto` params): nvcc forbids defining an
+// extended __device__ lambda (NEON_LAMBDA below) inside a function with `auto` parameters.
+template<
+    unsigned int I,
+    typename SystemType,
+    typename ExecType,
+    typename FactoryType,
+    typename ValuesType,
+    typename MatAddrType,
+    typename DiagType>
 void solveImplicitTransformComponentDist(
-    const auto& sys,
+    const SystemType& sys,
     Vector<Vec3>& x,
-    const auto& exec,
+    const ExecType& exec,
     std::shared_ptr<const gko::Executor> gkoExec,
     const gko::experimental::mpi::communicator& comm,
     std::shared_ptr<const gko::LinOp> gkoMtx,
-    const auto& factory,
+    const FactoryType& factory,
     SolverStats& stats,
     const L1ResidualControl* l1Control,
-    auto values,
-    const auto& ma,
-    auto diagC,
+    ValuesType values,
+    const MatAddrType& ma,
+    DiagType diagC,
     localIdx nrows
 )
 {

--- a/src/linearAlgebra/ginkgo/ginkgoDistributed.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgoDistributed.cpp
@@ -108,8 +108,7 @@ std::shared_ptr<const gko::LinOp> createGkoMtxDist(
     const COOMatrix<scalar, IndexType>& bmtx,
     const CommunicationPattern& commPattern,
     std::shared_ptr<gko::experimental::distributed::index_map<label, gko::int64>>& imapCache,
-    std::shared_ptr<gko::matrix::Coo<scalar, IndexType>>& nonLocalMtxCache,
-    const std::string& localMatrixFormat
+    std::shared_ptr<gko::matrix::Coo<scalar, IndexType>>& nonLocalMtxCache
 )
 {
     // commPattern is currently unused here: all the connectivity information needed to build
@@ -139,22 +138,10 @@ std::shared_ptr<const gko::LinOp> createGkoMtxDist(
     const auto nrows = static_cast<gko::size_type>(mtx.sparsity()->rows());
     const auto matrixSize = gko::dim<2> {nrows, nrows};
 
-    std::shared_ptr<const gko::LinOp> localMtx;
-    if (localMatrixFormat == "Sellp")
-    {
-        auto sellp = gko::share(gko::matrix::Sellp<scalar, IndexType>::create(exec, matrixSize));
+    std::shared_ptr<const gko::LinOp> localMtx =
         gko::share(gko::matrix::Csr<scalar, IndexType>::create_const(
-                       exec, matrixSize, std::move(vals), std::move(col), std::move(row)
-                   ))
-            ->convert_to(sellp);
-        localMtx = sellp;
-    }
-    else
-    {
-        localMtx = gko::share(gko::matrix::Csr<scalar, IndexType>::create_const(
             exec, matrixSize, std::move(vals), std::move(col), std::move(row)
         ));
-    }
 
     const auto nNonLocalNnz = static_cast<gko::size_type>(bmtx.values().size());
 
@@ -459,8 +446,7 @@ void solveComponentDist(
     auto& stats,
     const L1ResidualControl* l1Control,
     std::shared_ptr<gko::experimental::distributed::index_map<label, gko::int64>>& imapCache,
-    std::shared_ptr<gko::matrix::Coo<scalar, localIdx>>& nonLocalMtxCache,
-    const std::string& localMatrixFormat
+    std::shared_ptr<gko::matrix::Coo<scalar, localIdx>>& nonLocalMtxCache
 )
 {
     auto rhs = getComponent<I>(sys.rhs());
@@ -477,9 +463,8 @@ void solveComponentDist(
     auto comm = gko::experimental::mpi::communicator(
         commPattern.env.comm(), !commPattern.env.gpuAwareMpi()
     );
-    auto gkoMtx = createGkoMtxDist(
-        exec, comm, mtx, nonLocalMtx, commPattern, imapCache, nonLocalMtxCache, localMatrixFormat
-    );
+    auto gkoMtx =
+        createGkoMtxDist(exec, comm, mtx, nonLocalMtx, commPattern, imapCache, nonLocalMtxCache);
     auto solver = gko::share(factory->generate(gkoMtx));
     stats.entries.push_back(solve_impl_dist(exec, comm, rhs, xcopy, gkoMtx, solver, l1Control));
     setComponent<I>(xcopy, x);
@@ -549,8 +534,7 @@ SolverStats GinkgoSolver::solveDist(
         sys.offDiagonalMatrix(),
         commPattern,
         cachedImap_,
-        cachedNonLocalMtx_,
-        localMatrixFormat_
+        cachedNonLocalMtx_
     );
     auto solver = gko::share(factory_->generate(gkoMtx));
     const L1ResidualControl* l1Control = l1Control_ ? &l1Control_.value() : nullptr;
@@ -564,37 +548,13 @@ SolverStats GinkgoSolver::solveDist(
     auto stats = SolverStats {};
     const L1ResidualControl* l1Control = l1Control_ ? &l1Control_.value() : nullptr;
     solveComponentDist<0>(
-        sys,
-        x,
-        gkoExec_,
-        factory_,
-        stats,
-        l1Control,
-        cachedImap_,
-        cachedNonLocalMtx_,
-        localMatrixFormat_
+        sys, x, gkoExec_, factory_, stats, l1Control, cachedImap_, cachedNonLocalMtx_
     );
     solveComponentDist<1>(
-        sys,
-        x,
-        gkoExec_,
-        factory_,
-        stats,
-        l1Control,
-        cachedImap_,
-        cachedNonLocalMtx_,
-        localMatrixFormat_
+        sys, x, gkoExec_, factory_, stats, l1Control, cachedImap_, cachedNonLocalMtx_
     );
     solveComponentDist<2>(
-        sys,
-        x,
-        gkoExec_,
-        factory_,
-        stats,
-        l1Control,
-        cachedImap_,
-        cachedNonLocalMtx_,
-        localMatrixFormat_
+        sys, x, gkoExec_, factory_, stats, l1Control, cachedImap_, cachedNonLocalMtx_
     );
     return stats;
 }
@@ -616,8 +576,7 @@ SolverStats GinkgoSolver::solveDist(
         sys.offDiagonalMatrix(),
         commPattern,
         cachedImap_,
-        cachedNonLocalMtx_,
-        localMatrixFormat_
+        cachedNonLocalMtx_
     );
 
     // Implicit transform-BC path: solve the three components segregated, applying each column's
@@ -689,7 +648,7 @@ SolverStats GinkgoSolver::solveDist(
 template std::
     shared_ptr<const gko::LinOp>
     createGkoMtxDist<
-        localIdx>(std::shared_ptr<const gko::Executor>, const gko::experimental::mpi::communicator&, const CSRMatrix<scalar, localIdx>&, const COOMatrix<scalar, localIdx>&, const CommunicationPattern&, std::shared_ptr<gko::experimental::distributed::index_map<label, gko::int64>>&, std::shared_ptr<gko::matrix::Coo<scalar, localIdx>>&, const std::string&);
+        localIdx>(std::shared_ptr<const gko::Executor>, const gko::experimental::mpi::communicator&, const CSRMatrix<scalar, localIdx>&, const COOMatrix<scalar, localIdx>&, const CommunicationPattern&, std::shared_ptr<gko::experimental::distributed::index_map<label, gko::int64>>&, std::shared_ptr<gko::matrix::Coo<scalar, localIdx>>&);
 
 }
 

--- a/src/linearAlgebra/ginkgo/ginkgoDistributed.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgoDistributed.cpp
@@ -495,9 +495,7 @@ void solveImplicitTransformComponentDist(
     parallelFor(
         exec,
         {0, nrows},
-        NEON_LAMBDA(const localIdx cell) {
-            Kokkos::atomic_sub(&values[ma.diagIdx(cell)], diagC[cell][I]);
-        },
+        NEON_LAMBDA(const localIdx cell) { values[ma.diagIdx(cell)] -= diagC[cell][I]; },
         "applyImplicitTransformDiagDist"
     );
     gkoExec->synchronize();
@@ -511,9 +509,7 @@ void solveImplicitTransformComponentDist(
     parallelFor(
         exec,
         {0, nrows},
-        NEON_LAMBDA(const localIdx cell) {
-            Kokkos::atomic_add(&values[ma.diagIdx(cell)], diagC[cell][I]);
-        },
+        NEON_LAMBDA(const localIdx cell) { values[ma.diagIdx(cell)] += diagC[cell][I]; },
         "restoreImplicitTransformDiagDist"
     );
     gkoExec->synchronize();
@@ -537,7 +533,10 @@ SolverStats GinkgoSolver::solveDist(
         cachedNonLocalMtx_
     );
     auto solver = gko::share(factory_->generate(gkoMtx));
-    const L1ResidualControl* l1Control = l1Control_ ? &l1Control_.value() : nullptr;
+    // When the configFile names the L1 criterion it is already built into the solver
+    // (l1InConfig_); suppress the post-hoc attach so it is not applied twice.
+    const L1ResidualControl* l1Control =
+        (l1Control_ && !l1InConfig_) ? &l1Control_.value() : nullptr;
     return {solve_impl_dist(gkoExec_, comm, sys.rhs(), x, gkoMtx, solver, l1Control)};
 }
 
@@ -546,7 +545,10 @@ SolverStats GinkgoSolver::solveDist(
 ) const
 {
     auto stats = SolverStats {};
-    const L1ResidualControl* l1Control = l1Control_ ? &l1Control_.value() : nullptr;
+    // When the configFile names the L1 criterion it is already built into the solver
+    // (l1InConfig_); suppress the post-hoc attach so it is not applied twice.
+    const L1ResidualControl* l1Control =
+        (l1Control_ && !l1InConfig_) ? &l1Control_.value() : nullptr;
     solveComponentDist<0>(
         sys, x, gkoExec_, factory_, stats, l1Control, cachedImap_, cachedNonLocalMtx_
     );
@@ -568,7 +570,10 @@ SolverStats GinkgoSolver::solveDist(
     auto comm = gko::experimental::mpi::communicator(
         commPattern.env.comm(), !commPattern.env.gpuAwareMpi()
     );
-    const L1ResidualControl* l1Control = l1Control_ ? &l1Control_.value() : nullptr;
+    // When the configFile names the L1 criterion it is already built into the solver
+    // (l1InConfig_); suppress the post-hoc attach so it is not applied twice.
+    const L1ResidualControl* l1Control =
+        (l1Control_ && !l1InConfig_) ? &l1Control_.value() : nullptr;
     auto gkoMtx = createGkoMtxDist(
         gkoExec_,
         comm,

--- a/src/linearAlgebra/ginkgo/ginkgoL1Stop.cpp
+++ b/src/linearAlgebra/ginkgo/ginkgoL1Stop.cpp
@@ -135,8 +135,7 @@ std::pair<scalar, std::vector<scalar>> computeL1NormFactor(
     return {combined, perCol};
 }
 
-/* @brief Ginkgo stopping criterion based on the L1-scaled residual, shared by the serial
- * (VecType = gko::matrix::Dense) and distributed (VecType = distributed::Vector) solves.
+/* @brief Ginkgo stopping criterion based on the L1-scaled residual.
  *
  * The iteration stops on the scaled residual sum|b - A x| / normFactor, using an absolute
  * tolerance, a relative tolerance (relative to the initial residual) and a maximum
@@ -145,12 +144,23 @@ std::pair<scalar, std::vector<scalar>> computeL1NormFactor(
  * also matches OpenFOAM's recurrently-updated residual); it is recomputed with a single SpMV
  * only when the solver does not expose one (e.g. multigrid). For a distributed vector the
  * norms are global.
+ *
+ * The criterion is NOT templated on the vector type: a single factory serves the serial
+ * (gko::matrix::Dense), multi-RHS (Vec3 as a [nrows x 3] Dense) and distributed
+ * (distributed::Vector) solves. check_impl() dispatches on the runtime type of the solver's
+ * solution/residual, and a templated checkTyped() carries the per-type implementation. This
+ * lets a SINGLE factory instance be registered once in the Ginkgo config registry and named
+ * from a configFile (see makeL1CriterionFactory), instead of one factory per vector type.
+ *
+ * The system matrix and right-hand side are taken from the CriterionArgs the solver passes
+ * at generate() time when the `matrix`/`b` factory parameters are left null. The config path
+ * relies on this (JSON cannot carry the live operands); the programmatic path
+ * (attachL1StopAndSolve) sets them explicitly and they take precedence.
  */
-template<typename VecType>
 class L1ResidualCriterion :
-    public gko::EnablePolymorphicObject<L1ResidualCriterion<VecType>, gko::stop::Criterion>
+    public gko::EnablePolymorphicObject<L1ResidualCriterion, gko::stop::Criterion>
 {
-    friend class gko::EnablePolymorphicObject<L1ResidualCriterion<VecType>, gko::stop::Criterion>;
+    friend class gko::EnablePolymorphicObject<L1ResidualCriterion, gko::stop::Criterion>;
     using Criterion = gko::stop::Criterion;
 
 public:
@@ -170,15 +180,21 @@ public:
 
         localIdx GKO_FACTORY_PARAMETER_SCALAR(check_frequency, 1);
 
+        // Optional: live operands for the programmatic path. Left null on the config path,
+        // where they are sourced from the CriterionArgs in the constructor instead.
         std::shared_ptr<const gko::LinOp> GKO_FACTORY_PARAMETER_SCALAR(matrix, nullptr);
 
-        std::shared_ptr<const VecType> GKO_FACTORY_PARAMETER_SCALAR(b, nullptr);
+        std::shared_ptr<const gko::LinOp> GKO_FACTORY_PARAMETER_SCALAR(b, nullptr);
 
         std::add_pointer<scalar>::type GKO_FACTORY_PARAMETER_SCALAR(init_residual, NULL);
 
         std::add_pointer<scalar>::type GKO_FACTORY_PARAMETER_SCALAR(final_residual, NULL);
 
         std::add_pointer<gko::size_type>::type GKO_FACTORY_PARAMETER_SCALAR(num_iters, NULL);
+
+        // Set to true by the criterion on its first check; lets the caller tell whether the
+        // (config-registered) criterion actually ran and populated the residual reports.
+        std::add_pointer<bool>::type GKO_FACTORY_PARAMETER_SCALAR(fired, NULL);
 
         // Per-column scaled residual output for multi-RHS (Vec3) solves.
         // When non-null, filled with one entry per column (size == ncols).
@@ -196,15 +212,18 @@ public:
     GKO_ENABLE_BUILD_METHOD(Factory);
 
     explicit L1ResidualCriterion(std::shared_ptr<const gko::Executor> exec)
-        : gko::EnablePolymorphicObject<L1ResidualCriterion<VecType>, Criterion>(std::move(exec))
+        : gko::EnablePolymorphicObject<L1ResidualCriterion, Criterion>(std::move(exec))
     {}
 
-    explicit L1ResidualCriterion(const Factory* factory, const gko::stop::CriterionArgs&)
-        : gko::EnablePolymorphicObject<L1ResidualCriterion<VecType>, Criterion>(
-            factory->get_executor()
-        ),
+    explicit L1ResidualCriterion(const Factory* factory, const gko::stop::CriterionArgs& args)
+        : gko::EnablePolymorphicObject<L1ResidualCriterion, Criterion>(factory->get_executor()),
           parameters_ {factory->get_parameters()}
-    {}
+    {
+        // Prefer the explicitly-set factory operands (programmatic path); otherwise take the
+        // system matrix and RHS the solver supplies through the CriterionArgs (config path).
+        matrix_ = parameters_.matrix ? parameters_.matrix : args.system_matrix;
+        b_ = parameters_.b ? parameters_.b : args.b;
+    }
 
 protected:
 
@@ -216,8 +235,6 @@ protected:
         const Criterion::Updater& updater
     ) override
     {
-        const auto exec = this->get_executor();
-
         // The current solution is needed for the normFactor reference state (and for the
         // residual recompute fallback). For the iterative solvers used here (Cg/BiCGStab)
         // it is set on every check that can stop.
@@ -225,7 +242,36 @@ protected:
         {
             return false;
         }
+
+        // Dispatch on the concrete runtime vector type so one criterion/factory serves the
+        // serial (Dense) and distributed paths.
+        if (dynamic_cast<const dense*>(updater.solution_) != nullptr)
+        {
+            return checkTyped<dense>(stoppingId, setFinalized, stop_status, one_changed, updater);
+        }
+#ifdef NF_WITH_MPI_SUPPORT
+        if (dynamic_cast<const dist*>(updater.solution_) != nullptr)
+        {
+            return checkTyped<dist>(stoppingId, setFinalized, stop_status, one_changed, updater);
+        }
+#endif
+        return false;
+    }
+
+private:
+
+    template<typename VecType>
+    bool checkTyped(
+        gko::uint8 stoppingId,
+        bool setFinalized,
+        gko::array<gko::stopping_status>* stop_status,
+        bool* one_changed,
+        const Criterion::Updater& updater
+    )
+    {
+        const auto exec = this->get_executor();
         const auto* solution = gko::as<VecType>(updater.solution_);
+        const auto* bVec = gko::as<VecType>(b_.get());
         const auto numIter = updater.num_iterations_;
 
         // Skip the residual-norm evaluation on iterations where the criterion cannot stop
@@ -257,8 +303,8 @@ protected:
         {
             const auto one = gko::initialize<dense>({1.0}, exec);
             const auto negOne = gko::initialize<dense>({-1.0}, exec);
-            rOwned = parameters_.b->clone();
-            parameters_.matrix->apply(negOne.get(), solution, one.get(), rOwned.get());
+            rOwned = bVec->clone();
+            matrix_->apply(negOne.get(), solution, one.get(), rOwned.get());
             r = rOwned.get();
         }
 
@@ -270,15 +316,18 @@ protected:
         const bool isFirstIter = firstIter_;
         if (firstIter_)
         {
-            auto [combined, perCol] = computeL1NormFactor<VecType>(
-                exec, parameters_.matrix.get(), parameters_.b.get(), solution, r
-            );
+            auto [combined, perCol] =
+                computeL1NormFactor<VecType>(exec, matrix_.get(), bVec, solution, r);
             normFactor_ = combined;
             perColNormFactor_ = std::move(perCol);
             initResidual_ = rNorm / normFactor_;
             if (parameters_.init_residual != NULL)
             {
                 *(parameters_.init_residual) = initResidual_;
+            }
+            if (parameters_.fired != NULL)
+            {
+                *(parameters_.fired) = true;
             }
             firstIter_ = false;
         }
@@ -346,7 +395,9 @@ protected:
         return result;
     }
 
-private:
+    std::shared_ptr<const gko::LinOp> matrix_;
+
+    std::shared_ptr<const gko::LinOp> b_;
 
     mutable bool firstIter_ = true;
 
@@ -378,7 +429,7 @@ L1ResidualResult attachL1StopAndSolve(
 
     const bool multiRhs = b->get_size()[1] > 1;
 
-    auto params = L1ResidualCriterion<VecType>::build()
+    auto params = L1ResidualCriterion::build()
                       .with_absolute_tolerance(control.tolerance)
                       .with_relative_tolerance(control.relTol)
                       .with_min_iter(control.minIter)
@@ -442,6 +493,35 @@ L1ResidualResult solveWithL1StopDist(
     return attachL1StopAndSolve<dist>(exec, mtx, b, x, solver, control);
 }
 #endif
+
+std::shared_ptr<gko::stop::CriterionFactory> makeL1CriterionFactory(
+    std::shared_ptr<const gko::Executor> exec,
+    const L1ResidualControl& control,
+    L1ResidualResult* report
+)
+{
+    // matrix / b are deliberately left unset: the criterion sources them from the
+    // CriterionArgs the solver supplies at generate() time (the config path cannot pass
+    // the live operands through JSON). The reporting pointers, when a report sink is given,
+    // let the solve path recover the scaled L1 residual and iteration count even though the
+    // criterion now lives inside the Ginkgo-built solver rather than being attached post-hoc.
+    auto params = L1ResidualCriterion::build()
+                      .with_absolute_tolerance(control.tolerance)
+                      .with_relative_tolerance(control.relTol)
+                      .with_min_iter(control.minIter)
+                      .with_max_iter(control.maxIter)
+                      .with_check_frequency(control.checkFrequency);
+    if (report != nullptr)
+    {
+        params.with_init_residual(&report->initResNorm)
+            .with_final_residual(&report->finalResNorm)
+            .with_num_iters(&report->numIter)
+            .with_fired(&report->fired)
+            .with_per_col_init_residuals(&report->perColInitNorms)
+            .with_per_col_final_residuals(&report->perColFinalNorms);
+    }
+    return gko::share(params.on(exec));
+}
 
 #endif
 

--- a/test/distributed/operator.cpp
+++ b/test/distributed/operator.cpp
@@ -525,6 +525,80 @@ TEST_CASE("createGkoMtxDist - local CSR block holds zero-copy view of Matrix val
 
     REQUIRE(localCsr->get_const_values() == lsDst.matrix().values().data());
 }
+
+// Distributed counterpart of the serial implicit transform-BC solver test: a scalar matrix with a
+// Vec3 RHS and a per-component diagonal correction, solved across ranks via solveDist. The
+// off-diagonals (including the halo/offDiagonalMatrix) are left zero so each rank's diagonal block
+// is decoupled and the per-rank answer is analytic: x_c = b_c / (D - diagCmpt_c). Covers both the
+// standard and the l1ScaledResidual stopping criteria.
+TEST_CASE("Distributed implicit transform diagonal solve")
+{
+    auto [execName, exec] = GENERATE(allAvailableExecutor());
+    NeoN::mpi::Environment mpiEnviron;
+
+    const localIdx nCellsLocal = 4;
+    auto meshPart = create1DUniformMeshPart(exec, nCellsLocal);
+    auto ls = la::createEmptyLinearSystem<scalar, Vec3>(meshPart);
+    const localIdx n = ls.rhs().size();
+
+    // a populated communication pattern is what routes Solver::solve to solveDist
+    REQUIRE_FALSE(ls.commPattern().sendCounts.empty());
+
+    // diagonal D·I (off-diagonals and halo left zero → decoupled per rank)
+    const scalar D = 10.0;
+    {
+        auto values = ls.matrix().values().view();
+        const auto ma = ls.faceToMatrixAddress()->view(ls.matrix().rowOffs().view());
+        parallelFor(
+            exec, {0, n}, NEON_LAMBDA(const localIdx c) { values[ma.diagIdx(c)] = D; }, "setDiag"
+        );
+    }
+    const Vec3 dc(1.0, 2.0, 3.0);
+    fill(ls.ensureDiagCmpt(), dc);
+    const scalar bVal = 6.0;
+    fill(ls.rhs(), Vec3(bVal, bVal, bVal));
+
+    auto requireAnalytic = [&](const Vector<Vec3>& sol)
+    {
+        auto host = sol.copyToHost();
+        auto v = host.view();
+        for (localIdx i = 0; i < n; ++i)
+        {
+            REQUIRE(v[i][0] == Catch::Approx(bVal / (D - dc[0])).margin(1e-8));
+            REQUIRE(v[i][1] == Catch::Approx(bVal / (D - dc[1])).margin(1e-8));
+            REQUIRE(v[i][2] == Catch::Approx(bVal / (D - dc[2])).margin(1e-8));
+        }
+    };
+
+    SECTION("standard stopping criterion")
+    {
+        Dictionary solverDict {
+            {{"solver", std::string {"Ginkgo"}},
+             {"type", "solver::Cg"},
+             {"criteria", Dictionary {{{"iteration", 50}, {"relative_residual_norm", 1e-10}}}}}
+        };
+        auto solver = la::Solver(exec, solverDict);
+        Vector<Vec3> x(exec, n, Vec3(0.0, 0.0, 0.0));
+        auto stats = solver.solve(ls, x);
+        REQUIRE(stats.entries.size() == 3); // three segregated component solves
+        requireAnalytic(x);
+    }
+
+    SECTION("l1ScaledResidual stopping criterion")
+    {
+        Dictionary solverDict {
+            {{"solver", std::string {"Ginkgo"}},
+             {"type", "solver::Cg"},
+             {"l1ScaledResidual", true},
+             {"criteria", Dictionary {{{"iteration", 50}, {"absolute_residual_norm", 1e-10}}}}}
+        };
+        auto solver = la::Solver(exec, solverDict);
+        Vector<Vec3> x(exec, n, Vec3(0.0, 0.0, 0.0));
+        auto stats = solver.solve(ls, x);
+        REQUIRE(stats.entries.size() == 3);
+        requireAnalytic(x);
+    }
+}
 #endif // NF_WITH_GINKGO
 
 // Validates the linearUpwind deferred correction across processor boundaries AND through the fused

--- a/test/finiteVolume/cellCentred/boundary/volume/volSymmetry.cpp
+++ b/test/finiteVolume/cellCentred/boundary/volume/volSymmetry.cpp
@@ -76,6 +76,9 @@ TEST_CASE("symmetry_slip_volume")
 
             boundary->correctBoundaryCondition(field);
 
+            // default mode is deferred (multi-RHS friendly)
+            REQUIRE(boundary->attributes().transformImplicit == false);
+
             auto [refValuesH, valuesH, refGradH, nHatH, deltaCoeffsH, faceCellsH, internalH] =
                 copyToHosts(
                     field.boundaryData().refValue(),
@@ -112,6 +115,55 @@ TEST_CASE("symmetry_slip_volume")
                 for (auto d = 0u; d < 3; ++d)
                 {
                     REQUIRE(gradValueV[d] == Catch::Approx(gExpected[d]));
+                }
+            }
+        }
+
+        // === vector field: implicit mode ======================================
+        {
+            auto field = NeoN::Field<NeoN::Vec3>(exec, mesh.nCells(), mesh.boundaryMesh().offset());
+            NeoN::fill(field.internalVector(), NeoN::Vec3(1.0, -1.0, 0.5));
+            NeoN::fill(field.boundaryData().refGrad(), NeoN::Vec3(-1.0, -1.0, -1.0));
+            NeoN::fill(field.boundaryData().value(), NeoN::Vec3(-1.0, -1.0, -1.0));
+
+            NeoN::Dictionary dict;
+            dict.insert("implicit", true);
+            auto boundary =
+                NeoN::finiteVolume::cellCentred::VolumeBoundaryFactory<NeoN::Vec3>::create(
+                    "symmetry", mesh, dict, 0
+                );
+
+            boundary->correctBoundaryCondition(field);
+
+            REQUIRE(boundary->attributes().transformImplicit == true);
+
+            auto [valuesH, refGradH, nHatH, faceCellsH, internalH] = copyToHosts(
+                field.boundaryData().value(),
+                field.boundaryData().refGrad(),
+                mesh.boundaryMesh().faceUnitNormals(),
+                mesh.boundaryMesh().faceOwners(),
+                field.internalVector()
+            );
+
+            for (auto& boundaryValueV : valuesH.view(boundary->range()))
+            {
+                const auto i = static_cast<NeoN::localIdx>(&boundaryValueV - valuesH.data());
+                const auto nV = nHatH.view()[i];
+                const auto intV = internalH.view()[faceCellsH.view()[i]];
+                const auto vExpected = intV - nV * (intV & nV);
+
+                for (auto d = 0u; d < 3; ++d)
+                {
+                    REQUIRE(boundaryValueV[d] == Catch::Approx(vExpected[d]));
+                }
+            }
+
+            // implicit mode leaves refGrad zero (normal damping handled at assembly/solve)
+            for (auto& gradValueV : refGradH.view(boundary->range()))
+            {
+                for (auto d = 0u; d < 3; ++d)
+                {
+                    REQUIRE(gradValueV[d] == Catch::Approx(0.0));
                 }
             }
         }

--- a/test/finiteVolume/cellCentred/boundary/volume/volSymmetry.cpp
+++ b/test/finiteVolume/cellCentred/boundary/volume/volSymmetry.cpp
@@ -68,7 +68,20 @@ TEST_CASE("symmetry_slip_volume")
             NeoN::fill(field.boundaryData().refValue(), NeoN::Vec3(-1.0, -1.0, -1.0));
             NeoN::fill(field.boundaryData().value(), NeoN::Vec3(-1.0, -1.0, -1.0));
 
+            // The default (no "implicit" key) selects the implicit normal-damping treatment.
+            {
+                NeoN::Dictionary defaultDict;
+                auto defaultBoundary =
+                    NeoN::finiteVolume::cellCentred::VolumeBoundaryFactory<NeoN::Vec3>::create(
+                        bcName, mesh, defaultDict, 0
+                    );
+                REQUIRE(defaultBoundary->attributes().transformImplicit == true);
+            }
+
+            // Opt into the deferred treatment: the normal damping is written into refGrad (RHS),
+            // which is multi-RHS friendly.
             NeoN::Dictionary dict;
+            dict.insert("implicit", false);
             auto boundary =
                 NeoN::finiteVolume::cellCentred::VolumeBoundaryFactory<NeoN::Vec3>::create(
                     bcName, mesh, dict, 0
@@ -76,7 +89,6 @@ TEST_CASE("symmetry_slip_volume")
 
             boundary->correctBoundaryCondition(field);
 
-            // default mode is deferred (multi-RHS friendly)
             REQUIRE(boundary->attributes().transformImplicit == false);
 
             auto [refValuesH, valuesH, refGradH, nHatH, deltaCoeffsH, faceCellsH, internalH] =

--- a/test/finiteVolume/cellCentred/operator/laplacianOperator.cpp
+++ b/test/finiteVolume/cellCentred/operator/laplacianOperator.cpp
@@ -269,4 +269,78 @@ TEMPLATE_TEST_CASE(
     );
 }
 
+// Implicit slip/symmetry: the scalar-matrix Vec3 Laplacian assembly must populate the linear
+// system's per-component diagonal correction (diagCmpt) with γ|S|·coeff·Δ·|n_c|, accumulated per
+// cell, rather than touching the shared scalar diagonal. This is the assembly half of the implicit
+// transform-BC path (the solver applies it column-by-column).
+TEST_CASE("laplacianOperator implicit transform diagCmpt")
+{
+    auto [execName, exec] = GENERATE(allAvailableExecutor());
+
+    SECTION("implicit slip diagonal correction on " + execName)
+    {
+        auto mesh = createSingleCellMesh(exec);
+
+        auto surfaceBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<scalar>>(mesh);
+        fvcc::SurfaceField<scalar> gamma(exec, "gamma", mesh, surfaceBCs);
+        const scalar gammaValue = 2.0;
+        fill(gamma.internalVector(), gammaValue);
+        fill(gamma.boundaryData().value(), gammaValue);
+
+        std::vector<fvcc::VolumeBoundary<Vec3>> bcs;
+        for (NeoN::localIdx patchID = 0; patchID < mesh.nBoundaries(); ++patchID)
+        {
+            bcs.push_back(fvcc::VolumeBoundary<Vec3>(
+                mesh, Dictionary({{"type", std::string("slip")}, {"implicit", true}}), patchID
+            ));
+        }
+        auto phi = VolumeField<Vec3>(exec, "phi", mesh, bcs);
+        fill(phi.internalVector(), Vec3(1.0, -1.0, 0.5));
+        phi.correctBoundaryConditions();
+
+        const scalar coeff = 1.0;
+        // GaussGreenLaplacian's constructor consumes interpolation/gradient tokens directly (the
+        // DSL strips the leading "Gauss" operator name first), so pass only those two here.
+        Input input = TokenList({std::string("linear"), std::string("uncorrected")});
+        auto ls = NeoN::la::createEmptyLinearSystem<scalar, Vec3>(mesh);
+        fvcc::GaussGreenLaplacian<Vec3, scalar> lapOp(exec, mesh, input);
+        lapOp.laplacian(ls, gamma, phi, dsl::Coeff(coeff));
+
+        // the implicit transform path must have lazily allocated diagCmpt, one Vec3 per cell
+        REQUIRE(ls.diagCmpt());
+        REQUIRE(ls.diagCmpt()->size() == mesh.nCells());
+
+        auto [diagCmptH, nH, magSfH, deltaH, ownerH] = copyToHosts(
+            *ls.diagCmpt(),
+            mesh.boundaryMesh().faceUnitNormals(),
+            mesh.boundaryMesh().faceAreas(),
+            mesh.boundaryMesh().deltaCoeffs(),
+            mesh.boundaryMesh().faceOwners()
+        );
+
+        // expected: per cell, sum over its boundary faces of γ|S|·coeff·Δ·|n_c|
+        std::vector<Vec3> expected(static_cast<size_t>(mesh.nCells()), Vec3(0.0, 0.0, 0.0));
+        for (NeoN::localIdx f = 0; f < mesh.nBoundaryFaces(); ++f)
+        {
+            const auto own = static_cast<size_t>(ownerH.view()[f]);
+            const auto n = nH.view()[f];
+            const scalar w = gammaValue * magSfH.view()[f] * coeff * deltaH.view()[f];
+            expected[own][0] += w * std::abs(n[0]);
+            expected[own][1] += w * std::abs(n[1]);
+            expected[own][2] += w * std::abs(n[2]);
+        }
+
+        auto diagV = diagCmptH.view();
+        for (NeoN::localIdx c = 0; c < mesh.nCells(); ++c)
+        {
+            for (auto d = 0u; d < 3; ++d)
+            {
+                REQUIRE(diagV[c][d] == Catch::Approx(expected[static_cast<size_t>(c)][d]));
+            }
+        }
+        // no face on this mesh has a z-normal, so the z-component must be exactly zero
+        REQUIRE(diagV[0][2] == Catch::Approx(0.0));
+    }
+}
+
 } // namespace NeoN

--- a/test/linearAlgebra/ginkgo.cpp
+++ b/test/linearAlgebra/ginkgo.cpp
@@ -365,4 +365,86 @@ TEST_CASE("MatrixAssembly - Ginkgo")
         }
     }
 }
+
+// Exercises the implicit transform-BC solver path: a scalar matrix with a Vec3 RHS plus a
+// per-component diagonal correction (diagCmpt). The three components are solved segregated, with
+// each column's correction temporarily subtracted from the shared diagonal and then restored.
+// Using a purely diagonal matrix gives an analytic answer x_c = b_c / (D - diagCmpt_c).
+TEST_CASE("Implicit transform diagonal correction solve - Ginkgo")
+{
+    auto [execName, exec] = GENERATE(allAvailableExecutor());
+
+    const localIdx nCells = 4;
+    auto mesh = NeoN::create1DUniformMesh(exec, nCells);
+    auto ls = NeoN::la::createEmptyLinearSystem<scalar, Vec3>(mesh);
+
+    // diagonal D·I (off-diagonals left at zero)
+    const scalar D = 10.0;
+    {
+        auto values = ls.matrix().values().view();
+        const auto ma = ls.faceToMatrixAddress()->view(ls.matrix().rowOffs().view());
+        NeoN::parallelFor(
+            exec,
+            {0, nCells},
+            NEON_LAMBDA(const localIdx c) { values[ma.diagIdx(c)] = D; },
+            "setDiag"
+        );
+    }
+
+    // per-component diagonal correction (subtracted by the solver) and a uniform RHS
+    const Vec3 dc(1.0, 2.0, 3.0);
+    NeoN::fill(ls.ensureDiagCmpt(), dc);
+    const scalar bVal = 6.0;
+    NeoN::fill(ls.rhs(), Vec3(bVal, bVal, bVal));
+
+    // analytic per-component solution: x_c = b_c / (D - diagCmpt_c)
+    auto requireAnalytic = [&](const Vector<Vec3>& sol)
+    {
+        auto host = sol.copyToHost();
+        auto v = host.view();
+        for (localIdx i = 0; i < nCells; ++i)
+        {
+            REQUIRE(v[i][0] == Catch::Approx(bVal / (D - dc[0])).margin(1e-8));
+            REQUIRE(v[i][1] == Catch::Approx(bVal / (D - dc[1])).margin(1e-8));
+            REQUIRE(v[i][2] == Catch::Approx(bVal / (D - dc[2])).margin(1e-8));
+        }
+    };
+
+    SECTION("standard stopping criterion " + execName)
+    {
+        Dictionary solverDict {
+            {{"solver", std::string {"Ginkgo"}},
+             {"type", "solver::Cg"},
+             {"criteria", Dictionary {{{"iteration", 20}, {"relative_residual_norm", 1e-10}}}}}
+        };
+        auto solver = NeoN::la::Solver(exec, solverDict);
+
+        Vector<Vec3> x(exec, nCells, Vec3(0.0, 0.0, 0.0));
+        auto stats = solver.solve(ls, x);
+        REQUIRE(stats.entries.size() == 3); // three segregated component solves
+        requireAnalytic(x);
+
+        // Re-solving must give the same answer: only holds if the shared diagonal was restored
+        // after each column (otherwise it would be doubly corrected, D - 2·dc).
+        Vector<Vec3> x2(exec, nCells, Vec3(0.0, 0.0, 0.0));
+        solver.solve(ls, x2);
+        requireAnalytic(x2);
+    }
+
+    SECTION("l1ScaledResidual stopping criterion " + execName)
+    {
+        Dictionary solverDict {
+            {{"solver", std::string {"Ginkgo"}},
+             {"type", "solver::Cg"},
+             {"l1ScaledResidual", true},
+             {"criteria", Dictionary {{{"iteration", 20}, {"absolute_residual_norm", 1e-10}}}}}
+        };
+        auto solver = NeoN::la::Solver(exec, solverDict);
+
+        Vector<Vec3> x(exec, nCells, Vec3(0.0, 0.0, 0.0));
+        auto stats = solver.solve(ls, x);
+        REQUIRE(stats.entries.size() == 3);
+        requireAnalytic(x);
+    }
+}
 #endif


### PR DESCRIPTION
This PR adds support for fully implicit slip/symmetry (“transform”) boundary handling in the scalar-matrix + Vec3-RHS path by introducing a per-component diagonal correction store (diagCmpt) that is applied per component at solve time (serial + distributed). It also refactors the L1-scaled residual stopping criterion so it can be registered and referenced from Ginkgo config files, and adds tests covering these paths.

