### PR TITLE
update documentation reflecting wheels shipment

### DIFF
--- a/.github/workflows/conda_packages.yaml
+++ b/.github/workflows/conda_packages.yaml
@@ -1,0 +1,311 @@
+name: Conda packages
+
+# Builds the neon-pde conda package with rattler-build and publishes it to a prefix.dev
+# channel, so that `pixi add neon-pde -c https://prefix.dev/<channel>` resolves a release.
+#
+# Requires two repository settings:
+#   vars.PREFIX_DEV_CHANNEL   the prefix.dev channel name, e.g. exasim-project
+#   secrets.PREFIX_DEV_API_KEY  an API key with write access to that channel
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      build_cpu:
+        description: "Build the CPU conda packages"
+        required: false
+        default: true
+        type: boolean
+      build_cuda:
+        description: "Build the Linux CUDA conda package"
+        required: false
+        default: false
+        type: boolean
+      build_rocm:
+        description: "Build the Linux ROCm conda package (experimental, no Ginkgo backend)"
+        required: false
+        default: false
+        type: boolean
+      publish:
+        description: "Publish the built packages to prefix.dev"
+        required: false
+        default: false
+        type: boolean
+      channel:
+        description: "Override the prefix.dev channel to publish to"
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+env:
+  RATTLER_BUILD_VERSION: "0.75.0"
+
+jobs:
+  version:
+    name: Resolve package version
+    runs-on: ubuntu-latest
+    if: github.repository == 'exasim-project/NeoN'
+    outputs:
+      channel: ${{ steps.version.outputs.channel }}
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Same stable/nightly scheme as python_wheels.yaml so a conda package and a wheel built
+      # from the same commit carry the same version.
+      - name: Resolve stable or nightly version
+        id: version
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            version="${GITHUB_REF_NAME#v}"
+            channel="stable"
+          else
+            serial="$(date -u +%Y%m%d%H%M)${GITHUB_RUN_NUMBER}"
+            version="$(python scripts/set_package_version.py --nightly "${serial}")"
+            channel="nightly"
+          fi
+
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "channel=${channel}" >> "${GITHUB_OUTPUT}"
+
+  build-cpu:
+    name: CPU ${{ matrix.python }} ${{ matrix.target-platform }}
+    needs: version
+    runs-on: ${{ matrix.os }}
+    if: >
+      github.repository == 'exasim-project/NeoN' &&
+      (github.event_name != 'workflow_dispatch' || inputs.build_cpu)
+    strategy:
+      fail-fast: false
+      matrix:
+        # One job per (platform x python version), mirroring the wheel matrix.
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-14, macos-15-intel]
+        # No 3.9: conda-forge has no nanobind for it, which the stub generation step needs.
+        # Python 3.9 users get the PyPI wheel.
+        python: ["3.10", "3.11", "3.12", "3.13"]
+        # target-platform is attached per os rather than being a matrix dimension of its own.
+        include:
+          - os: ubuntu-latest
+            target-platform: linux-64
+          - os: ubuntu-24.04-arm
+            target-platform: linux-aarch64
+          - os: macos-14
+            target-platform: osx-arm64
+          - os: macos-15-intel
+            target-platform: osx-64
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Stamp package version
+        run: python3 scripts/set_package_version.py "${{ needs.version.outputs.version }}"
+
+      - name: Install rattler-build
+        run: |
+          ci/install_rattler_build.sh "${RATTLER_BUILD_VERSION}" "${HOME}/.local/bin"
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+
+      # The conda clang toolchain needs an SDK to compile against; GitHub runners ship one with
+      # Xcode rather than as a conda package.
+      - name: Point the conda toolchain at the macOS SDK
+        if: runner.os == 'macOS'
+        run: echo "CONDA_BUILD_SYSROOT=$(xcrun --show-sdk-path)" >> "${GITHUB_ENV}"
+
+      - name: Build conda package
+        env:
+          NEON_VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          ci/build_conda_packages.sh \
+            --python "${{ matrix.python }}" \
+            --gpu cpu \
+            --target-platform "${{ matrix.target-platform }}" \
+            --output-dir output
+
+      - name: Upload conda package artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: conda-cpu-${{ matrix.target-platform }}-py${{ matrix.python }}
+          path: output/**/*.conda
+
+  build-cuda:
+    name: CUDA ${{ matrix.cuda-version }} linux-64
+    needs: version
+    runs-on: ubuntu-latest
+    if: >
+      github.repository == 'exasim-project/NeoN' &&
+      (startsWith(github.ref, 'refs/tags/v') ||
+      (github.event_name == 'workflow_dispatch' && inputs.build_cuda))
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Matches the published CUDA wheel: CUDA 12.8, CPython 3.12, NVIDIA Ampere (sm_80).
+          - cuda-version: "12.8"
+            python: "3.12"
+            cuda-architectures: "80"
+            kokkos-arch: AMPERE80
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # nvcc, cuDNN-free CUDA libraries and Kokkos all come from conda-forge, so unlike the CUDA
+      # wheel job this needs no system CUDA toolkit. Free the runner disk the build will need.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          df -h /
+
+      - name: Stamp package version
+        run: python3 scripts/set_package_version.py "${{ needs.version.outputs.version }}"
+
+      - name: Install rattler-build
+        run: |
+          ci/install_rattler_build.sh "${RATTLER_BUILD_VERSION}" "${HOME}/.local/bin"
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+
+      - name: Build CUDA conda package
+        env:
+          NEON_VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          ci/build_conda_packages.sh \
+            --python "${{ matrix.python }}" \
+            --gpu cuda \
+            --target-platform linux-64 \
+            --cuda-version "${{ matrix.cuda-version }}" \
+            --cuda-architectures "${{ matrix.cuda-architectures }}" \
+            --kokkos-arch "${{ matrix.kokkos-arch }}" \
+            --output-dir output
+
+      - name: Upload CUDA conda package artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: conda-cuda-linux-64-py${{ matrix.python }}
+          path: output/**/*.conda
+
+  build-rocm:
+    name: ROCm ${{ matrix.rocm-version }} linux-64
+    needs: version
+    runs-on: ubuntu-latest
+    # Manual dispatch only. conda-forge ships hip-devel and hipcc but none of the ROCm math
+    # libraries (rocBLAS, rocSPARSE, rocThrust, rocPRIM) that Ginkgo's HIP backend needs, so this
+    # package is Kokkos HIP without a Ginkgo solver backend and is not part of a tagged release.
+    if: >
+      github.repository == 'exasim-project/NeoN' &&
+      github.event_name == 'workflow_dispatch' && inputs.build_rocm
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rocm-version: "6.3"
+            python: "3.12"
+            hip-architectures: gfx90a
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          df -h /
+
+      - name: Stamp package version
+        run: python3 scripts/set_package_version.py "${{ needs.version.outputs.version }}"
+
+      - name: Install rattler-build
+        run: |
+          ci/install_rattler_build.sh "${RATTLER_BUILD_VERSION}" "${HOME}/.local/bin"
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+
+      - name: Build ROCm conda package
+        env:
+          NEON_VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          ci/build_conda_packages.sh \
+            --python "${{ matrix.python }}" \
+            --gpu rocm \
+            --target-platform linux-64 \
+            --rocm-version "${{ matrix.rocm-version }}" \
+            --hip-architectures "${{ matrix.hip-architectures }}" \
+            --output-dir output
+
+      - name: Upload ROCm conda package artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: conda-rocm-linux-64-py${{ matrix.python }}
+          path: output/**/*.conda
+
+  publish:
+    name: Publish to prefix.dev
+    needs: [build-cpu, build-cuda, build-rocm]
+    # Publish whatever built. A skipped GPU job must not block a tagged CPU release, but a
+    # failed one must, so this checks for failure rather than for success.
+    if: >
+      always() &&
+      github.repository == 'exasim-project/NeoN' &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled') &&
+      (startsWith(github.ref, 'refs/tags/v') ||
+      (github.event_name == 'workflow_dispatch' && inputs.publish))
+    runs-on: ubuntu-latest
+    environment:
+      name: prefix-dev
+      url: https://prefix.dev/channels/${{ inputs.channel || vars.PREFIX_DEV_CHANNEL }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install rattler-build
+        run: |
+          ci/install_rattler_build.sh "${RATTLER_BUILD_VERSION}" "${HOME}/.local/bin"
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+
+      - name: Download conda package artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: conda-*
+          path: packages
+          merge-multiple: true
+
+      - name: List packages selected for publishing
+        run: find packages -type f -name "*.conda" -print -exec ls -lh {} \;
+
+      - name: Publish to prefix.dev
+        env:
+          PREFIX_API_KEY: ${{ secrets.PREFIX_DEV_API_KEY }}
+          PREFIX_CHANNEL: ${{ inputs.channel || vars.PREFIX_DEV_CHANNEL }}
+        run: |
+          if [[ -z "${PREFIX_CHANNEL}" ]]; then
+            echo "No prefix.dev channel configured."
+            echo "Set the PREFIX_DEV_CHANNEL repository variable or pass the channel input."
+            exit 1
+          fi
+
+          mapfile -t packages < <(find packages -type f -name "*.conda" | sort)
+          if [[ ${#packages[@]} -eq 0 ]]; then
+            echo "No .conda packages were downloaded, nothing to publish."
+            exit 1
+          fi
+
+          rattler-build upload prefix --channel "${PREFIX_CHANNEL}" --skip-existing "${packages[@]}"

--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,9 @@ __pycache__
 _skbuild
 dist/
 wheelhouse/
+
+# rattler-build conda packages
+output/
 uv.lock
 *.bck
 *log

--- a/03ReleaseCandidate.md
+++ b/03ReleaseCandidate.md
@@ -1,0 +1,201 @@
+<!--
+SPDX-FileCopyrightText: 2026 NeoN authors
+
+SPDX-License-Identifier: MIT
+-->
+
+# NeoN v0.3.0rc1 — Release Candidate
+
+NeoN is a portable C++20 library of CFD primitives — Kokkos-backed containers, cell-centred
+finite-volume operators, a PDE DSL and Ginkgo linear solvers. It is the next-generation
+high-performance backend for CFD frameworks like NeoFOAM and OpenFOAM, not a standalone solver.
+
+When v0.2 was released we announced that v0.3 would focus on performance optimisations, multi-GPU
+and Python support. This release candidate delivers a first implementation of the latter two, and
+we would like them exercised on real cases before v0.3.0 is tagged.
+
+- Tag: [`v0.3.0rc1`](https://github.com/exasim-project/NeoN/releases/tag/v0.3.0rc1)
+- Python package: [`neon_pde` on PyPI](https://pypi.org/project/neon_pde/)
+- Full changelog: [`CHANGELOG.md`](https://github.com/exasim-project/NeoN/blob/develop/CHANGELOG.md)
+
+## Highlights
+
+### Distributed support (experimental)
+
+NeoN now runs across multiple MPI ranks, and therefore across multiple GPUs.
+
+- Processor boundaries carry exact processor-face geometry, with non-orthogonal corrected and
+  limited surface-normal gradient corrections across rank boundaries
+  ([#528](https://github.com/exasim-project/NeoN/pull/528)).
+- The linear system is assembled distributed through Ginkgo. The off-diagonal matrix is built with
+  local row indices and non-local columns are widened on the executor, removing host round-trips
+  from the assembly path.
+- Boundary conditions gained a one-time `set()` / per-iteration `update()` interface
+  ([#528](https://github.com/exasim-project/NeoN/pull/528)).
+- Mesh partitioning (`include/NeoN/distributed/partitioning.hpp`) and a communication pattern
+  abstraction (`communicationPattern.hpp`), on top of the existing `Environment` and half/full
+  duplex communication buffers.
+- Strong and weak scaling benchmarks under `benchmarks/distributed/`, and a distributed test suite
+  under `test/distributed/` driven by `mpirun`.
+
+Correctness fixes in this cycle covered multi-patch (scotch) halo exchange, the `ddtFluxCorr`
+processor-face correction, processor boundary conditions on coupled patches, and row-sorted
+non-local COO so the distributed apply is correct on CUDA
+([#528](https://github.com/exasim-project/NeoN/pull/528)).
+
+### Python bindings
+
+NeoN is now importable from Python as the `neon` package
+([#382](https://github.com/exasim-project/NeoN/pull/382)).
+
+- Exposes executors, containers, fields, meshes, surface interpolation, the DSL, the linear algebra
+  layer and the document database.
+- Implemented with [nanobind](https://github.com/wjakob/nanobind), so the bindings stay a thin
+  layer over the C++ API.
+- 25 pre-built wheels: CPython 3.9–3.13 on Linux (x86-64 and ARM64), macOS (Apple Silicon and
+  Intel) and Windows (AMD64).
+- No compiler, Kokkos installation or CUDA toolkit is needed to get started.
+
+```bash
+pip install --pre neon_pde
+```
+
+```python
+import neon
+
+neon.initialize()
+executor = neon.CPUExecutor()
+vector = neon.ScalarVector(executor, 10, 1.0)
+print(neon.__version__, neon.__has_serial__, neon.__has_cpu__, neon.__has_gpu__)
+del vector, executor          # Kokkos aborts if allocations outlive finalize
+neon.finalize()
+```
+
+### Also in this cycle
+
+- `slip` and `inletOutlet` volume boundary conditions
+  ([#565](https://github.com/exasim-project/NeoN/pull/565)).
+- Corrected and limited-corrected face-normal gradient schemes
+  ([#514](https://github.com/exasim-project/NeoN/pull/514)) and a `linearUpwind` scheme
+  ([#548](https://github.com/exasim-project/NeoN/pull/548)).
+- Experimental cell-based assembly strategies and COO/CSR matrix support
+  ([#471](https://github.com/exasim-project/NeoN/pull/471),
+  [#486](https://github.com/exasim-project/NeoN/pull/486)).
+- Tensor and symmTensor primitives, `Su`-type source terms, and passing fields to boundary
+  conditions ([#428](https://github.com/exasim-project/NeoN/pull/428)).
+- DSL expression optimiser infrastructure for operator fusing
+  ([#452](https://github.com/exasim-project/NeoN/pull/452)).
+- Experimental Umpire memory management ([#455](https://github.com/exasim-project/NeoN/pull/455)),
+  a uniform mesh generator ([#475](https://github.com/exasim-project/NeoN/pull/475)) and an L1-norm
+  stopping criterion ([#538](https://github.com/exasim-project/NeoN/pull/538)).
+- Kokkos bumped to 5.0.2, Ginkgo to 2.0.0.
+
+## What we would like tested
+
+This is a release candidate, and it is most useful to us in other people's hands. Concretely:
+
+1. **Distributed results against serial.** Run the same case on one rank and on many, and report any
+   divergence. Non-orthogonal meshes and multi-patch decompositions are the most valuable, since
+   that is where the processor-face corrections are newest.
+2. **Rank counts and hardware we do not have.** Our CI runners are CPU-only; the distributed CUDA
+   path is not runtime-tested in CI at all. Multi-GPU runs on real hardware are the single most
+   useful thing anyone can contribute right now.
+3. **The Python API.** Does it feel natural from Python, or does it read like C++ in disguise? Which
+   objects are missing? Where does the lifetime model surprise you?
+4. **Wheel installation.** Report any platform or Python version where `pip install --pre neon_pde`
+   fails or the extension does not import.
+
+Issues, discussions and pull requests are all welcome at
+<https://github.com/exasim-project/NeoN>.
+
+## Known limitations
+
+- **Distributed support is experimental.** The API is expected to change before it is considered
+  stable.
+- **The Python wheels are built without MPI.** `NeoN_WITH_MPI=OFF`, along with PETSc, ADIOS2 and
+  SUNDIALS, so the distributed features are C++-only for now. Distributed and Python are two
+  separate features in this release, not one combined one.
+- **No GPU wheels are published for this release candidate.** CUDA wheels are built on tags but are
+  attached to a GitHub Release, and none exists for `v0.3.0rc1` yet. GPU users must build from
+  source; see `doc/python_bindings.rst`.
+- **CUDA wheels, when published, are narrow by design:** CUDA 12.8, CPython 3.12, Linux x86-64,
+  NVIDIA Ampere (`sm_80`). They are not runtime-tested in CI because GitHub-hosted runners have no
+  GPU.
+- **No conda/pixi packages yet.** The rattler-build recipe and prefix.dev publishing workflow exist
+  on a branch but are not merged, and the channel is not live. Targeted at v0.3.0 final.
+
+## Contributors
+
+This pre-release would not have been possible without: Gregor Olenik, Hendrik Hetmann,
+Chih-Ta Wang, Dheeraj Raghunathan, Andrei Maftei and Henning Scheufler.
+
+NeoN is a community-driven project and we welcome feedback and contributions.
+
+---
+
+## Appendix: announcement copy
+
+Ready to paste. Plain text, matching the style of the previous NeoFOAM release posts: no emoji, no
+bold, hashtags inline in the prose, hyphen bullets, URLs inline.
+
+### LinkedIn (2,216 characters; limit 3,000)
+
+```text
+The NeoN team is proud to announce the v0.3.0rc1 pre-release https://github.com/exasim-project/NeoN/releases/tag/v0.3.0rc1 of NeoN, the next-generation high-performance backend for #CFD frameworks like #NeoFOAM and #OpenFOAM. When we released v0.2 we announced that v0.3 would focus on multi-GPU and Python support. This release candidate delivers a first implementation of both, and before we tag the final release we would like your help testing them.
+
+Distributed support (experimental):
+- Runs across multiple MPI ranks, and therefore across multiple GPUs;
+- Processor boundaries with exact processor-face geometry, including non-orthogonal corrected and limited surface-normal gradient corrections across rank boundaries;
+- Distributed linear system assembly through #Ginkgo, with the off-diagonal matrix built on the executor rather than on the host;
+- Mesh partitioning, together with strong and weak scaling benchmarks.
+
+Python bindings:
+- Executors, containers, fields, meshes, the DSL, and the linear algebra layer are now available from Python;
+- Implemented with nanobind, keeping the bindings a thin layer over the C++ API;
+- Installable with "pip install --pre neon_pde" https://pypi.org/project/neon_pde/, with pre-built wheels for CPython 3.9 to 3.13 on Linux (x86-64 and ARM64), macOS (Apple Silicon and Intel), and Windows;
+- No compiler, #Kokkos installation, or CUDA toolkit needed to get started.
+
+This is a release candidate rather than a final release, and it is most useful to us in other people's hands. Please run it on your meshes, at your rank counts, and on your hardware, and tell us where the distributed results disagree with a serial run, where the Python API feels awkward, or where a wheel refuses to install. Issues, discussions, and pull requests are all welcome at https://github.com/exasim-project/NeoN.
+
+NeoN is a community-driven project and we welcome feedback and contributions. A big thanks to all contributors who made this pre-release possible: Gregor Olenik, Hendrik Hetmann, Chih-Ta Wang, Dheeraj Raghunathan, Andrei Maftei, and Henning Scheufler.
+
+A full list of changes can be found in the CHANGELOG https://github.com/exasim-project/NeoN/blob/develop/CHANGELOG.md.
+```
+
+### Mastodon (494 characters as Mastodon counts links; limit 500)
+
+```text
+NeoN v0.3.0rc1 — release candidate 🚀
+
+Portable C++20 CFD primitives (Kokkos + Ginkgo), the numerics layer behind NeoFOAM.
+
+🌐 Distributed/MPI (experimental): processor boundaries with exact proc-face geometry, non-orthogonal corrected snGrad across ranks, distributed assembly via Ginkgo, partitioning + scaling benchmarks.
+
+🐍 Python bindings (nanobind): fields, meshes, DSL, solvers.
+pip install --pre neon_pde
+
+Please stress-test it and tell us what breaks.
+
+https://github.com/exasim-project/NeoN
+#CFD #HPC
+```
+
+### X / Bluesky (262 characters raw; 255 on X, where links count as 23)
+
+```text
+NeoN v0.3.0rc1 — release candidate for our portable C++20 CFD library.
+
+New: experimental distributed/MPI support, and Python bindings.
+
+pip install --pre neon_pde
+
+It's an RC for a reason. Please test it and tell us what breaks.
+
+github.com/exasim-project/NeoN
+```
+
+### Suggested visual
+
+Both previous NeoFOAM release posts carried an image (a validation plot and a vortex-shedding
+animation). A strong-scaling plot generated from `benchmarks/distributed/strongScaling.cpp` would
+fit that pattern and would directly illustrate the headline feature.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,19 @@ The package requires Python 3.9–3.13 and NumPy.
 
     pip install neon_pde
 
+**Conda / pixi (from prefix.dev).** The same releases are published as conda
+packages named `neon-pde` to a [prefix.dev](https://prefix.dev) channel, which
+also installs the NeoN C++ runtime, headers and CMake package files into the
+environment:
+
+    pixi add neon-pde -c https://prefix.dev/exasim-project -c conda-forge
+
+    # CUDA 12.8, CPython 3.12, NVIDIA Ampere (sm_80), linux-64
+    pixi add "neon-pde=*=cuda_py312*" -c https://prefix.dev/exasim-project -c conda-forge
+
+Conda packages cover CPython 3.10–3.13 on `linux-64`, `linux-aarch64`, `osx-64`
+and `osx-arm64`; Windows and Python 3.9 are wheel-only.
+
 **CUDA (from GitHub Releases).** GPU wheels are *not* published to PyPI because
 they are large and depend on the NVIDIA driver. They are attached to the
 corresponding [GitHub Release](https://github.com/exasim-project/NeoN/releases)
@@ -153,6 +166,22 @@ version and are published to PyPI only for stable `v*.*.*` tags.
 CUDA wheels are currently limited to CUDA 12.8 on Linux x86-64 with CPython
 3.12. They use a local version suffix such as `0.1.0+cuda128`, are uploaded as
 workflow artifacts, and are attached to the GitHub Release for stable tags.
+
+### Conda packages
+
+Conda packages are built from `recipe/recipe.yaml` with
+[rattler-build](https://rattler.build) by
+`.github/workflows/conda_packages.yaml`, on the same triggers and with the same
+version scheme as the wheels, and are published to prefix.dev. Build one locally
+with:
+
+    ci/install_rattler_build.sh                       # optional, pinned release
+    ci/build_conda_packages.sh --python 3.12 --gpu cpu
+
+The GPU flavour is part of the build string (`cpu_py312_*`, `cuda_py312_*`,
+`rocm_py312_*`), so all flavours coexist in one channel. The ROCm flavour is
+experimental and manual-dispatch only: conda-forge has no rocBLAS/rocSPARSE/
+rocThrust/rocPRIM, so it ships Kokkos HIP without the Ginkgo solver backend.
 GitHub-hosted runners do not provide a GPU, so the CUDA wheel build does not run
 runtime tests against the resulting wheel.
 

--- a/README.md
+++ b/README.md
@@ -120,10 +120,15 @@ intentionally not bundled). It does not require a local CUDA toolkit at runtime.
 **From source.** Building the bindings uses `scikit-build-core` and compiles the
 C++ library, so a C++20 compiler and CMake ≥ 3.22 are required:
 
-    pip install .                       # CPU build (production preset)
+    # CPU build. Both GPU backends must be disabled explicitly: with neither set,
+    # AutoEnableDevice.cmake probes for nvcc/hipcc and enables that backend.
+    pip install . --config-settings=cmake.define.Kokkos_ENABLE_CUDA=OFF \
+                  --config-settings=cmake.define.Kokkos_ENABLE_HIP=OFF
 
     # CUDA build (matching the released wheels)
     pip install . --config-settings=cmake.define.Kokkos_ENABLE_CUDA=ON \
+                  --config-settings=cmake.define.Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON \
+                  --config-settings=cmake.define.Kokkos_ARCH_AMPERE80=ON \
                   --config-settings=cmake.define.CMAKE_CUDA_ARCHITECTURES=80 \
                   --config-settings=cmake.define.CMAKE_CUDA_STANDARD=20
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,48 @@ We provide a set of unit tests which can be executed via ctest or
 
     cmake --build . --target test
 
+### Installing the Python bindings
+
+NeoN ships Python bindings as the `neon_pde` distribution (imported as `neon`).
+The package requires Python 3.9–3.13 and NumPy.
+
+**CPU (from PyPI).** Pre-built CPU wheels are published to PyPI for Linux
+(x86-64/ARM64), Windows (AMD64) and macOS (Apple Silicon/Intel):
+
+    pip install neon_pde
+
+**CUDA (from GitHub Releases).** GPU wheels are *not* published to PyPI because
+they are large and depend on the NVIDIA driver. They are attached to the
+corresponding [GitHub Release](https://github.com/exasim-project/NeoN/releases)
+and carry a local version suffix such as `+cuda128`. Download the wheel matching
+your Python version, or install it directly by URL:
+
+    # CUDA 12.8, CPython 3.12, Linux x86-64, NVIDIA Ampere (sm_80)
+    pip install https://github.com/exasim-project/NeoN/releases/download/v0.1.0/neon_pde-0.1.0+cuda128-cp312-cp312-manylinux_2_34_x86_64.whl
+
+The CUDA wheel needs a host NVIDIA driver providing `libcuda.so.1` (it is
+intentionally not bundled). It does not require a local CUDA toolkit at runtime.
+
+**From source.** Building the bindings uses `scikit-build-core` and compiles the
+C++ library, so a C++20 compiler and CMake ≥ 3.22 are required:
+
+    pip install .                       # CPU build (production preset)
+
+    # CUDA build (matching the released wheels)
+    pip install . --config-settings=cmake.define.Kokkos_ENABLE_CUDA=ON \
+                  --config-settings=cmake.define.CMAKE_CUDA_ARCHITECTURES=80 \
+                  --config-settings=cmake.define.CMAKE_CUDA_STANDARD=20
+
+Verify an installation with:
+
+```python
+import neon
+print(neon.__version__, neon.__has_serial__, neon.__has_cpu__, neon.__has_gpu__)
+```
+
+See [the documentation](https://exasim-project.com/NeoN/latest) for the full
+install-and-release workflow.
+
 ### Python Wheels
 
 The Python distribution name is `neon_pde`, which produces wheel filenames

--- a/ci/build_conda_packages.sh
+++ b/ci/build_conda_packages.sh
@@ -56,15 +56,21 @@ case "${gpu_variant}" in
     *) echo "--gpu must be one of cpu, cuda, rocm (got ${gpu_variant})" >&2; exit 1 ;;
 esac
 
+if [[ ! "${python_version}" =~ ^([0-9]+)\.([0-9]+) ]]; then
+    echo "--python expects a <major>.<minor> version, got '${python_version}'" >&2
+    exit 1
+fi
+
 # conda-forge only builds nanobind (needed for the nanobind.stubgen POST_BUILD step) for
-# python >=3.10. Python 3.9 is covered by the PyPI wheels instead.
-case "${python_version}" in
-    3.9 | 3.9.* | 2.*)
-        echo "python ${python_version} is not supported by the conda packages: conda-forge has" >&2
-        echo "no nanobind for it. Use the PyPI wheel for python 3.9." >&2
-        exit 1
-        ;;
-esac
+# python >=3.10, so that is the floor for the conda packages. Compare numerically rather than
+# listing versions: anything below the floor has to be rejected here, or it fails much later
+# inside rattler-build with an opaque dependency resolution error. Python 3.9 and older are
+# covered by the PyPI wheels instead.
+if (( BASH_REMATCH[1] < 3 || (BASH_REMATCH[1] == 3 && BASH_REMATCH[2] < 10) )); then
+    echo "python ${python_version} is not supported by the conda packages: conda-forge has no" >&2
+    echo "nanobind below python 3.10. Use the PyPI wheel for python 3.9 and older." >&2
+    exit 1
+fi
 
 if [[ -z "${target_platform}" ]]; then
     case "$(uname -s)/$(uname -m)" in

--- a/ci/build_conda_packages.sh
+++ b/ci/build_conda_packages.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 NeoN authors
+#
+# SPDX-License-Identifier: Unlicense
+
+# Build the NeoN conda package for one python version and one GPU flavour.
+#
+# Usage:
+#   ci/build_conda_packages.sh [--python 3.12] [--gpu cpu|cuda|rocm] [--output-dir output]
+#                              [--target-platform linux-64] [--cuda-version 12.8]
+#                              [--rocm-version 6.3] [--] [extra rattler-build arguments]
+#
+# The recipe reads the package version from NEON_VERSION rather than from
+# pyproject.toml, because reading a file from a recipe needs rattler-build's
+# --experimental flag. This script derives it from pyproject.toml so that both
+# local builds and CI stay in sync with neon.__version__.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+python_version="3.12"
+gpu_variant="cpu"
+output_dir="${repo_root}/output"
+target_platform=""
+cuda_version="12.8"
+rocm_version="6.3"
+# One Kokkos architecture per package, matching the published CUDA wheel (NVIDIA Ampere, sm_80).
+cuda_architectures="80"
+kokkos_arch="AMPERE80"
+hip_architectures="gfx90a"
+# glibc floor for the linux packages. 2.17 is the widest baseline conda-forge still ships a
+# sysroot for; macOS uses the deployment target instead.
+glibc_version="2.17"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --python) python_version="$2"; shift 2 ;;
+        --gpu) gpu_variant="$2"; shift 2 ;;
+        --output-dir) output_dir="$2"; shift 2 ;;
+        --target-platform) target_platform="$2"; shift 2 ;;
+        --cuda-version) cuda_version="$2"; shift 2 ;;
+        --rocm-version) rocm_version="$2"; shift 2 ;;
+        --cuda-architectures) cuda_architectures="$2"; shift 2 ;;
+        --kokkos-arch) kokkos_arch="$2"; shift 2 ;;
+        --hip-architectures) hip_architectures="$2"; shift 2 ;;
+        --glibc-version) glibc_version="$2"; shift 2 ;;
+        --) shift; break ;;
+        *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+case "${gpu_variant}" in
+    cpu | cuda | rocm) ;;
+    *) echo "--gpu must be one of cpu, cuda, rocm (got ${gpu_variant})" >&2; exit 1 ;;
+esac
+
+# conda-forge only builds nanobind (needed for the nanobind.stubgen POST_BUILD step) for
+# python >=3.10. Python 3.9 is covered by the PyPI wheels instead.
+case "${python_version}" in
+    3.9 | 3.9.* | 2.*)
+        echo "python ${python_version} is not supported by the conda packages: conda-forge has" >&2
+        echo "no nanobind for it. Use the PyPI wheel for python 3.9." >&2
+        exit 1
+        ;;
+esac
+
+if [[ -z "${target_platform}" ]]; then
+    case "$(uname -s)/$(uname -m)" in
+        Linux/x86_64) target_platform="linux-64" ;;
+        Linux/aarch64 | Linux/arm64) target_platform="linux-aarch64" ;;
+        Darwin/x86_64) target_platform="osx-64" ;;
+        Darwin/arm64) target_platform="osx-arm64" ;;
+        *) echo "Cannot infer the target platform on $(uname -s)/$(uname -m)" >&2; exit 1 ;;
+    esac
+fi
+
+NEON_VERSION="${NEON_VERSION:-$(python3 "${repo_root}/scripts/set_package_version.py" --print)}"
+export NEON_VERSION
+echo "Building neon-pde ${NEON_VERSION} for ${target_platform} (python ${python_version}, ${gpu_variant})" >&2
+
+variant_file="$(mktemp -t neon-variant.XXXXXX)"
+trap 'rm -f "${variant_file}"' EXIT
+
+{
+    echo "python:"
+    echo "  - \"${python_version}\""
+    echo "gpu_variant:"
+    echo "  - ${gpu_variant}"
+
+    # ${{ stdlib('c') }} in the recipe has no built-in default; the C runtime floor has to be
+    # named per target platform.
+    case "${target_platform}" in
+        osx-*)
+            # Kokkos uses C++17/20 aligned new/delete, which needs macOS 10.13+. The wheels pin
+            # 11.0 for both architectures; keep the conda packages on the same floor.
+            echo "c_stdlib:"
+            echo "  - macosx_deployment_target"
+            echo "c_stdlib_version:"
+            echo "  - \"11.0\""
+            echo "MACOSX_DEPLOYMENT_TARGET:"
+            echo "  - \"11.0\""
+            ;;
+        *)
+            echo "c_stdlib:"
+            echo "  - sysroot"
+            echo "c_stdlib_version:"
+            echo "  - \"${glibc_version}\""
+            ;;
+    esac
+
+    if [[ "${gpu_variant}" == "cuda" ]]; then
+        echo "cuda_version:"
+        echo "  - \"${cuda_version}\""
+        echo "cuda_compiler:"
+        echo "  - cuda-nvcc"
+        echo "cuda_compiler_version:"
+        echo "  - \"${cuda_version}\""
+        echo "cuda_architectures:"
+        echo "  - \"${cuda_architectures}\""
+        echo "kokkos_arch:"
+        echo "  - ${kokkos_arch}"
+    fi
+
+    if [[ "${gpu_variant}" == "rocm" ]]; then
+        echo "rocm_version:"
+        echo "  - \"${rocm_version}\""
+        echo "hip_architectures:"
+        echo "  - ${hip_architectures}"
+    fi
+} > "${variant_file}"
+
+{
+    echo "--- variant configuration ---"
+    cat "${variant_file}"
+    echo "-----------------------------"
+} >&2
+
+rattler_build="${RATTLER_BUILD:-rattler-build}"
+
+"${rattler_build}" build \
+    --recipe "${repo_root}/recipe/recipe.yaml" \
+    --variant-config "${variant_file}" \
+    --output-dir "${output_dir}" \
+    --target-platform "${target_platform}" \
+    --channel conda-forge \
+    "$@"

--- a/ci/install_rattler_build.sh
+++ b/ci/install_rattler_build.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 NeoN authors
+#
+# SPDX-License-Identifier: Unlicense
+
+# Install a pinned rattler-build release into a directory on PATH.
+# Usage: install_rattler_build.sh [version] [install_dir]
+
+set -euo pipefail
+
+version="${1:-${RATTLER_BUILD_VERSION:-0.75.0}}"
+install_dir="${2:-${RATTLER_BUILD_INSTALL_DIR:-${HOME}/.local/bin}}"
+
+case "$(uname -s)/$(uname -m)" in
+    # The musl builds are used on Linux so the binary does not depend on the runner's glibc.
+    Linux/x86_64) target="x86_64-unknown-linux-musl" ;;
+    Linux/aarch64 | Linux/arm64) target="aarch64-unknown-linux-musl" ;;
+    Darwin/x86_64) target="x86_64-apple-darwin" ;;
+    Darwin/arm64) target="aarch64-apple-darwin" ;;
+    *)
+        echo "Unsupported host for rattler-build: $(uname -s)/$(uname -m)" >&2
+        exit 1
+        ;;
+esac
+
+mkdir -p "${install_dir}"
+url="https://github.com/prefix-dev/rattler-build/releases/download/v${version}/rattler-build-${target}"
+curl -fsSL "${url}" -o "${install_dir}/rattler-build"
+curl -fsSL "${url}.sha256" -o "${install_dir}/rattler-build.sha256"
+
+# The release publishes "<sha>  rattler-build-<target>", so verify from the download directory
+# with the name the checksum file refers to.
+(
+    cd "${install_dir}"
+    mv rattler-build "rattler-build-${target}"
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum --check "rattler-build.sha256"
+    else
+        shasum --algorithm 256 --check "rattler-build.sha256"
+    fi
+    mv "rattler-build-${target}" rattler-build
+    rm -f rattler-build.sha256
+)
+chmod +x "${install_dir}/rattler-build"
+
+"${install_dir}/rattler-build" --version

--- a/doc/ci.rst
+++ b/doc/ci.rst
@@ -92,6 +92,51 @@ additional Python versions, CUDA versions, and GPU architectures after the packa
 validated on production hardware.
 
 -------------------------------
+Conda package CI/CD
+-------------------------------
+``.github/workflows/conda_packages.yaml`` builds the ``neon-pde`` conda package with
+``rattler-build`` and publishes it to a `prefix.dev <https://prefix.dev>`_ channel, so that NeoN can
+be consumed from a `pixi <https://pixi.sh>`_ environment. It runs on the same triggers as the wheel
+workflow (``v*.*.*`` tags and manual dispatch) and resolves its version with the same
+``scripts/set_package_version.py`` logic, so a wheel and a conda package built from one commit report
+the same ``neon.__version__``.
+
+The recipe lives in ``recipe/recipe.yaml``. ``ci/build_conda_packages.sh`` is the single entry point
+used by both CI and local builds: it exports ``NEON_VERSION``, writes the per-build variant
+configuration (python version, GPU flavour, C runtime floor) and calls ``rattler-build``.
+``ci/install_rattler_build.sh`` installs a pinned, checksum-verified rattler-build release.
+
+CPU packages are built for CPython 3.10-3.13 on ``linux-64``, ``linux-aarch64``, ``osx-64`` and
+``osx-arm64``. There is no ``win-64`` conda package, because NeoN disables Ginkgo on Windows and the
+wheel is the supported Windows path. Python 3.9 is also wheel-only: conda-forge builds ``nanobind``,
+which the ``nanobind.stubgen`` POST_BUILD step needs, only for Python 3.10 and newer. The GPU flavour is encoded in the build string
+(``cpu_py312_*``, ``cuda_py312_*``, ``rocm_py312_*``) so all flavours can coexist in one channel.
+
+Unlike the wheels, the conda package is installed by CMake rather than by ``pip``: the C++ runtime
+and its bundled Kokkos, Ginkgo, Umpire and cpptrace libraries go to ``$PREFIX/lib``, headers and
+CMake package files to ``$PREFIX/include`` and ``$PREFIX/lib/cmake/NeoN``, and only the python
+package is moved into ``site-packages``. Relocation is handled by rattler-build's rpath rewrite
+instead of by ``auditwheel``/``delocate``.
+
+.. note::
+
+   The build clones Kokkos, Ginkgo and Umpire from GitHub through CPM, so it needs network access
+   during the build. That is acceptable for our own channel but would not pass conda-forge's offline
+   build policy.
+
+Publishing requires two repository settings: a ``PREFIX_DEV_CHANNEL`` variable naming the target
+channel and a ``PREFIX_DEV_API_KEY`` secret holding an API key with write access to it. The publish
+job runs in the ``prefix-dev`` GitHub environment and uploads with ``--skip-existing``, so re-running
+it after a partial failure does not fail on packages that already landed.
+
+The CUDA package mirrors the CUDA wheel: CUDA 12.8, CPython 3.12, Linux x86-64, NVIDIA Ampere
+(``sm_80``). It depends on the ``__cuda`` virtual package so it cannot resolve on a machine without a
+suitable driver, and like the CUDA wheel it is not runtime-tested in CI. The ROCm package is
+manual-dispatch only and experimental: conda-forge ships ``hip-devel`` and ``hipcc`` but none of the
+ROCm math libraries (rocBLAS, rocSPARSE, rocThrust, rocPRIM) that Ginkgo's HIP backend needs, so that
+flavour is Kokkos HIP without a Ginkgo solver backend.
+
+-------------------------------
 Continuous Integration on LRZ GitLab
 -------------------------------
 The LRZ GitLab CI handles GPU-related operations.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -24,6 +24,7 @@ Table of Contents
 
    self
    installation
+   python_bindings
    contributing
    basics/index
    dsl/index

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -46,6 +46,11 @@ To browse the full list of build options it is recommended to use a build tool l
 By opening the the project with cmake-gui you can easily set these flags and configure the build.
 NeoN specific build flags are prefixed by ``NeoN_``.
 
+.. note::
+
+   To install or build the Python bindings (the ``neon_pde`` package), including
+   the CUDA variant, see :doc:`python_bindings`.
+
 Building for GPUs
 ^^^^^^^^^^^^^^^^^^
 NeoN will automatically enable ``Kokkos_ENABLE_CUDA`` or ``Kokkos_ENABLE_HIP`` if either of this is available on

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -51,6 +51,18 @@ NeoN specific build flags are prefixed by ``NeoN_``.
    To install or build the Python bindings (the ``neon_pde`` package), including
    the CUDA variant, see :doc:`python_bindings`.
 
+.. note::
+
+   Releases are also published as conda packages to `prefix.dev <https://prefix.dev>`_, which is the
+   quickest way to get a prebuilt NeoN (C++ runtime, headers and CMake package files included) into
+   a `pixi <https://pixi.sh>`_ environment:
+
+   .. code-block:: bash
+
+      pixi add neon-pde -c https://prefix.dev/exasim-project -c conda-forge
+
+   See :doc:`python_bindings` for the available platforms and GPU flavours.
+
 Building for GPUs
 ^^^^^^^^^^^^^^^^^^
 NeoN will automatically enable ``Kokkos_ENABLE_CUDA`` or ``Kokkos_ENABLE_HIP`` if either of this is available on

--- a/doc/python_bindings.rst
+++ b/doc/python_bindings.rst
@@ -1,0 +1,148 @@
+Python bindings (``neon_pde``)
+==============================
+
+NeoN provides Python bindings that expose the core containers, executors,
+fields and DSL to Python. The distribution is named ``neon_pde`` on PyPI, but
+the import package is ``neon``:
+
+.. code-block:: python
+
+   import neon
+   neon.initialize()
+   exec = neon.CPUExecutor()
+   v = neon.ScalarVector(exec, 10, 1.0)
+   neon.finalize()
+
+The package supports CPython 3.9–3.13 and depends on NumPy.
+
+.. contents::
+   :local:
+   :depth: 1
+
+Installing
+----------
+
+CPU wheels from PyPI
+^^^^^^^^^^^^^^^^^^^^^
+
+Pre-built CPU wheels are published to PyPI for Linux (x86-64 and ARM64),
+Windows (AMD64) and macOS (Apple Silicon and Intel). These are the default
+wheels for most users and require no CUDA toolkit or GPU:
+
+.. code-block:: bash
+
+   pip install neon_pde
+
+CPU wheels are built with the serial and OpenMP (CPU) Kokkos back ends. MPI and
+the optional HPC dependencies (PETSc, ADIOS2, SUNDIALS) are disabled so the
+package installs without external HPC libraries.
+
+CUDA wheels from GitHub Releases
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+GPU wheels are **not** published to PyPI. They are large and depend on the
+system NVIDIA driver, so they are attached to the matching
+`GitHub Release <https://github.com/exasim-project/NeoN/releases>`_ instead.
+CUDA wheels carry a local version suffix such as ``+cuda128``.
+
+The current CUDA wheel targets:
+
+* CUDA 12.8
+* CPython 3.12
+* Linux x86-64 (``manylinux_2_34``)
+* NVIDIA Ampere, compute capability ``sm_80``
+
+Download the wheel from the release page and install it, or install it directly
+by URL:
+
+.. code-block:: bash
+
+   pip install https://github.com/exasim-project/NeoN/releases/download/v0.1.0/neon_pde-0.1.0+cuda128-cp312-cp312-manylinux_2_34_x86_64.whl
+
+The CUDA wheel requires a host NVIDIA driver that provides ``libcuda.so.1``.
+That library is intentionally *not* bundled into the wheel, since it must match
+the installed driver. A local CUDA toolkit is **not** required at runtime.
+
+Because GitHub-hosted runners have no GPU, CUDA wheels are not runtime-tested in
+CI and must be validated on a machine with a compatible NVIDIA driver and GPU.
+
+Building from source
+^^^^^^^^^^^^^^^^^^^^^
+
+Building the bindings compiles the NeoN C++ library through
+`scikit-build-core <https://scikit-build-core.readthedocs.io>`_, so it needs a
+C++20 compiler and CMake ≥ 3.22 (see :doc:`installation`). From the repository
+root:
+
+.. code-block:: bash
+
+   pip install .                # CPU build using the production preset
+
+Build options are forwarded to CMake with ``--config-settings``. To build a
+CUDA-enabled package matching the released wheels:
+
+.. code-block:: bash
+
+   pip install . \
+     --config-settings=cmake.define.NeoN_BUILD_PYTHON_BINDINGS=ON \
+     --config-settings=cmake.define.Kokkos_ENABLE_CUDA=ON \
+     --config-settings=cmake.define.Kokkos_ARCH_AMPERE80=ON \
+     --config-settings=cmake.define.CMAKE_CUDA_ARCHITECTURES=80 \
+     --config-settings=cmake.define.CMAKE_CUDA_STANDARD=20
+
+For local development, an editable install rebuilds on import:
+
+.. code-block:: bash
+
+   pip install -e .[dev]
+
+Verifying an installation
+-------------------------
+
+The bindings expose the version and the compiled back-end feature flags. Use
+them to confirm which executors a wheel supports:
+
+.. code-block:: python
+
+   import neon
+   print(neon.__version__)      # e.g. 0.1.0 (or 0.1.0+cuda128 for a CUDA wheel)
+   print(neon.__has_serial__)   # serial executor available
+   print(neon.__has_cpu__)      # CPU (OpenMP) executor available
+   print(neon.__has_gpu__)      # GPU (CUDA/HIP) executor available
+
+The repository ships an equivalent smoke test at ``ci/check_installed_wheel.py``
+that CI runs against every repaired CPU wheel.
+
+Running the binding tests
+-------------------------
+
+The Python test suite lives in ``test/bindings`` and is driven by ``pytest``:
+
+.. code-block:: bash
+
+   pip install .[test]
+   pytest test/bindings
+
+Tests marked ``gpu`` are skipped automatically when no GPU executor is
+available.
+
+Versioning and release workflow
+-------------------------------
+
+The package version in ``pyproject.toml`` is the single source of truth. CMake
+reads it during configuration and it becomes ``neon.__version__``.
+
+Wheels are produced by the ``.github/workflows/python_wheels.yaml`` GitHub
+Actions workflow using ``cibuildwheel``:
+
+* **Stable releases** are triggered by tags named ``v*.*.*`` (e.g. ``v0.1.0``).
+  CPU wheels are published to PyPI via Trusted Publishing, and CUDA wheels are
+  attached to the GitHub Release for the tag.
+* **Manual builds** (``workflow_dispatch``) produce a development version with a
+  ``.dev`` suffix. Dispatch with ``build_wheels``, ``build_cpu`` and
+  ``publish_repository=testpypi`` to rehearse a publish against TestPyPI without
+  touching the production index.
+* The workflow does **not** run on ordinary branch pushes or pull requests.
+
+For the full CI/CD description, including recovery paths for re-publishing
+already-built artifacts, see :doc:`ci`.

--- a/doc/python_bindings.rst
+++ b/doc/python_bindings.rst
@@ -37,6 +37,55 @@ CPU wheels are built with the serial and OpenMP (CPU) Kokkos back ends. MPI and
 the optional HPC dependencies (PETSc, ADIOS2, SUNDIALS) are disabled so the
 package installs without external HPC libraries.
 
+Conda packages from prefix.dev
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The same releases are published as conda packages to the
+`prefix.dev <https://prefix.dev>`_ channel, which is the most convenient way to
+get NeoN into a `pixi <https://pixi.sh>`_ project. The conda package is named
+``neon-pde`` (the import package is still ``neon``):
+
+.. code-block:: bash
+
+   pixi add neon-pde -c https://prefix.dev/exasim-project -c conda-forge
+
+or, in ``pixi.toml``:
+
+.. code-block:: toml
+
+   [project]
+   channels = ["https://prefix.dev/exasim-project", "conda-forge"]
+
+   [dependencies]
+   neon-pde = "*"
+
+The channel provides CPython 3.10-3.13 packages for ``linux-64``,
+``linux-aarch64``, ``osx-64`` and ``osx-arm64``. There is no ``win-64`` conda
+package, and no Python 3.9 one — use the PyPI wheel for those. (3.9 is excluded
+because conda-forge builds ``nanobind``, which the stub generation step needs,
+only for Python 3.10 and newer.)
+
+Unlike the wheels, the conda package installs the NeoN C++ runtime into
+``$CONDA_PREFIX/lib`` and its headers and CMake package files into
+``$CONDA_PREFIX/include`` and ``$CONDA_PREFIX/lib/cmake/NeoN``, so a C++ project
+in the same environment can consume it with ``find_package(NeoN)``.
+
+GPU conda packages carry the accelerator in their build string, so the flavour is
+selected by matching on it:
+
+.. code-block:: bash
+
+   # CUDA 12.8, CPython 3.12, NVIDIA Ampere (sm_80), linux-64
+   pixi add "neon-pde=*=cuda_py312*" -c https://prefix.dev/exasim-project -c conda-forge
+
+The CUDA package depends on the ``__cuda`` virtual package, so it only resolves
+on a machine whose NVIDIA driver is new enough. A ROCm flavour
+(``rocm_py312*``) can be built on demand, but it ships Kokkos HIP **without** the
+Ginkgo solver backend: conda-forge provides ``hip-devel`` and ``hipcc`` but none
+of the ROCm math libraries (rocBLAS, rocSPARSE, rocThrust, rocPRIM) that
+Ginkgo's HIP backend requires. It is therefore not part of a tagged release and
+must be dispatched manually.
+
 CUDA wheels from GitHub Releases
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -96,6 +145,25 @@ For local development, an editable install rebuilds on import:
 
    pip install -e .[dev]
 
+Building the conda package
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The conda package is described by ``recipe/recipe.yaml`` and built with
+`rattler-build <https://rattler.build>`_. ``ci/build_conda_packages.sh`` wraps it:
+it derives the package version from ``pyproject.toml``, writes the per-build
+variant configuration (python version, GPU flavour, C runtime floor) and invokes
+``rattler-build``:
+
+.. code-block:: bash
+
+   ci/install_rattler_build.sh                       # optional, installs a pinned release
+   ci/build_conda_packages.sh --python 3.12 --gpu cpu
+   ci/build_conda_packages.sh --python 3.12 --gpu cuda --cuda-version 12.8
+
+Packages land in ``output/<subdir>/``. The build clones Kokkos, Ginkgo and
+Umpire through CPM, so it needs network access — unlike a conda-forge build,
+which would have to vendor them.
+
 Verifying an installation
 -------------------------
 
@@ -143,6 +211,15 @@ Actions workflow using ``cibuildwheel``:
   ``publish_repository=testpypi`` to rehearse a publish against TestPyPI without
   touching the production index.
 * The workflow does **not** run on ordinary branch pushes or pull requests.
+
+Conda packages are produced by ``.github/workflows/conda_packages.yaml`` on the
+same triggers and with the same version scheme, so a wheel and a conda package
+built from one commit report the same ``neon.__version__``. On a ``v*.*.*`` tag
+the CPU and CUDA packages are built and uploaded to prefix.dev; a manual
+dispatch can build any subset and only publishes when ``publish`` is set.
+Publishing needs two repository settings: the ``PREFIX_DEV_CHANNEL`` variable
+and the ``PREFIX_DEV_API_KEY`` secret (an API key with write access to that
+channel).
 
 For the full CI/CD description, including recovery paths for re-publishing
 already-built artifacts, see :doc:`ci`.

--- a/doc/python_bindings.rst
+++ b/doc/python_bindings.rst
@@ -9,8 +9,9 @@ the import package is ``neon``:
 
    import neon
    neon.initialize()
-   exec = neon.CPUExecutor()
-   v = neon.ScalarVector(exec, 10, 1.0)
+   executor = neon.CPUExecutor()
+   v = neon.ScalarVector(executor, 10, 1.0)
+   del v, executor          # Kokkos aborts if allocations outlive finalize
    neon.finalize()
 
 The package supports CPython 3.9–3.13 and depends on NumPy.
@@ -123,9 +124,19 @@ Building the bindings compiles the NeoN C++ library through
 C++20 compiler and CMake ≥ 3.22 (see :doc:`installation`). From the repository
 root:
 
+.. important::
+
+   Both GPU backends must be disabled explicitly for a CPU build. When neither
+   ``Kokkos_ENABLE_CUDA`` nor ``Kokkos_ENABLE_HIP`` is set, ``AutoEnableDevice.cmake``
+   probes for a CUDA or HIP compiler and turns the corresponding backend on, so a
+   plain ``pip install .`` produces a GPU build on any machine that happens to have
+   ``nvcc`` or ``hipcc`` on ``PATH``.
+
 .. code-block:: bash
 
-   pip install .                # CPU build using the production preset
+   pip install . \
+     --config-settings=cmake.define.Kokkos_ENABLE_CUDA=OFF \
+     --config-settings=cmake.define.Kokkos_ENABLE_HIP=OFF
 
 Build options are forwarded to CMake with ``--config-settings``. To build a
 CUDA-enabled package matching the released wheels:
@@ -135,9 +146,16 @@ CUDA-enabled package matching the released wheels:
    pip install . \
      --config-settings=cmake.define.NeoN_BUILD_PYTHON_BINDINGS=ON \
      --config-settings=cmake.define.Kokkos_ENABLE_CUDA=ON \
+     --config-settings=cmake.define.Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON \
      --config-settings=cmake.define.Kokkos_ARCH_AMPERE80=ON \
      --config-settings=cmake.define.CMAKE_CUDA_ARCHITECTURES=80 \
      --config-settings=cmake.define.CMAKE_CUDA_STANDARD=20
+
+``Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON`` is required, not optional: NeoN only
+marks its translation units as CUDA sources under that setting. Without it the build
+takes the traditional Kokkos path, which expects ``nvcc_wrapper`` as the C++ compiler
+— something a plain ``pip install`` does not select. The released CUDA wheels set it
+too (see ``.github/workflows/python_wheels.yaml``).
 
 For local development, an editable install rebuilds on import:
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 NeoN authors
+#
+# SPDX-License-Identifier: Unlicense
+
+set -euxo pipefail
+
+gpu_variant="${NEON_GPU_VARIANT:?NEON_GPU_VARIANT must be set by the recipe}"
+
+build_dir="${SRC_DIR}/build-conda"
+
+cmake_args=(
+    -G Ninja
+    -D CMAKE_BUILD_TYPE=Release
+    -D CMAKE_INSTALL_PREFIX="${PREFIX}"
+    # A conda prefix is always lib/, but GNUInstallDirs would pick lib64 or a Debian multiarch
+    # directory depending on the build image. The :STRING type is required: GNUInstallDirs declares
+    # this as a cache PATH, and CMake rewrites a relative PATH cache entry into an absolute one
+    # against the working directory, which would install everything under the build tree.
+    -D CMAKE_INSTALL_LIBDIR:STRING=lib
+    -D CMAKE_PREFIX_PATH="${PREFIX}"
+    # Matches the wheel build, and is what makes the bundled Kokkos install as shared libraries.
+    -D BUILD_SHARED_LIBS=ON
+    -D Python_EXECUTABLE="${PYTHON}"
+    -D Python_ROOT_DIR="${PREFIX}"
+    -D Python_FIND_STRATEGY=LOCATION
+    -D NeoN_BUILD_PYTHON_BINDINGS=ON
+    -D NeoN_BUILD_TESTS=OFF
+    -D NeoN_BUILD_BENCHMARKS=OFF
+    -D NeoN_BUILD_DOC=OFF
+    -D NeoN_DEVEL_TOOLS=OFF
+    # Same reduced dependency set as the published wheels: no MPI or optional HPC backends, so the
+    # package resolves without an external HPC stack.
+    -D NeoN_WITH_MPI=OFF
+    -D NeoN_WITH_PETSC=OFF
+    -D NeoN_WITH_ADIOS2=OFF
+    -D NeoN_WITH_SUNDIALS=OFF
+    # This is what installs libNeoN and the bundled Kokkos runtime into $PREFIX/lib. The CUDA wheel
+    # turns it off because auditwheel vendors those libraries instead; there is no such step here,
+    # so turning it off would ship a package without its own shared library.
+    -D NeoN_INSTALL_CMAKE_PACKAGE=ON
+    -D Kokkos_ENABLE_SERIAL=ON
+)
+
+case "${gpu_variant}" in
+    cpu)
+        cmake_args+=(
+            -D Kokkos_ENABLE_CUDA=OFF
+            -D Kokkos_ENABLE_HIP=OFF
+        )
+        ;;
+    cuda)
+        # Mirrors the CUDA wheel configuration, except that the CMake package files stay installed.
+        # Umpire is off there because its BLT build does not survive the relocation cleanly.
+        cmake_args+=(
+            -D NeoN_WITH_UMPIRE=OFF
+            -D CMAKE_CUDA_COMPILER="${BUILD_PREFIX}/bin/nvcc"
+            -D CMAKE_CUDA_HOST_COMPILER="${CXX}"
+            -D CMAKE_CUDA_ARCHITECTURES="${NEON_CUDA_ARCHITECTURES}"
+            -D CMAKE_CUDA_STANDARD=20
+            -D CMAKE_CUDA_STANDARD_REQUIRED=ON
+            -D CMAKE_CUDA_EXTENSIONS=OFF
+            -D CUDAToolkit_ROOT="${PREFIX}"
+            -D Kokkos_ENABLE_CUDA=ON
+            -D Kokkos_ENABLE_HIP=OFF
+            -D Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON
+            -D "Kokkos_ARCH_${NEON_KOKKOS_ARCH}=ON"
+        )
+        export CUDAToolkit_ROOT="${PREFIX}"
+        export CUDAHOSTCXX="${CXX}"
+        ;;
+    rocm)
+        # Ginkgo's HIP backend needs rocBLAS, rocSPARSE, rocThrust and rocPRIM, none of which exist
+        # on conda-forge (only hip-devel, hipcc and hip-runtime-amd do). The ROCm package therefore
+        # ships Kokkos HIP without a Ginkgo solver backend.
+        cmake_args+=(
+            -D NeoN_WITH_UMPIRE=OFF
+            -D NeoN_WITH_GINKGO=OFF
+            -D CMAKE_CXX_COMPILER=hipcc
+            -D CMAKE_HIP_ARCHITECTURES="${NEON_HIP_ARCHITECTURES}"
+            -D Kokkos_ENABLE_CUDA=OFF
+            -D Kokkos_ENABLE_HIP=ON
+            -D "Kokkos_ARCH_AMD_$(printf '%s' "${NEON_HIP_ARCHITECTURES}" | tr '[:lower:]' '[:upper:]')=ON"
+        )
+        ;;
+    *)
+        echo "Unknown NEON_GPU_VARIANT: ${gpu_variant}" >&2
+        exit 1
+        ;;
+esac
+
+cmake -S "${SRC_DIR}" -B "${build_dir}" "${cmake_args[@]}"
+cmake --build "${build_dir}" --parallel "${CPU_COUNT}"
+cmake --install "${build_dir}"
+
+# The non-scikit-build install path drops the python package in $PREFIX/lib/python/neon, which is
+# not on sys.path. Move it to site-packages; libNeoN and friends stay in $PREFIX/lib, where the
+# rpath rewrite in the recipe points.
+python_pkg_dir="${PREFIX}/lib/python/neon"
+if [[ ! -d "${python_pkg_dir}" ]]; then
+    echo "Expected the bindings to be installed to ${python_pkg_dir}" >&2
+    echo "Installed instead:" >&2
+    find "${PREFIX}" -name "_neon*.so" -o -name "_neon*.pyd" >&2 || true
+    exit 1
+fi
+
+mkdir -p "${SP_DIR}"
+rm -rf "${SP_DIR}/neon"
+mv "${python_pkg_dir}" "${SP_DIR}/neon"
+rmdir "${PREFIX}/lib/python"
+
+# nanobind.stubgen writes _neon.pyi next to the built extension but no install rule picks it up.
+# Ship it so editors and type checkers see the same API the wheels document.
+stub="${build_dir}/bindings/neon/_neon.pyi"
+if [[ -f "${stub}" ]]; then
+    cp "${stub}" "${SP_DIR}/neon/"
+fi

--- a/recipe/check_conda_package.py
+++ b/recipe/check_conda_package.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 NeoN authors
+#
+# SPDX-License-Identifier: MIT
+
+"""Smoke test for an installed NeoN conda package.
+
+The conda package is installed by CMake rather than pip, so it carries no
+``.dist-info`` and cannot be checked with ``importlib.metadata`` the way
+``ci/check_installed_wheel.py`` checks a wheel. The recipe version is passed
+through ``PKG_VERSION`` instead.
+"""
+
+from __future__ import annotations
+
+import os
+
+import neon
+
+
+def main() -> None:
+    expected = os.environ.get("PKG_VERSION")
+    if expected and neon.__version__ != expected:
+        raise SystemExit(
+            f"neon.__version__ ({neon.__version__}) does not match "
+            f"the conda package version ({expected})"
+        )
+
+    for attr in ("__has_serial__", "__has_cpu__", "__has_gpu__"):
+        value = getattr(neon, attr, None)
+        if not isinstance(value, bool):
+            raise SystemExit(f"neon.{attr} should be a bool, got {value!r}")
+
+    if not neon.__has_serial__:
+        raise SystemExit("Installed package does not report serial executor support")
+
+    neon.initialize()
+    try:
+        executor = neon.SerialExecutor()
+        vector = neon.ScalarVector(executor, 8, 1.0)
+        size = vector.size()
+        # Kokkos aborts if an allocation outlives Kokkos::finalize, so drop the containers
+        # before finalizing rather than leaving them to the interpreter's teardown.
+        del vector, executor
+    finally:
+        neon.finalize()
+
+    if size != 8:
+        raise SystemExit(f"Expected a vector of size 8, got {size}")
+
+
+if __name__ == "__main__":
+    main()

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: 2026 NeoN authors
+#
+# SPDX-License-Identifier: Unlicense
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+#
+# rattler-build recipe for the conda package published to https://prefix.dev.
+# Build it through ci/build_conda_packages.sh, which resolves NEON_VERSION and
+# writes the per-build variant file this recipe expects.
+
+context:
+  name: neon-pde
+  # project.version in pyproject.toml stays the single source of truth (CMake parses it too).
+  # rattler-build can only read that file with --experimental, so ci/build_conda_packages.sh
+  # exports it instead. Deliberately no default: an unset variable must fail the build rather
+  # than stamp a version that disagrees with neon.__version__.
+  version: ${{ env.get("NEON_VERSION") }}
+  gpu: ${{ gpu_variant }}
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  - path: ../
+
+build:
+  number: 0
+  # The GPU flavour has to appear in the build string: the cpu, cuda and rocm packages share a
+  # name and version and would otherwise be indistinguishable builds of the same package.
+  string: ${{ gpu }}_py${{ python | version_to_buildstring }}_h${{ hash }}_${{ build_number }}
+  skip:
+    # No Windows conda package: NeoN disables Ginkgo there and the wheel build is the supported
+    # Windows path. GPU flavours only make sense on Linux.
+    - win
+    - gpu != "cpu" and not linux
+  script:
+    file: build.sh
+    env:
+      NEON_GPU_VARIANT: ${{ gpu }}
+      NEON_CUDA_ARCHITECTURES: ${{ cuda_architectures | default("80") }}
+      NEON_KOKKOS_ARCH: ${{ kokkos_arch | default("AMPERE80") }}
+      NEON_HIP_ARCHITECTURES: ${{ hip_architectures | default("gfx90a") }}
+  variant:
+    # Without this the cpu, cuda and rocm builds of one python version hash identically.
+    use_keys:
+      - gpu_variant
+  dynamic_linking:
+    # NeoN vendors Kokkos, Ginkgo, Umpire, fmt and cpptrace through CPM and installs them beside
+    # libNeoN in $PREFIX/lib, which is exactly where the default rpath rewrite points.
+    rpaths:
+      - lib/
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
+    - if: gpu == "cuda"
+      then: ${{ compiler('cuda') }}
+    - cmake >=3.22
+    - ninja
+    # CPM and FetchContent clone Kokkos, Ginkgo and Umpire from GitHub during the build, so this
+    # recipe needs network access. That is fine for our own channel but would fail conda-forge's
+    # offline build policy.
+    - git
+    - if: gpu == "rocm"
+      then: hipcc ${{ rocm_version }}.*
+  host:
+    - python
+    # nanobind_add_module fetches its own C++ nanobind through CPM; this is the python-side
+    # package that provides the nanobind.stubgen module run as a POST_BUILD step. conda-forge
+    # only builds it for python >=3.10, which sets the floor for the conda packages (the wheels
+    # still cover 3.9).
+    - nanobind >=2.9
+    - if: gpu == "cuda"
+      then:
+        - cuda-version ==${{ cuda_version }}
+        - cuda-cudart-dev
+        - cuda-cccl
+        - libcublas-dev
+        - libcusparse-dev
+        - libcusolver-dev
+        - libcurand-dev
+    - if: gpu == "rocm"
+      then:
+        - hip-devel ${{ rocm_version }}.*
+        - hip-runtime-amd ${{ rocm_version }}.*
+  run:
+    - python
+    - numpy >=1.19
+    - if: gpu == "cuda"
+      then:
+        # __cuda is the virtual package for the host NVIDIA driver. Requiring it keeps the CUDA
+        # build from resolving on machines that cannot load libcuda.so.1.
+        - __cuda
+    - if: gpu == "rocm"
+      then: hip-runtime-amd ${{ rocm_version }}.*
+
+tests:
+  # GPU packages are not importable on the CI runners, which have no driver, so only the CPU
+  # flavour is smoke-tested here. GPU builds must be validated on a machine with a device.
+  - if: gpu == "cpu"
+    then:
+      script:
+        - python check_conda_package.py
+      files:
+        recipe:
+          - check_conda_package.py
+      requirements:
+        run:
+          - python
+
+about:
+  homepage: https://github.com/exasim-project/NeoN
+  repository: https://github.com/exasim-project/NeoN
+  documentation: https://exasim-project.com/NeoN
+  license: MIT
+  license_file:
+    - LICENSES/MIT.txt
+  summary: Python bindings for the NeoN CFD framework
+  description: |
+    NeoN provides portable, GPU-capable CFD primitives (Kokkos-backed containers,
+    cell-centred finite-volume operators, a PDE DSL and Ginkgo linear solvers).
+    This package ships the `neon` python module together with the NeoN C++ runtime.
+
+extra:
+  recipe-maintainers:
+    - greole
+    - exasim-project

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -91,9 +91,13 @@ requirements:
     - numpy >=1.19
     - if: gpu == "cuda"
       then:
-        # __cuda is the virtual package for the host NVIDIA driver. Requiring it keeps the CUDA
-        # build from resolving on machines that cannot load libcuda.so.1.
-        - __cuda
+        # __cuda is the virtual package for the host NVIDIA driver. Requiring it at all keeps the
+        # package from resolving on machines that cannot load libcuda.so.1, which cuda-version's
+        # `constrains: __cuda >=12` cannot do on its own: constrains are vacuously satisfied when
+        # the virtual package is absent. The major-version floor is stated explicitly rather than
+        # left to that transitive constraint. CUDA minor version compatibility means a 12.0 driver
+        # runs a 12.8 build, so the floor is the major version, not ${{ cuda_version }}.
+        - __cuda >=${{ (cuda_version | split(".")) [0] }}
     - if: gpu == "rocm"
       then: hip-runtime-amd ${{ rocm_version }}.*
 


### PR DESCRIPTION
This PR updates NeoN’s documentation to describe how Python wheels/bindings are distributed and installed (CPU wheels on PyPI, CUDA wheels via GitHub Releases), and adds a dedicated Sphinx page for Python bindings.