### PR TITLE
fixedValue: support per-face boundary values

### DIFF
--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedValue.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedValue.hpp
@@ -4,8 +4,11 @@
 
 #pragma once
 
+#include <vector>
+
 #include <Kokkos_Core.hpp>
 
+#include "NeoN/core/error.hpp"
 #include "NeoN/fields/field.hpp"
 #include "NeoN/finiteVolume/cellCentred/boundary/volumeBoundaryFactory.hpp"
 #include "NeoN/mesh/unstructured/unstructuredMesh.hpp"
@@ -44,6 +47,38 @@ void setFixedValue(
     );
 }
 
+// Per-face variant: the patch carries one value per boundary face, e.g. an inflow
+// profile read from a nonuniform OpenFOAM patch field.
+template<typename ValueType>
+void setFixedValues(
+    Field<ValueType>& domainVector,
+    std::pair<size_t, size_t> range,
+    const Vector<ValueType>& fixedValues
+)
+{
+    auto [refGradient, value, valueFraction, refValue] = views(
+        domainVector.boundaryData().refGrad(),
+        domainVector.boundaryData().value(),
+        domainVector.boundaryData().valueFraction(),
+        domainVector.boundaryData().refValue()
+    );
+    auto fixedValuesView = fixedValues.view();
+    const auto start = static_cast<localIdx>(range.first);
+
+    NeoN::parallelFor(
+        domainVector.exec(),
+        range,
+        NEON_LAMBDA(const localIdx i) {
+            auto patchValue = fixedValuesView[i - start];
+            refValue[i] = patchValue;
+            value[i] = patchValue;
+            valueFraction[i] = 1.0;      // only used refValue
+            refGradient[i] = patchValue; // not used
+        },
+        "setFixedValuesVolume"
+    );
+}
+
 }
 
 template<typename ValueType>
@@ -57,12 +92,41 @@ public:
 
     FixedValue(const UnstructuredMesh& mesh, const Dictionary& dict, localIdx patchID)
         : Base(mesh, dict, patchID, {.assignable = false, .fixesValue = true}),
-          fixedValue_(dict.get<ValueType>("fixedValue"))
-    {}
+          fixedValue_(
+              dict.contains("fixedValue") ? dict.get<ValueType>("fixedValue") : ValueType {}
+          ),
+          fixedValues_(
+              mesh.exec(),
+              dict.contains("fixedValues") ? dict.get<std::vector<ValueType>>("fixedValues")
+                                           : std::vector<ValueType> {}
+          )
+    {
+        if (!dict.contains("fixedValue") && !dict.contains("fixedValues"))
+        {
+            NF_THROW(
+                "fixedValue boundary condition on patch " + std::to_string(patchID)
+                + " requires either a uniform 'fixedValue' or a per-face 'fixedValues' entry"
+            );
+        }
+        if (fixedValues_.size() != 0 && fixedValues_.size() != this->patchSize())
+        {
+            NF_THROW(
+                "'fixedValues' holds " + std::to_string(fixedValues_.size()) + " values but patch "
+                + std::to_string(patchID) + " has " + std::to_string(this->patchSize()) + " faces"
+            );
+        }
+    }
 
     virtual void correctBoundaryCondition(Field<ValueType>& domainVector) final
     {
-        detail::setFixedValue(domainVector, this->range(), fixedValue_);
+        if (fixedValues_.size() > 0)
+        {
+            detail::setFixedValues(domainVector, this->range(), fixedValues_);
+        }
+        else
+        {
+            detail::setFixedValue(domainVector, this->range(), fixedValue_);
+        }
     }
 
     static std::string name() { return "fixedValue"; }
@@ -81,6 +145,7 @@ public:
 private:
 
     ValueType fixedValue_;
+    Vector<ValueType> fixedValues_; ///< empty unless the patch value is nonuniform
 };
 
 }

--- a/test/finiteVolume/cellCentred/boundary/volume/volFixedValue.cpp
+++ b/test/finiteVolume/cellCentred/boundary/volume/volFixedValue.cpp
@@ -61,4 +61,58 @@ TEST_CASE("fixedValue")
             REQUIRE(boundaryValue != setValue);
         }
     }
+
+    SECTION("PerFaceValues" + execName)
+    {
+        auto mesh = NeoN::createSingleCellMesh(exec);
+        auto field = NeoN::Field<NeoN::scalar>(exec, mesh.nCells(), mesh.boundaryMesh().offset());
+        NeoN::fill(field.internalVector(), 1.0);
+        NeoN::fill(field.boundaryData().refGrad(), -1.0);
+        NeoN::fill(field.boundaryData().refValue(), -1.0);
+        NeoN::fill(field.boundaryData().valueFraction(), -1.0);
+        NeoN::fill(field.boundaryData().value(), -1.0);
+
+        const auto& offset = mesh.boundaryMesh().offset();
+        const auto patchSize = static_cast<size_t>(offset[1] - offset[0]);
+
+        // one distinct value per face, as a nonuniform OpenFOAM patch field would supply
+        std::vector<NeoN::scalar> perFace(patchSize);
+        for (size_t i = 0; i < patchSize; ++i)
+        {
+            perFace[i] = 10.0 + static_cast<NeoN::scalar>(i);
+        }
+
+        NeoN::Dictionary dict;
+        dict.insert("fixedValues", perFace);
+        auto boundary =
+            NeoN::finiteVolume::cellCentred::VolumeBoundaryFactory<NeoN::scalar>::create(
+                "fixedValue", mesh, dict, 0
+            );
+
+        boundary->correctBoundaryCondition(field);
+
+        auto refValues = field.boundaryData().refValue().copyToHost();
+        auto values = field.boundaryData().value().copyToHost();
+
+        size_t i = 0;
+        for (auto& boundaryValue : values.view(boundary->range()))
+        {
+            REQUIRE(boundaryValue == perFace[i++]);
+        }
+        i = 0;
+        for (auto& boundaryValue : refValues.view(boundary->range()))
+        {
+            REQUIRE(boundaryValue == perFace[i++]);
+        }
+
+        // untouched patches keep their initial value
+        auto otherBoundary =
+            NeoN::finiteVolume::cellCentred::VolumeBoundaryFactory<NeoN::scalar>::create(
+                "fixedValue", mesh, dict, 1
+            );
+        for (auto& boundaryValue : values.view(otherBoundary->range()))
+        {
+            REQUIRE(boundaryValue == -1.0);
+        }
+    }
 }


### PR DESCRIPTION
FixedValue stored a single uniform value and rewrote every face with it, so a patch whose value varies per face (an inflow profile, a mapped field) could not be represented at all.

Accept an optional per-face "fixedValues" list alongside the uniform "fixedValue" entry, and copy it face by face in correctBoundaryCondition. The uniform path is unchanged. Construction now fails loudly when neither entry is present rather than reading an absent key.


Claude-Session: https://claude.ai/code/session_01NzEWhqzvNRLC4i4NWCGwHw

# Motivation
WHAT is it, WHY it is needed. :kissing_heart:
