### PR TITLE
Stack/python arch

### DIFF
--- a/.github/workflows/build_on_ubuntu.yaml
+++ b/.github/workflows/build_on_ubuntu.yaml
@@ -119,6 +119,21 @@ jobs:
 
       - name: Install NeoN
         run:  |
-          sudo cmake --install build/${{matrix.preset}}
-          sudo ls -la /usr/local/bin
-          sudo ls -la /usr/local/lib
+          cmake --install build/${{matrix.preset}} --prefix $PWD/install
+          ls -la install/bin
+          ls -la install/lib
+          ./install/bin/neon_test_vector
+
+      - name: Verify installed libs resolve all dependencies
+        run: |
+          fail=0
+          for f in install/lib/lib*.so*; do
+            [ -L "$f" ] && continue
+            missing=$(ldd "$f" 2>/dev/null | grep 'not found' || true)
+            if [ -n "$missing" ]; then
+              echo "FAIL $f has unresolved deps:"
+              echo "$missing"
+              fail=1
+            fi
+          done
+          exit $fail

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,24 +330,10 @@ if(NeoN_INSTALL_CMAKE_PACKAGE)
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/NeoNConfig.cmake"
           DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/NeoN)
 
-  # install internal ginkgo version (including enabled backend libs so they ship alongside
-  # libNeoN.so — required for dlopen at runtime when Ginkgo is built via CPM rather than found
-  # system-wide)
-  if(ginkgo_POPULATED)
-    set(_ginkgo_install_tgts ginkgo)
-    foreach(_ginkgo_backend ginkgo_omp ginkgo_cuda ginkgo_reference ginkgo_hip ginkgo_dpcpp
-                            ginkgo_device)
-      if(TARGET ${_ginkgo_backend})
-        list(APPEND _ginkgo_install_tgts ${_ginkgo_backend})
-      endif()
-    endforeach()
-    install(
-      TARGETS ${_ginkgo_install_tgts}
-      EXPORT GinkgoTargets
-      INCLUDES
-      DESTINATION include)
-    install(EXPORT GinkgoTargets NAMESPACE Ginkgo::)
-  endif()
+  # Ginkgo installs its own targets (including every enabled backend lib) and its own
+  # lib/cmake/Ginkgo/GinkgoTargets.cmake when fetched via CPM, so it must NOT be re-exported here: a
+  # second export of the same target to the same path is a hard "exported multiple times" error in
+  # install(EXPORT NeoNTargets). Same reasoning as umpire and cpptrace below.
 
   # install internal kokkos version — when Kokkos is built as a shared library
   # (BUILD_SHARED_LIBS=ON, as the python-bindings preset uses), libNeoN.so and any consumer dlopens
@@ -368,28 +354,15 @@ if(NeoN_INSTALL_CMAKE_PACKAGE)
     endif()
   endif()
 
-  if(nlohmann_json_POPULATED)
-    install(
-      TARGETS nlohmann_json
-      EXPORT nlohmannTargets
-      INCLUDES
-      DESTINATION include)
-    install(EXPORT nlohmannTargets NAMESPACE nlohmann_json::)
-  endif()
+  # nlohmann_json likewise installs itself into share/cmake/nlohmann_json when fetched via CPM.
 
   # umpire installs its own targets when fetched via CPM
 
-  # install internal cpptrace version
-  if(cpptrace_POPULATED)
-    install(
-      TARGETS cpptrace
-      EXPORT CpptraceTargets
-      INCLUDES
-      DESTINATION include)
-    install(EXPORT CpptraceTargets NAMESPACE cpptrace::)
-  endif()
+  # cpptrace installs its own targets when fetched via CPM. It cannot be added to a NeoN-owned
+  # export set anyway: the importable name cpptrace::cpptrace is an ALIAS, and the underlying target
+  # is called cpptrace-lib.
 
-  # install internal spdlog version TODO why does spdlog_POPULATED not work?
+  # install internal spdlog version
   if(spdlog_ADDED)
     install(
       TARGETS spdlog_header_only

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,14 +330,42 @@ if(NeoN_INSTALL_CMAKE_PACKAGE)
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/NeoNConfig.cmake"
           DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/NeoN)
 
-  # install internal ginkgo version
+  # install internal ginkgo version (including enabled backend libs so they ship alongside
+  # libNeoN.so — required for dlopen at runtime when Ginkgo is built via CPM rather than found
+  # system-wide)
   if(ginkgo_POPULATED)
+    set(_ginkgo_install_tgts ginkgo)
+    foreach(_ginkgo_backend ginkgo_omp ginkgo_cuda ginkgo_reference ginkgo_hip ginkgo_dpcpp
+                            ginkgo_device)
+      if(TARGET ${_ginkgo_backend})
+        list(APPEND _ginkgo_install_tgts ${_ginkgo_backend})
+      endif()
+    endforeach()
     install(
-      TARGETS ginkgo
+      TARGETS ${_ginkgo_install_tgts}
       EXPORT GinkgoTargets
       INCLUDES
       DESTINATION include)
     install(EXPORT GinkgoTargets NAMESPACE Ginkgo::)
+  endif()
+
+  # install internal kokkos version — when Kokkos is built as a shared library
+  # (BUILD_SHARED_LIBS=ON, as the python-bindings preset uses), libNeoN.so and any consumer dlopens
+  # libkokkoscore.so / libkokkoscontainers.so at runtime. Without this, the wheel ships libNeoN.so
+  # but not its kokkos runtime deps.
+  if(kokkos_POPULATED)
+    set(_kokkos_install_tgts)
+    foreach(_kokkos_tgt kokkoscore kokkoscontainers)
+      if(TARGET ${_kokkos_tgt})
+        get_target_property(_kokkos_type ${_kokkos_tgt} TYPE)
+        if(_kokkos_type STREQUAL "SHARED_LIBRARY")
+          list(APPEND _kokkos_install_tgts ${_kokkos_tgt})
+        endif()
+      endif()
+    endforeach()
+    if(_kokkos_install_tgts)
+      install(TARGETS ${_kokkos_install_tgts})
+    endif()
   endif()
 
   if(nlohmann_json_POPULATED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,10 +31,14 @@ project(
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD 20)
+# Use relocatable RPATHs so installed binaries/libraries find their siblings regardless of the
+# prefix passed to `cmake --install --prefix`, which is not known at configure time.
 if(APPLE)
   set(CMAKE_MACOSX_RPATH 1)
+  set(CMAKE_INSTALL_RPATH "@loader_path/../lib;@loader_path")
+else()
+  set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib;$ORIGIN")
 endif()
-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 
 # Add the cmake folder so the find_package command finds custom packages
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")

--- a/cmake/CxxThirdParty.cmake
+++ b/cmake/CxxThirdParty.cmake
@@ -117,6 +117,15 @@ if(${NeoN_WITH_UMPIRE})
     "ENABLE_TESTS OFF"
     SYSTEM
     YES)
+
+  # Umpire/BLT set INSTALL_RPATH to the absolute install prefix, which scikit-build-core's $ORIGIN
+  # rewriter doesn't catch. Force $ORIGIN so the installed libs can find their siblings (e.g.
+  # libumpire → libcamp).
+  foreach(_umpire_tgt umpire camp)
+    if(TARGET ${_umpire_tgt})
+      set_target_properties(${_umpire_tgt} PROPERTIES INSTALL_RPATH "\$ORIGIN")
+    endif()
+  endforeach()
 endif()
 
 if(${NeoN_WITH_ADIOS2})
@@ -264,6 +273,27 @@ if(${NeoN_WITH_GINKGO})
       "GINKGO_BUILD_PAPI_SDE OFF"
       "GINKGO_BUILD_CUDA ${Kokkos_ENABLE_CUDA}"
       "GINKGO_BUILD_HIP ${Kokkos_ENABLE_HIP}")
+
+    # Ginkgo's build_helpers.cmake forces its targets to ${PROJECT_BINARY_DIR}/lib, ignoring
+    # CMAKE_LIBRARY_OUTPUT_DIRECTORY. Route them into our shared lib output dir so all CPM-built
+    # deps live together and downstream RPATHs need only one entry.
+    foreach(
+      _ginkgo_tgt
+      ginkgo
+      ginkgo_omp
+      ginkgo_cuda
+      ginkgo_reference
+      ginkgo_hip
+      ginkgo_dpcpp
+      ginkgo_device)
+      if(TARGET ${_ginkgo_tgt})
+        set_target_properties(
+          ${_ginkgo_tgt}
+          PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
+                     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}"
+                     ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}")
+      endif()
+    endforeach()
   endif()
 endif()
 

--- a/src/bindings/CMakeLists.txt
+++ b/src/bindings/CMakeLists.txt
@@ -84,9 +84,10 @@ endif()
 target_link_libraries(_neon PRIVATE NeoN::NeoN)
 
 # Ensure the POST_BUILD stubgen step can dlopen all transitive deps (libNeoN.so, libumpire.so,
-# libcamp.so, libginkgo*, kokkos, ...) from the build tree. All shared libs are routed into
-# ${CMAKE_BINARY_DIR}/lib, so a single RPATH entry suffices.
-set_target_properties(_neon PROPERTIES BUILD_RPATH "${CMAKE_BINARY_DIR}/lib")
+# libcamp.so, libginkgo*, kokkos, ...) from the build tree. They all land in libNeoN's output
+# directory (the top-level CMAKE_LIBRARY_OUTPUT_DIRECTORY, which this file overrides locally for
+# _neon only), so a single RPATH entry pointing at it suffices.
+set_target_properties(_neon PROPERTIES BUILD_RPATH "$<TARGET_FILE_DIR:NeoN::NeoN>")
 
 if(NOT NeoN_ENABLE_CUDA AND NOT WIN32)
   # Stub generation imports _neon. Skipped for CUDA (may build without an NVIDIA driver present) and

--- a/src/bindings/CMakeLists.txt
+++ b/src/bindings/CMakeLists.txt
@@ -83,6 +83,11 @@ endif()
 # Link against the NeoN library to access executor classes
 target_link_libraries(_neon PRIVATE NeoN::NeoN)
 
+# Ensure the POST_BUILD stubgen step can dlopen all transitive deps (libNeoN.so, libumpire.so,
+# libcamp.so, libginkgo*, kokkos, ...) from the build tree. All shared libs are routed into
+# ${CMAKE_BINARY_DIR}/lib, so a single RPATH entry suffices.
+set_target_properties(_neon PROPERTIES BUILD_RPATH "${CMAKE_BINARY_DIR}/lib")
+
 if(NOT NeoN_ENABLE_CUDA AND NOT WIN32)
   # Stub generation imports _neon. Skipped for CUDA (may build without an NVIDIA driver present) and
   # on Windows (the extension's dependent DLLs are not on the loader search path at build time, so


### PR DESCRIPTION
## Pull request overview

This PR updates the CMake build/install logic to better support Python bindings and packaging by ensuring transitive shared-library dependencies are discoverable both in the build tree (for stub generation) and after installation, and it tightens CI by validating installed-library linkage.

**Changes:**
- Add build-tree RPATH handling for the `_neon` nanobind module to support `nanobind.stubgen`/`dlopen` during `POST_BUILD`.
- Extend install rules for CPM-provided dependencies (Ginkgo backends, shared Kokkos libs) and adjust some third-party RPATH/output-dir behavior.
- Update Ubuntu CI to install into a workspace prefix and check installed `.so` files for unresolved dependencies via `ldd`.