### PR TITLE
fixedValue: reject an empty per-face list

### DIFF
--- a/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedValue.hpp
+++ b/include/NeoN/finiteVolume/cellCentred/boundary/volume/fixedValue.hpp
@@ -101,14 +101,19 @@ public:
                                            : std::vector<ValueType> {}
           )
     {
-        if (!dict.contains("fixedValue") && !dict.contains("fixedValues"))
+        const bool hasUniform = dict.contains("fixedValue");
+        const bool hasPerFace = dict.contains("fixedValues");
+        if (!hasUniform && !hasPerFace)
         {
             NF_THROW(
                 "fixedValue boundary condition on patch " + std::to_string(patchID)
                 + " requires either a uniform 'fixedValue' or a per-face 'fixedValues' entry"
             );
         }
-        if (fixedValues_.size() != 0 && fixedValues_.size() != this->patchSize())
+        // Validate on the key being present, not on the list being non-empty: an empty
+        // 'fixedValues' on a non-empty patch is malformed per-face data, and testing the
+        // size alone would let it through to the uniform fallback and silently apply zero.
+        if (hasPerFace && fixedValues_.size() != this->patchSize())
         {
             NF_THROW(
                 "'fixedValues' holds " + std::to_string(fixedValues_.size()) + " values but patch "

--- a/test/finiteVolume/cellCentred/boundary/volume/volFixedValue.cpp
+++ b/test/finiteVolume/cellCentred/boundary/volume/volFixedValue.cpp
@@ -115,4 +115,43 @@ TEST_CASE("fixedValue")
             REQUIRE(boundaryValue == -1.0);
         }
     }
+
+    SECTION("RejectsMalformedDictionary" + execName)
+    {
+        auto mesh = NeoN::createSingleCellMesh(exec);
+
+        const auto& offset = mesh.boundaryMesh().offset();
+        const auto patchSize = static_cast<size_t>(offset[1] - offset[0]);
+        REQUIRE(patchSize > 0);
+
+        // neither a uniform nor a per-face entry: nothing to apply
+        NeoN::Dictionary empty;
+        REQUIRE_THROWS_AS(
+            NeoN::finiteVolume::cellCentred::VolumeBoundaryFactory<NeoN::scalar>::create(
+                "fixedValue", mesh, empty, 0
+            ),
+            NeoN::NeoNException
+        );
+
+        // a per-face list that does not match the patch
+        NeoN::Dictionary wrongSize;
+        wrongSize.insert("fixedValues", std::vector<NeoN::scalar>(patchSize + 1, 10.0));
+        REQUIRE_THROWS_AS(
+            NeoN::finiteVolume::cellCentred::VolumeBoundaryFactory<NeoN::scalar>::create(
+                "fixedValue", mesh, wrongSize, 0
+            ),
+            NeoN::NeoNException
+        );
+
+        // an empty per-face list is malformed too: accepting it would fall back to the
+        // default-constructed uniform value and silently write zero over the patch
+        NeoN::Dictionary emptyList;
+        emptyList.insert("fixedValues", std::vector<NeoN::scalar> {});
+        REQUIRE_THROWS_AS(
+            NeoN::finiteVolume::cellCentred::VolumeBoundaryFactory<NeoN::scalar>::create(
+                "fixedValue", mesh, emptyList, 0
+            ),
+            NeoN::NeoNException
+        );
+    }
 }


### PR DESCRIPTION
Follow-up to #599, addressing the review comment https://github.com/exasim-project/NeoN/pull/599#discussion_r3966085469 that was not resolved before the merge.

## The problem

`FixedValue`'s size guard only ran when the per-face list was non-empty:

```cpp
if (fixedValues_.size() != 0 && fixedValues_.size() != this->patchSize())
```

So an explicitly supplied *empty* `fixedValues` slipped through both checks — the "neither entry present" throw saw the key, and `0 != 0` short-circuited the size check. Construction succeeded, and `correctBoundaryCondition` then took the uniform branch and wrote the default-constructed `fixedValue_` over the patch: zero silently applied instead of the malformed per-face data being rejected.

## The fix

Validate on the key being present rather than on the list being non-empty, so every supplied per-face list must match the patch size. The `size() > 0` dispatch in `correctBoundaryCondition` stays correct — under the stricter check a zero-size list can only occur on a zero-size patch, where both branches are no-ops.

## Testing

`neon_test_volFixedValue` passes (22 assertions). The new `RejectsMalformedDictionary` section covers all three rejection paths — neither key, wrong-size list, empty list — none of which had coverage before. Reverting just the header change makes it fail on exactly the empty-list assertion, so the test pins the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFs1tt7sP68dxbWWfg5LNR